### PR TITLE
Add "Join with Ticket" to the main UI — second invitations had no path

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,6 +15,7 @@ import { uploadFileToRoom } from './lib/client';
 import { errorShape } from './lib/protocol';
 import { loadAliases, saveAliases, suggestedNames } from './lib/names';
 import { shortId } from './lib/format';
+import { splitInvite } from './lib/invite';
 import { NamesContext } from './components/names';
 import type { NameApi } from './components/names';
 import { ErrorNote, Modal, TreeMark, Wordmark } from './components/ui';
@@ -68,6 +69,7 @@ export default function App({ client }: { client: Client }) {
   const [mobileView, setMobileView] = useState<MobileView>('rooms');
   const [inviteOpen, setInviteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [joinOpen, setJoinOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [aliases, setAliases] = useState<Record<string, string>>(loadAliases);
 
@@ -461,6 +463,7 @@ export default function App({ client }: { client: Client }) {
             if (rid !== roomId) void openRoom(rid);
           }}
           onCreateRoom={() => setCreateOpen(true)}
+          onJoinRoom={() => setJoinOpen(true)}
         />
 
         <main className="center">
@@ -566,6 +569,18 @@ export default function App({ client }: { client: Client }) {
           />
         ) : null}
 
+        {joinOpen ? (
+          <JoinRoomModal
+            client={client}
+            onClose={() => setJoinOpen(false)}
+            onJoined={(rid) => {
+              setJoinOpen(false);
+              void refreshRooms();
+              void openRoom(rid);
+            }}
+          />
+        ) : null}
+
         {renameTarget ? (
           <RenameModal
             id={renameTarget}
@@ -580,6 +595,80 @@ export default function App({ client }: { client: Client }) {
 }
 
 // -- small modals -------------------------------------------------------------------
+
+function JoinRoomModal({
+  client,
+  onClose,
+  onJoined,
+}: {
+  client: Client;
+  onClose(): void;
+  onJoined(roomId: string): void;
+}) {
+  const [ticket, setTicket] = useState('');
+  const [peerAddr, setPeerAddr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<DaemonErrorShape | null>(null);
+
+  const join = async () => {
+    if (!ticket.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { ticket: t, peerAddr: addr } = splitInvite(ticket, peerAddr);
+      const { room_id } = await client.call('room.join', {
+        ticket: t,
+        ...(addr ? { peers: [addr] } : {}),
+      });
+      onJoined(room_id);
+    } catch (e) {
+      setError(errorShape(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal title="Join with a ticket" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void join();
+        }}
+      >
+        <p className="muted">
+          Paste the invite you received. A combined invite (<code>ticket#address</code>) fills in the peer address
+          automatically.
+        </p>
+        <label className="field">
+          <span>Ticket</span>
+          <textarea
+            value={ticket}
+            onChange={(e) => setTicket(e.target.value)}
+            placeholder="roomtkt1… or roomtkt1…#<endpoint_id>@host:port"
+            rows={3}
+            spellCheck={false}
+            autoFocus
+          />
+        </label>
+        <label className="field">
+          <span>
+            Peer address <em className="muted">(optional)</em>
+          </span>
+          <input
+            value={peerAddr}
+            onChange={(e) => setPeerAddr(e.target.value)}
+            placeholder="<endpoint_id>@203.0.113.7:4242"
+            spellCheck={false}
+          />
+        </label>
+        <button type="submit" className="btn btn-primary" disabled={busy || !ticket.trim()}>
+          {busy ? 'Joining…' : 'Join room'}
+        </button>
+        <ErrorNote error={error} />
+      </form>
+    </Modal>
+  );
+}
 
 function CreateRoomModal({
   client,

--- a/ui/src/components/Onboarding.tsx
+++ b/ui/src/components/Onboarding.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { splitInvite } from '../lib/invite';
 import type { Client, DaemonErrorShape } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
 import { CopyButton, ErrorNote, TreeMark, Wordmark } from './ui';
@@ -106,16 +107,7 @@ function RoomsStep({
     setJoining(true);
     setJoinError(null);
     try {
-      // A combined invite is `<ticket>#<peer addr>` in one paste (what the
-      // invite modal hands out). Neither part can contain `#`, so a plain
-      // split is unambiguous; an explicitly typed peer address wins.
-      let t = ticket.trim();
-      let addr = peerAddr.trim();
-      const hash = t.indexOf('#');
-      if (hash > 0) {
-        if (!addr) addr = t.slice(hash + 1).trim();
-        t = t.slice(0, hash).trim();
-      }
+      const { ticket: t, peerAddr: addr } = splitInvite(ticket, peerAddr);
       await client.call('room.join', {
         ticket: t,
         ...(addr ? { peers: [addr] } : {}),

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ export function Sidebar({
   onNav,
   onSelectRoom,
   onCreateRoom,
+  onJoinRoom,
 }: {
   rooms: RoomSummary[];
   currentRoomId: string | null;
@@ -42,6 +43,7 @@ export function Sidebar({
   onNav(key: NavKey): void;
   onSelectRoom(roomId: string): void;
   onCreateRoom(): void;
+  onJoinRoom(): void;
 }) {
   const names = useNames();
   const identityId = status?.identity?.identity_id ?? null;
@@ -134,6 +136,9 @@ export function Sidebar({
 
       <button type="button" className="create-room" onClick={onCreateRoom}>
         <span aria-hidden="true">⊕</span> Create Room
+      </button>
+      <button type="button" className="create-room join-room" onClick={onJoinRoom}>
+        <span aria-hidden="true">⇥</span> Join with Ticket
       </button>
 
       <footer className="identity-footer">

--- a/ui/src/lib/invite.ts
+++ b/ui/src/lib/invite.ts
@@ -1,0 +1,20 @@
+/** Split a combined invite (`<ticket>#<peer addr>`) into its parts.
+ *
+ *  Tickets are base32 (`roomtkt1…`) and peer addresses are
+ *  `<endpoint_id>@host:port[,…]` — neither can contain `#`, so the split is
+ *  unambiguous. An explicitly provided peer address wins over the embedded
+ *  one; a leading `#` is not treated as a separator (the honest failure is
+ *  the daemon's bad-ticket error, not a silent empty ticket). */
+export function splitInvite(
+  ticketInput: string,
+  peerAddrInput: string,
+): { ticket: string; peerAddr: string } {
+  let ticket = ticketInput.trim();
+  let peerAddr = peerAddrInput.trim();
+  const hash = ticket.indexOf('#');
+  if (hash > 0) {
+    if (!peerAddr) peerAddr = ticket.slice(hash + 1).trim();
+    ticket = ticket.slice(0, hash).trim();
+  }
+  return { ticket, peerAddr };
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -870,6 +870,16 @@ button.sender-name:not(:disabled):hover {
   border-color: var(--accent-line);
 }
 
+/* Quieter sibling of Create Room — joining is the invitee's path, not the
+   primary action, but it must exist outside onboarding (a second invitation
+   previously had no UI path at all). */
+.join-room {
+  margin-top: 0;
+  border-style: solid;
+  border-color: var(--border);
+  color: var(--text-mute);
+}
+
 .identity-footer {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;


### PR DESCRIPTION
## What

The first real two-user session (pilot with a co-worker in Côte d'Ivoire) confirmed the funnel gap found in review: `room.join` was only reachable from the onboarding screen, so once a user had any room, a received ticket could not be accepted in the UI at all.

- New `JoinRoomModal` in the main UI behind a quiet **Join with Ticket** button under **Create Room** in the sidebar
- Accepts the combined one-paste invite (`ticket#address`) or separate ticket + peer address
- Parser extracted to `ui/src/lib/invite.ts`, shared with onboarding (no behavior change there)
- On success: room list refreshes and the joined room opens

## Verification

- `tsc --noEmit` + vite build clean
- Sidebar placement verified by screenshot in mock mode
- Join logic is the same field-tested path onboarding uses; `#` cannot occur inside a ticket (base32) or peer address, so the split is unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)