### PR TITLE
test(release): retain historical schema 1 evidence under stable filenames (v0.5.0)

### DIFF
--- a/docs/evidence/v0.5.0/historical-schema1-direct.json
+++ b/docs/evidence/v0.5.0/historical-schema1-direct.json
@@ -1,0 +1,490 @@
+{
+  "schema": 1,
+  "run_id": "20260712T155534Z-d3d9ff69",
+  "started_at_utc": "2026-07-12T15:55:34.597Z",
+  "ended_at_utc": "2026-07-12T16:15:24.346Z",
+  "result": "pass",
+  "certifiable": false,
+  "mode": "remote-real-network",
+  "expected_path": "direct",
+  "source": {
+    "commit": "fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+    "dirty": false,
+    "origin": "git@github.com:kortiene/jeliya.git",
+    "public_source": true,
+    "published_at_origin": false,
+    "iroh_rooms_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+    "iroh_rooms": {
+      "kind": "local-git-url",
+      "source": "file:///tmp/iroh-room-v050-pin",
+      "requested_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+      "resolved_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+      "public_source": false,
+      "local_checkout": {
+        "commit": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+        "dirty": false,
+        "origin": "git@github.com:kortiene/iroh-room.git"
+      },
+      "releaseable": false,
+      "published_at_origin": false
+    },
+    "releaseable": false
+  },
+  "build": {
+    "mode": "from-source",
+    "source_bound": true,
+    "source_snapshot_commit": "fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+    "locked": true,
+    "embedded_ui": {
+      "built_from_source": true,
+      "package_lock_sha256": "e73a1a1eec083a05566a1a1b23f2bc06d4b13c6ed03fc0eb4ce42a6be42c2b92"
+    },
+    "features": [
+      "embed-ui"
+    ],
+    "targets": [
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-musl"
+    ],
+    "commands": [
+      "git archive fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+      "npm ci",
+      "npm run build",
+      "cargo +1.91.0 build --locked --release -p jeliyad --features embed-ui",
+      "cargo +1.91.0 zigbuild --locked --release -p jeliyad --features embed-ui --target x86_64-unknown-linux-musl"
+    ],
+    "toolchain": {
+      "rustc": {
+        "filename": "rustc",
+        "version": "rustc 1.91.0 (f8297e351 2025-10-28)\nbinary: rustc\ncommit-hash: f8297e351a40c1439a467bbbb6879088047f50b3\ncommit-date: 2025-10-28\nhost: x86_64-apple-darwin\nrelease: 1.91.0\nLLVM version: 21.1.2",
+        "sha256": "6af10058cf359759e66dd4401ba9f9898595c63607d41ad0374c113d65ef7eb5"
+      },
+      "cargo": {
+        "filename": "cargo",
+        "version": "cargo 1.91.0 (ea2d97820 2025-10-10)",
+        "sha256": "71f5cf378168db1306f89511ef91862216c5f831135b44ef31b1ec0ae144f9ac"
+      },
+      "node": {
+        "filename": "node",
+        "version": "v22.22.3",
+        "sha256": "edc0e47adde954e891939bb509a62accdad5f6b15f32ec56ed78f9d6b7dd7308"
+      },
+      "npm": {
+        "filename": "npm",
+        "version": "10.9.8",
+        "sha256": "8e5f6f3429f8cdbe693cdc29904e9d5a7b127a494bd15c804bd54c7403bfcbe7"
+      },
+      "zig": {
+        "filename": "zig",
+        "version": "0.15.2",
+        "sha256": "f76ad95c3f2ba6c8fd2ae0337bfb0fedd27e1223183597cfa0ddc517db1d5b20",
+        "expected_sha256": "f76ad95c3f2ba6c8fd2ae0337bfb0fedd27e1223183597cfa0ddc517db1d5b20",
+        "integrity_verified": true
+      },
+      "cargo_zigbuild": {
+        "filename": "cargo-zigbuild",
+        "version": "cargo-zigbuild 0.23.0",
+        "sha256": "c6548e4b05f4c6730795178b7101834626c7d72a9a490ac62b41127f6395676f"
+      },
+      "cargo_build_jobs": 2,
+      "installed_cross_target": "x86_64-unknown-linux-musl"
+    }
+  },
+  "binaries": {
+    "local": {
+      "filename": "jeliyad",
+      "sha256": "d614de6d2573435966293c9595110fc10dd815edab90563b0358643f80b58744",
+      "version": "0.5.0",
+      "relay_only_attested": false
+    },
+    "remote": {
+      "filename": "jeliyad",
+      "sha256": "873bc7932ff5976b010072ff2345fdbf493effc81448d381466908035d41dcab",
+      "expected_version": "0.5.0",
+      "expected_relay_only": false,
+      "execution_validation": "verified independently on every Linux execution host after transfer"
+    }
+  },
+  "hosts": [
+    {
+      "role": "a",
+      "host": "operator-local",
+      "os": "darwin",
+      "architecture": "x64"
+    },
+    {
+      "role": "b",
+      "host": "root@demo1",
+      "os": "Ubuntu 22.04.5 LTS",
+      "architecture": "x86_64",
+      "process_privilege": "dropped-to-unprivileged-system-uid",
+      "binary_validation": {
+        "sha256": "873bc7932ff5976b010072ff2345fdbf493effc81448d381466908035d41dcab",
+        "version": "0.5.0",
+        "execution_uid": "65534",
+        "relay_only_attested": false,
+        "relay_attestation_exit_status": 2
+      }
+    },
+    {
+      "role": "c",
+      "host": "root@demo2",
+      "os": "Ubuntu 22.04.5 LTS",
+      "architecture": "x86_64",
+      "process_privilege": "dropped-to-unprivileged-system-uid",
+      "binary_validation": {
+        "sha256": "873bc7932ff5976b010072ff2345fdbf493effc81448d381466908035d41dcab",
+        "version": "0.5.0",
+        "execution_uid": "65534",
+        "relay_only_attested": false,
+        "relay_attestation_exit_status": 2
+      }
+    }
+  ],
+  "distinct_public_egress": {
+    "evaluated": true,
+    "pairwise": {
+      "operator_to_b": {
+        "status": "different",
+        "family": "ipv4"
+      },
+      "operator_to_c": {
+        "status": "different",
+        "family": "ipv4"
+      },
+      "b_to_c": {
+        "status": "different",
+        "family": "ipv4"
+      }
+    },
+    "all_observed_addresses_different": true,
+    "autonomous_systems": {
+      "operator": "AS11426",
+      "role_b": "AS24940",
+      "role_c": "AS24940"
+    },
+    "distinct_autonomous_system_count": 2,
+    "independent_network_topology_proven": true,
+    "claim": "distinct public egress plus at least two independently resolved BGP origin ASNs; no IP address is persisted"
+  },
+  "assertions": [
+    {
+      "name": "a: identity ready",
+      "result": "pass",
+      "duration_ms": 55
+    },
+    {
+      "name": "b: identity ready",
+      "result": "pass",
+      "duration_ms": 279
+    },
+    {
+      "name": "c: identity ready",
+      "result": "pass",
+      "duration_ms": 256
+    },
+    {
+      "name": "A: room created",
+      "result": "pass",
+      "duration_ms": 17
+    },
+    {
+      "name": "A: room opened",
+      "result": "pass",
+      "duration_ms": 216
+    },
+    {
+      "name": "b: targeted room join",
+      "result": "pass",
+      "duration_ms": 4671
+    },
+    {
+      "name": "b: joined room opened",
+      "result": "pass",
+      "duration_ms": 235
+    },
+    {
+      "name": "A: observes b membership",
+      "result": "pass",
+      "duration_ms": 5
+    },
+    {
+      "name": "c: targeted room join",
+      "result": "pass",
+      "duration_ms": 2581
+    },
+    {
+      "name": "c: joined room opened",
+      "result": "pass",
+      "duration_ms": 194
+    },
+    {
+      "name": "A: observes c membership",
+      "result": "pass",
+      "duration_ms": 4
+    },
+    {
+      "name": "A: direct path settled",
+      "result": "pass",
+      "duration_ms": 4013
+    },
+    {
+      "name": "B: direct path settled",
+      "result": "pass",
+      "duration_ms": 2386
+    },
+    {
+      "name": "C: direct path settled",
+      "result": "pass",
+      "duration_ms": 2397
+    },
+    {
+      "name": "A to B message authored",
+      "result": "pass",
+      "duration_ms": 3
+    },
+    {
+      "name": "B receives A message",
+      "result": "pass",
+      "duration_ms": 271
+    },
+    {
+      "name": "B to A message authored",
+      "result": "pass",
+      "duration_ms": 133
+    },
+    {
+      "name": "A receives B message",
+      "result": "pass",
+      "duration_ms": 4
+    },
+    {
+      "name": "C receives both messages",
+      "result": "pass",
+      "duration_ms": 265
+    },
+    {
+      "name": "C message converges to A and B",
+      "result": "pass",
+      "duration_ms": 281
+    },
+    {
+      "name": "A shares candidate payload",
+      "result": "pass",
+      "duration_ms": 6
+    },
+    {
+      "name": "B lists candidate payload as available",
+      "result": "pass",
+      "duration_ms": 237
+    },
+    {
+      "name": "B fetches and BLAKE3-verifies payload",
+      "result": "pass",
+      "duration_ms": 1027
+    },
+    {
+      "name": "B fetched bytes are byte-identical",
+      "result": "pass",
+      "duration_ms": 857
+    },
+    {
+      "name": "A exposes one-peer pipe",
+      "result": "pass",
+      "duration_ms": 4
+    },
+    {
+      "name": "C pipe gate forwards zero bytes to the target",
+      "result": "pass",
+      "duration_ms": 2871
+    },
+    {
+      "name": "B observes and connects authorized pipe",
+      "result": "pass",
+      "duration_ms": 2411
+    },
+    {
+      "name": "A closes pipe and B observes closure",
+      "result": "pass",
+      "duration_ms": 262
+    },
+    {
+      "name": "B closes live room session",
+      "result": "pass",
+      "duration_ms": 304
+    },
+    {
+      "name": "A authors message while B session is closed",
+      "result": "pass",
+      "duration_ms": 2
+    },
+    {
+      "name": "B reopens and receives the offline message",
+      "result": "pass",
+      "duration_ms": 456
+    },
+    {
+      "name": "B reconnects over direct",
+      "result": "pass",
+      "duration_ms": 3928
+    },
+    {
+      "name": "A seeds isolated foreign-room fixtures",
+      "result": "pass",
+      "duration_ms": 20280
+    },
+    {
+      "name": "B public room-scoped RPCs do not disclose a foreign room ID",
+      "result": "pass",
+      "duration_ms": 2144
+    },
+    {
+      "name": "B local-file HTTP endpoint does not disclose a foreign room ID",
+      "result": "pass",
+      "duration_ms": 245
+    },
+    {
+      "name": "B aggregate reads omit the foreign room and agent projection",
+      "result": "pass",
+      "duration_ms": 282
+    }
+  ],
+  "cleanup": {
+    "completed": true,
+    "processes_stopped": true,
+    "temporary_artifacts_removed": true,
+    "failure_codes": []
+  },
+  "path_observations": {
+    "a": {
+      "expected_identities": 2,
+      "consecutive_observations": 3,
+      "expected_path": "direct"
+    },
+    "b": {
+      "expected_identities": 1,
+      "consecutive_observations": 3,
+      "expected_path": "direct"
+    },
+    "c": {
+      "expected_identities": 1,
+      "consecutive_observations": 3,
+      "expected_path": "direct"
+    }
+  },
+  "functional_evidence": {
+    "file": {
+      "bytes_expected": 262184,
+      "bytes_actual": 262184,
+      "engine_verified": true,
+      "expected_sha256": "7d1ba7caa1dfdab36d253cb51cc89d7568f2bff97526dfac0836488c43b83932",
+      "actual_sha256": "7d1ba7caa1dfdab36d253cb51cc89d7568f2bff97526dfac0836488c43b83932",
+      "sha256_equal": true
+    },
+    "pipe": {
+      "http_status": 200,
+      "bytes": 30,
+      "target_connections": 2,
+      "target_requests": 1,
+      "unauthorized_third_peer": {
+        "local_forwarder_created": true,
+        "response_received": false,
+        "target_connections": 0,
+        "target_requests": 0
+      }
+    },
+    "reconnect": {
+      "session_closed": true,
+      "message_authored_while_closed": true,
+      "offline_message_resynchronized": true,
+      "settled_path": {
+        "expected_identities": 1,
+        "consecutive_observations": 3,
+        "expected_path": "direct"
+      }
+    },
+    "foreign_room_non_disclosure": {
+      "rpc_methods_denied": [
+        "room.open",
+        "room.close",
+        "room.leave",
+        "room.timeline",
+        "room.members",
+        "invite.create",
+        "message.send",
+        "status.post",
+        "file.share",
+        "file.list",
+        "file.fetch",
+        "pipe.expose",
+        "pipe.list",
+        "pipe.connect",
+        "pipe.close",
+        "peers.status",
+        "agent.history"
+      ],
+      "local_file_http_denied": true,
+      "aggregate_reads_filtered": true,
+      "foreign_agent_projection_exercised": true,
+      "foreign_agent_join_attempts": 2,
+      "synchronization_isolation_claimed": false
+    },
+    "multi_peer": {
+      "peers": 3,
+      "convergence_verified": true
+    }
+  },
+  "sanitized_logs": {
+    "policy": "raw daemon logs are transient in run-owned data directories and removed after successful cleanup; retained log summaries store only per-stream line/byte counts and SHA-256 digests",
+    "roles": [
+      {
+        "role": "a",
+        "transport": "local-child",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 561,
+            "sha256": "ff4618d98d89b54f85ef5fbf565f1315987fe34c7306cdd97d5f9375b695f146"
+          },
+          "stderr": {
+            "lines": 75,
+            "bytes": 16181,
+            "sha256": "83fe78e080c890bf93e1aa481a93fc47fe30ab2b6fdc5c3598989d32530fbc79"
+          }
+        }
+      },
+      {
+        "role": "b",
+        "transport": "supervised-ssh",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 404,
+            "sha256": "1aed496d1ac3bed8ad7395dab49477a22e63a2dd2bfac50dedef9e1ca3b3d90d"
+          },
+          "stderr": {
+            "lines": 29,
+            "bytes": 9479,
+            "sha256": "6d924cb476e43631cd1ffac495536aba1c3365d2213e089f53689d9d90b86df4"
+          }
+        }
+      },
+      {
+        "role": "c",
+        "transport": "supervised-ssh",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 404,
+            "sha256": "bef412a89af41f489989eba3ecf2375356562cc76bb4cf1fa2cd4ae82486511a"
+          },
+          "stderr": {
+            "lines": 50,
+            "bytes": 16048,
+            "sha256": "42c307cbd2ad810e23e34745cb216c87d4c2c4bdefa5896b5a3f6a0ea46c2476"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/docs/evidence/v0.5.0/historical-schema1-relay.json
+++ b/docs/evidence/v0.5.0/historical-schema1-relay.json
@@ -1,0 +1,491 @@
+{
+  "schema": 1,
+  "run_id": "20260712T161837Z-f1d9c149",
+  "started_at_utc": "2026-07-12T16:18:37.634Z",
+  "ended_at_utc": "2026-07-12T16:38:54.363Z",
+  "result": "pass",
+  "certifiable": false,
+  "mode": "remote-relay-only-build",
+  "expected_path": "relay",
+  "source": {
+    "commit": "fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+    "dirty": false,
+    "origin": "git@github.com:kortiene/jeliya.git",
+    "public_source": true,
+    "published_at_origin": false,
+    "iroh_rooms_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+    "iroh_rooms": {
+      "kind": "local-git-url",
+      "source": "file:///tmp/iroh-room-v050-pin",
+      "requested_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+      "resolved_revision": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+      "public_source": false,
+      "local_checkout": {
+        "commit": "3702e8cbcd5ac1808791124dd6bc44068be5f822",
+        "dirty": false,
+        "origin": "git@github.com:kortiene/iroh-room.git"
+      },
+      "releaseable": false,
+      "published_at_origin": false
+    },
+    "releaseable": false
+  },
+  "build": {
+    "mode": "from-source",
+    "source_bound": true,
+    "source_snapshot_commit": "fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+    "locked": true,
+    "embedded_ui": {
+      "built_from_source": true,
+      "package_lock_sha256": "e73a1a1eec083a05566a1a1b23f2bc06d4b13c6ed03fc0eb4ce42a6be42c2b92"
+    },
+    "features": [
+      "embed-ui",
+      "relay-only-test"
+    ],
+    "targets": [
+      "x86_64-apple-darwin",
+      "x86_64-unknown-linux-musl"
+    ],
+    "commands": [
+      "git archive fe870c7c5b63f2bf52b031dd1bc8e27e83183be5",
+      "npm ci",
+      "npm run build",
+      "cargo +1.91.0 build --locked --release -p jeliyad --features embed-ui,relay-only-test",
+      "cargo +1.91.0 zigbuild --locked --release -p jeliyad --features embed-ui,relay-only-test --target x86_64-unknown-linux-musl"
+    ],
+    "toolchain": {
+      "rustc": {
+        "filename": "rustc",
+        "version": "rustc 1.91.0 (f8297e351 2025-10-28)\nbinary: rustc\ncommit-hash: f8297e351a40c1439a467bbbb6879088047f50b3\ncommit-date: 2025-10-28\nhost: x86_64-apple-darwin\nrelease: 1.91.0\nLLVM version: 21.1.2",
+        "sha256": "6af10058cf359759e66dd4401ba9f9898595c63607d41ad0374c113d65ef7eb5"
+      },
+      "cargo": {
+        "filename": "cargo",
+        "version": "cargo 1.91.0 (ea2d97820 2025-10-10)",
+        "sha256": "71f5cf378168db1306f89511ef91862216c5f831135b44ef31b1ec0ae144f9ac"
+      },
+      "node": {
+        "filename": "node",
+        "version": "v22.22.3",
+        "sha256": "edc0e47adde954e891939bb509a62accdad5f6b15f32ec56ed78f9d6b7dd7308"
+      },
+      "npm": {
+        "filename": "npm",
+        "version": "10.9.8",
+        "sha256": "8e5f6f3429f8cdbe693cdc29904e9d5a7b127a494bd15c804bd54c7403bfcbe7"
+      },
+      "zig": {
+        "filename": "zig",
+        "version": "0.15.2",
+        "sha256": "f76ad95c3f2ba6c8fd2ae0337bfb0fedd27e1223183597cfa0ddc517db1d5b20",
+        "expected_sha256": "f76ad95c3f2ba6c8fd2ae0337bfb0fedd27e1223183597cfa0ddc517db1d5b20",
+        "integrity_verified": true
+      },
+      "cargo_zigbuild": {
+        "filename": "cargo-zigbuild",
+        "version": "cargo-zigbuild 0.23.0",
+        "sha256": "c6548e4b05f4c6730795178b7101834626c7d72a9a490ac62b41127f6395676f"
+      },
+      "cargo_build_jobs": 2,
+      "installed_cross_target": "x86_64-unknown-linux-musl"
+    }
+  },
+  "binaries": {
+    "local": {
+      "filename": "jeliyad",
+      "sha256": "b8adb7b1e5678a71e70822597d13cc45b99c5c13d8877d7fe703c1218139982f",
+      "version": "0.5.0",
+      "relay_only_attested": true
+    },
+    "remote": {
+      "filename": "jeliyad",
+      "sha256": "fd1cec9254bbb90de591e544d3cbb1b366b398ac17c7da91e08cda2067dc0f75",
+      "expected_version": "0.5.0",
+      "expected_relay_only": true,
+      "execution_validation": "verified independently on every Linux execution host after transfer"
+    }
+  },
+  "hosts": [
+    {
+      "role": "a",
+      "host": "operator-local",
+      "os": "darwin",
+      "architecture": "x64"
+    },
+    {
+      "role": "b",
+      "host": "root@demo1",
+      "os": "Ubuntu 22.04.5 LTS",
+      "architecture": "x86_64",
+      "process_privilege": "dropped-to-unprivileged-system-uid",
+      "binary_validation": {
+        "sha256": "fd1cec9254bbb90de591e544d3cbb1b366b398ac17c7da91e08cda2067dc0f75",
+        "version": "0.5.0",
+        "execution_uid": "65534",
+        "relay_only_attested": true,
+        "relay_attestation_exit_status": 0
+      }
+    },
+    {
+      "role": "c",
+      "host": "root@demo2",
+      "os": "Ubuntu 22.04.5 LTS",
+      "architecture": "x86_64",
+      "process_privilege": "dropped-to-unprivileged-system-uid",
+      "binary_validation": {
+        "sha256": "fd1cec9254bbb90de591e544d3cbb1b366b398ac17c7da91e08cda2067dc0f75",
+        "version": "0.5.0",
+        "execution_uid": "65534",
+        "relay_only_attested": true,
+        "relay_attestation_exit_status": 0
+      }
+    }
+  ],
+  "distinct_public_egress": {
+    "evaluated": true,
+    "pairwise": {
+      "operator_to_b": {
+        "status": "different",
+        "family": "ipv4"
+      },
+      "operator_to_c": {
+        "status": "different",
+        "family": "ipv4"
+      },
+      "b_to_c": {
+        "status": "different",
+        "family": "ipv4"
+      }
+    },
+    "all_observed_addresses_different": true,
+    "autonomous_systems": {
+      "operator": "AS11426",
+      "role_b": "AS24940",
+      "role_c": "AS24940"
+    },
+    "distinct_autonomous_system_count": 2,
+    "independent_network_topology_proven": true,
+    "claim": "distinct public egress plus at least two independently resolved BGP origin ASNs; no IP address is persisted"
+  },
+  "assertions": [
+    {
+      "name": "a: identity ready",
+      "result": "pass",
+      "duration_ms": 54
+    },
+    {
+      "name": "b: identity ready",
+      "result": "pass",
+      "duration_ms": 347
+    },
+    {
+      "name": "c: identity ready",
+      "result": "pass",
+      "duration_ms": 257
+    },
+    {
+      "name": "A: room created",
+      "result": "pass",
+      "duration_ms": 16
+    },
+    {
+      "name": "A: room opened",
+      "result": "pass",
+      "duration_ms": 205
+    },
+    {
+      "name": "b: targeted room join",
+      "result": "pass",
+      "duration_ms": 4253
+    },
+    {
+      "name": "b: joined room opened",
+      "result": "pass",
+      "duration_ms": 210
+    },
+    {
+      "name": "A: observes b membership",
+      "result": "pass",
+      "duration_ms": 3
+    },
+    {
+      "name": "c: targeted room join",
+      "result": "pass",
+      "duration_ms": 1765
+    },
+    {
+      "name": "c: joined room opened",
+      "result": "pass",
+      "duration_ms": 176
+    },
+    {
+      "name": "A: observes c membership",
+      "result": "pass",
+      "duration_ms": 2
+    },
+    {
+      "name": "A: relay path settled",
+      "result": "pass",
+      "duration_ms": 3013
+    },
+    {
+      "name": "B: relay path settled",
+      "result": "pass",
+      "duration_ms": 2431
+    },
+    {
+      "name": "C: relay path settled",
+      "result": "pass",
+      "duration_ms": 2401
+    },
+    {
+      "name": "A to B message authored",
+      "result": "pass",
+      "duration_ms": 4
+    },
+    {
+      "name": "B receives A message",
+      "result": "pass",
+      "duration_ms": 257
+    },
+    {
+      "name": "B to A message authored",
+      "result": "pass",
+      "duration_ms": 131
+    },
+    {
+      "name": "A receives B message",
+      "result": "pass",
+      "duration_ms": 3
+    },
+    {
+      "name": "C receives both messages",
+      "result": "pass",
+      "duration_ms": 293
+    },
+    {
+      "name": "C message converges to A and B",
+      "result": "pass",
+      "duration_ms": 280
+    },
+    {
+      "name": "A shares candidate payload",
+      "result": "pass",
+      "duration_ms": 7
+    },
+    {
+      "name": "B lists candidate payload as available",
+      "result": "pass",
+      "duration_ms": 132
+    },
+    {
+      "name": "B fetches and BLAKE3-verifies payload",
+      "result": "pass",
+      "duration_ms": 1109
+    },
+    {
+      "name": "B fetched bytes are byte-identical",
+      "result": "pass",
+      "duration_ms": 820
+    },
+    {
+      "name": "A exposes one-peer pipe",
+      "result": "pass",
+      "duration_ms": 5
+    },
+    {
+      "name": "C pipe gate forwards zero bytes to the target",
+      "result": "pass",
+      "duration_ms": 2428
+    },
+    {
+      "name": "B observes and connects authorized pipe",
+      "result": "pass",
+      "duration_ms": 2481
+    },
+    {
+      "name": "A closes pipe and B observes closure",
+      "result": "pass",
+      "duration_ms": 781
+    },
+    {
+      "name": "B closes live room session",
+      "result": "pass",
+      "duration_ms": 285
+    },
+    {
+      "name": "A authors message while B session is closed",
+      "result": "pass",
+      "duration_ms": 3
+    },
+    {
+      "name": "B reopens and receives the offline message",
+      "result": "pass",
+      "duration_ms": 472
+    },
+    {
+      "name": "B reconnects over relay",
+      "result": "pass",
+      "duration_ms": 3544
+    },
+    {
+      "name": "A seeds isolated foreign-room fixtures",
+      "result": "pass",
+      "duration_ms": 21738
+    },
+    {
+      "name": "B public room-scoped RPCs do not disclose a foreign room ID",
+      "result": "pass",
+      "duration_ms": 2202
+    },
+    {
+      "name": "B local-file HTTP endpoint does not disclose a foreign room ID",
+      "result": "pass",
+      "duration_ms": 253
+    },
+    {
+      "name": "B aggregate reads omit the foreign room and agent projection",
+      "result": "pass",
+      "duration_ms": 280
+    }
+  ],
+  "cleanup": {
+    "completed": true,
+    "processes_stopped": true,
+    "temporary_artifacts_removed": true,
+    "failure_codes": []
+  },
+  "path_observations": {
+    "a": {
+      "expected_identities": 2,
+      "consecutive_observations": 3,
+      "expected_path": "relay"
+    },
+    "b": {
+      "expected_identities": 1,
+      "consecutive_observations": 3,
+      "expected_path": "relay"
+    },
+    "c": {
+      "expected_identities": 1,
+      "consecutive_observations": 3,
+      "expected_path": "relay"
+    }
+  },
+  "functional_evidence": {
+    "file": {
+      "bytes_expected": 262184,
+      "bytes_actual": 262184,
+      "engine_verified": true,
+      "expected_sha256": "04a10339cd627cd4510560e8d3d8c074efe1e7ac67a0d419086bd9fd7382f997",
+      "actual_sha256": "04a10339cd627cd4510560e8d3d8c074efe1e7ac67a0d419086bd9fd7382f997",
+      "sha256_equal": true
+    },
+    "pipe": {
+      "http_status": 200,
+      "bytes": 30,
+      "target_connections": 2,
+      "target_requests": 1,
+      "unauthorized_third_peer": {
+        "local_forwarder_created": true,
+        "response_received": false,
+        "target_connections": 0,
+        "target_requests": 0
+      }
+    },
+    "reconnect": {
+      "session_closed": true,
+      "message_authored_while_closed": true,
+      "offline_message_resynchronized": true,
+      "settled_path": {
+        "expected_identities": 1,
+        "consecutive_observations": 3,
+        "expected_path": "relay"
+      }
+    },
+    "foreign_room_non_disclosure": {
+      "rpc_methods_denied": [
+        "room.open",
+        "room.close",
+        "room.leave",
+        "room.timeline",
+        "room.members",
+        "invite.create",
+        "message.send",
+        "status.post",
+        "file.share",
+        "file.list",
+        "file.fetch",
+        "pipe.expose",
+        "pipe.list",
+        "pipe.connect",
+        "pipe.close",
+        "peers.status",
+        "agent.history"
+      ],
+      "local_file_http_denied": true,
+      "aggregate_reads_filtered": true,
+      "foreign_agent_projection_exercised": true,
+      "foreign_agent_join_attempts": 2,
+      "synchronization_isolation_claimed": false
+    },
+    "multi_peer": {
+      "peers": 3,
+      "convergence_verified": true
+    }
+  },
+  "sanitized_logs": {
+    "policy": "raw daemon logs are transient in run-owned data directories and removed after successful cleanup; retained log summaries store only per-stream line/byte counts and SHA-256 digests",
+    "roles": [
+      {
+        "role": "a",
+        "transport": "local-child",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 561,
+            "sha256": "2301d672870a2a8eb34f58744d6d9400e50d5c40dc30a4a458c1a35b80dd63bb"
+          },
+          "stderr": {
+            "lines": 71,
+            "bytes": 15133,
+            "sha256": "609bbedf33e56af3a04b1a59529df779a6e0352adf30b8d036f4f0329e8debd8"
+          }
+        }
+      },
+      {
+        "role": "b",
+        "transport": "supervised-ssh",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 404,
+            "sha256": "50e1971243a5cb02aba3851b1c3143f97f08c40be53544a6e550b1aa668959d0"
+          },
+          "stderr": {
+            "lines": 27,
+            "bytes": 8999,
+            "sha256": "0b30b23c9a9581daac285028bf69fda85a41f5bd37f6a464d3b9c207a42b8628"
+          }
+        }
+      },
+      {
+        "role": "c",
+        "transport": "supervised-ssh",
+        "streams": {
+          "stdout": {
+            "lines": 2,
+            "bytes": 404,
+            "sha256": "fb2cf9178f15145c42aa3ee0c8473e261150891c85af0229a50729458223a2b1"
+          },
+          "stderr": {
+            "lines": 47,
+            "bytes": 15922,
+            "sha256": "c7f7c0d4d0ede3cebe8308ae89ce2d6f9f73dee20dad35597e2344c4fee39197"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/scripts/check-release.test.mjs
+++ b/scripts/check-release.test.mjs
@@ -554,13 +554,16 @@ test("certifying network evidence has a closed, secret-free schema", () => {
   }
 });
 
-test("retained local network evidence remains explicitly non-certifying", () => {
+test("retained historical schema 1 network evidence remains explicitly non-certifying", () => {
   const verificationDoc = readFileSync(
     new URL("../docs/verification-evidence.md", import.meta.url),
     "utf8",
   );
+  // The certifying direct.json/relay.json are validated by the release gate
+  // (check-release --publish). The retained historical schema 1 manifests keep
+  // their own filenames so this guard proves they stay honestly non-certifying.
   for (const path of ["direct", "relay"]) {
-    const manifestUrl = new URL(`../docs/evidence/v0.5.0/${path}.json`, import.meta.url);
+    const manifestUrl = new URL(`../docs/evidence/v0.5.0/historical-schema1-${path}.json`, import.meta.url);
     const contents = readFileSync(manifestUrl);
     const manifest = JSON.parse(contents);
     assert.equal(manifest.certifiable, false);


### PR DESCRIPTION
Network-qualified commit for the v0.5.0 release evidence re-run.

The release will replace `docs/evidence/v0.5.0/{direct,relay}.json` with the certifying schema 2 manifests that `check-release --publish` validates. This preserves the prior schema 1 local-remediation manifests as `historical-schema1-{direct,relay}.json` and repoints the `retained ... non-certifying` guard at them, so it keeps proving the historical evidence stays honestly non-certifying without colliding with the certifying set.

Non-docs test change lands here (the network-qualified commit) so the subsequent evidence commit can be docs-only. The certifying direct+relay runs will be re-recorded against this commit.