### PR TITLE
Prepare v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "dirs",

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump to 0.3.1 (crates, UI package, lockfiles). Ships the Join with Ticket fix (#3) to installed users. Tag v0.3.1 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)