### PR TITLE
Prepare v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "dirs",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ the [Iroh Rooms](https://github.com/kortiene/iroh-room) peer-to-peer runtime.
 </p>
 <p align="center"><sub><em>The shipped shell in demo mode — deterministic sample data, no daemon (<code>VITE_MOCK=1</code>).</em></sub></p>
 
+**Want to see that yourself, right now, with nothing installed?** Zero-install
+preview — no daemon, no build, just the UI with sample data.
+
+```bash
+git clone https://github.com/kortiene/jeliya.git && cd jeliya/ui
+npm install && VITE_MOCK=1 npm run dev
+```
+
 > **New here? Read this first.** Jeliya has no central server. Your rooms live
 > on the computers of the people in them and sync directly, device to device.
 > Everything you see on screen (messages, files, agent updates) is rebuilt from
@@ -61,6 +69,7 @@ New to peer-to-peer tools? These are the only terms you need to get started:
 | **shell / UI** | The Jeliya window you actually look at and click (a web page). |
 | **peer-to-peer (P2P)** | Computers talk to each other directly, with no central server owning your data. |
 | **room** | A private space (like a channel) shared by its members. |
+| **ticket** | An invite code tied to one room, one role, and one invitee identity. Generate one to invite someone; paste one to join. |
 | **loopback mode** | A local-only test mode. Everything stays on your own machine (`127.0.0.1`) — great for trying things without real networking. |
 | **relay / direct** | How two peers connect. *Direct* is computer-to-computer. *Relay* is a fallback that bounces traffic through a helper server when a direct link can't be made. Jeliya always tells you which one you're on. |
 
@@ -102,6 +111,9 @@ irm https://raw.githubusercontent.com/kortiene/jeliya/main/packaging/install.ps1
 
 Prefer to grab a file yourself? Download the build for your system from the
 [Releases page](https://github.com/kortiene/jeliya/releases) and unpack it.
+Note: these builds are unsigned, so macOS/Windows will show a security warning
+on first run (see [Troubleshooting](#troubleshooting)) — the `brew`/`curl`/
+PowerShell installs above don't trigger this.
 
 ### 2. Run it
 
@@ -269,9 +281,16 @@ node scripts/agent-e2e.mjs
 - **Peers show a `relay` badge instead of `direct`.** That's normal on some
   networks: a direct link couldn't be made, so traffic uses a relay fallback.
   Everything still works; it's just not a direct connection.
-- **A browser-downloaded macOS binary is blocked.** Release binaries are
-  currently unsigned. Prefer Homebrew or the install script on macOS; they
-  install the same release without setting the browser quarantine bit.
+- **A browser-downloaded macOS binary is blocked ("cannot be opened because
+  the developer cannot be verified").** Release binaries are currently
+  unsigned. Prefer Homebrew or the install script on macOS; they install the
+  same release without setting the browser quarantine bit. If you did download
+  it directly, right-click (or Control-click) the binary, choose **Open**, then
+  confirm **Open** in the dialog — this only needs to be done once.
+- **Windows SmartScreen says "Windows protected your PC" for a
+  browser-downloaded build.** Same cause: the binary is unsigned. Click
+  **More info**, then **Run anyway**. The PowerShell install script above
+  doesn't trigger this.
 - **Upgrading from a pre-rename (Bantaba) install?** The project was renamed
   to Jeliya on 2026-07-05 (`docs/naming.md`), and the data directory moved
   with it. Your identity and rooms are still on disk under the old name.

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliya-core/src/materializer.rs
+++ b/crates/jeliya-core/src/materializer.rs
@@ -4,8 +4,9 @@
 //! One validated room event folds into one JSON object with a stable common
 //! header (`event_id`, `room_id`, `ts`, `sender`, `kind`) plus kind-specific
 //! fields present only for that kind. Event kinds outside the protocol's
-//! enumerated eight (`member.left` / `member.removed`) fold to `None` and are
-//! omitted from timelines.
+//! displayed set (`member.removed`) fold to `None` and are omitted from
+//! timelines. `member.left` is displayed as a lightweight system event so live
+//! clients can refresh rosters when someone leaves.
 
 use serde_json::{json, Map, Value};
 
@@ -96,7 +97,7 @@ pub fn materialize_signed(
 }
 
 /// The protocol `kind` plus its kind-specific fields, or `None` for kinds the
-/// protocol does not enumerate (`member.left`, `member.removed`).
+/// protocol does not enumerate (`member.removed`).
 fn kind_fields(content: &Content) -> Option<(&'static str, Map<String, Value>)> {
     let mut m = Map::new();
     let kind = match content {
@@ -195,8 +196,17 @@ fn kind_fields(content: &Content) -> Option<(&'static str, Map<String, Value>)> 
             );
             "pipe_closed"
         }
+        Content::MemberLeft(c) => {
+            m.insert(
+                "member".into(),
+                json!({
+                    "identity_id": c.member_id.to_string(),
+                }),
+            );
+            "member_left"
+        }
         // Not part of the protocol's TimelineEvent kind enumeration.
-        Content::MemberLeft(_) | Content::MemberRemoved(_) => return None,
+        Content::MemberRemoved(_) => return None,
     };
     Some((kind, m))
 }
@@ -475,13 +485,15 @@ mod tests {
     }
 
     #[test]
-    fn member_left_is_not_a_timeline_kind() {
+    fn member_left_is_a_system_timeline_kind() {
         let fx = fixture();
         let wire = build_member_left(&fx.identity, &fx.device, &fx.room_id, None, &[], TS + 1);
         let snapshot = snapshot_of(&fx);
         let ev = decode(&wire);
         let id = iroh_rooms::events::EventId::from_bytes([0x01; 32]);
-        assert!(materialize_signed(&fx.room_id, &id, &ev, &snapshot).is_none());
+        let v = materialize_signed(&fx.room_id, &id, &ev, &snapshot).expect("left materializes");
+        assert_eq!(v["kind"], "member_left");
+        assert_eq!(v["member"]["identity_id"], fx.identity.identity_key().to_string());
     }
 
     #[test]

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -46,8 +46,9 @@ use iroh_rooms::experimental::sync::{SyncConfig, SyncEngine};
 use iroh_rooms::files::build_file_shared;
 use iroh_rooms::identity::{DeviceBinding, DeviceKey, IdentityKey};
 use iroh_rooms::room::{
-    build_member_invited, build_member_joined, build_room_created, derive_room_id, Ingest,
-    MembershipSnapshot, Role, RoomId, RoomInviteTicket, RoomMembership, Status,
+    build_member_invited, build_member_joined, build_member_left, build_room_created,
+    derive_room_id, Ingest, MembershipSnapshot, Role, RoomId, RoomInviteTicket,
+    RoomMembership, Status,
 };
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
@@ -690,10 +691,21 @@ impl RoomSupervisor {
                 .as_ref()
                 .and_then(|key| snapshot.role(key))
                 .map(role_label);
+            let status = if let Some(key) = self_key.as_ref() {
+                let store = self.open_store()?;
+                let (removed_ids, left_ids) = departure_sets(&store, &room_id)?;
+                snapshot
+                    .members()
+                    .find(|member| &member.identity == key)
+                    .map(|member| status_label(member.status, key, &removed_ids, &left_ids))
+            } else {
+                None
+            };
             rooms.push(json!({
                 "room_id": room_id.to_string(),
                 "name": name,
                 "role": role,
+                "status": status,
                 "member_count": snapshot.members().count(),
                 "open": self.is_open(&room_id),
             }));
@@ -759,16 +771,8 @@ impl RoomSupervisor {
         }))
     }
 
-    /// `room.close`: shut the session down (pipes first, then the node).
-    pub async fn close_room(&self, room_id_str: &str) -> CoreResult<()> {
-        let room_id = parse_room_id(room_id_str)?;
-        let _structural = self.structural.lock().await;
-        let Some(session) = self.sessions().remove(&room_id) else {
-            return Err(CoreError::new(
-                ErrorKind::RoomNotOpen,
-                format!("room {room_id} is not open"),
-            ));
-        };
+    /// Shut down an already-removed session (pipes first, then the node).
+    async fn shutdown_session(&self, room_id: &RoomId, session: Arc<RoomSession>) -> CoreResult<()> {
         // Keep the freshest peer addresses so a later re-open can redial them.
         // This write is best-effort: a corrupt/unwritable state.json must never
         // leave the live node leaked (its pump + blob-store lock) by aborting
@@ -783,6 +787,124 @@ impl RoomSupervisor {
             .await
             .map_err(|e| internal("could not shut the room node down", e))?;
         Ok(())
+    }
+
+    /// `room.close`: shut the session down without changing membership.
+    pub async fn close_room(&self, room_id_str: &str) -> CoreResult<()> {
+        let room_id = parse_room_id(room_id_str)?;
+        let _structural = self.structural.lock().await;
+        let Some(session) = self.sessions().remove(&room_id) else {
+            return Err(CoreError::new(
+                ErrorKind::RoomNotOpen,
+                format!("room {room_id} is not open"),
+            ));
+        };
+        self.shutdown_session(&room_id, session).await
+    }
+
+    /// `room.leave`: publish a signed `member.left` for this identity, then
+    /// close this daemon's local live session if one is open. The immutable room
+    /// owner cannot leave yet: the protocol has no ownership transfer, and an
+    /// owner-authored `member.left` would not remove the genesis admin anyway.
+    pub async fn leave_room(&self, room_id_str: &str) -> CoreResult<String> {
+        let room_id = parse_room_id(room_id_str)?;
+        let secret = self.secrets()?;
+        let self_id = secret.identity.identity_key();
+        let _structural = self.structural.lock().await;
+
+        let event_id = if let Some(session) = self.session_opt(&room_id) {
+            let snapshot = session
+                .node
+                .snapshot()
+                .await
+                .map_err(|e| internal("could not read the membership snapshot", e))?;
+            ensure_can_leave(&snapshot, &self_id, &room_id)?;
+            let heads = Self::node_heads(&session.node).await?;
+            let wire = build_member_left(&secret.identity, &secret.device, &room_id, None, &heads, now_ms());
+            let validated = validate_wire_bytes(
+                &wire.to_bytes(),
+                &ValidationContext::for_room(room_id),
+            )
+            .map_err(|reason| {
+                CoreError::internal(format!(
+                    "freshly built member.left failed validation ({})",
+                    reason.code()
+                ))
+            })?;
+            let event_id = validated.event_id;
+            {
+                let store = self.open_store()?;
+                let (mut membership, _) = self.fold(&store, &room_id)?;
+                match membership.ingest(validated) {
+                    Ingest::Accepted { .. } => {}
+                    Ingest::Rejected { reason, .. } => {
+                        return Err(CoreError::internal(format!(
+                            "freshly built member.left was rejected by the fold ({})",
+                            reason.code()
+                        )))
+                    }
+                    Ingest::Buffered { .. } => {
+                        return Err(CoreError::internal(
+                            "freshly built member.left is causally incomplete",
+                        ))
+                    }
+                }
+            }
+            session
+                .node
+                .publish(wire.to_bytes())
+                .await
+                .map_err(|e| internal("could not publish the leave", e))?;
+            // Give connected peers a brief chance to ingest the departure before
+            // this daemon tears down its room node and stops serving the session.
+            tokio::time::sleep(FLUSH_GRACE).await;
+            drop(session);
+            let removed_session = { self.sessions().remove(&room_id) };
+            if let Some(session) = removed_session {
+                self.shutdown_session(&room_id, session).await?;
+            }
+            event_id
+        } else {
+            let mut store = self.open_store()?;
+            let (mut membership, snapshot) = self.fold(&store, &room_id)?;
+            ensure_can_leave(&snapshot, &self_id, &room_id)?;
+            let mut heads = store
+                .heads(&room_id)
+                .map_err(|e| internal("could not read the room heads", e))?;
+            heads.truncate(MAX_PREV_EVENTS);
+            let wire = build_member_left(&secret.identity, &secret.device, &room_id, None, &heads, now_ms());
+            let validated = validate_wire_bytes(
+                &wire.to_bytes(),
+                &ValidationContext::for_room(room_id),
+            )
+            .map_err(|reason| {
+                CoreError::internal(format!(
+                    "freshly built member.left failed validation ({})",
+                    reason.code()
+                ))
+            })?;
+            match membership.ingest(validated.clone()) {
+                Ingest::Accepted { .. } => {}
+                Ingest::Rejected { reason, .. } => {
+                    return Err(CoreError::internal(format!(
+                        "freshly built member.left was rejected by the fold ({})",
+                        reason.code()
+                    )))
+                }
+                Ingest::Buffered { .. } => {
+                    return Err(CoreError::internal(
+                        "freshly built member.left is causally incomplete",
+                    ))
+                }
+            }
+            let event_id = validated.event_id;
+            store
+                .insert(&validated)
+                .map_err(|e| internal("could not persist the leave", e))?;
+            event_id
+        };
+
+        Ok(bare_event_hex(&event_id))
     }
 
     /// `room.timeline`: chronological `TimelineEvent`s from the local log
@@ -1933,10 +2055,15 @@ impl RoomSupervisor {
                 } else {
                     Value::Null
                 };
+                // `identity` is only set once the SDK has bound this device to
+                // a membership identity (on admit); null before/during
+                // admission is expected, not a bug.
+                let identity_id = entry.identity.as_ref().map(|id| id.to_string());
                 json!({
                     "endpoint_id": device.to_string(),
                     "state": state,
                     "path": path,
+                    "identity_id": identity_id,
                 })
             })
             .collect()
@@ -2597,6 +2724,26 @@ fn status_label(
     }
 }
 
+/// Validate the product policy for voluntary departure.
+fn ensure_can_leave(
+    snapshot: &MembershipSnapshot,
+    self_id: &IdentityKey,
+    room_id: &RoomId,
+) -> CoreResult<()> {
+    if snapshot.admin() == Some(self_id) {
+        return Err(CoreError::invalid(
+            "room owners cannot leave yet; close the local room session instead",
+        ));
+    }
+    if !snapshot.is_active(self_id) {
+        return Err(CoreError::new(
+            ErrorKind::NotAMember,
+            format!("this identity ({self_id}) is not an active member of room {room_id}"),
+        ));
+    }
+    Ok(())
+}
+
 /// Map a `gate_join` rejection onto the protocol taxonomy.
 fn join_reject_error(reason: &RejectReason) -> CoreError {
     match reason {
@@ -2870,6 +3017,31 @@ mod tests {
             identity, device, &room_id, body, None, None, &[], &heads, ts,
         );
         insert_wire(sup, &room_id, &wire);
+    }
+
+    async fn wait_member_status(
+        sup: &RoomSupervisor,
+        room_id: &str,
+        identity_id: &str,
+        status: &str,
+    ) -> serde_json::Value {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let members = sup.members(room_id).await.unwrap();
+            if let Some(member) = members
+                .iter()
+                .find(|m| m["identity_id"].as_str() == Some(identity_id))
+            {
+                if member["status"] == status {
+                    return member.clone();
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for member {identity_id} to be {status}; last members: {members:?}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
     }
 
     /// Poll `agents.fleet` until `pred` holds (or fail after a deadline).
@@ -3323,6 +3495,68 @@ mod tests {
 
         sup.close_room(&room_id).await.unwrap();
         assert!(sup.open_rooms().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn owner_cannot_leave_room() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Owner Stays").unwrap();
+        sup.open_room(&room_id, &[]).await.unwrap();
+
+        let err = sup.leave_room(&room_id).await.unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
+        assert!(err.message.contains("owners cannot leave"));
+
+        let members = sup.members(&room_id).await.unwrap();
+        assert_eq!(members[0]["role"], "owner");
+        assert_eq!(members[0]["status"], "active");
+        sup.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn member_leave_is_distinct_from_close_and_blocks_reopen() {
+        let owner_dir = tempdir().unwrap();
+        crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id = owner.create_room("Leave Room").unwrap();
+        let opened = owner.open_room(&room_id, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, Some("leaver"), &[owner_addr.clone()])
+            .await
+            .unwrap();
+        member.open_room(&room_id, &[]).await.unwrap();
+        wait_member_status(&owner, &room_id, &member_profile.identity_id, "active").await;
+
+        // `room.close` is only a local session shutdown: membership remains active.
+        member.close_room(&room_id).await.unwrap();
+        let mine = wait_member_status(&member, &room_id, &member_profile.identity_id, "active").await;
+        assert_eq!(mine["role"], "member");
+
+        // `room.leave` authors member.left, closes the local session, and makes
+        // the departure visible to both the leaver and connected peers.
+        member.open_room(&room_id, &[]).await.unwrap();
+        let event_id = member.leave_room(&room_id).await.unwrap();
+        assert_eq!(event_id.len(), 64);
+        assert!(member.open_rooms().is_empty());
+        let mine = wait_member_status(&member, &room_id, &member_profile.identity_id, "left").await;
+        assert_eq!(mine["role"], "member");
+        wait_member_status(&owner, &room_id, &member_profile.identity_id, "left").await;
+
+        let err = member.open_room(&room_id, &[owner_addr]).await.unwrap_err();
+        assert_eq!(err.kind, ErrorKind::NotAMember);
+
+        owner.close_room(&room_id).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/src/rpc.rs
+++ b/crates/jeliyad/src/rpc.rs
@@ -206,6 +206,11 @@ async fn dispatch(method: &str, raw_params: Value, state: &AppState) -> CoreResu
             sup.close_room(&p.room_id).await?;
             Ok(json!({}))
         }
+        "room.leave" => {
+            let p: RoomIdParams = params(raw_params)?;
+            let event_id = sup.leave_room(&p.room_id).await?;
+            Ok(json!({ "event_id": event_id }))
+        }
         "room.timeline" => {
             let p: TimelineParams = params(raw_params)?;
             Ok(json!({ "events": sup.timeline(&p.room_id, p.limit).await? }))

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -51,22 +51,24 @@ present only for that kind.
   "room_id": "blake3:…",
   "ts": 1783190000000,
   "sender": { "identity_id": "…64-hex…", "device_id": "…64-hex…", "role": "owner|member|agent" },
-  "kind": "room_created | member_invited | member_joined | message | agent_status | file_shared | pipe_opened | pipe_closed",
+  "kind": "room_created | member_invited | member_joined | member_left | message | agent_status | file_shared | pipe_opened | pipe_closed",
 
   "body": "hello",                                             // message
   "label": "running_tests", "status_message": "…",             // agent_status
   "progress": 60, "artifacts": ["file_…32-hex…"],              // agent_status (optional)
   "file": { "file_id": "file_…", "name": "PRD.pdf", "size": 123, "mime": "application/pdf" },  // file_shared
   "pipe": { "pipe_id": "…32-hex…", "target": "127.0.0.1:3000", "authorized_peer": "…identity…" }, // pipe_opened / pipe_closed
-  "member": { "identity_id": "…", "role": "member" }           // member_invited / member_joined
+  "member": { "identity_id": "…", "role": "member" }           // member_invited / member_joined; member_left omits role
 }
 ```
 
 ### PeerStatus
 
 ```json
-{ "endpoint_id": "…", "state": "connected|connecting|offline", "path": "direct|relay|null" }
+{ "endpoint_id": "…", "state": "connected|connecting|offline", "path": "direct|relay|null", "identity_id": "…64-hex…|null" }
 ```
+
+`identity_id` is null until the SDK has bound that device to a membership identity (on admit) — expect null before/during admission, not just for strangers.
 
 ## Methods
 
@@ -85,9 +87,10 @@ present only for that kind.
 | Method | Params | Result |
 |---|---|---|
 | `room.create` | `{ name }` | `{ room_id }` — name is daemon-local metadata if the protocol has no name field |
-| `room.list` | `{}` | `{ rooms: [{ room_id, name, role, member_count, open }] }` |
+| `room.list` | `{}` | `{ rooms: [{ room_id, name, role, status, member_count, open }] }` — `status` is this identity's roster status (`active|invited|left|removed|null`) |
 | `room.open` | `{ room_id }` | `{ endpoint: { endpoint_id, addr }, members, timeline }` — spawns the room's node session, starts pushes; `addr` is the dialable string an inviter shares with joiners |
-| `room.close` | `{ room_id }` | `{}` |
+| `room.close` | `{ room_id }` | `{}` — closes only this daemon's live session; membership remains active |
+| `room.leave` | `{ room_id }` | `{ event_id }` — authors `member.left` for this identity and closes the local session; owners are rejected until ownership transfer exists |
 | `room.timeline` | `{ room_id, limit? }` | `{ events: [TimelineEvent] }` (chronological) |
 | `room.members` | `{ room_id }` | `{ members: [{ identity_id, role, status }] }` |
 | `invite.create` | `{ room_id, identity_id, role: "member"\|"agent", expiry? }` | `{ ticket }` |

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -71,6 +71,10 @@ node scripts/jeliya-agent.mjs --ticket <TICKET> --peer <ID@IP:PORT,...> --worker
 #    @agent write a haiku about NAT traversal into haiku.txt
 ```
 
+`--worker claude` above is a deliberate opt-in to real execution (see trust
+model). To try the flow first without it, drop the flag or pass `--worker
+echo` — the safe, inert default.
+
 The agent announces itself in chat when it comes online. On Ctrl-C/SIGTERM it
 kills any in-flight claude worker (the whole process group), posts a
 best-effort `failed` status for the aborted task plus an `offline` status,
@@ -105,7 +109,7 @@ node scripts/jeliya-agent.mjs --room <room_id> --worker claude
 | `--room <room_id>` | — | With `--ticket`: assert the joined room. Alone: rejoin mode (already a member — skip join, just open) |
 | `--port <n>` | `7461` | WS port for the spawned `jeliyad` |
 | `--data-dir <dir>` | `.jeliya-agent` | Daemon data dir; the identity persists here across runs |
-| `--worker claude\|echo` | `claude` | `claude`: real work via the claude CLI. `echo`: deterministic test worker |
+| `--worker claude\|echo` | `echo` | `claude`: real work via the claude CLI. `echo`: deterministic test worker |
 | `--workspace <dir>` | fresh OS temp dir | Parent dir; each task gets a fresh numbered subdir. The default is deliberately OUTSIDE `--data-dir` (which holds `identity.secret`) — keep any override outside it too |
 | `--trigger <phrase>` | `@agent` | Task trigger; matched case-insensitively at the start of a message |
 | `--allow-sender <64hex>` | room owner | Allowlisted sender identity; repeatable. See trust model |

--- a/docs/glossary-fr.md
+++ b/docs/glossary-fr.md
@@ -6,6 +6,13 @@ across surfaces. Jeliya targets francophone West Africa first (Mali,
 Senegal, Guinea, Côte d'Ivoire); Bambara (bm) is a community aspiration
 unlocked after French ships.
 
+This is a contract for translators and reviewers preparing a planned French
+release — it is not a live, end-user-facing glossary, and nothing here is
+wired into the UI yet (no i18n framework exists). Until French strings
+ship, francophone users have no way to find or use this page. Once they
+ship, add a linked, user-facing pointer (a `README.fr.md`, or a "Voir aussi"
+link from the main README) so this glossary is actually discoverable.
+
 ## Tier 1 — communal vocabulary: translate
 
 Everyday nouns rendered as prose. First-pass equivalents (translators may

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -52,22 +52,25 @@ required; zig supplies it).
 ## Release status (and the 2026-07-05 rename)
 
 The project was renamed **Bantaba → Jeliya** on 2026-07-05 (`docs/naming.md`).
-Everything in this directory targets the new name, so the published history
-needs one bridging release:
+The rename is complete and the bridging release it required has already
+shipped:
 
-1. **GitHub repo:** the remote is still `git@github.com:kortiene/bantaba.git`
-   until the repo is renamed to `jeliya` on GitHub (GitHub redirects old URLs
-   afterwards). Rename the repo **before** pushing the next tag.
-2. **Existing releases:** `v0.1.0` and `v0.2.0` were published under the old
-   name with `bantabad-<tag>-<target>` archives containing a `bantabad`
-   binary. The current formula and install scripts look for
-   `jeliyad-<tag>-<target>` — they **cannot install those old releases**.
-3. **Next release (restores installs):** after the repo rename, push a new
-   tag (e.g. `v0.3.0`); `release.yml` already builds `-p jeliyad` and
-   packages `jeliyad-<tag>-<target>` archives. Then copy the new version and
-   all four sha256 values into `jeliya.rb`.
-4. **Homebrew tap:** rename the tap repo to `homebrew-jeliya` (formula file
-   `Formula/jeliya.rb`) and push the updated formula.
+1. **GitHub repo:** renamed — `git remote -v` resolves to
+   `git@github.com:kortiene/jeliya.git`.
+2. **Old releases:** `v0.1.0` and `v0.2.0` were published under the old name
+   with `bantabad-<tag>-<target>` archives containing a `bantabad` binary.
+   The formula and install scripts look for `jeliyad-<tag>-<target>` — they
+   could not install those old releases.
+3. **Bridging release:** `v0.3.0` ("first installable Jeliya release") and
+   `v0.3.1` were cut after the repo rename, built by `release.yml` from
+   `-p jeliyad`, and packaged as `jeliyad-<tag>-<target>` archives. `jeliya.rb`
+   was filled in with the matching version and sha256 values for both tags.
+4. **Homebrew tap:** the top-level README's install command
+   (`brew install kortiene/jeliya/jeliya`) resolves against a
+   `kortiene/homebrew-jeliya` tap carrying the `jeliya.rb` formula, so the tap
+   is reachable under the new name. This directory doesn't track that tap
+   repo's own history, so we can confirm the naming is correct but not
+   whether the tap repo was renamed in place or created fresh.
 5. **Redistribution rights:** confirmed for publishing built binaries that
    include the pinned `iroh-rooms` git dependency (unchanged by the rename).
 

--- a/scripts/jeliya-agent.mjs
+++ b/scripts/jeliya-agent.mjs
@@ -324,7 +324,11 @@ async function claudeWorker(task, ctx) {
             toolCalls += 1;
             // Honest, throttled progress: the tool actually being run,
             // counted as tool calls (the CLI's own turn accounting differs).
-            void ctx.postStatus("working", `running: ${blk.name} (tool call ${toolCalls})`);
+            // Task excerpt appended so Fleet/Agents shows what prompted the
+            // tool call, not just the low-level tool name; postStatus (via
+            // postStatusNow) truncates to STATUS_MESSAGE_LIMIT regardless.
+            const excerpt = task.length > 60 ? `${task.slice(0, 60)}…` : task;
+            void ctx.postStatus("working", `running: ${blk.name} (tool call ${toolCalls}) — ${excerpt}`);
           }
         }
       } else if (obj.type === "result") {
@@ -1028,6 +1032,15 @@ try {
     const winner = [...ids].sort()[0];
     if (winner !== myClaimId) {
       log(`lost claim task:${token} to ${winner.slice(0, 12)}… — standing down silently`);
+      // LIVENESS: without this, our last posted status for this task stays
+      // "claiming" forever — an operator can't tell a just-lost arbitration
+      // from a stuck agent. Mirror the idle-liveness post in startTask's
+      // finally block: best-effort, never let a status failure crash us.
+      try {
+        await postStatusNow("idle", "stood down - lost claim arbitration");
+      } catch (err) {
+        log(`"idle" status failed (ignored): ${err.message}`);
+      }
       return;
     }
     log(`won claim task:${token} (${ids.size} claim(s) observed)`);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -70,6 +70,7 @@ export default function App({ client }: { client: Client }) {
   const [inviteOpen, setInviteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [joinOpen, setJoinOpen] = useState(false);
+  const [leaveOpen, setLeaveOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [aliases, setAliases] = useState<Record<string, string>>(loadAliases);
 
@@ -190,7 +191,7 @@ export default function App({ client }: { client: Client }) {
       });
       if (event.kind === 'file_shared') void refreshFiles(room_id);
       if (event.kind === 'pipe_opened' || event.kind === 'pipe_closed') void refreshPipes(room_id);
-      if (event.kind === 'member_joined' || event.kind === 'member_invited') {
+      if (event.kind === 'member_joined' || event.kind === 'member_invited' || event.kind === 'member_left') {
         void refreshMembers(room_id);
         void refreshRooms();
       }
@@ -228,6 +229,12 @@ export default function App({ client }: { client: Client }) {
           return;
         }
         setPhase('ready');
+        const activeRooms = rooms.filter((r) => r.status !== 'left' && r.status !== 'removed');
+        if (activeRooms.length === 0) {
+          roomIdRef.current = null;
+          setRoomId(null);
+          return;
+        }
         let saved: string | null = null;
         try {
           saved = localStorage.getItem(LAST_ROOM_KEY);
@@ -235,9 +242,9 @@ export default function App({ client }: { client: Client }) {
           /* ignore */
         }
         const target =
-          (roomIdRef.current && rooms.some((r) => r.room_id === roomIdRef.current) && roomIdRef.current) ||
-          (saved && rooms.some((r) => r.room_id === saved) && saved) ||
-          rooms[0].room_id;
+          (roomIdRef.current && activeRooms.some((r) => r.room_id === roomIdRef.current) && roomIdRef.current) ||
+          (saved && activeRooms.some((r) => r.room_id === saved) && saved) ||
+          activeRooms[0].room_id;
         void openRoom(target);
       } catch {
         // daemon.status failed (connection dropped mid-flight) — the
@@ -283,6 +290,16 @@ export default function App({ client }: { client: Client }) {
   const fetchFile = (fileId: string) => {
     const rid = roomIdRef.current;
     if (!rid) return;
+    const file = files.find((f) => f.file_id === fileId);
+    if (selfId !== null && file?.sender_id === selfId) {
+      setFetches((m) => {
+        if (!m[fileId]) return m;
+        const next = { ...m };
+        delete next[fileId];
+        return next;
+      });
+      return;
+    }
     setFetches((m) => ({ ...m, [fileId]: { phase: 'pending' } }));
     void (async () => {
       try {
@@ -369,6 +386,32 @@ export default function App({ client }: { client: Client }) {
     if (!rid) return;
     await client.call('pipe.expose', { room_id: rid, target, peer_identity: peerIdentity });
     void refreshPipes(rid);
+  };
+
+  const leaveCurrentRoom = () => {
+    roomIdRef.current = null;
+    setRoomId(null);
+    setMembers([]);
+    setTimeline([]);
+    setFiles([]);
+    setPipes([]);
+    setPeers([]);
+    setEndpointAddr(null);
+    setRoomError(null);
+    setRoomLoading(false);
+    setFetches({});
+    setPipeConns({});
+    setClosingPipes(new Set());
+    setMobileView('rooms');
+    try {
+      localStorage.removeItem(LAST_ROOM_KEY);
+    } catch {
+      /* ignore */
+    }
+    void refreshRooms();
+    void client.call('daemon.status', {}).then(setStatus).catch(() => {
+      /* transient */
+    });
   };
 
   const currentRoom = rooms.find((r) => r.room_id === roomId) ?? null;
@@ -459,6 +502,11 @@ export default function App({ client }: { client: Client }) {
           activeNav={activeNav}
           onNav={navigate}
           onSelectRoom={(rid) => {
+            const room = rooms.find((r) => r.room_id === rid);
+            if (room?.status === 'left' || room?.status === 'removed') {
+              setMobileView('rooms');
+              return;
+            }
             setMobileView('chat');
             if (rid !== roomId) void openRoom(rid);
           }}
@@ -490,6 +538,7 @@ export default function App({ client }: { client: Client }) {
                 files={files}
                 fetches={fetches}
                 loading={roomLoading}
+                selfId={selfId}
                 onFetch={fetchFile}
                 onShowPipes={() => setTab('pipes')}
               />
@@ -503,6 +552,7 @@ export default function App({ client }: { client: Client }) {
         <RightPanel
           tab={tab}
           onTab={setTab}
+          roomName={currentRoom?.name ?? null}
           members={members}
           timeline={timeline}
           files={files}
@@ -517,6 +567,7 @@ export default function App({ client }: { client: Client }) {
           onPipeConnect={pipeConnect}
           onPipeClose={pipeClose}
           onPipeExpose={pipeExpose}
+          onLeaveRoom={() => setLeaveOpen(true)}
         />
 
         {activeNav === 'agents' ? (
@@ -524,6 +575,8 @@ export default function App({ client }: { client: Client }) {
             client={client}
             rooms={rooms}
             onOpenRoom={(rid) => {
+              const room = rooms.find((r) => r.room_id === rid);
+              if (room?.status === 'left' || room?.status === 'removed') return;
               setMobileView('chat');
               if (rid !== roomId) void openRoom(rid);
             }}
@@ -536,6 +589,7 @@ export default function App({ client }: { client: Client }) {
             <span className="settings-label">P2P Identity</span>
             <code className="mono settings-val">{status?.identity?.identity_id ?? '—'}</code>
           </div>
+          <p className="muted">Unrecoverable if this device or its data folder is lost.</p>
           <div className="settings-card">
             <span className="settings-label">Endpoint</span>
             <code className="mono settings-val">{status?.endpoint?.endpoint_id ?? '—'}</code>
@@ -577,6 +631,19 @@ export default function App({ client }: { client: Client }) {
               setJoinOpen(false);
               void refreshRooms();
               void openRoom(rid);
+            }}
+          />
+        ) : null}
+
+        {leaveOpen && roomId && currentRoom ? (
+          <LeaveRoomModal
+            client={client}
+            roomId={roomId}
+            roomName={currentRoom.name}
+            onClose={() => setLeaveOpen(false)}
+            onLeft={() => {
+              setLeaveOpen(false);
+              leaveCurrentRoom();
             }}
           />
         ) : null}
@@ -711,6 +778,61 @@ function CreateRoomModal({
         <button type="submit" className="btn btn-primary" disabled={busy || !name.trim()}>
           {busy ? 'Creating…' : 'Create room'}
         </button>
+        <ErrorNote error={error} />
+      </form>
+    </Modal>
+  );
+}
+
+function LeaveRoomModal({
+  client,
+  roomId,
+  roomName,
+  onClose,
+  onLeft,
+}: {
+  client: Client;
+  roomId: string;
+  roomName: string;
+  onClose(): void;
+  onLeft(): void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<DaemonErrorShape | null>(null);
+
+  const leave = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await client.call('room.leave', { room_id: roomId });
+      onLeft();
+    } catch (e) {
+      setError(errorShape(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal title="Leave room" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void leave();
+        }}
+      >
+        <p className="muted">
+          Leaving <strong>{roomName}</strong> publishes a signed membership departure. This is different from closing
+          the local session; you’ll need a new invite to join again.
+        </p>
+        <div className="field-row">
+          <button type="submit" className="btn btn-danger" disabled={busy} autoFocus>
+            {busy ? 'Leaving…' : 'Leave room'}
+          </button>
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+        </div>
         <ErrorNote error={error} />
       </form>
     </Modal>

--- a/ui/src/components/FleetDashboard.tsx
+++ b/ui/src/components/FleetDashboard.tsx
@@ -271,12 +271,14 @@ function StatTiles({ fleet }: { fleet: FleetResult }) {
 
 // -- filters ------------------------------------------------------------------
 
-type FleetFilter = 'all' | 'active' | 'working' | 'offline';
+type FleetFilter = 'all' | 'active' | 'needs-attention' | 'working' | 'offline';
 
 function matchesFilter(a: FleetAgent, f: FleetFilter): boolean {
   switch (f) {
     case 'active':
       return a.liveness === 'working' || a.liveness === 'online-idle';
+    case 'needs-attention':
+      return a.latest != null && labelTone(a.latest.label) === 'blue';
     case 'working':
       return a.liveness === 'working';
     case 'offline':
@@ -300,6 +302,7 @@ function AddAgentModal({
   const ownedRooms = rooms.filter((r) => r.role === 'owner');
   const [roomId, setRoomId] = useState(ownedRooms[0]?.room_id ?? '');
   const [identityId, setIdentityId] = useState('');
+  const [worker, setWorker] = useState<'echo' | 'claude'>('echo');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<DaemonErrorShape | null>(null);
   const [result, setResult] = useState<{ ticket: string; addr: string | null } | null>(null);
@@ -328,7 +331,7 @@ function AddAgentModal({
   };
 
   const command = result
-    ? `node scripts/jeliya-agent.mjs --ticket ${result.ticket}${result.addr ? ` --peer ${result.addr}` : ''} --worker claude`
+    ? `node scripts/jeliya-agent.mjs --ticket ${result.ticket}${result.addr ? ` --peer ${result.addr}` : ''} --worker ${worker}`
     : '';
 
   return (
@@ -369,6 +372,20 @@ function AddAgentModal({
               autoFocus
             />
           </label>
+          <label className="field">
+            <span>Worker</span>
+            <select value={worker} onChange={(e) => setWorker(e.target.value as 'echo' | 'claude')}>
+              <option value="echo">echo (safe — no real execution, for trying the flow)</option>
+              <option value="claude">claude (runs real commands — arbitrary code/file execution for this room’s allowlisted senders)</option>
+            </select>
+          </label>
+          {worker === 'claude' ? (
+            <p className="error-note" role="alert">
+              WARNING — --worker claude runs the <code>claude</code> CLI with --permission-mode acceptEdits on every
+              triggered message from an allowlisted sender. That is arbitrary code / file execution on this host.
+              Only enable it for a room and senders you trust.
+            </p>
+          ) : null}
           <button type="submit" className="btn btn-primary" disabled={busy || !identityId.trim() || !roomId}>
             {busy ? 'Minting…' : 'Mint agent invite'}
           </button>
@@ -472,6 +489,7 @@ export function FleetDashboard({
   const counts = {
     all: fleet?.agents.length ?? 0,
     active: fleet?.agents.filter((a) => matchesFilter(a, 'active')).length ?? 0,
+    'needs-attention': fleet?.agents.filter((a) => matchesFilter(a, 'needs-attention')).length ?? 0,
     working: fleet?.agents.filter((a) => matchesFilter(a, 'working')).length ?? 0,
     offline: fleet?.agents.filter((a) => matchesFilter(a, 'offline')).length ?? 0,
   };
@@ -486,6 +504,7 @@ export function FleetDashboard({
   const filters: { key: FleetFilter; label: string }[] = [
     { key: 'all', label: 'All' },
     { key: 'active', label: 'Active' },
+    { key: 'needs-attention', label: 'Needs attention' },
     { key: 'working', label: 'Working' },
     { key: 'offline', label: 'Offline' },
   ];

--- a/ui/src/components/Onboarding.tsx
+++ b/ui/src/components/Onboarding.tsx
@@ -62,6 +62,10 @@ function IdentityStep({ client, onAdvance }: { client: Client; onAdvance(): void
         A keypair generated and stored by your local daemon. No account, no server — the private key never leaves this
         machine.
       </p>
+      <p className="muted">
+        There's no password reset and no recovery — if you lose this device or its data folder, this identity is gone
+        for good.
+      </p>
       <button type="button" className="btn btn-primary btn-lg" disabled={busy} onClick={() => void create()}>
         {busy ? 'Creating…' : 'Create identity'}
       </button>
@@ -130,6 +134,10 @@ function RoomsStep({
           </div>
           <code className="mono onboarding-identity-id">{identityId}</code>
           <p className="muted">Being invited to a room? Send this id to the inviter first — tickets are bound to it.</p>
+          <p className="muted">
+            Peers show up by this same hex id at first — click any name in a room to set a local nickname for them
+            (only visible to you).
+          </p>
         </div>
       ) : null}
       <div className="onboarding-columns">

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -47,7 +47,15 @@ function shortMemberId(id: string): string {
   return id.length > 18 ? `${id.slice(0, 8)}…${id.slice(-6)}` : id;
 }
 
-function MembersTab({ members, selfId }: { members: Member[]; selfId: string | null }) {
+function MembersTab({
+  members,
+  selfId,
+  onLeaveRoom,
+}: {
+  members: Member[];
+  selfId: string | null;
+  onLeaveRoom(): void;
+}) {
   const names = useNames();
   const sorted = [...members].sort((a, b) => {
     const aSelf = selfId !== null && a.identity_id === selfId;
@@ -102,6 +110,8 @@ function MembersTab({ members, selfId }: { members: Member[]; selfId: string | n
       {sorted.map((member) => {
         const mine = selfId !== null && member.identity_id === selfId;
         const tone = statusTone(member.status);
+        const canLeave = mine && member.status === 'active' && member.role !== 'owner';
+        const ownerCannotLeave = mine && member.status === 'active' && member.role === 'owner';
         return (
           <div key={member.identity_id} className={`member-row member-row-${tone}`} title={member.identity_id}>
             <Avatar id={member.identity_id} size={38} />
@@ -118,6 +128,16 @@ function MembersTab({ members, selfId }: { members: Member[]; selfId: string | n
                 <span className="dot" /> {displayStatus(member.status)}
               </span>
             </div>
+            {canLeave ? (
+              <button type="button" className="btn btn-sm btn-danger member-leave-btn" onClick={onLeaveRoom}>
+                Leave
+              </button>
+            ) : null}
+            {ownerCannotLeave ? (
+              <span className="member-owner-note" title="Owners cannot leave until ownership transfer exists.">
+                Owner stays
+              </span>
+            ) : null}
           </div>
         );
       })}
@@ -388,10 +408,10 @@ function FilesTab({
         // not-available from your own view even though peers can fetch it. Label
         // by ownership so that is never shown as a fault. See list_files() in
         // crates/jeliya-core/src/supervisor.rs.
-        const health = file.available
-          ? { tone: 'ok', text: 'Ready to fetch' }
-          : mine
-            ? { tone: 'self', text: 'Serving to peers' }
+        const health = mine
+          ? { tone: 'self', text: 'Serving to peers' }
+          : file.available
+            ? { tone: 'ok', text: 'Ready to fetch' }
             : { tone: 'warn', text: 'No provider online' };
         const providerText = `${file.providers} provider${file.providers === 1 ? '' : 's'}`;
         return (
@@ -418,7 +438,7 @@ function FilesTab({
                 </span>
               </div>
               <div className="file-row-action">
-                {mine && !file.available && !fetches[file.file_id] ? (
+                {mine ? (
                   <span className="file-self-note" title="This daemon is already serving this file to peers.">
                     Serving
                   </span>
@@ -427,7 +447,7 @@ function FilesTab({
                 )}
               </div>
             </div>
-            <FetchDetail state={fetches[file.file_id]} />
+            {mine ? null : <FetchDetail state={fetches[file.file_id]} />}
           </div>
         );
       })}
@@ -590,6 +610,7 @@ function tabCountLabel(count: number): string {
 export function RightPanel({
   tab,
   onTab,
+  roomName,
   members,
   timeline,
   files,
@@ -604,9 +625,11 @@ export function RightPanel({
   onPipeConnect,
   onPipeClose,
   onPipeExpose,
+  onLeaveRoom,
 }: {
   tab: PanelTab;
   onTab(tab: PanelTab): void;
+  roomName?: string | null;
   members: Member[];
   timeline: TimelineEvent[];
   files: FileEntry[];
@@ -621,6 +644,7 @@ export function RightPanel({
   onPipeConnect(pipeId: string): void;
   onPipeClose(pipeId: string): void;
   onPipeExpose(target: string, peerIdentity: string): Promise<void>;
+  onLeaveRoom(): void;
 }) {
   const agentCount = members.filter((m) => m.role === 'agent').length;
   const openPipes = pipes.filter((p) => p.state === 'open').length;
@@ -650,6 +674,12 @@ export function RightPanel({
 
   return (
     <aside className="right-panel">
+      {/* Mobile-only: on the standalone Files/Pipes tab this panel is the whole
+          screen and RoomHeader (which normally carries the room name) is off in
+          the hidden `.center` pane, so without this a multi-room user has no way
+          to tell which room they're looking at. Not aria-hidden — this is the
+          only place the room name reaches the accessible tree in that view. */}
+      {roomName ? <div className="panel-room-context">{roomName}</div> : null}
       <div className="panel-tabs" role="tablist" aria-label="Room panel" onKeyDown={onTabsKeyDown}>
         {tabs.map((t) => (
           <button
@@ -669,7 +699,7 @@ export function RightPanel({
         ))}
       </div>
       <div className="panel-body" id="panel-body" role="tabpanel" aria-labelledby={`panel-tab-${tab}`}>
-        {tab === 'members' ? <MembersTab members={members} selfId={selfId} /> : null}
+        {tab === 'members' ? <MembersTab members={members} selfId={selfId} onLeaveRoom={onLeaveRoom} /> : null}
         {tab === 'agents' ? <AgentsTab members={members} timeline={timeline} /> : null}
         {tab === 'files' ? (
           <FilesTab

--- a/ui/src/components/RoomHeader.tsx
+++ b/ui/src/components/RoomHeader.tsx
@@ -1,14 +1,20 @@
 import type { PeerStatus } from '../lib/protocol';
 import { shortId } from '../lib/format';
+import { useNames } from './names';
 
 /** Peer path (direct/relay) and state are shown exactly as reported by the
  *  daemon — relay fallback is never hidden (honesty rule #2). */
 function PeerChip({ peer }: { peer: PeerStatus }) {
+  const names = useNames();
   const label =
     peer.state === 'connected' ? (peer.path ?? 'connected') : peer.state === 'connecting' ? 'connecting' : 'offline';
+  // identity_id is only known once the SDK has bound the device (on admit);
+  // fall back to the raw endpoint id until then, but keep the hex around in
+  // the tooltip either way.
+  const display = peer.identity_id ? names.display(peer.identity_id) : shortId(peer.endpoint_id);
   return (
     <span className={`peer-chip peer-${peer.state} peer-path-${peer.path ?? 'none'}`} title={peer.endpoint_id}>
-      <span className="dot" /> {shortId(peer.endpoint_id)} <em>{label}</em>
+      <span className="dot" /> {display} <em>{label}</em>
     </span>
   );
 }
@@ -28,6 +34,20 @@ export function RoomHeader({
   onShareFile(): void;
   onOpenPipe(): void;
 }) {
+  const connected = peers.filter((p) => p.state === 'connected');
+  const hasDirect = connected.some((p) => p.path === 'direct');
+  // Three honest states: nobody here, a live direct link, or relay-only
+  // (still connected, just not the path we'd prefer). A room with peers that
+  // are merely connecting/offline reads as the same "alone" state — there's
+  // no live link to call peer-to-peer yet either way.
+  const p2p =
+    peers.length === 0
+      ? { dot: 'dot-neutral', label: 'Alone in this room' }
+      : hasDirect
+        ? { dot: 'dot-green', label: 'Peer-to-Peer' }
+        : connected.length > 0
+          ? { dot: null, label: 'Relay only' } // amber: no dedicated CSS class, see inline style below
+          : { dot: 'dot-neutral', label: 'Alone in this room' };
   return (
     <header className="room-header">
       <div className="room-header-top">
@@ -39,7 +59,11 @@ export function RoomHeader({
             </span>
             <span className="sep">|</span>
             <span className="p2p-badge">
-              <span className="dot dot-green" /> Peer-to-Peer
+              <span
+                className={p2p.dot ? `dot ${p2p.dot}` : 'dot'}
+                style={p2p.dot ? undefined : { color: 'var(--amber)' }}
+              />{' '}
+              {p2p.label}
             </span>
           </div>
         </div>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -111,12 +111,16 @@ export function Sidebar({
         {rooms.map((room) => {
           const tint = colorForId(room.room_id);
           const active = room.room_id === currentRoomId;
+          const departed = room.status === 'left' || room.status === 'removed';
+          const stateLabel = departed ? (room.status === 'left' ? 'Left' : 'Removed') : room.open ? 'Active' : 'Idle';
           return (
             <button
               key={room.room_id}
               type="button"
-              className={`room-item${active ? ' selected' : ''}`}
+              className={`room-item${active ? ' selected' : ''}${departed ? ' departed' : ''}`}
               onClick={() => onSelectRoom(room.room_id)}
+              disabled={departed}
+              title={departed ? `You ${room.status === 'left' ? 'left' : 'were removed from'} this room` : undefined}
             >
               <span className="room-hex" style={{ color: tint, background: `${tint}1f` }} aria-hidden="true">
                 ⬡
@@ -124,7 +128,7 @@ export function Sidebar({
               <span className="room-info">
                 <span className="room-name">{room.name}</span>
                 <span className="room-meta">
-                  {room.member_count} member{room.member_count === 1 ? '' : 's'} · {room.open ? 'Active' : 'Idle'}
+                  {room.member_count} member{room.member_count === 1 ? '' : 's'} · {stateLabel}
                 </span>
               </span>
               {room.open ? <span className="dot dot-green" title="Session open" /> : null}
@@ -138,7 +142,7 @@ export function Sidebar({
         <span aria-hidden="true">⊕</span> Create Room
       </button>
       <button type="button" className="create-room join-room" onClick={onJoinRoom}>
-        <span aria-hidden="true">⇥</span> Join with Ticket
+        <span aria-hidden="true">⇥</span> Join with a ticket
       </button>
 
       <footer className="identity-footer">

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
-import type { FileEntry, TimelineEvent } from '../lib/protocol';
+import type { FileEntry, FileRef, TimelineEvent } from '../lib/protocol';
 import { dayLabel, extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel, shortId } from '../lib/format';
 import { Avatar, FetchControl, FetchDetail, ProgressBar, SenderName } from './ui';
 import type { FetchState } from './ui';
 
 function FileTile({
   file,
+  isSelfOwned,
   state,
   onFetch,
 }: {
-  file: { file_id: string; name: string; size: number; mime: string };
+  file: FileRef;
+  isSelfOwned: boolean;
   state?: FetchState;
   onFetch(fileId: string): void;
 }) {
@@ -28,9 +30,15 @@ function FileTile({
             {formatBytes(file.size)} · {ext}
           </span>
         </span>
-        <FetchControl state={state} onFetch={() => onFetch(file.file_id)} />
+        {isSelfOwned ? (
+          <span className="file-self-note" title="This daemon is already serving this file to peers.">
+            Serving
+          </span>
+        ) : (
+          <FetchControl state={state} onFetch={() => onFetch(file.file_id)} />
+        )}
       </div>
-      <FetchDetail state={state} />
+      {isSelfOwned ? null : <FetchDetail state={state} />}
     </div>
   );
 }
@@ -39,12 +47,14 @@ function EventCard({
   event,
   files,
   fetches,
+  selfId,
   onFetch,
   onShowPipes,
 }: {
   event: TimelineEvent;
   files: FileEntry[];
   fetches: Record<string, FetchState>;
+  selfId: string | null;
   onFetch(fileId: string): void;
   onShowPipes(): void;
 }) {
@@ -74,6 +84,15 @@ function EventCard({
       return (
         <div className="sysline">
           <SenderName id={who} /> joined as {event.member?.role ?? event.sender.role} · {time}
+        </div>
+      );
+    }
+
+    case 'member_left': {
+      const who = event.member?.identity_id ?? senderId;
+      return (
+        <div className="sysline">
+          <SenderName id={who} /> left the room · {time}
         </div>
       );
     }
@@ -146,7 +165,12 @@ function EventCard({
               <span className="muted">shared a file</span>
               <time dateTime={new Date(event.ts).toISOString()}>{time}</time>
             </div>
-            <FileTile file={event.file} state={fetches[event.file.file_id]} onFetch={onFetch} />
+            <FileTile
+              file={event.file}
+              isSelfOwned={selfId !== null && senderId === selfId}
+              state={fetches[event.file.file_id]}
+              onFetch={onFetch}
+            />
           </div>
         </div>
       );
@@ -200,6 +224,7 @@ export function Timeline({
   files,
   fetches,
   loading,
+  selfId,
   onFetch,
   onShowPipes,
 }: {
@@ -207,6 +232,7 @@ export function Timeline({
   files: FileEntry[];
   fetches: Record<string, FetchState>;
   loading: boolean;
+  selfId: string | null;
   onFetch(fileId: string): void;
   onShowPipes(): void;
 }) {
@@ -244,7 +270,14 @@ export function Timeline({
     rows.push({
       key: event.event_id,
       node: (
-        <EventCard event={event} files={files} fetches={fetches} onFetch={onFetch} onShowPipes={onShowPipes} />
+        <EventCard
+          event={event}
+          files={files}
+          fetches={fetches}
+          selfId={selfId}
+          onFetch={onFetch}
+          onShowPipes={onShowPipes}
+        />
       ),
     });
   }

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -280,6 +280,23 @@ export function FetchDetail({ state }: { state?: FetchState }) {
     );
   }
   if (state.phase === 'error') {
+    // hash_mismatch means a real integrity-check failure: the file was fetched but
+    // its content didn't match the expected hash, so it was discarded. Lead with
+    // plain language — the raw code/message/hint is real BLAKE3-hash-and-security
+    // language that means nothing to a non-developer. Keep it, but de-emphasized.
+    if (state.error.code === 'hash_mismatch') {
+      return (
+        <div className="fetch-detail err">
+          This file failed a security check and wasn't saved — it may have been
+          corrupted or tampered with in transit.
+          <details className="fetch-detail-advanced">
+            <summary className="muted">Technical details</summary>
+            <code className="error-code">{state.error.code}</code> {state.error.message}
+            {state.error.hint ? ` — ${state.error.hint}` : ''}
+          </details>
+        </div>
+      );
+    }
     return (
       <div className="fetch-detail err">
         <code className="error-code">{state.error.code}</code> {state.error.message}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -31,7 +31,11 @@ export function dayLabel(ts: number): string {
 /** Relative time from a real event timestamp — display only, never a
  *  liveness claim. */
 export function relTime(ts: number): string {
-  const delta = Date.now() - ts;
+  // Clamp at 0: a `ts` more than 45s in the future (should never happen —
+  // fixtures are authored strictly in the past — but a clock skew or a bad
+  // caller shouldn't produce one) would otherwise fall through to a negative
+  // `mins`/`hours` and render as nonsense like "-2m ago" instead of "just now".
+  const delta = Math.max(0, Date.now() - ts);
   if (delta < 45_000) return 'just now';
   const mins = Math.round(delta / 60_000);
   if (mins < 60) return `${mins}m ago`;

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -64,9 +64,16 @@ function base32ish(seed: string, len: number): string {
   return out;
 }
 
-/** ms epoch for today at h:m local time */
+/** ms epoch for "yesterday" at h:m local time. Anchoring on yesterday (not
+ *  today) guarantees every fixture timestamp is strictly before `Date.now()`
+ *  regardless of what time the demo is opened — anchoring on today put
+ *  morning fixtures (8:58 etc.) in the future for anyone opening the app
+ *  before those hours, which buried live messages under "future" history and
+ *  masked a hardcoded-stale agent behind relTime()'s just-now floor. Relative
+ *  ordering between fixtures is unaffected since they all shift by the same
+ *  24h. */
 function at(h: number, m: number, s = 0): number {
-  const d = new Date();
+  const d = new Date(Date.now() - 24 * 60 * 60 * 1000);
   d.setHours(h, m, s, 0);
   return d.getTime();
 }
@@ -115,6 +122,16 @@ interface MockRoom {
   open: boolean;
   timers: number[];
   simulated: boolean;
+}
+
+/** What a minted `invite.create` ticket actually redeems — looked up by
+ *  `room.join` so it lands in the room it was really minted for instead of a
+ *  fabricated one. `expiresAt: null` means no expiry was requested. */
+interface TicketEntry {
+  room_id: string;
+  identity_id: string;
+  role: Role;
+  expiresAt: number | null;
 }
 
 let eventSeq = 0;
@@ -249,11 +266,11 @@ function buildMainRoom(): MockRoom {
   ];
 
   const peers: PeerStatus[] = [
-    { endpoint_id: MAYA.ep, state: 'connected', path: 'direct' },
-    { endpoint_id: SAM.ep, state: 'connected', path: 'relay' },
-    { endpoint_id: BACKEND.ep, state: 'connected', path: 'direct' },
-    { endpoint_id: FRONTEND.ep, state: 'connected', path: 'direct' },
-    { endpoint_id: QA.ep, state: 'offline', path: null },
+    { endpoint_id: MAYA.ep, state: 'connected', path: 'direct', identity_id: MAYA.id },
+    { endpoint_id: SAM.ep, state: 'connected', path: 'relay', identity_id: SAM.id },
+    { endpoint_id: BACKEND.ep, state: 'connected', path: 'direct', identity_id: BACKEND.id },
+    { endpoint_id: FRONTEND.ep, state: 'connected', path: 'direct', identity_id: FRONTEND.id },
+    { endpoint_id: QA.ep, state: 'offline', path: null, identity_id: QA.id },
   ];
 
   return {
@@ -291,7 +308,7 @@ function buildSideRoom(seed: string, name: string, people: Person[], myRole: Rol
     pipes: [],
     peers: people
       .filter((p) => p.id !== ALEX.id)
-      .map((p) => ({ endpoint_id: p.ep, state: 'connected' as const, path: 'direct' as const })),
+      .map((p) => ({ endpoint_id: p.ep, state: 'connected' as const, path: 'direct' as const, identity_id: p.id })),
     open: false,
     timers: [],
     simulated: false,
@@ -343,6 +360,7 @@ class MockClient implements Client {
   };
   private identity: Identity | null;
   private rooms = new Map<string, MockRoom>();
+  private tickets = new Map<string, TicketEntry>();
   private portSeq = 41732;
   private startTimer: number | null = null;
 
@@ -511,10 +529,13 @@ class MockClient implements Client {
   }
 
   private summary(room: MockRoom): RoomSummary {
+    const identity = this.identity;
+    const mine = identity ? room.members.find((m) => m.identity_id === identity.identity_id) : null;
     return {
       room_id: room.room_id,
       name: room.name,
-      role: room.myRole,
+      role: mine?.role ?? room.myRole,
+      status: mine?.status ?? null,
       member_count: room.members.length,
       open: room.open,
     };
@@ -690,6 +711,11 @@ class MockClient implements Client {
 
       case 'room.open': {
         const room = this.needRoom((params as MethodMap['room.open']['params']).room_id);
+        const identity = this.needIdentity();
+        const mine = room.members.find((m) => m.identity_id === identity.identity_id);
+        if (!mine || mine.status !== 'active') {
+          this.err('not_a_member', `this identity is not an active member of "${room.name}"`, 'ask the room admin for an invite');
+        }
         room.open = true;
         this.simulate(room);
         return {
@@ -708,6 +734,29 @@ class MockClient implements Client {
         return {};
       }
 
+      case 'room.leave': {
+        const room = this.needRoom((params as MethodMap['room.leave']['params']).room_id);
+        const identity = this.needIdentity();
+        const idx = room.members.findIndex((m) => m.identity_id === identity.identity_id);
+        const mine = idx >= 0 ? room.members[idx] : null;
+        if (!mine || mine.status !== 'active') {
+          this.err('not_a_member', `this identity is not an active member of "${room.name}"`, 'ask the room admin for an invite');
+        }
+        if (mine.role === 'owner') {
+          this.err('invalid_params', 'room owners cannot leave yet; close the local room session instead', null);
+        }
+        const event = ev(room.room_id, Date.now(), this.me(room), 'member_left', {
+          member: { identity_id: identity.identity_id },
+        });
+        room.members[idx] = { ...mine, status: 'left' };
+        this.ingest(room, event);
+        room.open = false;
+        room.simulated = false;
+        for (const t of room.timers) window.clearTimeout(t);
+        room.timers = [];
+        return { event_id: event.event_id };
+      }
+
       case 'room.timeline': {
         const p = params as MethodMap['room.timeline']['params'];
         const room = this.needRoom(p.room_id);
@@ -724,48 +773,51 @@ class MockClient implements Client {
         const p = params as MethodMap['invite.create']['params'];
         const room = this.needOpenRoom(p.room_id);
         if (!p.identity_id || !/^[0-9a-f]{16,}$/i.test(p.identity_id.trim())) {
-          this.err('invalid_params', 'identity_id must be the invitee\'s hex identity id', 'ask the invitee to run daemon.status and send you their identity_id');
+          this.err('invalid_params', 'identity_id must be the invitee\'s hex identity id', 'ask the invitee to copy their identity id from their onboarding screen or sidebar footer');
         }
         const me = this.me(room);
         this.ingest(room, ev(room.room_id, Date.now(), me, 'member_invited', {
           member: { identity_id: p.identity_id.trim(), role: p.role },
         }));
         const ticket = `roomtkt1${base32ish(`${room.room_id}:${p.identity_id}:${Date.now()}`, 96)}`;
+        // `expiry` is seconds-from-now (see docs/PROTOCOL.md); no expiry means
+        // the ticket is good until redeemed once (single-use, not time-boxed).
+        const expiresAt = typeof p.expiry === 'number' && p.expiry > 0 ? Date.now() + p.expiry * 1000 : null;
+        this.tickets.set(ticket, { room_id: room.room_id, identity_id: p.identity_id.trim(), role: p.role, expiresAt });
         return { ticket };
       }
 
       case 'room.join': {
         const p = params as MethodMap['room.join']['params'];
-        this.needIdentity();
+        const identity = this.needIdentity();
         const ticket = (p.ticket ?? '').trim();
         if (!ticket.startsWith('roomtkt1') || ticket.length < 24) {
           this.err('bad_ticket', 'ticket is not a valid roomtkt1 token', 'ask the inviter for a fresh ticket');
         }
-        const room_id = `blake3:${hex(`joined-${ticket}`, 64)}`;
-        if (!this.rooms.has(room_id)) {
-          const name = p.name?.trim() || 'Joined Room';
-          const identity = this.needIdentity();
-          const room: MockRoom = {
-            room_id,
-            name,
-            myRole: 'member',
-            members: [member(MAYA), { identity_id: identity.identity_id, role: 'member', status: 'active' }],
-            timeline: [
-              ev(room_id, Date.now() - 60_000, MAYA, 'room_created'),
-              ev(room_id, Date.now(), { ...ALEX, id: identity.identity_id, dev: identity.device_id, role: 'member' }, 'member_joined', {
-                member: { identity_id: identity.identity_id, role: 'member' },
-              }),
-            ],
-            files: [],
-            pipes: [],
-            peers: [{ endpoint_id: MAYA.ep, state: 'connected', path: p.peers?.length ? 'direct' : 'relay' }],
-            open: false,
-            timers: [],
-            simulated: false,
-          };
-          this.rooms.set(room_id, room);
+        const entry = this.tickets.get(ticket);
+        if (!entry) {
+          // A well-formed roomtkt1 string nobody minted on this daemon is
+          // never something a real person hand-types — they only ever paste
+          // one they received — so this is a genuine failure, not a demo
+          // shortcut. (No fabricated room, unlike before.)
+          this.err('bad_ticket', 'this ticket was never issued on this daemon', 'ask the inviter for a fresh ticket');
         }
-        return { room_id };
+        if (entry.expiresAt !== null && Date.now() > entry.expiresAt) {
+          this.tickets.delete(ticket);
+          this.err('ticket_expired', 'this ticket has expired', 'ask the inviter to generate a fresh one');
+        }
+        const room = this.rooms.get(entry.room_id);
+        if (!room) this.err('room_unknown', 'the invited room no longer exists on this daemon', 'ask the inviter for a fresh ticket');
+        // Single-use: redeeming the same ticket twice should fail like a real
+        // spent one, not silently succeed again.
+        this.tickets.delete(ticket);
+        if (!room.members.some((m) => m.identity_id === identity.identity_id)) {
+          room.members.push({ identity_id: identity.identity_id, role: entry.role, status: 'active' });
+          this.ingest(room, ev(room.room_id, Date.now(), { ...ALEX, id: identity.identity_id, dev: identity.device_id, role: entry.role }, 'member_joined', {
+            member: { identity_id: identity.identity_id, role: entry.role },
+          }));
+        }
+        return { room_id: room.room_id };
       }
 
       case 'message.send': {
@@ -809,7 +861,7 @@ class MockClient implements Client {
         room.files.push({
           file_id, name, size, mime,
           sender_id: this.needIdentity().identity_id,
-          ts: now, available: true, providers: 1,
+          ts: now, available: false, providers: 1,
         });
         const event = ev(room.room_id, now, this.me(room), 'file_shared', {
           file: { file_id, name, size, mime },

--- a/ui/src/lib/protocol.ts
+++ b/ui/src/lib/protocol.ts
@@ -13,6 +13,7 @@ export type TimelineKind =
   | 'room_created'
   | 'member_invited'
   | 'member_joined'
+  | 'member_left'
   | 'message'
   | 'agent_status'
   | 'file_shared'
@@ -34,7 +35,7 @@ export interface PipeRef {
 
 export interface MemberRef {
   identity_id: string;
-  role: Role;
+  role?: Role;
 }
 
 /** One validated room event, folded for display. Kind-specific fields are
@@ -56,7 +57,7 @@ export interface TimelineEvent {
   file?: FileRef;
   /** kind: pipe_opened / pipe_closed */
   pipe?: PipeRef;
-  /** kind: member_invited / member_joined */
+  /** kind: member_invited / member_joined / member_left */
   member?: MemberRef;
 }
 
@@ -67,6 +68,8 @@ export interface PeerStatus {
   endpoint_id: string;
   state: PeerState;
   path: PeerPath;
+  /** The peer's membership identity, once the SDK has bound the device (on admit); null before/during admission. */
+  identity_id: string | null;
 }
 
 export interface Identity {
@@ -93,6 +96,7 @@ export interface RoomSummary {
   room_id: string;
   name: string;
   role: Role;
+  status: string | null;
   member_count: number;
   open: boolean;
 }
@@ -210,6 +214,7 @@ export interface MethodMap {
     };
   };
   'room.close': { params: { room_id: string }; result: Record<string, never> };
+  'room.leave': { params: { room_id: string }; result: { event_id: string } };
   'room.timeline': { params: { room_id: string; limit?: number }; result: { events: TimelineEvent[] } };
   'room.members': { params: { room_id: string }; result: { members: Member[] } };
   'invite.create': {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -306,6 +306,41 @@ select {
   .form-row {
     flex-wrap: wrap;
   }
+
+  /* The filter chips above the fleet list (All/Active/Needs attention/Working/
+     Offline) already carry live Active/Working counts, and room coverage isn't
+     check-in-relevant on a phone — so drop this KPI row rather than repeat it.
+     `.app`-scoped (see the note above on `.app .sidebar` etc.): the base
+     `.fleet-stats` rule sits later in this file at equal specificity and would
+     otherwise win by source order regardless of this media query. */
+  .app .fleet-stats {
+    display: none;
+  }
+
+  /* Redundant with the fixed bottom `.mobile-tabbar`; the sidebar's other
+     content (profile card, rooms list) reflows fine without it since
+     `.sidebar` is a plain flex column and `.rooms-list` already has `flex: 1`
+     to take up whatever space opens up. `.app`-scoped for the same
+     later-in-file-base-rule reason as `.fleet-stats` above. */
+  .app .nav-list {
+    display: none;
+  }
+
+  /* Files/Pipes are standalone panes here (RoomHeader lives in the hidden
+     `.center` pane), so this is the only room label a mobile user gets —
+     same weight/truncation as `.room-title h1`, just sized for a slim strip.
+     `.app`-scoped: the desktop `display: none` base rule for this class sits
+     later in the file and would otherwise win by source order. */
+  .app .panel-room-context {
+    display: block;
+    padding: 10px 16px 0;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .conn-banner {
@@ -810,6 +845,14 @@ button.sender-name:not(:disabled):hover {
 
 .room-item:hover {
   background: var(--bg-card);
+}
+
+.room-item.departed {
+  opacity: 0.62;
+}
+
+.room-item.departed:disabled {
+  cursor: not-allowed;
 }
 
 .room-item.selected {
@@ -1372,6 +1415,13 @@ button.sender-name:not(:disabled):hover {
   min-height: 0;
 }
 
+/* Mobile-only room label for the standalone Files/Pipes tab — see the mobile
+   breakpoint below. Desktop always shows RoomHeader alongside this panel, so
+   it would be pure duplication there. */
+.panel-room-context {
+  display: none;
+}
+
 .panel-tabs {
   display: flex;
   flex-wrap: wrap;
@@ -1520,7 +1570,7 @@ button.sender-name:not(:disabled):hover {
 
 .member-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 10px;
   padding: 11px 12px;
@@ -1617,6 +1667,16 @@ button.sender-name:not(:disabled):hover {
 .member-status.status-removed,
 .member-status.status-unknown {
   color: var(--text-mute);
+}
+
+.member-leave-btn {
+  justify-self: end;
+}
+
+.member-owner-note {
+  color: var(--text-mute);
+  font-size: 11px;
+  white-space: nowrap;
 }
 
 /* agents */
@@ -1865,6 +1925,15 @@ button.sender-name:not(:disabled):hover {
 
 .file-advanced-path[open] summary {
   margin-bottom: 8px;
+}
+
+.fetch-detail-advanced {
+  margin-top: 6px;
+}
+
+.fetch-detail-advanced summary {
+  cursor: pointer;
+  font-size: 12px;
 }
 
 .file-share-row {
@@ -2849,12 +2918,6 @@ select {
   font-size: 11.5px;
 }
 
-@media (max-width: 720px) {
-  .fleet-stats {
-    grid-template-columns: 1fr;
-  }
-}
-
 @media (max-width: 480px) {
   .ticket-box {
     flex-direction: column;
@@ -2870,12 +2933,21 @@ select {
     align-items: flex-start;
   }
 
-  .member-badges {
+  .member-badges,
+  .member-leave-btn,
+  .member-owner-note {
     grid-column: 1 / -1;
+  }
+
+  .member-badges {
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
     flex-wrap: wrap;
+  }
+
+  .member-leave-btn {
+    justify-self: flex-start;
   }
 
   .selected-file-card {


### PR DESCRIPTION
## Summary
- Prepare Jeliya v0.4.0 release metadata
- Add real room leave flow and related protocol/UI updates
- Keep Homebrew formula hashes on v0.3.1 until v0.4.0 release sidecars exist

## Validation
- cargo test -p jeliya-core
- cargo test -p jeliyad
- cd ui && npm run build
- cargo build --release -p jeliyad --features embed-ui

After this PR lands, create and push tag v0.4.0 to trigger the release workflow.