### PR TITLE
v0.4.3 fix: improve file fetch states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.4.3] - 2026-07-07
+
+### Changed
+
+- Made file cards show honest fetch states: checking availability, ready to fetch, fetching, fetched, failed, and no provider online.
+- Replaced fetched-file status-only labels with direct `Open file` and `Copy path` actions.
+- Added a `Recheck` action for files whose providers are currently offline.
+
+### Fixed
+
+- Stopped showing `Fetch` for files that have already been fetched or have no online provider.
+- Improved file-row layout so provider status and file actions stay readable on desktop and mobile.
+
 ## [0.4.2] - 2026-07-07
 
 ### Added
@@ -10,4 +23,3 @@
 ### Changed
 
 - Captured the latest UI action error across room, message, file, pipe, join, create, and leave flows so reports include the failing context without exposing room contents.
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "dirs",

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -444,6 +444,12 @@ export default function App({ client }: { client: Client }) {
     void sendMessage(pending.body, clientId);
   };
 
+  const recheckFiles = useCallback(() => {
+    const rid = roomIdRef.current;
+    if (!rid) return;
+    void refreshFiles(rid);
+  }, [refreshFiles]);
+
   const fetchFile = (fileId: string) => {
     const rid = roomIdRef.current;
     if (!rid) return;
@@ -756,6 +762,7 @@ export default function App({ client }: { client: Client }) {
                 loading={roomLoading}
                 selfId={selfId}
                 onFetch={fetchFile}
+                onRecheckFiles={recheckFiles}
                 onRetryPendingMessage={retryPendingMessage}
                 onShowPipes={() => setTab('pipes')}
               />
@@ -783,6 +790,7 @@ export default function App({ client }: { client: Client }) {
           selfId={selfId}
           fetches={fetches}
           onFetch={fetchFile}
+          onRecheckFiles={recheckFiles}
           onSharePath={shareFilePath}
           onShareBrowserFile={shareBrowserFile}
           pipeConns={pipeConns}

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -5,7 +5,7 @@ import { errorShape } from '../lib/protocol';
 import { extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel } from '../lib/format';
 import { useNames } from './names';
 import { Avatar, ErrorNote, FetchControl, FetchDetail, ProgressBar, SenderName } from './ui';
-import type { FetchState } from './ui';
+import type { FetchAvailability, FetchState } from './ui';
 
 export type PanelTab = 'members' | 'agents' | 'files' | 'pipes';
 
@@ -219,6 +219,7 @@ function FilesTab({
   selfId,
   fetches,
   onFetch,
+  onRecheckFiles,
   onSharePath,
   onShareBrowserFile,
 }: {
@@ -226,6 +227,7 @@ function FilesTab({
   selfId: string | null;
   fetches: Record<string, FetchState>;
   onFetch(fileId: string): void;
+  onRecheckFiles(): void;
   onSharePath(path: string): Promise<void>;
   onShareBrowserFile(file: File): Promise<void>;
 }) {
@@ -414,7 +416,9 @@ function FilesTab({
         const type = fileTypeLabel(file, ext.toLowerCase());
         const mine = selfId !== null && file.sender_id === selfId;
         const fetchState = fetches[file.file_id];
+        const availability: FetchAvailability = { available: file.available, providers: file.providers };
         const fetched = fetchState?.phase === 'verified' || fetchState?.phase === 'fetched' || file.fetched;
+        const failedState = fetchState?.phase === 'error' ? fetchState : null;
         // `available` is "another provider device is a connected peer right now"
         // (the daemon excludes THIS device), so a file you shared reads as
         // not-available from your own view even though peers can fetch it. Label
@@ -424,6 +428,11 @@ function FilesTab({
           ? { tone: 'self', text: 'Serving to peers' }
           : fetched
             ? { tone: 'ok', text: 'Fetched locally' }
+          : failedState
+            ? {
+                tone: 'warn',
+                text: failedState.error.code === 'hash_mismatch' ? 'Security check failed' : 'Fetch failed',
+              }
           : file.available
             ? { tone: 'ok', text: 'Ready to fetch' }
             : { tone: 'warn', text: 'No provider online' };
@@ -457,7 +466,12 @@ function FilesTab({
                     Serving
                   </span>
                 ) : (
-                  <FetchControl state={fetchState} onFetch={() => onFetch(file.file_id)} />
+                  <FetchControl
+                    state={fetchState}
+                    availability={availability}
+                    onFetch={() => onFetch(file.file_id)}
+                    onRecheck={onRecheckFiles}
+                  />
                 )}
               </div>
             </div>
@@ -632,6 +646,7 @@ export function RightPanel({
   selfId,
   fetches,
   onFetch,
+  onRecheckFiles,
   onSharePath,
   onShareBrowserFile,
   pipeConns,
@@ -651,6 +666,7 @@ export function RightPanel({
   selfId: string | null;
   fetches: Record<string, FetchState>;
   onFetch(fileId: string): void;
+  onRecheckFiles(): void;
   onSharePath(path: string): Promise<void>;
   onShareBrowserFile(file: File): Promise<void>;
   pipeConns: Record<string, PipeConnState>;
@@ -721,6 +737,7 @@ export function RightPanel({
             selfId={selfId}
             fetches={fetches}
             onFetch={onFetch}
+            onRecheckFiles={onRecheckFiles}
             onSharePath={onSharePath}
             onShareBrowserFile={onShareBrowserFile}
           />

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import type { DaemonErrorShape, FileEntry, FileRef, TimelineEvent } from '../lib/protocol';
 import { dayLabel, extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel, shortId } from '../lib/format';
 import { Avatar, FetchControl, FetchDetail, ProgressBar, SenderName } from './ui';
-import type { FetchState } from './ui';
+import type { FetchAvailability, FetchState } from './ui';
 
 export interface PendingMessage {
   clientId: string;
@@ -23,12 +23,16 @@ function FileTile({
   file,
   isSelfOwned,
   state,
+  availability,
   onFetch,
+  onRecheckFiles,
 }: {
   file: FileRef;
   isSelfOwned: boolean;
   state?: FetchState;
+  availability?: FetchAvailability;
   onFetch(fileId: string): void;
+  onRecheckFiles(): void;
 }) {
   const tint = fileTint(file.name);
   const ext = extOf(file.name).toUpperCase() || 'FILE';
@@ -49,7 +53,13 @@ function FileTile({
             Serving
           </span>
         ) : (
-          <FetchControl state={state} onFetch={() => onFetch(file.file_id)} />
+          <FetchControl
+            state={state}
+            availability={availability}
+            availabilityPending={!availability}
+            onFetch={() => onFetch(file.file_id)}
+            onRecheck={onRecheckFiles}
+          />
         )}
       </div>
       {isSelfOwned ? null : <FetchDetail state={state} />}
@@ -64,6 +74,7 @@ function EventCard({
   selfId,
   compact,
   onFetch,
+  onRecheckFiles,
   onShowPipes,
 }: {
   event: TimelineEvent;
@@ -72,6 +83,7 @@ function EventCard({
   selfId: string | null;
   compact: boolean;
   onFetch(fileId: string): void;
+  onRecheckFiles(): void;
   onShowPipes(): void;
 }) {
   const senderId = event.sender.identity_id;
@@ -176,6 +188,7 @@ function EventCard({
 
     case 'file_shared': {
       if (!event.file) return null;
+      const fileEntry = files.find((f) => f.file_id === event.file?.file_id);
       return (
         <div className={`event-card${isOwn ? ' own' : ''}`}>
           {isOwn ? null : <Avatar id={senderId} />}
@@ -190,7 +203,11 @@ function EventCard({
               file={event.file}
               isSelfOwned={isOwn}
               state={fetches[event.file.file_id]}
+              availability={
+                fileEntry ? { available: fileEntry.available, providers: fileEntry.providers } : undefined
+              }
               onFetch={onFetch}
+              onRecheckFiles={onRecheckFiles}
             />
           </div>
         </div>
@@ -313,6 +330,7 @@ export function Timeline({
   loading,
   selfId,
   onFetch,
+  onRecheckFiles,
   onRetryPendingMessage,
   onShowPipes,
 }: {
@@ -323,6 +341,7 @@ export function Timeline({
   loading: boolean;
   selfId: string | null;
   onFetch(fileId: string): void;
+  onRecheckFiles(): void;
   onRetryPendingMessage(clientId: string): void;
   onShowPipes(): void;
 }) {
@@ -400,6 +419,7 @@ export function Timeline({
             selfId={selfId}
             compact={compact}
             onFetch={onFetch}
+            onRecheckFiles={onRecheckFiles}
             onShowPipes={onShowPipes}
           />
         ) : (

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -246,10 +246,52 @@ export type FetchState =
   | { phase: 'fetched'; path: string; bytes: number; url?: string }
   | { phase: 'error'; error: DaemonErrorShape };
 
-export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch(): void }) {
+export interface FetchAvailability {
+  available: boolean;
+  providers: number;
+}
+
+function providerTitle(availability?: FetchAvailability): string | undefined {
+  if (!availability) return undefined;
+  const providers = `${availability.providers} provider${availability.providers === 1 ? '' : 's'} listed`;
+  return availability.available ? `${providers}; at least one is online` : `${providers}; none are online right now`;
+}
+
+export function FetchControl({
+  state,
+  availability,
+  availabilityPending = false,
+  onFetch,
+  onRecheck,
+}: {
+  state?: FetchState;
+  availability?: FetchAvailability;
+  availabilityPending?: boolean;
+  onFetch(): void;
+  onRecheck?(): void;
+}) {
   if (!state) {
+    if (availabilityPending) {
+      return (
+        <button type="button" className="btn btn-sm" disabled>
+          <span className="spinner" aria-hidden="true" /> Checking…
+        </button>
+      );
+    }
+    if (availability && !availability.available) {
+      return (
+        <span className="fetch-actions" title={providerTitle(availability)}>
+          <span className="fetch-offline">No provider online</span>
+          {onRecheck ? (
+            <button type="button" className="btn btn-sm btn-ghost" onClick={onRecheck}>
+              Recheck
+            </button>
+          ) : null}
+        </span>
+      );
+    }
     return (
-      <button type="button" className="btn btn-sm" onClick={onFetch}>
+      <button type="button" className="btn btn-sm" onClick={onFetch} title={providerTitle(availability)}>
         Fetch
       </button>
     );
@@ -263,8 +305,17 @@ export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch()
   }
   if (state.phase === 'verified' || state.phase === 'fetched') {
     return (
-      <span className="fetch-ok" title={`${state.phase === 'verified' ? 'verified' : 'fetched'} · ${state.path}`}>
-        {state.phase === 'verified' ? '✓ Verified' : '✓ Fetched'}
+      <span className="fetch-actions">
+        {state.url ? (
+          <a className="btn btn-sm btn-primary" href={state.url} target="_blank" rel="noreferrer">
+            Open file
+          </a>
+        ) : (
+          <span className="fetch-ok" title={`${state.phase === 'verified' ? 'verified' : 'fetched'} · ${state.path}`}>
+            {state.phase === 'verified' ? '✓ Verified' : '✓ Fetched'}
+          </span>
+        )}
+        <CopyButton text={state.path} label="Copy path" ariaLabel="Copy saved file path" />
       </span>
     );
   }
@@ -272,11 +323,43 @@ export function FetchControl({ state, onFetch }: { state?: FetchState; onFetch()
   if (state.error.code === 'hash_mismatch') {
     return <span className="fetch-err">✕ Failed</span>;
   }
+  if (availability && !availability.available) {
+    return (
+      <span className="fetch-actions" title={providerTitle(availability)}>
+        <span className="fetch-offline">No provider online</span>
+        {onRecheck ? (
+          <button type="button" className="btn btn-sm btn-ghost" onClick={onRecheck}>
+            Recheck
+          </button>
+        ) : null}
+      </span>
+    );
+  }
   return (
     <button type="button" className="btn btn-sm btn-danger" onClick={onFetch}>
       Retry
     </button>
   );
+}
+
+function fetchErrorCopy(error: DaemonErrorShape): { message: string; detail?: string } {
+  switch (error.code) {
+    case 'file_unavailable':
+      return {
+        message: 'No provider is online for this file yet. Recheck when the sender is back online.',
+        detail: error.hint ?? error.message,
+      };
+    case 'provider_refused':
+      return {
+        message: 'The provider refused this fetch. Ask the sender to keep the room open, then retry.',
+        detail: error.hint ?? error.message,
+      };
+    default:
+      return {
+        message: error.message,
+        detail: error.hint ?? undefined,
+      };
+  }
 }
 
 export function FetchDetail({ state }: { state?: FetchState }) {
@@ -314,10 +397,16 @@ export function FetchDetail({ state }: { state?: FetchState }) {
         </div>
       );
     }
+    const copy = fetchErrorCopy(state.error);
     return (
       <div className="fetch-detail err">
-        <code className="error-code">{state.error.code}</code> {state.error.message}
-        {state.error.hint ? ` — ${state.error.hint}` : ''}
+        {copy.message}
+        {copy.detail ? (
+          <details className="fetch-detail-advanced">
+            <summary className="muted">Technical details</summary>
+            <code className="error-code">{state.error.code}</code> {copy.detail}
+          </details>
+        ) : null}
       </div>
     );
   }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1591,6 +1591,27 @@ button.sender-name:not(:disabled):hover {
   white-space: nowrap;
 }
 
+.fetch-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.fetch-offline {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-strong);
+  color: var(--amber);
+  background: var(--bg-raise);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 .fetch-err {
   color: var(--red);
   font-size: 12.5px;
@@ -2254,7 +2275,8 @@ button.sender-name:not(:disabled):hover {
 }
 
 .file-row-main {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: flex-start;
   gap: 11px;
 }
@@ -2327,7 +2349,8 @@ button.sender-name:not(:disabled):hover {
 }
 
 .file-row-action {
-  flex: none;
+  grid-column: 2;
+  justify-self: start;
 }
 
 .file-self-note {
@@ -3286,9 +3309,16 @@ select {
   }
 
   .file-row-action .btn,
+  .file-row-action .fetch-actions,
   .file-self-note {
     justify-content: center;
     width: 100%;
+  }
+
+  .file-row-action .fetch-actions .btn,
+  .file-row-action .fetch-offline {
+    flex: 1 1 140px;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary

- Improves file fetch UX in the timeline and Files panel with explicit states: `Checking...`, `Fetch`, `Fetching...`, `No provider online`, `Recheck`, `Retry`, `Open file`, and `Copy path`.
- Uses `file.list` availability/provider data so offline or already-fetched files do not show a misleading `Fetch` action.
- Updates file fetch error copy to lead with recovery guidance and keep technical details behind disclosure.
- Fixes desktop/mobile file-row layout so provider status and actions remain readable.
- Prepares release `v0.4.3` with changelog and version bumps.

## Test Coverage

No new test files added. This is a UI-state rendering change over existing daemon protocol fields. Coverage is through existing Rust tests, the two-daemon e2e script, production build, and focused Playwright browser assertions.

## Pre-Landing Review

No issues found in manual pre-landing review. The change keeps `file.list` as the source of provider availability and `fetches` as the local fetch action state; it does not invent delivery or availability states.

## Design Review

Design review focused on the file card actions. The first desktop QA pass found the offline action group squeezing metadata in the right panel; fixed by moving file-row actions into a second grid row. Rechecked desktop and mobile with no horizontal overflow.

## Eval Results

No prompt-related files changed — evals skipped.

## Plan Completion

No plan file detected.

## Verification Results

- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — 56 passed, 1 ignored
- [x] `npm run build` — `tsc --noEmit && vite build`
- [x] `cargo build --release -p jeliyad --features embed-ui`
- [x] `./target/release/jeliyad --version` — `jeliyad 0.4.3`
- [x] `node scripts/e2e.mjs --mode loopback` — 67 assertions green, including file share/list/fetch verified byte-identical
- [x] Playwright desktop Files panel QA — offline file shows `No provider online` + `Recheck`, fetched file shows `Open file` + `Copy path`
- [x] Playwright timeline QA — same file states validated in chat timeline
- [x] Playwright mobile QA at 390x844 — no horizontal overflow

## TODOS

No tracked `TODOS.md` file exists, so no TODO items were updated.

## Test plan

- [x] Verify unavailable file cards do not show `Fetch`.
- [x] Verify fetched file cards show `Open file` and `Copy path`.
- [x] Verify two-daemon file transfer still fetches verified bytes.
- [x] Verify desktop and mobile file layouts remain readable.

Generated with Codex.
