### PR TITLE
fix(release): pass --repo to gh release create in the publish job

### DIFF
--- a/scripts/finalize-release.sh
+++ b/scripts/finalize-release.sh
@@ -124,7 +124,12 @@ gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
   -f sha="$GITHUB_SHA" \
   >/dev/null
 created_tag=1
+# `gh release create` is the only gh call here that does not take an explicit
+# `repos/<owner>/<repo>` path, so it must be told the repository: the publish
+# job has no working-tree checkout, and without --repo gh tries to resolve the
+# repository from local git and fails with "not a git repository".
 gh release create "$tag" "${assets[@]}" \
+  --repo "${GITHUB_REPOSITORY}" \
   --verify-tag \
   --target "$GITHUB_SHA" \
   --title "Jeliya $tag — Evidence-Backed Technical Preview" \


### PR DESCRIPTION
The publish job runs `finalize-release.sh` from a working directory that is **not** a git checkout (it only fetches the verification source into a subdir). Every other `gh` call uses an explicit `repos/${GITHUB_REPOSITORY}/...` path, but `gh release create` inferred the repo from local git and failed with `fatal: not a git repository` — **after** creating the tag.

Fix: pass `--repo "${GITHUB_REPOSITORY}"` to `gh release create`.

Surfaced while cutting **v0.5.0**: the run built, validated, sealed, and smoked all assets and created the tag, then failed at this line. v0.5.0 was recovered by publishing the sealed asset set directly. This unblocks the publish step for the next release.