### PR TITLE
chore(release): repin iroh-rooms to published cross-room-isolation remediation (v0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms"
-version = "0.1.0"
-source = "git+https://github.com/kortiene/iroh-room?rev=3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020#3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
 dependencies = [
  "iroh",
  "iroh-rooms-core",
@@ -2020,8 +2020,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-core"
-version = "0.1.0"
-source = "git+https://github.com/kortiene/iroh-room?rev=3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020#3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -2034,16 +2034,18 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-net"
-version = "0.1.0"
-source = "git+https://github.com/kortiene/iroh-room?rev=3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020#3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020"
+version = "0.1.0-rc.1"
+source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
 dependencies = [
  "anyhow",
+ "bao-tree",
  "blake3",
  "bytes",
  "hex",
  "iroh",
  "iroh-blobs",
  "iroh-rooms-core",
+ "n0-future",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4072,7 +4074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.91"
 
 [workspace.dependencies]
-# Pinned to the analyzed developer-preview rev; the local ~/TAC/iroh-room
+# Pinned to the reviewed cross-room event-lookup isolation remediation,
+# published on iroh-room main (tag v0.1.0-rc.2). The local ~/TAC/iroh-room
 # working tree is intentionally NOT used (it drifts).
-iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020", features = ["experimental"] }
+iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb", features = ["experimental"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/app/macos/Podfile.lock
+++ b/app/macos/Podfile.lock
@@ -2,12 +2,15 @@ PODS:
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
@@ -15,12 +18,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -8,12 +8,11 @@ description = "Jeliya resident core: the only crate in the project that talks to
 
 [features]
 default = []
-# Publication gate for the diagnostic relay verifier. Until the reviewed
-# upstream feature is published and pinned, this stays intentionally empty;
-# the cfg-gated const assertion in lib.rs then makes an attempted relay build
-# fail closed instead of producing a falsely attested binary. When the pin is
-# available, change this to `["iroh-rooms/relay-only-test"]`.
-relay-only-test = []
+# Publication gate for the diagnostic relay verifier. The reviewed upstream
+# feature is now published and pinned (iroh-room tag v0.1.0-rc.2), so this
+# forwards to it; the cfg-gated const assertion in lib.rs verifies the upstream
+# clear_ip_transports seam is actually active, failing closed otherwise.
+relay-only-test = ["iroh-rooms/relay-only-test"]
 
 [dependencies]
 # The SDK facade (stable tier + experimental online runtime). This crate is the

--- a/release/evidence-ed25519-public.pem
+++ b/release/evidence-ed25519-public.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEADj/isMCMZeedOm4a67o29lY2huG7Ti2s+mqi9Y8Bjkg=
+-----END PUBLIC KEY-----

--- a/scripts/package-macos.mjs
+++ b/scripts/package-macos.mjs
@@ -35,7 +35,6 @@
 import { execFileSync, spawn } from "node:child_process";
 import {
   copyFileSync,
-  cpSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -235,7 +234,11 @@ if (flags.has("--skip-dmg")) {
   const staging = join(dist, ".dmg-staging");
   rmSync(staging, { recursive: true, force: true });
   mkdirSync(staging, { recursive: true });
-  cpSync(appBundle, join(staging, "Jeliya.app"), { recursive: true });
+  // ditto (not fs.cpSync) preserves framework structure verbatim. cpSync
+  // resolves relative symlinks to absolute build-tree paths, which both
+  // un-relocates the bundle (flutter_assets not found on other machines /
+  // once the build tree moves) and unseals the signed frameworks.
+  run("ditto", [appBundle, join(staging, "Jeliya.app")]);
   symlinkSync("/Applications", join(staging, "Applications"));
   dmgPath = join(dist, `Jeliya-v${appVersion}-macos.dmg`);
   rmSync(dmgPath, { force: true });


### PR DESCRIPTION
Network-qualified candidate for the v0.5.0 release evidence.

- **Repin `iroh-rooms` → `d0ceb0b`** (iroh-room tag `v0.1.0-rc.2`): the reviewed cross-room event-lookup isolation fix + compile-time relay-only test seam, now published on iroh-room `main` (patch-identical to the audited hardening commits). `Cargo.lock` refreshed (requested == resolved == d0ceb0b).
- **Forward `relay-only-test` → `iroh-rooms/relay-only-test`** now that the upstream seam exists; the `jeliya-core` const assertion verifies it is actually active (fails closed otherwise). Verified locally: `cargo build --features relay-only-test` compiles.
- **Add the release-evidence Ed25519 public key** (SPKI) for detached-signature verification of the v0.5.0 network evidence (private key stays off-repo/CI).
- Incidental: `package-macos.mjs` uses `ditto` (not `fs.cpSync`) so the DMG bundle stays relocatable; sync `Podfile.lock` (`share_plus`).

Unblocks the v0.5.0 forced-relay verification evidence.