### PR TITLE
fix(dart): locate the test repo root by a checked-in marker, not the built binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `/ws` and `/api/*` refuse requests whose `Host` header is not loopback (DNS-rebinding guard), and `/api/files/local` is no longer reachable without auth.
 - Files fetched from room peers are now served as downloads (`Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, inert content-type) instead of rendered inline, so a peer-supplied `text/html`/`svg` cannot run script in the daemon's origin.
 - Daemon diagnostics moved from bare stderr prints to `tracing` (stderr + rolling file).
+- Three `jeliya_protocol` test files located the repo root via the BUILT `target/debug/jeliyad`, so on an unbuilt checkout (CI, fresh clone) they failed to LOAD before their own `jeliyad not built` skip guard could run — ci.yml's first live run caught it. The repo-root marker is now the checked-in `docs/PROTOCOL.md`; daemon-bound suites skip cleanly without the binary and run in full with it.
 - Fixed the file-fetch UI keying friendly copy on a phantom `provider_refused` code the daemon never emits; the authorization-wall case now correctly handles `file_unauthorized`, and `hash_mismatch` gets an explicit hard-stop message. Aligned the TypeScript wire types (`protocol.ts`) and the mock reference client with the daemon: `daemon.status` gains `protocol`/`pid`/`port`/`data_dir`, `daemon.shutdown` is typed, `room.open` documents its `peers` hints, `invite.create` expiry accepts a string or seconds, and pipe/room fields that can be null are typed nullable (surfacing several latent null-handling fixes in the UI).
 
 ## [0.4.3] - 2026-07-07

--- a/dart/jeliya_protocol/test/daemon_http_test.dart
+++ b/dart/jeliya_protocol/test/daemon_http_test.dart
@@ -11,10 +11,14 @@ import 'dart:io';
 import 'package:jeliya_protocol/jeliya_protocol.dart';
 import 'package:test/test.dart';
 
+/// Walk up to the repo root by a CHECKED-IN marker (docs/PROTOCOL.md), not
+/// the built binary: on an unbuilt checkout (CI, fresh clone) the root must
+/// still resolve so the `jeliyad not built` skip guard below can run —
+/// using the binary as the marker made loading THROW instead of skipping.
 Directory _repoRoot() {
   var dir = Directory.current;
   for (var i = 0; i < 8; i++) {
-    if (File('${dir.path}/target/debug/jeliyad').existsSync()) return dir;
+    if (File('${dir.path}/docs/PROTOCOL.md').existsSync()) return dir;
     final parent = dir.parent;
     if (parent.path == dir.path) break;
     dir = parent;

--- a/dart/jeliya_protocol/test/review_regressions_test.dart
+++ b/dart/jeliya_protocol/test/review_regressions_test.dart
@@ -15,10 +15,14 @@ import 'package:jeliya_protocol/jeliya_protocol.dart';
 import 'package:jeliya_protocol/testing.dart';
 import 'package:test/test.dart';
 
+/// Walk up to the repo root by a CHECKED-IN marker (docs/PROTOCOL.md), not
+/// the built binary: on an unbuilt checkout (CI, fresh clone) the root must
+/// still resolve so the `jeliyad not built` skip guard below can run —
+/// using the binary as the marker made loading THROW instead of skipping.
 Directory _repoRoot() {
   var dir = Directory.current;
   for (var i = 0; i < 8; i++) {
-    if (File('${dir.path}/target/debug/jeliyad').existsSync()) return dir;
+    if (File('${dir.path}/docs/PROTOCOL.md').existsSync()) return dir;
     final parent = dir.parent;
     if (parent.path == dir.path) break;
     dir = parent;

--- a/dart/jeliya_protocol/test/supervisor_test.dart
+++ b/dart/jeliya_protocol/test/supervisor_test.dart
@@ -9,10 +9,14 @@ import 'dart:io';
 import 'package:jeliya_protocol/jeliya_protocol.dart';
 import 'package:test/test.dart';
 
+/// Walk up to the repo root by a CHECKED-IN marker (docs/PROTOCOL.md), not
+/// the built binary: on an unbuilt checkout (CI, fresh clone) the root must
+/// still resolve so the `jeliyad not built` skip guard below can run —
+/// using the binary as the marker made loading THROW instead of skipping.
 Directory _repoRoot() {
   var dir = Directory.current;
   for (var i = 0; i < 8; i++) {
-    if (File('${dir.path}/target/debug/jeliyad').existsSync()) return dir;
+    if (File('${dir.path}/docs/PROTOCOL.md').existsSync()) return dir;
     final parent = dir.parent;
     if (parent.path == dir.path) break;
     dir = parent;


### PR DESCRIPTION
Fixes the 3 load failures in ci.yml's first live run (#12 post-merge).

`daemon_http_test`, `supervisor_test`, and `review_regressions_test` used the **built** `target/debug/jeliyad` as their repo-root marker, so on an unbuilt checkout (CI, fresh clone) `_repoRoot()` threw at load time — before their own `jeliyad not built` skip guards could run. `conformance_test` was immune because its marker is a checked-in file.

The marker is now `docs/PROTOCOL.md`:
- without the binary, the daemon-bound suites **skip** exactly like `conformance_test` (verified locally by hiding the binary: `+5 ~4: All tests passed!`)
- with it, the full 182 still run (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)