### PR TITLE
v0.4.1 Prepare release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "dirs",

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliya-core/src/error.rs
+++ b/crates/jeliya-core/src/error.rs
@@ -82,9 +82,7 @@ impl ErrorKind {
             Self::HashMismatch => Some("do not trust this file; ask for a fresh file.share"),
             Self::PeerUnreachable => Some("ask the peer to open the room, then retry"),
             Self::NotAMember => Some("ask the room admin for an invite"),
-            Self::InvalidParams
-            | Self::PipeDenied
-            | Self::Internal => None,
+            Self::InvalidParams | Self::PipeDenied | Self::Internal => None,
         }
     }
 }

--- a/crates/jeliya-core/src/fleet.rs
+++ b/crates/jeliya-core/src/fleet.rs
@@ -107,14 +107,25 @@ pub fn aggregate_liveness<I: IntoIterator<Item = Liveness>>(per_room: I) -> Live
 
 #[cfg(test)]
 mod tests {
-    use super::{aggregate_liveness, derive_liveness, is_working_class, Liveness, STALE_WORKING_MS};
+    use super::{
+        aggregate_liveness, derive_liveness, is_working_class, Liveness, STALE_WORKING_MS,
+    };
 
     const NOW: u64 = 1_783_190_000_000;
 
     #[test]
     fn only_the_exact_working_label_is_working_class() {
         assert!(is_working_class("working"));
-        for label in ["online", "done", "failed", "idle", "offline", "claiming", "Working", "working_hard"] {
+        for label in [
+            "online",
+            "done",
+            "failed",
+            "idle",
+            "offline",
+            "claiming",
+            "Working",
+            "working_hard",
+        ] {
             assert!(!is_working_class(label), "{label} must be idle-class");
         }
     }

--- a/crates/jeliya-core/src/identity.rs
+++ b/crates/jeliya-core/src/identity.rs
@@ -73,7 +73,10 @@ pub fn ensure_dir(dir: &Path) -> CoreResult<()> {
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
-            CoreError::internal(format!("could not set permissions on {}: {e}", dir.display()))
+            CoreError::internal(format!(
+                "could not set permissions on {}: {e}",
+                dir.display()
+            ))
         })?;
     }
     Ok(())
@@ -216,8 +219,8 @@ impl SecretKeys {
 
 /// Decode a 32-byte seed from lowercase hex; intermediates are zeroized.
 fn signing_key_from_seed_hex(seed_hex: &str) -> CoreResult<SigningKey> {
-    let mut raw = hex::decode(seed_hex)
-        .map_err(|_| CoreError::internal("secret seed is not valid hex"))?;
+    let mut raw =
+        hex::decode(seed_hex).map_err(|_| CoreError::internal("secret seed is not valid hex"))?;
     let key = if let Ok(seed) = <[u8; SEED_LEN]>::try_from(raw.as_slice()) {
         let seed = Zeroizing::new(seed);
         SigningKey::from_seed(&seed)
@@ -274,7 +277,10 @@ mod tests {
         let loaded = load_profile(dir.path()).unwrap().unwrap();
         assert_eq!(loaded.identity_id, profile.identity_id);
         let keys = SecretKeys::load(dir.path()).unwrap();
-        assert_eq!(keys.identity.identity_key().to_string(), profile.identity_id);
+        assert_eq!(
+            keys.identity.identity_key().to_string(),
+            profile.identity_id
+        );
         assert_eq!(keys.device.device_key().to_string(), profile.device_id);
     }
 

--- a/crates/jeliya-core/src/localstate.rs
+++ b/crates/jeliya-core/src/localstate.rs
@@ -11,7 +11,7 @@
 //! protocol has no rename event.
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{CoreError, CoreResult};
 use crate::identity::ensure_dir;
@@ -34,6 +34,17 @@ pub struct RoomMeta {
     /// `room.join`/`room.open`, plus addresses harvested from live sessions.
     #[serde(default)]
     pub peer_hints: Vec<String>,
+    /// Files this daemon fetched and verified locally, keyed by `file_<hex>`.
+    #[serde(default)]
+    pub fetched_files: BTreeMap<String, FetchedFileMeta>,
+}
+
+/// Daemon-local record of a verified file fetch.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FetchedFileMeta {
+    pub path: PathBuf,
+    pub bytes: u64,
+    pub fetched_at_ms: u64,
 }
 
 /// The whole daemon-local state file.
@@ -59,9 +70,7 @@ pub fn load(data_dir: &Path) -> CoreResult<LocalState> {
     let path = data_dir.join(STATE_FILE);
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(LocalState::default())
-        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(LocalState::default()),
         Err(err) => {
             return Err(CoreError::internal(format!(
                 "could not read {}: {err}",
@@ -94,6 +103,7 @@ pub fn remember_room(data_dir: &Path, room_id: &str, name: Option<&str>) -> Core
         name: None,
         added_at_ms: crate::now_ms(),
         peer_hints: Vec::new(),
+        fetched_files: BTreeMap::new(),
     });
     if let Some(name) = name {
         entry.name = Some(name.to_owned());
@@ -120,6 +130,7 @@ pub fn add_peer_hints(data_dir: &Path, room_id: &str, hints: &[String]) -> CoreR
         name: None,
         added_at_ms: crate::now_ms(),
         peer_hints: Vec::new(),
+        fetched_files: BTreeMap::new(),
     });
     for hint in hints {
         let id_part = hint.split('@').next().unwrap_or(hint).trim().to_owned();
@@ -140,9 +151,51 @@ pub fn peer_hints(data_dir: &Path, room_id: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Record a verified local copy produced by `file.fetch`.
+pub fn remember_fetched_file(
+    data_dir: &Path,
+    room_id: &str,
+    file_id: &str,
+    path: &Path,
+    bytes: u64,
+) -> CoreResult<()> {
+    let mut state = load(data_dir)?;
+    let entry = state.rooms.entry(room_id.to_owned()).or_insert(RoomMeta {
+        name: None,
+        added_at_ms: crate::now_ms(),
+        peer_hints: Vec::new(),
+        fetched_files: BTreeMap::new(),
+    });
+    entry.fetched_files.insert(
+        file_id.to_owned(),
+        FetchedFileMeta {
+            path: path.to_path_buf(),
+            bytes,
+            fetched_at_ms: crate::now_ms(),
+        },
+    );
+    save(data_dir, &state)
+}
+
+/// A verified local fetch record if the file still exists with the expected
+/// byte length. If the user deleted or replaced the file, do not surface a stale
+/// "fetched" state.
+#[must_use]
+pub fn fetched_file(data_dir: &Path, room_id: &str, file_id: &str) -> Option<FetchedFileMeta> {
+    let meta = load(data_dir)
+        .ok()?
+        .rooms
+        .get(room_id)?
+        .fetched_files
+        .get(file_id)?
+        .clone();
+    let ok = std::fs::metadata(&meta.path).is_ok_and(|m| m.is_file() && m.len() == meta.bytes);
+    ok.then_some(meta)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{load, local_name, remember_room};
+    use super::{fetched_file, load, local_name, remember_fetched_file, remember_room};
     use tempfile::tempdir;
 
     #[test]
@@ -164,5 +217,20 @@ mod tests {
         );
         assert_eq!(local_name(dir.path(), "blake3:cd"), None);
         assert_eq!(load(dir.path()).unwrap().rooms.len(), 2);
+    }
+
+    #[test]
+    fn fetched_file_roundtrips_only_while_file_exists_with_expected_size() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("download.txt");
+        std::fs::write(&file, b"hello").unwrap();
+        remember_fetched_file(dir.path(), "blake3:ab", "file_01", &file, 5).unwrap();
+
+        let fetched = fetched_file(dir.path(), "blake3:ab", "file_01").unwrap();
+        assert_eq!(fetched.path, file);
+        assert_eq!(fetched.bytes, 5);
+
+        std::fs::write(&file, b"changed").unwrap();
+        assert!(fetched_file(dir.path(), "blake3:ab", "file_01").is_none());
     }
 }

--- a/crates/jeliya-core/src/materializer.rs
+++ b/crates/jeliya-core/src/materializer.rs
@@ -269,10 +269,10 @@ mod tests {
         // by) when the fixture validates statelessly; kind-only fixtures that
         // deliberately skip a real invite handshake (member.joined) fall back
         // to a fixed placeholder id — the shape assertions never depend on it.
-        let event_id = validate_wire_bytes(&wire.to_bytes(), &ctx).map_or(
-            iroh_rooms::events::EventId::from_bytes([0x0f; 32]),
-            |v| v.event_id,
-        );
+        let event_id = validate_wire_bytes(&wire.to_bytes(), &ctx)
+            .map_or(iroh_rooms::events::EventId::from_bytes([0x0f; 32]), |v| {
+                v.event_id
+            });
         materialize_signed(&fx.room_id, &event_id, &ev, &snapshot).expect("materializes")
     }
 
@@ -342,11 +342,8 @@ mod tests {
         let fx = fixture();
         let joiner_identity = SigningKey::generate();
         let joiner_device = SigningKey::generate();
-        let binding = DeviceBinding::create(
-            &fx.room_id,
-            &joiner_identity,
-            joiner_device.device_key(),
-        );
+        let binding =
+            DeviceBinding::create(&fx.room_id, &joiner_identity, joiner_device.device_key());
         let wire = build_member_joined(
             &joiner_identity,
             &joiner_device,
@@ -493,7 +490,10 @@ mod tests {
         let id = iroh_rooms::events::EventId::from_bytes([0x01; 32]);
         let v = materialize_signed(&fx.room_id, &id, &ev, &snapshot).expect("left materializes");
         assert_eq!(v["kind"], "member_left");
-        assert_eq!(v["member"]["identity_id"], fx.identity.identity_key().to_string());
+        assert_eq!(
+            v["member"]["identity_id"],
+            fx.identity.identity_key().to_string()
+        );
     }
 
     #[test]

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -32,8 +32,8 @@ use iroh_rooms::events::constants::{
     MAX_STATUS_LABEL_BYTES, MAX_STATUS_MESSAGE_BYTES, SHORT_ID_LEN,
 };
 use iroh_rooms::events::{
-    build_agent_status, build_message_text, capability_hash, validate_wire_bytes, Content,
-    EventId, EventType, RejectReason, SignedEvent, ValidationContext, WireEvent,
+    build_agent_status, build_message_text, capability_hash, validate_wire_bytes, Content, EventId,
+    EventType, RejectReason, SignedEvent, ValidationContext, WireEvent,
 };
 use iroh_rooms::experimental::pipe_runtime::{is_loopback_target, PipeError, PipeForwarder};
 use iroh_rooms::experimental::session::{
@@ -47,8 +47,8 @@ use iroh_rooms::files::build_file_shared;
 use iroh_rooms::identity::{DeviceBinding, DeviceKey, IdentityKey};
 use iroh_rooms::room::{
     build_member_invited, build_member_joined, build_member_left, build_room_created,
-    derive_room_id, Ingest, MembershipSnapshot, Role, RoomId, RoomInviteTicket,
-    RoomMembership, Status,
+    derive_room_id, Ingest, MembershipSnapshot, Role, RoomId, RoomInviteTicket, RoomMembership,
+    Status,
 };
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
@@ -84,6 +84,24 @@ const PIPE_SYNC_WAIT: Duration = Duration::from_secs(10);
 /// Backoff between attempts to reclaim an owned `Node` for shutdown while an
 /// in-flight network op still borrows the session (see `reclaim_session`).
 const RECLAIM_POLL: Duration = Duration::from_millis(50);
+/// Event types that the sync protocol serves through the never-windowed
+/// authorization pull.
+const MEMBERSHIP_EVENT_TYPES: [EventType; 5] = [
+    EventType::RoomCreated,
+    EventType::MemberInvited,
+    EventType::MemberJoined,
+    EventType::MemberLeft,
+    EventType::MemberRemoved,
+];
+
+/// A verified local file copy that can be served by the loopback HTTP endpoint.
+#[derive(Debug, Clone)]
+pub struct LocalFile {
+    pub path: PathBuf,
+    pub name: String,
+    pub mime: String,
+    pub bytes: u64,
+}
 
 /// One open room: the SDK node (transport + engine + blob serving), the live
 /// connection-event subscription, connector-side pipe forwarders, and the
@@ -250,8 +268,11 @@ impl RoomSupervisor {
         // WAL allows a single writer at a time. The busy_timeout lets a colliding
         // writer wait inside SQLite instead of erroring instantly, which retires
         // the old application-level `with_busy_retry` backoff loop.
-        EventStore::open_with(&self.db_path(), &StoreOptions::new(Some(Duration::from_millis(5000))))
-            .map_err(|e| internal("could not open the event store", e))
+        EventStore::open_with(
+            &self.db_path(),
+            &StoreOptions::new(Some(Duration::from_millis(5000))),
+        )
+        .map_err(|e| internal("could not open the event store", e))
     }
 
     /// Confine `file.share` to files inside the daemon's data dir, excluding the
@@ -287,10 +308,10 @@ impl RoomSupervisor {
                         || name.starts_with(localstate::STATE_FILE)
                 });
         if is_reserved_child {
-            return Err(CoreError::invalid(
-                "refusing to share a daemon secret/state file",
-            )
-            .with_hint("that path holds daemon-private data"));
+            return Err(
+                CoreError::invalid("refusing to share a daemon secret/state file")
+                    .with_hint("that path holds daemon-private data"),
+            );
         }
         Ok(())
     }
@@ -303,7 +324,10 @@ impl RoomSupervisor {
     /// The map lock is released before the caller does any network work.
     fn session(&self, room_id: &RoomId) -> CoreResult<Arc<RoomSession>> {
         self.sessions().get(room_id).cloned().ok_or_else(|| {
-            CoreError::new(ErrorKind::RoomNotOpen, format!("room {room_id} is not open"))
+            CoreError::new(
+                ErrorKind::RoomNotOpen,
+                format!("room {room_id} is not open"),
+            )
         })
     }
 
@@ -433,6 +457,86 @@ impl RoomSupervisor {
             .map_err(|e| internal("could not read the room heads", e))?;
         heads.truncate(MAX_PREV_EVENTS);
         Ok(heads)
+    }
+
+    /// Current heads inside the never-windowed authorization class: every
+    /// membership event plus every admin-authored event. Membership writes use
+    /// these heads so late join bootstrap can pull every parent via
+    /// `WantMembership`, while admin-authored writes still advance the admin
+    /// sequence through admin content events.
+    fn authorization_class_heads(
+        store: &EventStore,
+        room_id: &RoomId,
+        admin: &IdentityKey,
+    ) -> CoreResult<Vec<EventId>> {
+        let mut ids = BTreeSet::new();
+        let mut events = Vec::new();
+        for ty in MEMBERSHIP_EVENT_TYPES {
+            for stored in store
+                .by_type(room_id, ty)
+                .map_err(|e| internal("could not read membership events", e))?
+            {
+                if ids.insert(stored.event_id) {
+                    events.push(stored);
+                }
+            }
+        }
+        for stored in store
+            .by_sender(room_id, admin)
+            .map_err(|e| internal("could not read admin-authored events", e))?
+        {
+            if ids.insert(stored.event_id) {
+                events.push(stored);
+            }
+        }
+
+        let mut cited = BTreeSet::new();
+        for stored in &events {
+            let validated = validate_wire_bytes(
+                &stored.wire.to_bytes(),
+                &ValidationContext::for_room(*room_id),
+            )
+            .map_err(|reason| {
+                CoreError::internal(format!(
+                    "stored authorization event failed validation ({})",
+                    reason.code()
+                ))
+            })?;
+            for parent in validated.event.prev_events {
+                if ids.contains(&parent) {
+                    cited.insert(parent);
+                }
+            }
+        }
+
+        let mut heads: Vec<EventId> = ids.difference(&cited).copied().collect();
+        heads.truncate(MAX_PREV_EVENTS);
+        Ok(heads)
+    }
+
+    fn downloaded_file_meta(
+        &self,
+        file_id: &[u8; SHORT_ID_LEN],
+        name: &str,
+        bytes: u64,
+    ) -> Option<localstate::FetchedFileMeta> {
+        let clean_name = sanitize_name(name, *file_id);
+        let dir = self.data_dir.join(DOWNLOADS_DIR);
+        let candidates = [
+            dir.join(&clean_name),
+            dir.join(format!("{}_{}", hex::encode(file_id), clean_name)),
+        ];
+        for path in candidates {
+            let ok = std::fs::metadata(&path).is_ok_and(|m| m.is_file() && m.len() == bytes);
+            if ok {
+                return Some(localstate::FetchedFileMeta {
+                    path,
+                    bytes,
+                    fetched_at_ms: 0,
+                });
+            }
+        }
+        None
     }
 
     /// Self-validate a freshly authored wire event and publish it through the
@@ -605,7 +709,12 @@ impl RoomSupervisor {
     /// clone — those ops are all bounded by their own timeouts, so this
     /// terminates. Tears any local pipe forwarders down first.
     async fn reclaim_session(session: Arc<RoomSession>) -> Node {
-        for (_, forwarder) in session.forwarders.lock().expect("forwarders poisoned").drain() {
+        for (_, forwarder) in session
+            .forwarders
+            .lock()
+            .expect("forwarders poisoned")
+            .drain()
+        {
             forwarder.shutdown();
         }
         let mut arc = session;
@@ -631,23 +740,27 @@ impl RoomSupervisor {
         let secret = self.secrets()?;
 
         let mut room_nonce = [0u8; ROOM_NONCE_LEN];
-        getrandom::fill(&mut room_nonce)
-            .map_err(|e| internal("OS CSPRNG unavailable", e))?;
+        getrandom::fill(&mut room_nonce).map_err(|e| internal("OS CSPRNG unavailable", e))?;
         let created_at = now_ms();
         let sender_id = secret.identity.identity_key();
         let room_id = derive_room_id(&sender_id, &room_nonce, created_at);
 
-        let wire = build_room_created(&secret.identity, &secret.device, name, &room_nonce, created_at);
-        let validated = validate_wire_bytes(
-            &wire.to_bytes(),
-            &ValidationContext::for_room(room_id),
-        )
-        .map_err(|reason| {
-            CoreError::internal(format!(
-                "freshly built genesis failed validation ({})",
-                reason.code()
-            ))
-        })?;
+        let wire = build_room_created(
+            &secret.identity,
+            &secret.device,
+            name,
+            &room_nonce,
+            created_at,
+        );
+        let validated =
+            validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(room_id)).map_err(
+                |reason| {
+                    CoreError::internal(format!(
+                        "freshly built genesis failed validation ({})",
+                        reason.code()
+                    ))
+                },
+            )?;
 
         let mut store = self.open_store()?;
         store
@@ -687,6 +800,22 @@ impl RoomSupervisor {
             let Ok(snapshot) = self.snapshot_for(&room_id).await else {
                 continue; // a corrupt room fails its own reads, not the index
             };
+            // "YOUR ROOMS" must mean rooms this identity actually belongs (or
+            // belonged) to. A room can land in the local store purely because a
+            // shared peer's sync backfilled its membership sub-DAG — e.g. the
+            // room's owner is also our peer in a DIFFERENT room — even though we
+            // were never invited to it. Such a room has no entry for us in the
+            // member set. Listing it would both leak a room we are not in (its
+            // name and member count) and hand the UI a room that answers every
+            // `room.open` with `not_a_member`. Skip it. `member.left`/
+            // `member.removed` keep the subject in the member set, so archived
+            // (left/removed) rooms still list.
+            let self_member = self_key
+                .as_ref()
+                .and_then(|key| snapshot.members().find(|member| &member.identity == key));
+            if self_key.is_some() && self_member.is_none() {
+                continue;
+            }
             let role = self_key
                 .as_ref()
                 .and_then(|key| snapshot.role(key))
@@ -694,10 +823,7 @@ impl RoomSupervisor {
             let status = if let Some(key) = self_key.as_ref() {
                 let store = self.open_store()?;
                 let (removed_ids, left_ids) = departure_sets(&store, &room_id)?;
-                snapshot
-                    .members()
-                    .find(|member| &member.identity == key)
-                    .map(|member| status_label(member.status, key, &removed_ids, &left_ids))
+                self_member.map(|member| status_label(member.status, key, &removed_ids, &left_ids))
             } else {
                 None
             };
@@ -772,13 +898,18 @@ impl RoomSupervisor {
     }
 
     /// Shut down an already-removed session (pipes first, then the node).
-    async fn shutdown_session(&self, room_id: &RoomId, session: Arc<RoomSession>) -> CoreResult<()> {
+    async fn shutdown_session(
+        &self,
+        room_id: &RoomId,
+        session: Arc<RoomSession>,
+    ) -> CoreResult<()> {
         // Keep the freshest peer addresses so a later re-open can redial them.
         // This write is best-effort: a corrupt/unwritable state.json must never
         // leave the live node leaked (its pump + blob-store lock) by aborting
         // before shutdown.
         let harvested = Self::harvest_peer_hints(&session.node).await;
-        if let Err(err) = localstate::add_peer_hints(&self.data_dir, &room_id.to_string(), &harvested)
+        if let Err(err) =
+            localstate::add_peer_hints(&self.data_dir, &room_id.to_string(), &harvested)
         {
             eprintln!("warning: could not persist peer hints for {room_id}: {err}");
         }
@@ -819,18 +950,30 @@ impl RoomSupervisor {
                 .await
                 .map_err(|e| internal("could not read the membership snapshot", e))?;
             ensure_can_leave(&snapshot, &self_id, &room_id)?;
-            let heads = Self::node_heads(&session.node).await?;
-            let wire = build_member_left(&secret.identity, &secret.device, &room_id, None, &heads, now_ms());
-            let validated = validate_wire_bytes(
-                &wire.to_bytes(),
-                &ValidationContext::for_room(room_id),
-            )
-            .map_err(|reason| {
-                CoreError::internal(format!(
-                    "freshly built member.left failed validation ({})",
-                    reason.code()
-                ))
-            })?;
+            let admin_identity = snapshot
+                .admin()
+                .copied()
+                .ok_or_else(|| CoreError::internal("room snapshot has no admin"))?;
+            let heads = {
+                let store = self.open_store()?;
+                Self::authorization_class_heads(&store, &room_id, &admin_identity)?
+            };
+            let wire = build_member_left(
+                &secret.identity,
+                &secret.device,
+                &room_id,
+                None,
+                &heads,
+                now_ms(),
+            );
+            let validated =
+                validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(room_id))
+                    .map_err(|reason| {
+                        CoreError::internal(format!(
+                            "freshly built member.left failed validation ({})",
+                            reason.code()
+                        ))
+                    })?;
             let event_id = validated.event_id;
             {
                 let store = self.open_store()?;
@@ -868,21 +1011,27 @@ impl RoomSupervisor {
             let mut store = self.open_store()?;
             let (mut membership, snapshot) = self.fold(&store, &room_id)?;
             ensure_can_leave(&snapshot, &self_id, &room_id)?;
-            let mut heads = store
-                .heads(&room_id)
-                .map_err(|e| internal("could not read the room heads", e))?;
-            heads.truncate(MAX_PREV_EVENTS);
-            let wire = build_member_left(&secret.identity, &secret.device, &room_id, None, &heads, now_ms());
-            let validated = validate_wire_bytes(
-                &wire.to_bytes(),
-                &ValidationContext::for_room(room_id),
-            )
-            .map_err(|reason| {
-                CoreError::internal(format!(
-                    "freshly built member.left failed validation ({})",
-                    reason.code()
-                ))
-            })?;
+            let admin_identity = snapshot
+                .admin()
+                .copied()
+                .ok_or_else(|| CoreError::internal("room snapshot has no admin"))?;
+            let heads = Self::authorization_class_heads(&store, &room_id, &admin_identity)?;
+            let wire = build_member_left(
+                &secret.identity,
+                &secret.device,
+                &room_id,
+                None,
+                &heads,
+                now_ms(),
+            );
+            let validated =
+                validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(room_id))
+                    .map_err(|reason| {
+                        CoreError::internal(format!(
+                            "freshly built member.left failed validation ({})",
+                            reason.code()
+                        ))
+                    })?;
             match membership.ingest(validated.clone()) {
                 Ingest::Accepted { .. } => {}
                 Ingest::Rejected { reason, .. } => {
@@ -998,10 +1147,7 @@ impl RoomSupervisor {
                     format!("only the room owner can issue invites for {room_id}"),
                 ));
             }
-            let mut heads = store
-                .heads(&room_id)
-                .map_err(|e| internal("could not read the room heads", e))?;
-            heads.truncate(MAX_PREV_EVENTS);
+            let heads = Self::authorization_class_heads(&store, &room_id, &admin_identity)?;
 
             let wire = build_member_invited(
                 &secret.identity,
@@ -1016,16 +1162,14 @@ impl RoomSupervisor {
                 &heads,
                 created_at,
             );
-            let validated = validate_wire_bytes(
-                &wire.to_bytes(),
-                &ValidationContext::for_room(room_id),
-            )
-            .map_err(|reason| {
-                CoreError::internal(format!(
-                    "freshly built member.invited failed validation ({})",
-                    reason.code()
-                ))
-            })?;
+            let validated =
+                validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(room_id))
+                    .map_err(|reason| {
+                        CoreError::internal(format!(
+                            "freshly built member.invited failed validation ({})",
+                            reason.code()
+                        ))
+                    })?;
             match membership.ingest(validated.clone()) {
                 Ingest::Accepted { .. } => {}
                 Ingest::Rejected { reason, .. } => {
@@ -1083,9 +1227,16 @@ impl RoomSupervisor {
         display_name: Option<&str>,
         peers: &[String],
     ) -> CoreResult<String> {
-        let ticket: RoomInviteTicket = ticket_str.trim().parse().map_err(|e: iroh_rooms::room::TicketError| {
-            CoreError::new(ErrorKind::BadTicket, format!("bad ticket ({}): {e}", e.code()))
-        })?;
+        let ticket: RoomInviteTicket =
+            ticket_str
+                .trim()
+                .parse()
+                .map_err(|e: iroh_rooms::room::TicketError| {
+                    CoreError::new(
+                        ErrorKind::BadTicket,
+                        format!("bad ticket ({}): {e}", e.code()),
+                    )
+                })?;
         let secret = self.secrets()?;
         let self_id = secret.identity.identity_key();
         if self_id != ticket.invitee_key {
@@ -1217,13 +1368,10 @@ impl RoomSupervisor {
             tokio::time::sleep(POLL_INTERVAL).await;
         }
 
-        let mut heads = {
+        let heads = {
             let store = self.open_store()?;
-            store
-                .heads(&room_id)
-                .map_err(|e| internal("could not read the room heads", e))?
+            Self::authorization_class_heads(&store, &room_id, &ticket.inviter_identity)?
         };
-        heads.truncate(MAX_PREV_EVENTS);
         let created_at = now_ms();
         let binding = DeviceBinding::create(&room_id, &secret.identity, secret.device.device_key());
         let wire = build_member_joined(
@@ -1238,16 +1386,15 @@ impl RoomSupervisor {
             &heads,
             created_at,
         );
-        let validated = validate_wire_bytes(
-            &wire.to_bytes(),
-            &ValidationContext::for_room(room_id),
-        )
-        .map_err(|reason| {
-            CoreError::internal(format!(
-                "freshly built member.joined failed validation ({})",
-                reason.code()
-            ))
-        })?;
+        let validated =
+            validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(room_id)).map_err(
+                |reason| {
+                    CoreError::internal(format!(
+                        "freshly built member.joined failed validation ({})",
+                        reason.code()
+                    ))
+                },
+            )?;
 
         // Local fold-check: the deterministic verdict every peer reaches —
         // a bad secret / expiry / role fails here instead of a doomed push.
@@ -1434,9 +1581,8 @@ impl RoomSupervisor {
         // Classify + confine the path before touching anything (a bad or
         // out-of-bounds share writes nothing).
         let path = Path::new(path_str);
-        let meta = std::fs::metadata(path).map_err(|e| {
-            CoreError::invalid(format!("cannot read {}: {e}", path.display()))
-        })?;
+        let meta = std::fs::metadata(path)
+            .map_err(|e| CoreError::invalid(format!("cannot read {}: {e}", path.display())))?;
         if meta.is_dir() {
             return Err(CoreError::invalid(format!(
                 "{} is a directory, not a file",
@@ -1544,6 +1690,7 @@ impl RoomSupervisor {
             .by_type(&room_id, EventType::FileShared)
             .map_err(|e| internal("could not read file.shared events", e))?;
         let session = self.session_opt(&room_id);
+        let room_id_str = room_id.to_string();
 
         let mut files = Vec::with_capacity(events.len());
         for se in &events {
@@ -1559,13 +1706,15 @@ impl RoomSupervisor {
             };
             let provider_online = session.as_deref().is_some_and(|s| {
                 providers.iter().any(|p| {
-                    endpoint_id_of(*p).is_ok_and(|id| {
-                        s.node.peer_state(id) == Some(PeerConnState::Connected)
-                    })
+                    endpoint_id_of(*p)
+                        .is_ok_and(|id| s.node.peer_state(id) == Some(PeerConnState::Connected))
                 })
             });
+            let file_id = file_handle(&f.file_id);
+            let fetched = localstate::fetched_file(&self.data_dir, &room_id_str, &file_id)
+                .or_else(|| self.downloaded_file_meta(&f.file_id, &f.name, f.size_bytes));
             files.push(json!({
-                "file_id": file_handle(&f.file_id),
+                "file_id": file_id,
                 "name": f.name,
                 "size": f.size_bytes,
                 "mime": f.mime_type,
@@ -1573,6 +1722,10 @@ impl RoomSupervisor {
                 "ts": ev.created_at,
                 "available": provider_online,
                 "providers": providers.len(),
+                "fetched": fetched.is_some(),
+                "local_path": fetched.as_ref().map(|meta| meta.path.display().to_string()),
+                "local_bytes": fetched.as_ref().map(|meta| meta.bytes),
+                "fetched_at_ms": fetched.as_ref().map(|meta| meta.fetched_at_ms),
             }));
         }
         Ok(files)
@@ -1715,12 +1868,63 @@ impl RoomSupervisor {
             ));
         }
         save_atomic(&target, &data)?;
+        localstate::remember_fetched_file(
+            &self.data_dir,
+            &room_id.to_string(),
+            &file_handle(&file_id),
+            &target,
+            data.len() as u64,
+        )?;
 
         Ok(json!({
             "path": target.display().to_string(),
             "bytes": data.len(),
             "verified": true,
         }))
+    }
+
+    /// A previously verified local copy addressed by protocol identifiers, never
+    /// by a browser-supplied filesystem path.
+    pub fn local_file(&self, room_id_str: &str, file_id_str: &str) -> CoreResult<LocalFile> {
+        let room_id = parse_room_id(room_id_str)?;
+        let file_id = parse_file_id(file_id_str)?;
+        let store = self.open_store()?;
+        if store
+            .count(&room_id)
+            .map_err(|e| internal("could not count the room's stored events", e))?
+            == 0
+        {
+            return Err(CoreError::new(
+                ErrorKind::RoomUnknown,
+                format!("no room {room_id} in {}", self.data_dir.display()),
+            ));
+        }
+        let events = store
+            .by_type(&room_id, EventType::FileShared)
+            .map_err(|e| internal("could not read file.shared events", e))?;
+        let Some((shared, _)) = find_file_shared(&events, file_id) else {
+            return Err(CoreError::new(
+                ErrorKind::FileUnavailable,
+                format!("no such file {file_id_str} in room {room_id}"),
+            ));
+        };
+        let file_id_handle = file_handle(&file_id);
+        let room_id_key = room_id.to_string();
+        let Some(local) = localstate::fetched_file(&self.data_dir, &room_id_key, &file_id_handle)
+            .or_else(|| self.downloaded_file_meta(&file_id, &shared.name, shared.size_bytes))
+        else {
+            return Err(CoreError::new(
+                ErrorKind::FileUnavailable,
+                format!("file {file_id_str} has not been fetched on this daemon"),
+            )
+            .with_hint("fetch the file first, then open the local copy"));
+        };
+        Ok(LocalFile {
+            path: local.path,
+            name: shared.name,
+            mime: shared.mime_type,
+            bytes: local.bytes,
+        })
     }
 
     // ------------------------------------------------------------------
@@ -1737,7 +1941,9 @@ impl RoomSupervisor {
     ) -> CoreResult<Value> {
         let room_id = parse_room_id(room_id_str)?;
         let target = SocketAddr::from_str(target_str.trim()).map_err(|e| {
-            CoreError::invalid(format!("invalid target {target_str:?} (expected ip:port): {e}"))
+            CoreError::invalid(format!(
+                "invalid target {target_str:?} (expected ip:port): {e}"
+            ))
         })?;
         if !is_loopback_target(&target) {
             return Err(CoreError::new(
@@ -1777,7 +1983,12 @@ impl RoomSupervisor {
                 now_ms(),
             )
             .await
-            .map_err(|e| CoreError::new(ErrorKind::PipeDenied, format!("could not expose the pipe: {e:#}")))?;
+            .map_err(|e| {
+                CoreError::new(
+                    ErrorKind::PipeDenied,
+                    format!("could not expose the pipe: {e:#}"),
+                )
+            })?;
 
         let event_id = self
             .find_pipe_event(&room_id, EventType::PipeOpened, pipe_id)
@@ -2245,8 +2456,11 @@ impl RoomSupervisor {
         // Known rooms: everything in the event store plus the localstate
         // index (a room remembered before/without any synced events still
         // counts toward rooms_total — it is honestly known, just unreadable).
-        let mut known: BTreeSet<String> =
-            localstate::load(&self.data_dir)?.rooms.keys().cloned().collect();
+        let mut known: BTreeSet<String> = localstate::load(&self.data_dir)?
+            .rooms
+            .keys()
+            .cloned()
+            .collect();
 
         // Phase 1 (sync): enumerate the store's rooms and read each room's
         // display name. The `!Sync` store is opened, fully used, and DROPPED
@@ -2387,7 +2601,8 @@ impl RoomSupervisor {
                         now,
                     );
                     let agg = agents.entry(identity.to_string()).or_default();
-                    agg.rooms.push(json!({ "room_id": room_str, "name": room_name }));
+                    agg.rooms
+                        .push(json!({ "room_id": room_str, "name": room_name }));
                     agg.per_room_liveness.push(liveness);
                     if let Some(latest) = sig.latest {
                         let newer = match &agg.latest {
@@ -2406,8 +2621,7 @@ impl RoomSupervisor {
                         }
                     }
                     if let Some(seen) = sig.last_seen_ts {
-                        agg.last_seen_ts =
-                            Some(agg.last_seen_ts.map_or(seen, |t| t.max(seen)));
+                        agg.last_seen_ts = Some(agg.last_seen_ts.map_or(seen, |t| t.max(seen)));
                     }
                 }
             }
@@ -2583,16 +2797,16 @@ fn parse_room_id(s: &str) -> CoreResult<RoomId> {
 fn parse_file_id(s: &str) -> CoreResult<[u8; SHORT_ID_LEN]> {
     let trimmed = s.trim();
     let hex_part = trimmed.strip_prefix("file_").unwrap_or(trimmed);
-    let bytes = hex::decode(hex_part)
-        .map_err(|_| CoreError::invalid(format!("invalid file_id {s:?}")))?;
+    let bytes =
+        hex::decode(hex_part).map_err(|_| CoreError::invalid(format!("invalid file_id {s:?}")))?;
     <[u8; SHORT_ID_LEN]>::try_from(bytes.as_slice())
         .map_err(|_| CoreError::invalid(format!("invalid file_id {s:?} (expected file_<32-hex>)")))
 }
 
 /// Parse a 32-hex pipe id into 16 bytes.
 fn parse_pipe_id(s: &str) -> CoreResult<[u8; SHORT_ID_LEN]> {
-    let bytes = hex::decode(s.trim())
-        .map_err(|_| CoreError::invalid(format!("invalid pipe_id {s:?}")))?;
+    let bytes =
+        hex::decode(s.trim()).map_err(|_| CoreError::invalid(format!("invalid pipe_id {s:?}")))?;
     <[u8; SHORT_ID_LEN]>::try_from(bytes.as_slice())
         .map_err(|_| CoreError::invalid(format!("invalid pipe_id {s:?} (expected 32 hex chars)")))
 }
@@ -2614,8 +2828,9 @@ fn parse_peers(peers: &[String]) -> CoreResult<Vec<EndpointAddr>> {
                 Some((id, rest)) => (id, Some(rest)),
                 None => (s, None),
             };
-            let id = EndpointId::from_str(id_part.trim())
-                .map_err(|e| CoreError::invalid(format!("invalid peer endpoint id {id_part:?}: {e}")))?;
+            let id = EndpointId::from_str(id_part.trim()).map_err(|e| {
+                CoreError::invalid(format!("invalid peer endpoint id {id_part:?}: {e}"))
+            })?;
             let mut addr = EndpointAddr::new(id);
             if let Some(rest) = addr_part {
                 for sock in rest.split(',').map(str::trim).filter(|s| !s.is_empty()) {
@@ -2917,8 +3132,8 @@ fn guess_mime(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_expiry, parse_file_id, parse_pipe_id, sanitize_name, validate_room_name,
-        RoomSupervisor,
+        parse_expiry, parse_file_id, parse_pipe_id, sanitize_name, validate_room_name, Content,
+        EventType, RoomSupervisor,
     };
     use crate::error::ErrorKind;
     use iroh_rooms::events::{validate_wire_bytes, ValidationContext, WireEvent};
@@ -3014,7 +3229,15 @@ mod tests {
         let mut heads = sup.open_store().unwrap().heads(&room_id).unwrap();
         heads.truncate(super::MAX_PREV_EVENTS);
         let wire = super::build_message_text(
-            identity, device, &room_id, body, None, None, &[], &heads, ts,
+            identity,
+            device,
+            &room_id,
+            body,
+            None,
+            None,
+            &[],
+            &heads,
+            ts,
         );
         insert_wire(sup, &room_id, &wire);
     }
@@ -3115,7 +3338,15 @@ mod tests {
         // THE RULE at the RPC level: a fresh "working" status with no
         // connected peer reads stale — never working, never active.
         let t1 = crate::now_ms();
-        seed_status(&sup, &room_id, &agent_identity, &agent_device, "working", Some(40), t1);
+        seed_status(
+            &sup,
+            &room_id,
+            &agent_identity,
+            &agent_device,
+            "working",
+            Some(40),
+            t1,
+        );
         let fleet = sup.agents_fleet().await.unwrap();
         let agent = &fleet["agents"][0];
         assert_eq!(agent["liveness"], "stale");
@@ -3128,7 +3359,15 @@ mod tests {
         assert_eq!(agent["last_seen_ts"], t1);
 
         // An idle-class latest with no peer reads offline.
-        seed_status(&sup, &room_id, &agent_identity, &agent_device, "idle", None, t1 + 1);
+        seed_status(
+            &sup,
+            &room_id,
+            &agent_identity,
+            &agent_device,
+            "idle",
+            None,
+            t1 + 1,
+        );
         let fleet = sup.agents_fleet().await.unwrap();
         assert_eq!(fleet["agents"][0]["liveness"], "offline");
         assert_eq!(fleet["agents"][0]["latest"]["label"], "idle");
@@ -3262,9 +3501,24 @@ mod tests {
             seed_agent_member(&sup, &room_id_str, &identity, &device).await;
             for i in 0..20 {
                 ts += 1;
-                seed_status(&sup, &room_id_str, &identity, &device, "working", Some(i), ts);
+                seed_status(
+                    &sup,
+                    &room_id_str,
+                    &identity,
+                    &device,
+                    "working",
+                    Some(i),
+                    ts,
+                );
                 ts += 1;
-                seed_message(&sup, &room_id_str, &identity, &device, &format!("m{a}-{i}"), ts);
+                seed_message(
+                    &sup,
+                    &room_id_str,
+                    &identity,
+                    &device,
+                    &format!("m{a}-{i}"),
+                    ts,
+                );
             }
             agents.push((identity, device));
         }
@@ -3299,9 +3553,14 @@ mod tests {
         // count cannot be stale). A fresh invite adds one Invited member.
         let before = open_snapshot.members().count();
         let newcomer = SigningKey::generate();
-        sup.create_invite(&room_id_str, &newcomer.identity_key().to_string(), "agent", None)
-            .await
-            .unwrap();
+        sup.create_invite(
+            &room_id_str,
+            &newcomer.identity_key().to_string(),
+            "agent",
+            None,
+        )
+        .await
+        .unwrap();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         let grown = loop {
             let snap = sup.snapshot_for(&room_id).await.unwrap();
@@ -3320,9 +3579,151 @@ mod tests {
             let store = sup.open_store().unwrap();
             sup.fold(&store, &room_id).unwrap().1
         };
-        assert_eq!(fold_after, grown, "grown open snapshot != fold after invite");
+        assert_eq!(
+            fold_after, grown,
+            "grown open snapshot != fold after invite"
+        );
 
         sup.close_room(&room_id_str).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn invite_after_member_content_does_not_depend_on_chat_heads() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = sup.create_room("Late Join").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+
+        let agent_identity = SigningKey::generate();
+        let agent_device = SigningKey::generate();
+        seed_agent_member(&sup, &room_id_str, &agent_identity, &agent_device).await;
+        seed_message(
+            &sup,
+            &room_id_str,
+            &agent_identity,
+            &agent_device,
+            "non-admin chat head",
+            crate::now_ms(),
+        );
+
+        let message_id = {
+            let store = sup.open_store().unwrap();
+            store
+                .by_type(&room_id, EventType::MessageText)
+                .unwrap()
+                .last()
+                .expect("seeded message exists")
+                .event_id
+        };
+        let newcomer = SigningKey::generate();
+        let ticket_str = sup
+            .create_invite(
+                &room_id_str,
+                &newcomer.identity_key().to_string(),
+                "member",
+                None,
+            )
+            .await
+            .unwrap();
+        let ticket: RoomInviteTicket = ticket_str.parse().unwrap();
+
+        let invite = {
+            let store = sup.open_store().unwrap();
+            store
+                .by_type(&room_id, EventType::MemberInvited)
+                .unwrap()
+                .into_iter()
+                .find(|stored| {
+                    let ev = validate_wire_bytes(
+                        &stored.wire.to_bytes(),
+                        &ValidationContext::for_room(room_id),
+                    )
+                    .unwrap();
+                    matches!(
+                        ev.event.content,
+                        Content::MemberInvited(ref invite) if invite.invite_id == ticket.invite_id
+                    )
+                })
+                .expect("new invite event was persisted")
+        };
+        let invite = validate_wire_bytes(
+            &invite.wire.to_bytes(),
+            &ValidationContext::for_room(room_id),
+        )
+        .unwrap();
+
+        assert!(
+            !invite.event.prev_events.contains(&message_id),
+            "member.invited must keep the membership sub-DAG closed; prev_events contained a chat head"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn late_join_after_agent_message_loopback() {
+        let owner_dir = tempdir().unwrap();
+        crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id = owner.create_room("Late Join Live").unwrap();
+        let opened = owner.open_room(&room_id, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let agent_dir = tempdir().unwrap();
+        let agent_profile = crate::identity::create(agent_dir.path()).unwrap();
+        let agent = RoomSupervisor::new(agent_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id, &agent_profile.identity_id, "agent", None)
+            .await
+            .unwrap();
+        agent
+            .join_room(&ticket, Some("agent"), std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        agent
+            .open_room(&room_id, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        wait_member_status(&owner, &room_id, &agent_profile.identity_id, "active").await;
+
+        agent
+            .send_message(&room_id, "agent says hello")
+            .await
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let timeline = owner.timeline(&room_id, None).await.unwrap();
+            if timeline
+                .iter()
+                .any(|event| event["body"].as_str() == Some("agent says hello"))
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "owner never synced the agent message; timeline: {timeline:?}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        let late_dir = tempdir().unwrap();
+        let late_profile = crate::identity::create(late_dir.path()).unwrap();
+        let late = RoomSupervisor::new(late_dir.path().to_path_buf(), true).unwrap();
+        let late_ticket = owner
+            .create_invite(&room_id, &late_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        late.join_room(
+            &late_ticket,
+            Some("late member"),
+            std::slice::from_ref(&owner_addr),
+        )
+        .await
+        .unwrap();
+        wait_member_status(&owner, &room_id, &late_profile.identity_id, "active").await;
+
+        late.close_room(&room_id).await.ok();
+        agent.close_room(&room_id).await.unwrap();
+        owner.close_room(&room_id).await.unwrap();
     }
 
     /// PERF: the O(full-history)-per-call re-fold is gone. With ~1000
@@ -3343,7 +3744,15 @@ mod tests {
         let mut ts = crate::now_ms();
         for i in 0..1000 {
             ts += 1;
-            seed_status(&sup, &room_id_str, &identity, &device, "working", Some(i % 101), ts);
+            seed_status(
+                &sup,
+                &room_id_str,
+                &identity,
+                &device,
+                "working",
+                Some(i % 101),
+                ts,
+            );
         }
 
         // Warm the closed-room fold cache once (this call pays the single fold).
@@ -3385,7 +3794,10 @@ mod tests {
     #[test]
     fn file_and_pipe_id_codecs() {
         let id = [0xabu8; 16];
-        assert_eq!(parse_file_id(&format!("file_{}", "ab".repeat(16))).unwrap(), id);
+        assert_eq!(
+            parse_file_id(&format!("file_{}", "ab".repeat(16))).unwrap(),
+            id
+        );
         assert_eq!(parse_file_id(&"ab".repeat(16)).unwrap(), id);
         assert!(parse_file_id("file_xyz").is_err());
         assert_eq!(parse_pipe_id(&"ab".repeat(16)).unwrap(), id);
@@ -3407,7 +3819,10 @@ mod tests {
             sanitize_name("../../.ssh/authorized_keys", [0; 16]),
             "authorized_keys"
         );
-        assert_eq!(sanitize_name("..", [0xaa; 16]), format!("file_{}", "aa".repeat(16)));
+        assert_eq!(
+            sanitize_name("..", [0xaa; 16]),
+            format!("file_{}", "aa".repeat(16))
+        );
     }
 
     #[test]
@@ -3441,6 +3856,56 @@ mod tests {
         assert_eq!(members.len(), 1);
         assert_eq!(members[0]["role"], "owner");
         assert_eq!(members[0]["status"], "active");
+    }
+
+    #[tokio::test]
+    async fn list_rooms_excludes_rooms_this_identity_is_not_a_member_of() {
+        // Regression: a foreign room's membership sub-DAG can be backfilled into
+        // our store by a shared peer's sync (that peer is in a room WITH us and
+        // also in this OTHER room), even though we were never invited. Such a
+        // room must not appear in `room.list` — listing it leaks a room we are
+        // not in and hands the UI a room whose every `room.open` returns
+        // `not_a_member` (and then `message.send` returns `room_not_open`).
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+
+        // A room WE own — the control that must still list.
+        let mine = sup.create_room("Mine").unwrap();
+
+        // A room authored entirely by a STRANGER, persisted straight into our
+        // store the way a sync backfill lands it. We author no event in it.
+        let stranger_id = SigningKey::generate();
+        let stranger_dev = SigningKey::generate();
+        let nonce = [0x11; super::ROOM_NONCE_LEN];
+        let created_at = crate::now_ms();
+        let foreign_room_id =
+            super::derive_room_id(&stranger_id.identity_key(), &nonce, created_at);
+        let genesis =
+            super::build_room_created(&stranger_id, &stranger_dev, "Not Yours", &nonce, created_at);
+        insert_wire(&sup, &foreign_room_id, &genesis);
+
+        // Sanity: the foreign room's genesis really is in our store.
+        {
+            let store = sup.open_store().unwrap();
+            assert!(store.count(&foreign_room_id).unwrap() >= 1);
+        }
+
+        let rooms = sup.list_rooms().await.unwrap();
+        let ids: Vec<&str> = rooms.iter().filter_map(|r| r["room_id"].as_str()).collect();
+        assert!(ids.contains(&mine.as_str()), "our own room must list");
+        assert!(
+            !ids.contains(&foreign_room_id.to_string().as_str()),
+            "a room we are not a member of must be excluded from room.list"
+        );
+        assert_eq!(rooms.len(), 1, "only our own room lists; got {rooms:?}");
+
+        // And the honest failure still stands if the UI somehow targets it.
+        let err = sup
+            .open_room(&foreign_room_id.to_string(), &[])
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::NotAMember);
     }
 
     #[tokio::test]
@@ -3540,7 +4005,8 @@ mod tests {
 
         // `room.close` is only a local session shutdown: membership remains active.
         member.close_room(&room_id).await.unwrap();
-        let mine = wait_member_status(&member, &room_id, &member_profile.identity_id, "active").await;
+        let mine =
+            wait_member_status(&member, &room_id, &member_profile.identity_id, "active").await;
         assert_eq!(mine["role"], "member");
 
         // `room.leave` authors member.left, closes the local session, and makes
@@ -3584,12 +4050,102 @@ mod tests {
             .iter()
             .find(|f| f["file_id"] == file_id.as_str())
             .expect("the shared file appears in file.list");
-        assert_eq!(row["available"], false, "self-only provider is not fetchable");
+        assert_eq!(
+            row["available"], false,
+            "self-only provider is not fetchable"
+        );
 
         let err = sup.fetch_file(&room_id, &file_id, None).await.unwrap_err();
         assert_eq!(err.kind, ErrorKind::FileUnavailable);
 
+        let downloads = dir.path().join(super::DOWNLOADS_DIR);
+        std::fs::create_dir_all(&downloads).unwrap();
+        std::fs::write(downloads.join("shared.txt"), b"hello jeliya file").unwrap();
+        let files = sup.list_files(&room_id).await.unwrap();
+        let row = files
+            .iter()
+            .find(|f| f["file_id"] == file_id.as_str())
+            .expect("the shared file appears in file.list");
+        assert_eq!(
+            row["fetched"], true,
+            "a previously downloaded default-path copy should suppress Fetch"
+        );
+
         sup.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fetched_file_state_survives_room_reload_loopback() {
+        let owner_dir = tempdir().unwrap();
+        crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id = owner.create_room("Fetched Files").unwrap();
+        let opened = owner.open_room(&room_id, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let path = owner_dir.path().join("report.txt");
+        std::fs::write(&path, b"verified bytes").unwrap();
+        let shared = owner
+            .share_file(&room_id, path.to_str().unwrap(), None, None)
+            .await
+            .unwrap();
+        let file_id = shared["file_id"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, Some("fetcher"), std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        member
+            .open_room(&room_id, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let files = member.list_files(&room_id).await.unwrap();
+            let row = files
+                .iter()
+                .find(|f| f["file_id"].as_str() == Some(file_id.as_str()));
+            if row.is_some_and(|f| f["available"] == true) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "member never saw the shared file become fetchable; last id: {file_id}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        let fetched = member.fetch_file(&room_id, &file_id, None).await.unwrap();
+        assert_eq!(fetched["verified"], true);
+
+        member.close_room(&room_id).await.unwrap();
+        let member_restarted = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let files = member_restarted.list_files(&room_id).await.unwrap();
+        let row = files
+            .iter()
+            .find(|f| f["file_id"].as_str() == Some(file_id.as_str()))
+            .expect("shared file remains listed after restart");
+        assert_eq!(row["fetched"], true);
+        assert_eq!(row["local_bytes"], 14);
+        assert_eq!(row["local_path"], fetched["path"]);
+
+        let local = member_restarted.local_file(&room_id, &file_id).unwrap();
+        assert_eq!(
+            local.path.display().to_string(),
+            fetched["path"].as_str().unwrap()
+        );
+        assert_eq!(local.name, "report.txt");
+        assert_eq!(local.bytes, 14);
+
+        owner.close_room(&room_id).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/src/main.rs
+++ b/crates/jeliyad/src/main.rs
@@ -107,7 +107,11 @@ async fn main() {
         }
     };
     if addr.port() != args.port {
-        eprintln!("note: port {} was in use; bound {} instead", args.port, addr.port());
+        eprintln!(
+            "note: port {} was in use; bound {} instead",
+            args.port,
+            addr.port()
+        );
     }
 
     if ui.is_serving() {
@@ -116,7 +120,10 @@ async fn main() {
             data_dir.display()
         );
     } else {
-        println!("jeliyad listening on ws://{addr}/ws (data dir: {})", data_dir.display());
+        println!(
+            "jeliyad listening on ws://{addr}/ws (data dir: {})",
+            data_dir.display()
+        );
     }
 
     tokio::spawn(push_loop(state.clone()));

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -14,14 +14,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use futures_util::{SinkExt, StreamExt};
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
-use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE, ORIGIN};
+use hyper::header::{HeaderValue, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE, ORIGIN};
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use serde_json::{json, Value};
 
+use hyper_util::rt::TokioIo;
 use jeliya_core::error::CoreError;
 use jeliya_core::supervisor::FILE_UPLOAD_MAX_BYTES;
-use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
@@ -77,9 +77,8 @@ impl UiSource {
     fn load(&self, rel: &str) -> Option<(Bytes, &'static str)> {
         match self {
             #[cfg(feature = "embed-ui")]
-            UiSource::Embedded => {
-                UiAssets::get(rel).map(|file| (Bytes::from(file.data.into_owned()), guess_mime(rel)))
-            }
+            UiSource::Embedded => UiAssets::get(rel)
+                .map(|file| (Bytes::from(file.data.into_owned()), guess_mime(rel))),
             UiSource::Dir(base) => std::fs::read(base.join(rel))
                 .ok()
                 .map(|bytes| (Bytes::from(bytes), guess_mime(rel))),
@@ -118,6 +117,12 @@ async fn route(mut req: Request<Incoming>, state: AppState, ui: UiSource) -> Res
         }
         return share_upload(req, state).await;
     }
+    if path == "/api/files/local" {
+        if req.method() != Method::GET {
+            return text(StatusCode::METHOD_NOT_ALLOWED, "method not allowed");
+        }
+        return local_file(req, state);
+    }
     if path.starts_with("/api/") {
         return text(StatusCode::NOT_FOUND, "not found");
     }
@@ -141,7 +146,10 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
         }
     }
     if !hyper_tungstenite::is_upgrade_request(&*req) {
-        return text(StatusCode::BAD_REQUEST, "expected a websocket upgrade; connect to /ws");
+        return text(
+            StatusCode::BAD_REQUEST,
+            "expected a websocket upgrade; connect to /ws",
+        );
     }
     match hyper_tungstenite::upgrade(req, None) {
         Ok((response, websocket)) => {
@@ -154,6 +162,57 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
         }
         Err(_) => text(StatusCode::BAD_REQUEST, "malformed websocket upgrade"),
     }
+}
+
+/// Serve a verified local file copy by `(room_id, file_id)`. The browser never
+/// supplies a filesystem path; the core maps protocol ids to a previously
+/// verified local copy.
+fn local_file(req: Request<Incoming>, state: AppState) -> Response<Full<Bytes>> {
+    let query = parse_query(req.uri().query().unwrap_or(""));
+    let Some(room_id) = query.get("room_id").filter(|v| !v.trim().is_empty()) else {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            &CoreError::invalid("missing room_id for local file"),
+        );
+    };
+    let Some(file_id) = query.get("file_id").filter(|v| !v.trim().is_empty()) else {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            &CoreError::invalid("missing file_id for local file"),
+        );
+    };
+    let file = match state.supervisor.local_file(room_id, file_id) {
+        Ok(file) => file,
+        Err(err) => return json_error(StatusCode::BAD_REQUEST, &err),
+    };
+    let bytes = match std::fs::read(&file.path) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return json_error(
+                StatusCode::NOT_FOUND,
+                &CoreError::internal(format!("could not read local file copy: {err}")),
+            )
+        }
+    };
+    if bytes.len() as u64 != file.bytes {
+        return json_error(
+            StatusCode::CONFLICT,
+            &CoreError::internal("local file copy changed before it could be served"),
+        );
+    }
+    let display_name =
+        upload_display_name(Some(&file.name)).unwrap_or_else(|_| "download".to_owned());
+    let content_type = HeaderValue::from_str(&file.mime)
+        .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream"));
+    let content_disposition = HeaderValue::from_str(&content_disposition_value(&display_name))
+        .unwrap_or_else(|_| HeaderValue::from_static("inline; filename=\"download\""));
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, file.bytes.to_string())
+        .header(CONTENT_DISPOSITION, content_disposition)
+        .body(Full::new(Bytes::from(bytes)))
+        .expect("local file response is well-formed")
 }
 
 /// Browser-backed file sharing. The browser cannot reveal a real local path for
@@ -173,7 +232,11 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
     }
 
     if let Some(content_length) = req.headers().get(CONTENT_LENGTH) {
-        match content_length.to_str().ok().and_then(|v| v.parse::<u64>().ok()) {
+        match content_length
+            .to_str()
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+        {
             Some(n) if n <= FILE_UPLOAD_MAX_BYTES => {}
             Some(n) => {
                 return json_error(
@@ -250,7 +313,8 @@ async fn read_limited(mut body: Incoming, max: u64) -> Result<Bytes, CoreError> 
     let mut out = Vec::new();
     let mut total = 0_u64;
     while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|e| CoreError::invalid(format!("could not read upload body: {e}")))?;
+        let frame =
+            frame.map_err(|e| CoreError::invalid(format!("could not read upload body: {e}")))?;
         if let Ok(data) = frame.into_data() {
             total += data.len() as u64;
             if total > max {
@@ -295,6 +359,55 @@ fn upload_display_name(raw: Option<&str>) -> Result<String, CoreError> {
         return Err(CoreError::invalid("file name is empty after sanitizing"));
     }
     Ok(cleaned)
+}
+
+fn disposition_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|ch| match ch {
+            '"' | '\\' | '\r' | '\n' => '_',
+            ch if ch == ' ' || ch.is_ascii_graphic() => ch,
+            _ => '_',
+        })
+        .collect();
+    if cleaned.trim_matches('_').is_empty() {
+        "download".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+fn content_disposition_value(name: &str) -> String {
+    format!(
+        "inline; filename=\"{}\"; filename*=UTF-8''{}",
+        disposition_filename(name),
+        rfc5987_filename(name)
+    )
+}
+
+fn rfc5987_filename(name: &str) -> String {
+    let mut out = String::new();
+    for byte in name.as_bytes() {
+        match *byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'!'
+            | b'#'
+            | b'$'
+            | b'&'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~' => out.push(*byte as char),
+            byte => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
 }
 
 fn unique_stage_name(display_name: &str) -> String {
@@ -345,7 +458,11 @@ fn serve_static(path: &str, ui: &UiSource) -> Response<Full<Bytes>> {
     let Some(rel) = safe_rel(path) else {
         return text(StatusCode::BAD_REQUEST, "bad path");
     };
-    let rel = if rel.is_empty() { "index.html".to_owned() } else { rel };
+    let rel = if rel.is_empty() {
+        "index.html".to_owned()
+    } else {
+        rel
+    };
 
     if let Some((bytes, mime)) = ui.load(&rel) {
         return asset(bytes, mime);

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -108,7 +108,7 @@ present only for that kind.
 | Method | Params | Result |
 |---|---|---|
 | `file.share` | `{ room_id, path, name?, mime? }` | `{ file_id, event_id }` — imports into the blob store and authors `file.shared` |
-| `file.list` | `{ room_id }` | `{ files: [{ file_id, name, size, mime, sender_id, ts, available, providers }] }` |
+| `file.list` | `{ room_id }` | `{ files: [{ file_id, name, size, mime, sender_id, ts, available, providers, fetched?, local_path?, local_bytes?, fetched_at_ms? }] }` |
 | `file.fetch` | `{ room_id, file_id, save_dir? }` | `{ path, bytes, verified: true }` — errors use `file_unavailable` / `file_unauthorized` / `hash_mismatch`, never a silent partial |
 
 Browser UI upload helper: because a browser file picker cannot reveal a real
@@ -119,6 +119,13 @@ stages the bytes under the daemon data dir, calls the same confined
 `file.share` import path, then removes the staged copy. Its JSON envelope is
 `{ ok: true, result: { file_id, event_id } }` or
 `{ ok: false, error: { code, message, hint } }`.
+
+Browser UI local-open helper: `GET /api/files/local?room_id=<room_id>&file_id=<file_id>`
+serves a previously fetched local copy from the daemon's loopback origin. The
+browser never supplies a filesystem path; the daemon resolves `(room_id,
+file_id)` against verified local fetch state or the default downloads path,
+then returns the file inline with `Content-Disposition`. Missing or stale local
+copies return the standard JSON error envelope.
 
 ### Pipes
 

--- a/packaging/jeliya.rb
+++ b/packaging/jeliya.rb
@@ -1,8 +1,8 @@
 # Homebrew formula for the `jeliyad` daemon.
 #
-# Filled for v0.4.0 — the first release under the Jeliya name (the project
-# renamed from Bantaba on 2026-07-05; docs/naming.md). Earlier releases
-# shipped `bantabad-*` archives and cannot be installed by this formula.
+# Currently filled for v0.4.1. v0.4.0 was the first release under the Jeliya
+# name (the project renamed from Bantaba on 2026-07-05; docs/naming.md). Earlier
+# releases shipped `bantabad-*` archives and cannot be installed by this formula.
 #
 # This belongs in a tap, not homebrew-core: publish it as
 #   kortiene/homebrew-jeliya  (repo `homebrew-jeliya`, file `Formula/jeliya.rb`)
@@ -16,28 +16,28 @@
 class Jeliya < Formula
   desc "Jeliya peer-to-peer daemon (jeliyad): serves the Jeliya UI over a local WebSocket"
   homepage "https://github.com/kortiene/jeliya"
-  version "0.4.0"
+  version "0.4.1"
   license "MIT OR Apache-2.0"
 
   on_macos do
     on_arm do
       url "https://github.com/kortiene/jeliya/releases/download/v#{version}/jeliyad-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "e00692bdf33e80de651d0dff7da8eaade0116d3e82f96d1e5a963526a8bfd144"
+      sha256 "b997bdc735bc5437c7974f5841d14a56d72c2bd89e3845866137566d30b38698"
     end
     on_intel do
       url "https://github.com/kortiene/jeliya/releases/download/v#{version}/jeliyad-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "b5644323dc93be9bc627a98495bc300e4c486c1f5448dd7c4f07ee421aa1dce1"
+      sha256 "a91e2cb9e794027d62e0551e9cef0c1fa58f60494801a903084b738480c4bf97"
     end
   end
 
   on_linux do
     on_arm do
       url "https://github.com/kortiene/jeliya/releases/download/v#{version}/jeliyad-v#{version}-aarch64-unknown-linux-musl.tar.gz"
-      sha256 "acf7d96515250db4de2b4190ad494e81e09a8847c9c5eda8e8f1ba49220575df"
+      sha256 "0bebf060bb30e088c056d82a41b1f7bc4317e3ae6daa03c01f4235c79919f8aa"
     end
     on_intel do
       url "https://github.com/kortiene/jeliya/releases/download/v#{version}/jeliyad-v#{version}-x86_64-unknown-linux-musl.tar.gz"
-      sha256 "3842f28bf1768e08092b96d4a175ebe4490b285ca9836fe77557e57618d5c9dd"
+      sha256 "46fbb43762d1077943e30977c02dcd2acd0831903a0d2128aaa6382fb95ca26a"
     end
   end
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,6 +16,8 @@ import { errorShape } from './lib/protocol';
 import { loadAliases, saveAliases, suggestedNames } from './lib/names';
 import { shortId } from './lib/format';
 import { splitInvite } from './lib/invite';
+import { joinRoomWithRetry } from './lib/join';
+import type { JoinProgress } from './lib/join';
 import { NamesContext } from './components/names';
 import type { NameApi } from './components/names';
 import { ErrorNote, Modal, TreeMark, Wordmark } from './components/ui';
@@ -26,6 +28,7 @@ import type { NavKey } from './components/Sidebar';
 import { MobileTabBar } from './components/MobileTabBar';
 import { RoomHeader } from './components/RoomHeader';
 import { Timeline } from './components/Timeline';
+import type { PendingMessage } from './components/Timeline';
 import { Composer } from './components/Composer';
 import { RightPanel } from './components/RightPanel';
 import type { PanelTab, PipeConnState } from './components/RightPanel';
@@ -40,6 +43,38 @@ type MobileView = 'rooms' | 'chat' | 'agents' | 'pipes' | 'files' | 'settings';
 
 const LAST_ROOM_KEY = 'jeliya.lastRoom';
 
+function localFileUrl(roomId: string, fileId: string): string {
+  const params = new URLSearchParams({ room_id: roomId, file_id: fileId });
+  return `/api/files/local?${params.toString()}`;
+}
+
+function persistedFetchState(roomId: string, file: FileEntry): FetchState | null {
+  if (!file.fetched || !file.local_path) return null;
+  return {
+    phase: 'fetched',
+    path: file.local_path,
+    bytes: file.local_bytes ?? file.size,
+    url: localFileUrl(roomId, file.file_id),
+  };
+}
+
+function mergeFetchedFiles(
+  previous: Record<string, FetchState>,
+  roomId: string,
+  files: FileEntry[],
+): Record<string, FetchState> {
+  let next = previous;
+  for (const file of files) {
+    const persisted = persistedFetchState(roomId, file);
+    if (!persisted) continue;
+    const current = next[file.file_id];
+    if (current?.phase === 'pending' || current?.phase === 'verified') continue;
+    if (next === previous) next = { ...previous };
+    next[file.file_id] = persisted;
+  }
+  return next;
+}
+
 export default function App({ client }: { client: Client }) {
   const [conn, setConn] = useState<ConnectionState>(client.getState());
   const [phase, setPhase] = useState<Phase>('boot');
@@ -51,6 +86,9 @@ export default function App({ client }: { client: Client }) {
   const roomIdRef = useRef<string | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [timeline, setTimeline] = useState<TimelineEvent[]>([]);
+  const timelineRef = useRef<TimelineEvent[]>([]);
+  const pendingSeq = useRef(0);
+  const [pendingMessages, setPendingMessages] = useState<Record<string, PendingMessage[]>>({});
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [pipes, setPipes] = useState<PipeEntry[]>([]);
   const [peers, setPeers] = useState<PeerStatus[]>([]);
@@ -80,7 +118,10 @@ export default function App({ client }: { client: Client }) {
     async (rid: string) => {
       try {
         const { files } = await client.call('file.list', { room_id: rid });
-        if (roomIdRef.current === rid) setFiles(files);
+        if (roomIdRef.current === rid) {
+          setFiles(files);
+          setFetches((current) => mergeFetchedFiles(current, rid, files));
+        }
       } catch {
         /* transient — next push retries */
       }
@@ -148,6 +189,16 @@ export default function App({ client }: { client: Client }) {
         if (roomIdRef.current !== rid) return;
         setMembers(opened.members);
         setTimeline(opened.timeline);
+        setPendingMessages((byRoom) => {
+          const list = byRoom[rid];
+          if (!list?.some((message) => message.eventId)) return byRoom;
+          const eventIds = new Set(opened.timeline.map((event) => event.event_id));
+          const nextList = list.filter((message) => !message.eventId || !eventIds.has(message.eventId));
+          const next = { ...byRoom };
+          if (nextList.length > 0) next[rid] = nextList;
+          else delete next[rid];
+          return next;
+        });
         setRoomLoading(false);
         setEndpointAddr(opened.endpoint.addr ?? null);
         const [f, p, ps] = await Promise.all([
@@ -157,6 +208,7 @@ export default function App({ client }: { client: Client }) {
         ]);
         if (roomIdRef.current !== rid) return;
         setFiles(f.files);
+        setFetches((current) => mergeFetchedFiles(current, rid, f.files));
         setPipes(p.pipes);
         setPeers(ps.peers);
         void refreshRooms(); // open flag changed
@@ -169,6 +221,10 @@ export default function App({ client }: { client: Client }) {
     },
     [client, refreshRooms],
   );
+
+  useEffect(() => {
+    timelineRef.current = timeline;
+  }, [timeline]);
 
   // -- lifecycle: connect once, subscribe pushes -------------------------------
 
@@ -189,6 +245,17 @@ export default function App({ client }: { client: Client }) {
         next.splice(i, 0, event);
         return next;
       });
+      if (event.kind === 'message') {
+        setPendingMessages((byRoom) => {
+          const list = byRoom[room_id];
+          if (!list?.some((message) => message.eventId === event.event_id)) return byRoom;
+          const nextList = list.filter((message) => message.eventId !== event.event_id);
+          const next = { ...byRoom };
+          if (nextList.length > 0) next[room_id] = nextList;
+          else delete next[room_id];
+          return next;
+        });
+      }
       if (event.kind === 'file_shared') void refreshFiles(room_id);
       if (event.kind === 'pipe_opened' || event.kind === 'pipe_closed') void refreshPipes(room_id);
       if (event.kind === 'member_joined' || event.kind === 'member_invited' || event.kind === 'member_left') {
@@ -281,10 +348,65 @@ export default function App({ client }: { client: Client }) {
 
   // -- actions --------------------------------------------------------------------
 
-  const sendMessage = async (body: string) => {
+  const updatePendingForRoom = (rid: string, updater: (messages: PendingMessage[]) => PendingMessage[]) => {
+    setPendingMessages((byRoom) => {
+      const nextList = updater(byRoom[rid] ?? []);
+      const next = { ...byRoom };
+      if (nextList.length > 0) next[rid] = nextList;
+      else delete next[rid];
+      return next;
+    });
+  };
+
+  const sendMessage = async (body: string, retryClientId?: string) => {
     if (!roomIdRef.current) return;
-    await client.call('message.send', { room_id: roomIdRef.current, body });
-    // The event itself arrives via the room.event push (exactly once).
+    const rid = roomIdRef.current;
+    const clientId = retryClientId ?? `pending-${Date.now()}-${pendingSeq.current++}`;
+    const ts = Date.now();
+
+    if (retryClientId) {
+      updatePendingForRoom(rid, (messages) =>
+        messages.map((message) =>
+          message.clientId === clientId ? { ...message, phase: 'sending', ts, error: undefined } : message,
+        ),
+      );
+    } else {
+      updatePendingForRoom(rid, (messages) => [
+        ...messages,
+        {
+          clientId,
+          body,
+          ts,
+          phase: 'sending',
+        },
+      ]);
+    }
+
+    try {
+      const { event_id } = await client.call('message.send', { room_id: rid, body });
+      const alreadyVisible = timelineRef.current.some((event) => event.event_id === event_id);
+      updatePendingForRoom(rid, (messages) =>
+        alreadyVisible
+          ? messages.filter((message) => message.clientId !== clientId)
+          : messages.map((message) =>
+              message.clientId === clientId ? { ...message, phase: 'syncing', eventId: event_id } : message,
+            ),
+      );
+    } catch (e) {
+      updatePendingForRoom(rid, (messages) =>
+        messages.map((message) =>
+          message.clientId === clientId ? { ...message, phase: 'failed', error: errorShape(e) } : message,
+        ),
+      );
+    }
+  };
+
+  const retryPendingMessage = (clientId: string) => {
+    const rid = roomIdRef.current;
+    if (!rid) return;
+    const pending = (pendingMessages[rid] ?? []).find((message) => message.clientId === clientId);
+    if (!pending) return;
+    void sendMessage(pending.body, clientId);
   };
 
   const fetchFile = (fileId: string) => {
@@ -305,7 +427,15 @@ export default function App({ client }: { client: Client }) {
       try {
         const result = await client.call('file.fetch', { room_id: rid, file_id: fileId });
         if (roomIdRef.current !== rid) return;
-        setFetches((m) => ({ ...m, [fileId]: { phase: 'verified', path: result.path, bytes: result.bytes } }));
+        setFetches((m) => ({
+          ...m,
+          [fileId]: {
+            phase: 'verified',
+            path: result.path,
+            bytes: result.bytes,
+            url: localFileUrl(rid, fileId),
+          },
+        }));
       } catch (e) {
         if (roomIdRef.current !== rid) return;
         setFetches((m) => ({ ...m, [fileId]: { phase: 'error', error: errorShape(e) } }));
@@ -520,6 +650,7 @@ export default function App({ client }: { client: Client }) {
               <RoomHeader
                 name={currentRoom.name}
                 memberCount={members.length || currentRoom.member_count}
+                members={members}
                 peers={peers}
                 onInvite={() => setInviteOpen(true)}
                 onShareFile={() => setTab('files')}
@@ -535,14 +666,22 @@ export default function App({ client }: { client: Client }) {
               <Timeline
                 key={roomId}
                 events={timeline}
+                pendingMessages={roomId ? (pendingMessages[roomId] ?? []) : []}
                 files={files}
                 fetches={fetches}
                 loading={roomLoading}
                 selfId={selfId}
                 onFetch={fetchFile}
+                onRetryPendingMessage={retryPendingMessage}
                 onShowPipes={() => setTab('pipes')}
               />
-              <Composer roomName={currentRoom.name} disabled={conn !== 'connected'} onSend={sendMessage} />
+              <Composer
+                roomId={currentRoom.room_id}
+                roomName={currentRoom.name}
+                disabled={conn !== 'connected'}
+                onSend={sendMessage}
+                onShareFile={shareBrowserFile}
+              />
             </>
           ) : (
             <div className="center-empty muted">Select a room</div>
@@ -676,20 +815,23 @@ function JoinRoomModal({
   const [peerAddr, setPeerAddr] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<DaemonErrorShape | null>(null);
+  const [progress, setProgress] = useState<JoinProgress | null>(null);
 
   const join = async () => {
     if (!ticket.trim() || busy) return;
     setBusy(true);
     setError(null);
+    setProgress(null);
     try {
       const { ticket: t, peerAddr: addr } = splitInvite(ticket, peerAddr);
-      const { room_id } = await client.call('room.join', {
+      const { room_id } = await joinRoomWithRetry(client, {
         ticket: t,
         ...(addr ? { peers: [addr] } : {}),
-      });
+      }, setProgress);
       onJoined(room_id);
     } catch (e) {
       setError(errorShape(e));
+      setProgress(null);
       setBusy(false);
     }
   };
@@ -731,6 +873,15 @@ function JoinRoomModal({
         <button type="submit" className="btn btn-primary" disabled={busy || !ticket.trim()}>
           {busy ? 'Joining…' : 'Join room'}
         </button>
+        {progress ? (
+          <div className="join-progress" role="status">
+            <span className="spinner" aria-hidden="true" />
+            <span>{progress.message}</span>
+            <em>
+              Attempt {progress.attempt}/{progress.maxAttempts}
+            </em>
+          </div>
+        ) : null}
         <ErrorNote error={error} />
       </form>
     </Modal>

--- a/ui/src/components/Composer.tsx
+++ b/ui/src/components/Composer.tsx
@@ -1,43 +1,114 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { DaemonErrorShape } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
 import { ErrorNote } from './ui';
 
 export function Composer({
+  roomId,
   roomName,
   disabled,
   onSend,
+  onShareFile,
 }: {
+  roomId: string;
   roomName: string;
   disabled: boolean;
   onSend(body: string): Promise<void>;
+  onShareFile(file: File): Promise<void>;
 }) {
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  const [sharing, setSharing] = useState(false);
+  const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<DaemonErrorShape | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const draftKey = `jeliya.draft.${roomId}`;
+
+  useEffect(() => {
+    try {
+      setDraft(localStorage.getItem(draftKey) ?? '');
+    } catch {
+      setDraft('');
+    }
+  }, [draftKey]);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = '0px';
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+  }, [draft]);
+
+  const updateDraft = (value: string) => {
+    setDraft(value);
+    try {
+      if (value) localStorage.setItem(draftKey, value);
+      else localStorage.removeItem(draftKey);
+    } catch {
+      /* ignore */
+    }
+  };
 
   const send = async () => {
     const body = draft.trim();
     if (!body || sending || disabled) return;
+    const previousDraft = draft;
+    updateDraft('');
     setSending(true);
     setError(null);
     try {
       await onSend(body);
-      setDraft('');
     } catch (e) {
+      updateDraft(previousDraft);
       setError(errorShape(e));
     } finally {
       setSending(false);
     }
   };
 
+  const shareFiles = async (files: FileList | File[]) => {
+    const picked = Array.from(files).filter((file) => file.size > 0);
+    if (picked.length === 0 || disabled || sharing) return;
+    setSharing(true);
+    setError(null);
+    try {
+      for (const file of picked) {
+        await onShareFile(file);
+      }
+    } catch (e) {
+      setError(errorShape(e));
+    } finally {
+      setSharing(false);
+      setDragging(false);
+    }
+  };
+
   return (
     <div className="composer">
       <ErrorNote error={error} />
-      <div className="composer-bar">
+      <div
+        className={`composer-bar${dragging ? ' is-dragging' : ''}`}
+        onDragOver={(e) => {
+          if (disabled) return;
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          if (disabled) return;
+          e.preventDefault();
+          void shareFiles(e.dataTransfer.files);
+        }}
+      >
         <textarea
+          ref={textareaRef}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => updateDraft(e.target.value)}
+          onPaste={(e) => {
+            if (e.clipboardData.files.length === 0) return;
+            e.preventDefault();
+            void shareFiles(e.clipboardData.files);
+          }}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault();
@@ -59,7 +130,9 @@ export function Composer({
           {sending ? '…' : '➤'}
         </button>
       </div>
-      <div className="composer-hint muted">Enter to send · Shift+Enter for a new line</div>
+      <div className="composer-hint muted">
+        {sharing ? 'Sharing file…' : 'Enter to send · Shift+Enter for a new line · Paste or drop a file to share'}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/InviteModal.tsx
+++ b/ui/src/components/InviteModal.tsx
@@ -30,7 +30,17 @@ export function InviteModal({
     setError(null);
     setTicket(null);
     try {
-      const expirySecs = expiry.trim() ? Number(expiry.trim()) : undefined;
+      const expiryText = expiry.trim();
+      const expiryValue = expiryText ? Number(expiryText) : undefined;
+      if (expiryText && (expiryValue === undefined || !Number.isInteger(expiryValue) || expiryValue <= 0)) {
+        setError({
+          code: 'invalid_params',
+          message: 'expiry must be a positive number of seconds',
+          hint: 'leave it blank or use a value like 3600',
+        });
+        return;
+      }
+      const expirySecs = expiryValue;
       const result = await client.call('invite.create', {
         room_id: roomId,
         identity_id: invitee,
@@ -58,6 +68,13 @@ export function InviteModal({
             Tickets are bound to one identity. Ask the invitee for their identity id — it is shown on their onboarding
             screen and in their sidebar footer, with a copy button.
           </p>
+          <div className="invite-readiness">
+            <span className="dot dot-green" aria-hidden="true" />
+            <div>
+              <strong>This room is open for inviting.</strong>
+              <p>Keep it open until the invitee finishes joining. Jeliya can only bootstrap them while an owner is reachable.</p>
+            </div>
+          </div>
           <label className="field">
             <span>Invitee identity id</span>
             <input
@@ -96,6 +113,13 @@ export function InviteModal({
         </form>
       ) : endpointAddr ? (
         <div>
+          <div className="invite-readiness invite-ready">
+            <span className="dot dot-green" aria-hidden="true" />
+            <div>
+              <strong>Ready to send.</strong>
+              <p>Stay in this room until they join. If they still see “couldn't reach inviter,” copy a fresh invite and retry.</p>
+            </div>
+          </div>
           <p className="muted">
             Send this one paste to the invitee — it is the ticket and your dialable address together. They paste it
             into “Join with a ticket” and the address fills in automatically.
@@ -135,6 +159,13 @@ export function InviteModal({
         </div>
       ) : (
         <div>
+          <div className="invite-readiness invite-caution">
+            <span className="dot" aria-hidden="true" />
+            <div>
+              <strong>No dialable address reported yet.</strong>
+              <p>Keep this room open. The joiner may still connect via discovery or relay, but a fresh room address is more reliable.</p>
+            </div>
+          </div>
           <p className="muted">Send this ticket to the invitee. They join with it (room.join).</p>
           <div className="ticket-box">
             <textarea

--- a/ui/src/components/Onboarding.tsx
+++ b/ui/src/components/Onboarding.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { splitInvite } from '../lib/invite';
 import type { Client, DaemonErrorShape } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
+import { joinRoomWithRetry } from '../lib/join';
+import type { JoinProgress } from '../lib/join';
 import { CopyButton, ErrorNote, TreeMark, Wordmark } from './ui';
 
 /** No identity yet → create one. No rooms yet → create or join by ticket.
@@ -91,6 +93,7 @@ function RoomsStep({
   const [peerAddr, setPeerAddr] = useState('');
   const [joining, setJoining] = useState(false);
   const [joinError, setJoinError] = useState<DaemonErrorShape | null>(null);
+  const [joinProgress, setJoinProgress] = useState<JoinProgress | null>(null);
 
   const create = async () => {
     if (!name.trim()) return;
@@ -110,15 +113,17 @@ function RoomsStep({
     if (!ticket.trim()) return;
     setJoining(true);
     setJoinError(null);
+    setJoinProgress(null);
     try {
       const { ticket: t, peerAddr: addr } = splitInvite(ticket, peerAddr);
-      await client.call('room.join', {
+      await joinRoomWithRetry(client, {
         ticket: t,
         ...(addr ? { peers: [addr] } : {}),
-      });
+      }, setJoinProgress);
       onAdvance();
     } catch (e) {
       setJoinError(errorShape(e));
+      setJoinProgress(null);
     } finally {
       setJoining(false);
     }
@@ -201,6 +206,15 @@ function RoomsStep({
         <button type="submit" className="btn btn-primary" disabled={joining || !ticket.trim()}>
           {joining ? 'Joining…' : 'Join room'}
         </button>
+        {joinProgress ? (
+          <div className="join-progress" role="status">
+            <span className="spinner" aria-hidden="true" />
+            <span>{joinProgress.message}</span>
+            <em>
+              Attempt {joinProgress.attempt}/{joinProgress.maxAttempts}
+            </em>
+          </div>
+        ) : null}
         <ErrorNote error={joinError} />
       </form>
       </div>

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -236,16 +236,26 @@ function FilesTab({
   const [shareError, setShareError] = useState<DaemonErrorShape | null>(null);
   const totalBytes = files.reduce((sum, file) => sum + file.size, 0);
   const availableCount = files.filter((file) => file.available).length;
+  const fetchedCount = files.filter((file) => {
+    const state = fetches[file.file_id];
+    return state?.phase === 'verified' || state?.phase === 'fetched' || file.fetched;
+  }).length;
   const providerCount = files.reduce((sum, file) => sum + file.providers, 0);
   // A file this device shared reports available:false from its own view (the
   // daemon excludes self from the provider set), so it is neither fetchable here
   // nor a fault. Count those separately to keep the summary honest.
   const servingCount = files.filter((file) => !file.available && selfId !== null && file.sender_id === selfId).length;
-  const waitingProviderCount = files.length - availableCount - servingCount;
+  const waitingProviderCount = files.filter((file) => {
+    const state = fetches[file.file_id];
+    const fetched = state?.phase === 'verified' || state?.phase === 'fetched' || file.fetched;
+    const serving = !file.available && selfId !== null && file.sender_id === selfId;
+    return !file.available && !serving && !fetched;
+  }).length;
   const heroDetail =
     files.length === 0
       ? 'Share a readable path and peers can fetch a verified copy over P2P.'
       : `${formatBytes(totalBytes)} in the room · ${availableCount} fetchable here` +
+        (fetchedCount > 0 ? ` · ${fetchedCount} fetched` : '') +
         (servingCount > 0 ? ` · ${servingCount} served by you` : '');
   const shareHelpId = 'file-share-help';
   const selectedType = selectedFile ? selectedFileTypeLabel(selectedFile) : null;
@@ -403,6 +413,8 @@ function FilesTab({
         const ext = extOf(file.name).toUpperCase() || 'FILE';
         const type = fileTypeLabel(file, ext.toLowerCase());
         const mine = selfId !== null && file.sender_id === selfId;
+        const fetchState = fetches[file.file_id];
+        const fetched = fetchState?.phase === 'verified' || fetchState?.phase === 'fetched' || file.fetched;
         // `available` is "another provider device is a connected peer right now"
         // (the daemon excludes THIS device), so a file you shared reads as
         // not-available from your own view even though peers can fetch it. Label
@@ -410,6 +422,8 @@ function FilesTab({
         // crates/jeliya-core/src/supervisor.rs.
         const health = mine
           ? { tone: 'self', text: 'Serving to peers' }
+          : fetched
+            ? { tone: 'ok', text: 'Fetched locally' }
           : file.available
             ? { tone: 'ok', text: 'Ready to fetch' }
             : { tone: 'warn', text: 'No provider online' };
@@ -417,7 +431,7 @@ function FilesTab({
         return (
           <div
             key={file.file_id}
-            className={`file-row${!file.available && !mine ? ' unavailable' : ''}`}
+            className={`file-row${!file.available && !mine && !fetched ? ' unavailable' : ''}`}
             title={file.file_id}
           >
             <div className="file-row-main">
@@ -443,11 +457,11 @@ function FilesTab({
                     Serving
                   </span>
                 ) : (
-                  <FetchControl state={fetches[file.file_id]} onFetch={() => onFetch(file.file_id)} />
+                  <FetchControl state={fetchState} onFetch={() => onFetch(file.file_id)} />
                 )}
               </div>
             </div>
-            {mine ? null : <FetchDetail state={fetches[file.file_id]} />}
+            {mine ? null : <FetchDetail state={fetchState} />}
           </div>
         );
       })}

--- a/ui/src/components/RoomHeader.tsx
+++ b/ui/src/components/RoomHeader.tsx
@@ -1,4 +1,4 @@
-import type { PeerStatus } from '../lib/protocol';
+import type { Member, PeerStatus } from '../lib/protocol';
 import { shortId } from '../lib/format';
 import { useNames } from './names';
 
@@ -22,6 +22,7 @@ function PeerChip({ peer }: { peer: PeerStatus }) {
 export function RoomHeader({
   name,
   memberCount,
+  members,
   peers,
   onInvite,
   onShareFile,
@@ -29,11 +30,15 @@ export function RoomHeader({
 }: {
   name: string;
   memberCount: number;
+  members: Member[];
   peers: PeerStatus[];
   onInvite(): void;
   onShareFile(): void;
   onOpenPipe(): void;
 }) {
+  const activeCount = members.length > 0 ? members.filter((m) => m.status === 'active').length : memberCount;
+  const invitedCount = members.filter((m) => m.status === 'invited').length;
+  const agentCount = members.filter((m) => m.role === 'agent').length;
   const connected = peers.filter((p) => p.state === 'connected');
   const hasDirect = connected.some((p) => p.path === 'direct');
   // Three honest states: nobody here, a live direct link, or relay-only
@@ -55,8 +60,24 @@ export function RoomHeader({
           <h1>{name}</h1>
           <div className="room-subtitle">
             <span>
-              {memberCount} member{memberCount === 1 ? '' : 's'}
+              {activeCount} active
             </span>
+            {agentCount > 0 ? (
+              <>
+                <span className="sep">|</span>
+                <span>
+                  {agentCount} agent{agentCount === 1 ? '' : 's'}
+                </span>
+              </>
+            ) : null}
+            {invitedCount > 0 ? (
+              <>
+                <span className="sep">|</span>
+                <span className="pending-invites">
+                  {invitedCount} invite{invitedCount === 1 ? '' : 's'} pending
+                </span>
+              </>
+            ) : null}
             <span className="sep">|</span>
             <span className="p2p-badge">
               <span

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -1,9 +1,23 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { FileEntry, FileRef, TimelineEvent } from '../lib/protocol';
+import type { DaemonErrorShape, FileEntry, FileRef, TimelineEvent } from '../lib/protocol';
 import { dayLabel, extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel, shortId } from '../lib/format';
 import { Avatar, FetchControl, FetchDetail, ProgressBar, SenderName } from './ui';
 import type { FetchState } from './ui';
+
+export interface PendingMessage {
+  clientId: string;
+  body: string;
+  ts: number;
+  phase: 'sending' | 'syncing' | 'failed';
+  eventId?: string;
+  error?: DaemonErrorShape;
+}
+
+type TimelineItem = { type: 'event'; event: TimelineEvent } | { type: 'pending'; pending: PendingMessage };
+type TimelineSide = 'own' | 'remote' | 'system';
+
+const GROUP_WINDOW_MS = 5 * 60 * 1000;
 
 function FileTile({
   file,
@@ -48,6 +62,7 @@ function EventCard({
   files,
   fetches,
   selfId,
+  compact,
   onFetch,
   onShowPipes,
 }: {
@@ -55,11 +70,13 @@ function EventCard({
   files: FileEntry[];
   fetches: Record<string, FetchState>;
   selfId: string | null;
+  compact: boolean;
   onFetch(fileId: string): void;
   onShowPipes(): void;
 }) {
   const senderId = event.sender.identity_id;
   const time = formatTime(event.ts);
+  const isOwn = selfId !== null && senderId === selfId;
 
   switch (event.kind) {
     case 'room_created':
@@ -98,17 +115,17 @@ function EventCard({
     }
 
     case 'message': {
-      // The desktop mockup renders every message uniformly left-aligned with an
-      // avatar — not a two-sided chat — so own messages are not special-cased.
       return (
-        <div className="msg-row">
-          <Avatar id={senderId} />
+        <div className={`msg-row${isOwn ? ' own' : ''}${compact ? ' compact' : ''}`}>
+          {isOwn ? null : compact ? <span className="avatar-spacer" aria-hidden="true" /> : <Avatar id={senderId} />}
           <div className="msg-col">
-            <div className="msg-meta">
-              <SenderName id={senderId} className="msg-sender" />
-              {event.sender.role === 'agent' ? <span className="chip chip-role">AGENT</span> : null}
-              <time dateTime={new Date(event.ts).toISOString()}>{time}</time>
-            </div>
+            {!compact ? (
+              <div className="msg-meta">
+                <SenderName id={senderId} className="msg-sender" />
+                {event.sender.role === 'agent' ? <span className="chip chip-role">AGENT</span> : null}
+                <time dateTime={new Date(event.ts).toISOString()}>{time}</time>
+              </div>
+            ) : null}
             <div className="msg-bubble">{event.body}</div>
           </div>
         </div>
@@ -119,14 +136,18 @@ function EventCard({
       const label = event.label ?? 'status';
       const artifacts = event.artifacts ?? [];
       return (
-        <div className="event-card">
-          <Avatar id={senderId} />
+        <div className={`event-card agent-work-card${isOwn ? ' own' : ''}`}>
+          {isOwn ? null : <Avatar id={senderId} />}
           <div className="event-main">
             <div className="event-head">
               <SenderName id={senderId} className="event-sender" />
-              {event.sender.role === 'agent' ? <span className="chip chip-role">AGENT</span> : null}
+              <span className="chip chip-role">AGENT</span>
               <time dateTime={new Date(event.ts).toISOString()}>{time}</time>
               <span className={`chip chip-label tone-${labelTone(label)}`}>{prettyLabel(label)}</span>
+            </div>
+            <div className="agent-work-title">
+              <span aria-hidden="true">✦</span>
+              <strong>{prettyLabel(label)}</strong>
             </div>
             {event.status_message ? <p className="event-text">{event.status_message}</p> : null}
             {typeof event.progress === 'number' ? (
@@ -156,8 +177,8 @@ function EventCard({
     case 'file_shared': {
       if (!event.file) return null;
       return (
-        <div className="event-card">
-          <Avatar id={senderId} />
+        <div className={`event-card${isOwn ? ' own' : ''}`}>
+          {isOwn ? null : <Avatar id={senderId} />}
           <div className="event-main">
             <div className="event-head">
               <SenderName id={senderId} className="event-sender" />
@@ -167,7 +188,7 @@ function EventCard({
             </div>
             <FileTile
               file={event.file}
-              isSelfOwned={selfId !== null && senderId === selfId}
+              isSelfOwned={isOwn}
               state={fetches[event.file.file_id]}
               onFetch={onFetch}
             />
@@ -179,8 +200,8 @@ function EventCard({
     case 'pipe_opened': {
       if (!event.pipe) return null;
       return (
-        <div className="event-card">
-          <Avatar id={senderId} />
+        <div className={`event-card${isOwn ? ' own' : ''}`}>
+          {isOwn ? null : <Avatar id={senderId} />}
           <div className="event-main">
             <div className="event-head">
               <SenderName id={senderId} className="event-sender" />
@@ -219,47 +240,144 @@ function EventCard({
   }
 }
 
+function PendingMessageCard({
+  message,
+  compact,
+  onRetry,
+}: {
+  message: PendingMessage;
+  compact: boolean;
+  onRetry(clientId: string): void;
+}) {
+  const label =
+    message.phase === 'failed'
+      ? "Couldn't send"
+      : message.phase === 'syncing'
+        ? 'Sent locally, syncing...'
+        : 'Sending...';
+  return (
+    <div className={`msg-row own pending ${message.phase}${compact ? ' compact' : ''}`}>
+      <div className="msg-col">
+        {!compact ? (
+          <div className="msg-meta pending-meta">
+            <span>You</span>
+            <time dateTime={new Date(message.ts).toISOString()}>{formatTime(message.ts)}</time>
+          </div>
+        ) : null}
+        <div className="msg-bubble">{message.body}</div>
+        <div className="pending-line">
+          {message.phase !== 'failed' ? <span className="spinner" aria-hidden="true" /> : null}
+          <span>{label}</span>
+          {message.phase === 'failed' ? (
+            <button type="button" className="text-btn" onClick={() => onRetry(message.clientId)}>
+              Retry
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function itemTs(item: TimelineItem): number {
+  return item.type === 'event' ? item.event.ts : item.pending.ts;
+}
+
+function itemSender(item: TimelineItem, selfId: string | null): string | null {
+  if (item.type === 'pending') return selfId;
+  return item.event.kind === 'message' ? item.event.sender.identity_id : null;
+}
+
+function shouldGroup(prev: TimelineItem | null, item: TimelineItem, selfId: string | null): boolean {
+  if (!prev) return false;
+  const sender = itemSender(item, selfId);
+  const prevSender = itemSender(prev, selfId);
+  if (!sender || !prevSender || sender !== prevSender) return false;
+  return itemTs(item) - itemTs(prev) <= GROUP_WINDOW_MS;
+}
+
+function itemSide(item: TimelineItem, selfId: string | null): TimelineSide {
+  if (item.type === 'pending') return 'own';
+  const { event } = item;
+  if (!['message', 'agent_status', 'file_shared', 'pipe_opened'].includes(event.kind)) {
+    return 'system';
+  }
+  return selfId !== null && event.sender.identity_id === selfId ? 'own' : 'remote';
+}
+
 export function Timeline({
   events,
+  pendingMessages,
   files,
   fetches,
   loading,
   selfId,
   onFetch,
+  onRetryPendingMessage,
   onShowPipes,
 }: {
   events: TimelineEvent[];
+  pendingMessages: PendingMessage[];
   files: FileEntry[];
   fetches: Record<string, FetchState>;
   loading: boolean;
   selfId: string | null;
   onFetch(fileId: string): void;
+  onRetryPendingMessage(clientId: string): void;
   onShowPipes(): void;
 }) {
   const scroller = useRef<HTMLDivElement | null>(null);
   const stickToBottom = useRef(true);
+  const previousItemCount = useRef(0);
+  const [newItemCount, setNewItemCount] = useState(0);
+
+  const items: TimelineItem[] = [
+    ...events.map((event) => ({ type: 'event' as const, event })),
+    ...pendingMessages.map((pending) => ({ type: 'pending' as const, pending })),
+  ].sort((a, b) => itemTs(a) - itemTs(b));
 
   useEffect(() => {
     const el = scroller.current;
-    if (el && stickToBottom.current) {
-      el.scrollTop = el.scrollHeight;
+    const previous = previousItemCount.current;
+    const delta = Math.max(0, items.length - previous);
+    if (el) {
+      if (stickToBottom.current) {
+        el.scrollTop = el.scrollHeight;
+        setNewItemCount(0);
+      } else if (delta > 0) {
+        setNewItemCount((count) => count + delta);
+      }
     }
-  }, [events.length]);
+    previousItemCount.current = items.length;
+  }, [items.length]);
 
   const onScroll = () => {
     const el = scroller.current;
     if (!el) return;
     stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 140;
+    if (stickToBottom.current) setNewItemCount(0);
+  };
+
+  const scrollToBottom = () => {
+    const el = scroller.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    stickToBottom.current = true;
+    setNewItemCount(0);
   };
 
   let lastDay = '';
-  const rows: { key: string; node: ReactNode }[] = [];
-  for (const event of events) {
-    const day = dayLabel(event.ts);
+  const rows: { key: string; node: ReactNode; side: TimelineSide; compact: boolean }[] = [];
+  let prevItem: TimelineItem | null = null;
+  for (const item of items) {
+    const ts = itemTs(item);
+    const day = dayLabel(ts);
     if (day !== lastDay) {
       lastDay = day;
       rows.push({
-        key: `day-${day}-${event.event_id}`,
+        key: `day-${day}-${item.type === 'event' ? item.event.event_id : item.pending.clientId}`,
+        side: 'system',
+        compact: false,
         node: (
           <div className="day-divider">
             <span>{day}</span>
@@ -267,23 +385,40 @@ export function Timeline({
         ),
       });
     }
+    const compact = shouldGroup(prevItem, item, selfId);
+    const side = itemSide(item, selfId);
     rows.push({
-      key: event.event_id,
-      node: (
-        <EventCard
-          event={event}
-          files={files}
-          fetches={fetches}
-          selfId={selfId}
-          onFetch={onFetch}
-          onShowPipes={onShowPipes}
-        />
-      ),
+      key: item.type === 'event' ? item.event.event_id : item.pending.clientId,
+      side,
+      compact,
+      node:
+        item.type === 'event' ? (
+          <EventCard
+            event={item.event}
+            files={files}
+            fetches={fetches}
+            selfId={selfId}
+            compact={compact}
+            onFetch={onFetch}
+            onShowPipes={onShowPipes}
+          />
+        ) : (
+          <PendingMessageCard message={item.pending} compact={compact} onRetry={onRetryPendingMessage} />
+        ),
     });
+    prevItem = item;
   }
 
   return (
-    <div className="timeline" ref={scroller} onScroll={onScroll} role="log" aria-label="Room timeline" aria-busy={loading}>
+    <div className="timeline-shell">
+      <div
+        className="timeline"
+        ref={scroller}
+        onScroll={onScroll}
+        role="log"
+        aria-label="Room timeline"
+        aria-busy={loading}
+      >
       {loading ? (
         <div aria-hidden="true">
           <div className="skel-row">
@@ -311,12 +446,21 @@ export function Timeline({
         </div>
       ) : null}
       {rows.map((row) => (
-        <div key={row.key} className="timeline-row">
+        <div
+          key={row.key}
+          className={`timeline-row side-${row.side}${row.compact ? ' is-compact' : ''}`}
+        >
           {row.node}
         </div>
       ))}
-      {!loading && events.length === 0 ? (
+      {!loading && items.length === 0 ? (
         <div className="timeline-empty muted">No events yet — say something below.</div>
+      ) : null}
+      </div>
+      {newItemCount > 0 ? (
+        <button type="button" className="new-messages" onClick={scrollToBottom}>
+          {newItemCount} new message{newItemCount === 1 ? '' : 's'}
+        </button>
       ) : null}
     </div>
   );

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { DaemonErrorShape } from '../lib/protocol';
 import { colorForId, formatBytes, initials } from '../lib/format';
+import { friendlyError } from '../lib/errors';
 import { useNames } from './names';
 
 // -- brand mark ---------------------------------------------------------------
@@ -126,10 +127,17 @@ export function CopyButton({ text, label = 'Copy', ariaLabel }: { text: string; 
 
 export function ErrorNote({ error }: { error: DaemonErrorShape | null }) {
   if (!error) return null;
+  const friendly = friendlyError(error);
   return (
     <div className="error-note" role="alert">
-      <code className="error-code">{error.code}</code> {error.message}
-      {error.hint ? <div className="error-hint">→ {error.hint}</div> : null}
+      <strong className="error-title">{friendly.title}</strong>
+      <span>{friendly.message}</span>
+      {friendly.action ? <div className="error-hint">{friendly.action}</div> : null}
+      <details className="error-details">
+        <summary>Technical details</summary>
+        <code className="error-code">{error.code}</code> {error.message}
+        {error.hint ? <div>{error.hint}</div> : null}
+      </details>
     </div>
   );
 }
@@ -234,7 +242,8 @@ export function Modal({
 
 export type FetchState =
   | { phase: 'pending' }
-  | { phase: 'verified'; path: string; bytes: number }
+  | { phase: 'verified'; path: string; bytes: number; url?: string }
+  | { phase: 'fetched'; path: string; bytes: number; url?: string }
   | { phase: 'error'; error: DaemonErrorShape };
 
 export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch(): void }) {
@@ -252,10 +261,10 @@ export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch()
       </button>
     );
   }
-  if (state.phase === 'verified') {
+  if (state.phase === 'verified' || state.phase === 'fetched') {
     return (
-      <span className="fetch-ok" title={`verified · ${state.path}`}>
-        ✓ Verified
+      <span className="fetch-ok" title={`${state.phase === 'verified' ? 'verified' : 'fetched'} · ${state.path}`}>
+        {state.phase === 'verified' ? '✓ Verified' : '✓ Fetched'}
       </span>
     );
   }
@@ -272,10 +281,18 @@ export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch()
 
 export function FetchDetail({ state }: { state?: FetchState }) {
   if (!state) return null;
-  if (state.phase === 'verified') {
+  if (state.phase === 'verified' || state.phase === 'fetched') {
+    const path = state.url ? (
+      <a className="fetch-path-link" href={state.url} target="_blank" rel="noreferrer" title="Open local file copy">
+        <code>{state.path}</code>
+      </a>
+    ) : (
+      <code>{state.path}</code>
+    );
     return (
       <div className="fetch-detail ok">
-        Verified · {formatBytes(state.bytes)} · saved to <code>{state.path}</code>
+        {state.phase === 'verified' ? 'Verified' : 'Fetched'} · {formatBytes(state.bytes)} · saved to{' '}
+        {path}
       </div>
     );
   }

--- a/ui/src/lib/errors.ts
+++ b/ui/src/lib/errors.ts
@@ -1,0 +1,60 @@
+import type { DaemonErrorShape } from './protocol';
+
+export interface FriendlyError {
+  title: string;
+  message: string;
+  action?: string;
+}
+
+export function friendlyError(error: DaemonErrorShape): FriendlyError {
+  switch (error.code) {
+    case 'peer_unreachable':
+      return {
+        title: "Couldn't reach the inviter",
+        message: 'The invite is readable, but this device could not reach the room admin in time.',
+        action: 'Ask the inviter to keep the room open, then retry. A fresh combined invite can help if the address changed.',
+      };
+    case 'bad_ticket':
+      return {
+        title: "This invite can't be used",
+        message: 'The ticket is invalid for this identity, malformed, or no longer matches the room invite.',
+        action: 'Ask for a new invite generated for your current identity id.',
+      };
+    case 'ticket_expired':
+      return {
+        title: 'This invite expired',
+        message: 'The room rejected the ticket because its expiry time has passed.',
+        action: 'Ask the inviter to generate a fresh ticket.',
+      };
+    case 'room_not_open':
+      return {
+        title: 'Open the room first',
+        message: 'This action needs a live room session on your daemon.',
+        action: 'Open the room, wait for it to sync, then try again.',
+      };
+    case 'not_a_member':
+      return {
+        title: "You're not an active member",
+        message: 'The signed room history does not currently admit this identity as an active member.',
+        action: 'Use a valid invite for this identity or ask the room owner to re-add you.',
+      };
+    case 'room_unknown':
+      return {
+        title: "This room isn't local yet",
+        message: 'The daemon does not have enough room history to open this room.',
+        action: 'Join with an invite, or open the room with a reachable peer hint.',
+      };
+    case 'connection_lost':
+      return {
+        title: 'Daemon connection lost',
+        message: 'The local UI is not connected to jeliyad right now.',
+        action: 'Wait for reconnect, then retry the action.',
+      };
+    default:
+      return {
+        title: 'Something went wrong',
+        message: error.message,
+        action: error.hint ?? undefined,
+      };
+  }
+}

--- a/ui/src/lib/join.ts
+++ b/ui/src/lib/join.ts
@@ -1,0 +1,60 @@
+import type { Client, DaemonErrorShape } from './protocol';
+import { errorShape } from './protocol';
+
+export type JoinPhase = 'connecting' | 'retrying';
+
+export interface JoinProgress {
+  phase: JoinPhase;
+  attempt: number;
+  maxAttempts: number;
+  message: string;
+  lastError?: DaemonErrorShape;
+}
+
+const JOIN_ATTEMPTS = 5;
+const RETRY_DELAYS_MS = [1_500, 2_000, 3_000, 4_000];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+export async function joinRoomWithRetry(
+  client: Client,
+  params: { ticket: string; peers?: string[] },
+  onProgress?: (progress: JoinProgress) => void,
+): Promise<{ room_id: string }> {
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= JOIN_ATTEMPTS; attempt += 1) {
+    onProgress?.({
+      phase: 'connecting',
+      attempt,
+      maxAttempts: JOIN_ATTEMPTS,
+      message:
+        attempt === 1
+          ? 'Finding the inviter and syncing the room invite...'
+          : `Retrying join (${attempt}/${JOIN_ATTEMPTS})...`,
+    });
+
+    try {
+      return await client.call('room.join', params);
+    } catch (e) {
+      lastError = e;
+      const err = errorShape(e);
+      if (err.code !== 'peer_unreachable' || attempt === JOIN_ATTEMPTS) {
+        throw e;
+      }
+      const delay = RETRY_DELAYS_MS[Math.min(attempt - 1, RETRY_DELAYS_MS.length - 1)];
+      onProgress?.({
+        phase: 'retrying',
+        attempt,
+        maxAttempts: JOIN_ATTEMPTS,
+        message: `The first path did not answer. Retrying in ${Math.round(delay / 1000)}s...`,
+        lastError: err,
+      });
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -892,7 +892,12 @@ class MockClient implements Client {
               return;
             }
             const dir = p.save_dir ?? '~/Downloads/Jeliya';
-            resolve({ path: `${dir}/${file.name}`, bytes: file.size, verified: true as const });
+            const path = `${dir}/${file.name}`;
+            file.fetched = true;
+            file.local_path = path;
+            file.local_bytes = file.size;
+            file.fetched_at_ms = Date.now();
+            resolve({ path, bytes: file.size, verified: true as const });
           }, 900 + Math.random() * 500);
         });
       }

--- a/ui/src/lib/protocol.ts
+++ b/ui/src/lib/protocol.ts
@@ -116,6 +116,10 @@ export interface FileEntry {
   ts: number;
   available: boolean;
   providers: number;
+  fetched?: boolean;
+  local_path?: string | null;
+  local_bytes?: number | null;
+  fetched_at_ms?: number | null;
 }
 
 export type PipeState = 'open' | 'closed';

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -603,6 +603,26 @@ button.sender-name:not(:disabled):hover {
   border: 1px solid rgba(242, 109, 109, 0.35);
   color: var(--text);
   font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.error-title {
+  color: var(--text);
+  font-size: 13.5px;
+}
+
+.error-details {
+  margin-top: 2px;
+  color: var(--text-mute);
+  font-size: 12px;
+}
+
+.error-details summary {
+  width: max-content;
+  cursor: pointer;
+  color: var(--text-dim);
 }
 
 .error-code {
@@ -613,9 +633,28 @@ button.sender-name:not(:disabled):hover {
 }
 
 .error-hint {
-  margin-top: 3px;
   color: var(--text-dim);
   font-size: 12.5px;
+}
+
+.join-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 9px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-line);
+  color: var(--text-dim);
+  font-size: 12.5px;
+}
+
+.join-progress em {
+  margin-left: auto;
+  color: var(--text-mute);
+  font-style: normal;
+  white-space: nowrap;
 }
 
 .progress {
@@ -1068,6 +1107,10 @@ button.sender-name:not(:disabled):hover {
   color: var(--accent);
 }
 
+.pending-invites {
+  color: var(--amber);
+}
+
 .room-actions {
   display: flex;
   gap: 8px;
@@ -1141,6 +1184,13 @@ button.sender-name:not(:disabled):hover {
 
 /* ---------- timeline ---------- */
 
+.timeline-shell {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
 .timeline {
   flex: 1;
   overflow-y: auto;
@@ -1152,7 +1202,28 @@ button.sender-name:not(:disabled):hover {
 }
 
 .timeline-row {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   margin: 5px 0;
+}
+
+.timeline-row.side-own {
+  align-items: flex-end;
+}
+
+.timeline-row.side-remote {
+  align-items: flex-start;
+}
+
+.timeline-row.side-own + .timeline-row.side-remote,
+.timeline-row.side-remote + .timeline-row.side-own {
+  margin-top: 12px;
+}
+
+.timeline-row.is-compact {
+  margin-top: -2px;
 }
 
 .timeline-empty {
@@ -1188,7 +1259,28 @@ button.sender-name:not(:disabled):hover {
 .msg-row {
   display: flex;
   gap: 12px;
-  max-width: 78%;
+  max-width: min(78%, 760px);
+}
+
+.msg-row.own {
+  justify-content: flex-end;
+}
+
+.msg-row.compact {
+  margin-top: 0;
+}
+
+.msg-row.own .msg-col {
+  align-items: flex-end;
+}
+
+.msg-row.own .msg-meta {
+  justify-content: flex-end;
+}
+
+.avatar-spacer {
+  width: 34px;
+  flex: none;
 }
 
 .msg-col {
@@ -1223,6 +1315,72 @@ button.sender-name:not(:disabled):hover {
   max-width: 72ch;
 }
 
+.msg-row:not(.own) .msg-bubble {
+  border-left: 2px solid rgba(106, 168, 247, 0.34);
+  background: #0c1519;
+}
+
+.msg-row.own .msg-bubble {
+  border-color: rgba(47, 214, 164, 0.42);
+  border-radius: 14px 4px 14px 14px;
+  background: linear-gradient(135deg, rgba(47, 214, 164, 0.2), rgba(31, 180, 168, 0.13));
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16);
+}
+
+.msg-row.compact .msg-bubble {
+  border-top-left-radius: 8px;
+}
+
+.msg-row.own.compact .msg-bubble {
+  border-top-left-radius: 14px;
+  border-top-right-radius: 8px;
+}
+
+.msg-row.pending .msg-bubble {
+  color: var(--text-dim);
+}
+
+.pending-line {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  color: var(--text-mute);
+  font-size: 11.5px;
+}
+
+.pending-line .spinner {
+  width: 11px;
+  height: 11px;
+}
+
+.text-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.text-btn:hover {
+  text-decoration: underline;
+}
+
+.new-messages {
+  position: absolute;
+  left: 50%;
+  bottom: 14px;
+  transform: translateX(-50%);
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--bg-card-2);
+  color: var(--accent);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
 /* Event rows share the flat message anatomy (avatar + content column); the
    inner file/pipe tile is the single card level — never a card-in-card. */
 .event-card {
@@ -1231,9 +1389,37 @@ button.sender-name:not(:disabled):hover {
   padding: 4px 0;
 }
 
+.event-card.own {
+  width: min(78%, 760px);
+  justify-content: flex-end;
+}
+
 .event-main {
   flex: 1;
   min-width: 0;
+}
+
+.event-card.own .event-main {
+  flex: 0 1 100%;
+}
+
+.event-card.own .event-head {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.event-card.own .file-tile,
+.event-card.own .pipe-tile {
+  border-color: rgba(47, 214, 164, 0.34);
+  background: rgba(47, 214, 164, 0.1);
+}
+
+.agent-work-card .event-main {
+  max-width: 78ch;
+  padding: 10px 12px;
+  border-radius: 11px;
+  background: rgba(106, 168, 247, 0.08);
+  border: 1px solid rgba(106, 168, 247, 0.22);
 }
 
 .event-head {
@@ -1246,6 +1432,19 @@ button.sender-name:not(:disabled):hover {
 
 .event-head .chip-label {
   margin-left: auto;
+}
+
+.agent-work-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  color: var(--text);
+  font-size: 13.5px;
+}
+
+.agent-work-title span {
+  color: var(--blue);
 }
 
 .event-text {
@@ -1350,6 +1549,18 @@ button.sender-name:not(:disabled):hover {
   color: var(--text-dim);
 }
 
+.fetch-path-link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent), transparent 45%);
+  text-underline-offset: 3px;
+}
+
+.fetch-path-link:hover code,
+.fetch-path-link:focus-visible code {
+  color: var(--accent-strong);
+}
+
 .fetch-detail.err {
   color: var(--red);
 }
@@ -1380,6 +1591,11 @@ button.sender-name:not(:disabled):hover {
   border-color: var(--accent-line);
 }
 
+.composer-bar.is-dragging {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
 .composer-bar textarea {
   flex: 1;
   resize: none;
@@ -1387,7 +1603,7 @@ button.sender-name:not(:disabled):hover {
   border: none;
   outline: none;
   color: var(--text);
-  max-height: 120px;
+  max-height: 150px;
   padding: 6px 4px;
 }
 
@@ -2482,6 +2698,42 @@ select {
 
 .invite-advanced {
   margin: 10px 0 14px;
+}
+
+.invite-readiness {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 12px 0 14px;
+  padding: 10px 12px;
+  border-radius: 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+}
+
+.invite-readiness strong {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--text);
+}
+
+.invite-readiness p {
+  color: var(--text-dim);
+  font-size: 12.5px;
+}
+
+.invite-ready {
+  background: var(--accent-dim);
+  border-color: var(--accent-line);
+}
+
+.invite-caution {
+  background: var(--amber-dim);
+  border-color: var(--amber-line);
+}
+
+.invite-caution .dot {
+  color: var(--amber);
 }
 
 .invite-advanced summary {


### PR DESCRIPTION
## Summary
- Improves the chat experience with clearer own/remote message separation, friendlier join/retry errors, and better pending-message handling.
- Persists fetched-file state so already downloaded room files render as fetched after reloads or daemon restarts.
- Adds a safe local file-open endpoint: `GET /api/files/local?room_id=...&file_id=...`, so fetched file paths in the UI are clickable without exposing arbitrary filesystem paths.
- Bumps `jeliya-core`, `jeliyad`, and `jeliya-ui` to `0.4.1`.
- Updates the Homebrew formula to `0.4.1` with SHA256 values copied from the published release sidecars.

## Verification
- [x] `npm run build`
- [x] `cargo check -p jeliyad`
- [x] `cargo test --workspace`
- [x] `cargo build --release -p jeliyad --features embed-ui`
- [x] `target/release/jeliyad --version` → `jeliyad 0.4.1`
- [x] `ruby -c packaging/jeliya.rb`
- [x] GitHub Actions release workflow succeeded on all 5 targets.
- [x] GitHub Release has 10 assets: 5 archives + 5 `.sha256` sidecars.
- [x] Manual loopback check: `/api/files/local?...` returned `200 OK` with `application/pdf` for a fetched PDF.

## Release
- Release: https://github.com/kortiene/jeliya/releases/tag/v0.4.1
- Workflow run: https://github.com/kortiene/jeliya/actions/runs/28862136309

Note: direct push to protected `main` was correctly rejected, so this PR brings `main` into sync with the already-published `v0.4.1` tag and formula update.