### PR TITLE
Repin iroh-rooms to v0.1.0-rc.3 with the join capability proof; Linux Flutter app + packaging gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,110 @@ jobs:
             :app:processDebugMainManifest \
             --no-daemon
 
+  linux-flutter:
+    name: Linux Flutter app + bundled sidecar
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Linux desktop build and smoke dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            appstream \
+            clang \
+            cmake \
+            desktop-file-utils \
+            libgtk-3-dev \
+            liblzma-dev \
+            libstdc++-12-dev \
+            ninja-build \
+            pkg-config \
+            xauth \
+            xvfb
+
+      - name: Setup Rust 1.96.0
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: 1.96.0
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.2
+        with:
+          key: linux-flutter-sidecar
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.22.3'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: 3.41.5
+          cache: true
+
+      - name: Verify Linux packaging helpers
+        run: node --test scripts/package-linux.test.mjs
+
+      # The packaging gate builds both release binaries, injects jeliyad through
+      # the Linux CMake sidecar contract, and launches the resulting app under
+      # Xvfb to prove supervised startup and teardown without assuming a display.
+      - name: Build and exercise the source-supported Linux bundle
+        run: |
+          set -euo pipefail
+          flutter config --enable-linux-desktop
+          xvfb-run -a node scripts/package-linux.mjs
+
+      - name: Verify the Linux bundle and source-package contract
+        run: |
+          set -euo pipefail
+          bundle=app/build/linux/x64/release/bundle
+          version="$(sed -n 's/^version: *\([0-9][0-9.]*\).*/\1/p' app/pubspec.yaml)"
+          archive="dist/Jeliya-v${version}-linux-x86_64.tar.gz"
+          checksum="${archive}.sha256"
+
+          test -n "$version"
+          test -x "$bundle/jeliya"
+          test -x "$bundle/jeliyad"
+          test -s "$archive"
+          test -s "$checksum"
+          test -z "$(git status --porcelain -- app/pubspec.lock app/linux/flutter)"
+
+          "$bundle/jeliyad" --version
+          node scripts/smoke.mjs "$bundle/jeliyad"
+
+          ldd "$bundle/jeliya" | tee "$RUNNER_TEMP/jeliya-linux-ldd.txt"
+          # `! grep` would be exempt from errexit mid-script (SC2251); test the
+          # match explicitly so an unresolved library genuinely fails the step.
+          if grep -F 'not found' "$RUNNER_TEMP/jeliya-linux-ldd.txt"; then
+            echo 'unresolved shared library in the release bundle' >&2
+            exit 1
+          fi
+          desktop-file-validate \
+            "$bundle/share/applications/com.incubtek.jeliya.desktop"
+          appstreamcli validate --no-net \
+            "$bundle/share/metainfo/com.incubtek.jeliya.metainfo.xml"
+
+          tar -tzf "$archive" > "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          grep -Eq '(^|/)jeliya$' "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          grep -Eq '(^|/)jeliyad$' "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          grep -Eq '(^|/)share/applications/com\.incubtek\.jeliya\.desktop$' \
+            "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          grep -Eq '(^|/)share/doc/jeliya/LICENSE-APACHE$' \
+            "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          grep -Eq '(^|/)share/doc/jeliya/LICENSE-MIT$' \
+            "$RUNNER_TEMP/jeliya-linux-archive.txt"
+          (
+            cd dist
+            sha256sum -c "$(basename "$checksum")"
+          )
+
   rust-runtime:
     name: Rust + Dart + smoke + E2E + protocol conformance
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Repinned `iroh-rooms` from the `v0.5.0`-certified `d0ceb0b…` (rc.2-era) to
+  the published `v0.1.0-rc.3` tag
+  (`71fbb5007bef4ce83631c94762ec68c2beef3d79`). On top of the isolation
+  remediation and relay seam the certified pin already carried, rc.3 brings
+  the join-after-conversation deadlock fix (upstream PR #111 — at `d0ceb0b`,
+  and therefore in released `v0.5.0`, an invite minted after any non-admin
+  chat can never complete `room.join`), the join-bootstrap capability gate
+  (PRs #117/#120), size-independent membership reconciliation (PR #118, no
+  more ~30k-event ceiling), and deep pure-chat gap healing (PR #116).
+  `room.join` now presents the invite's capability proof
+  (`Node::spawn_join_bootstrap` with `BootstrapProof`); without it an rc.3
+  admin never serves the join bootstrap. Mixed-fleet caution: an rc.3 joiner
+  bootstrapping from a `v0.5.0`-era responder hard-stalls once it holds more
+  than ~1k events, and a `v0.5.0`-era joiner cannot bootstrap from an rc.3
+  admin (it sends no proof) — members of a room, especially its admin, must
+  upgrade together. The certified `v0.5.0` network evidence binds `d0ceb0b`
+  and does not transfer to this candidate; fresh certifying runs are required
+  before the next release.
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,13 @@ declined kindly.
   the contract.
 - **Prove it runs.** `node scripts/agent-e2e.mjs` proves the agent flow
   end-to-end with no network and no AI; `scripts/demo.sh` runs the full
-  two-daemon demo. Say in the PR what you ran. CI runs six required jobs on
-  every PR and push to main: `docs-ui`, `flutter`, `rust-runtime`, `msrv`,
-  `windows-installer`, and `dependency-security`. Together they cover docs,
-  UI, Flutter/i18n, Rust and Dart, smoke/E2E/protocol conformance, the 1.91.0
-  MSRV, Windows installer integrity, and Cargo/npm security audits. The same
-  complete matrix can be dispatched manually without publishing a release.
+  two-daemon demo. Say in the PR what you ran. CI runs seven required jobs on
+  every PR and push to main: `docs-ui`, `flutter`, `linux-flutter`,
+  `rust-runtime`, `msrv`, `windows-installer`, and `dependency-security`.
+  Together they cover docs, UI, Flutter/i18n, the native Linux bundle and its
+  supervised sidecar, Rust and Dart, smoke/E2E/protocol conformance, the
+  1.91.0 MSRV, Windows installer integrity, and Cargo/npm security audits.
+  The same complete matrix can be dispatched manually without publishing a release.
 - **Documentation is a contract.** `docs/PROFILE.md` defines metadata,
   lifecycle, navigation, and linking rules. Every page must remain reachable
   from `docs/index.md`; run `node scripts/check-docs.mjs` after editing the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,8 +2011,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms"
-version = "0.1.0-rc.1"
-source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
+version = "0.1.0-rc.3"
+source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
 dependencies = [
  "iroh",
  "iroh-rooms-core",
@@ -2021,8 +2021,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-core"
-version = "0.1.0-rc.1"
-source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
+version = "0.1.0-rc.3"
+source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -2035,8 +2035,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-net"
-version = "0.1.0-rc.1"
-source = "git+https://github.com/kortiene/iroh-room?rev=d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb#d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb"
+version = "0.1.0-rc.3"
+source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.91"
 
 [workspace.dependencies]
-# Pinned to the reviewed cross-room event-lookup isolation remediation,
-# published on iroh-room main (tag v0.1.0-rc.2). The local ~/TAC/iroh-room
-# working tree is intentionally NOT used (it drifts).
-iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb", features = ["experimental"] }
+# Pinned to the published v0.1.0-rc.3 tag commit (carries the cross-room
+# isolation remediation, relay seam, join-after-conversation fix, and the
+# join-bootstrap capability gate). The local ~/TAC/iroh-room working tree is
+# intentionally NOT used (it drifts).
+iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "71fbb5007bef4ce83631c94762ec68c2beef3d79", features = ["experimental"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -166,21 +166,28 @@ jeliyad --version       # print the version
 
 ### What about a native desktop app?
 
-There's one in the repo: `app/` is a native Flutter macOS app at feature
-parity with the web UI, fully localized in English and French, with a signed,
-sandboxed packaging pipeline (`scripts/package-macos.mjs`, which emits a DMG —
-ad-hoc signed until Apple Developer enrollment completes). **No app release
-has been published yet** — every release so far ships only the `jeliyad`
-daemon — so installing today means the daemon above plus the browser UI.
+There's one in the repo: `app/` is a native Flutter desktop app for macOS and
+Linux at feature parity with the web UI, fully localized in English and
+French. macOS has a signed, sandboxed packaging pipeline
+(`scripts/package-macos.mjs`, which emits a DMG — ad-hoc signed until Apple
+Developer enrollment completes). Linux has a GTK host and a source packaging
+pipeline that builds a path-relocatable bundle with its supervised `jeliyad`
+sidecar; CI is configured to compile and inspect that bundle on Linux x86_64.
+
+**No native app release has been published yet** — every release so far ships
+only the `jeliyad` daemon — so installing today means the daemon above plus
+the browser UI. The Linux app is source-supported, not a downloadable app
+artifact. Build and packaging instructions are in
+[`app/README.md`](app/README.md).
+
 `app/` also runs on phones: below 900dp it lays out as a bottom-tab mobile
 app, and the Android build speaks the real protocol through an in-process
 (FFI) engine. A physical Android 13 smoke covered engine startup, local room
 operations, pushes, persistence, and the mobile UI with the engine configured
 for real networking. It did not connect that phone to a peer on another
 network or observe a direct or relay path, so Android cross-network behavior
-is not yet verified. The macOS app still runs its bundled sidecar
-loopback-only. Android release builds (store bundle and per-ABI sideload APKs)
-are wired and documented in
+is not yet verified. Android release builds (store bundle and per-ABI sideload
+APKs) are wired and documented in
 [`packaging/README.md`](packaging/README.md), but no APK or app bundle has
 been published either.
 
@@ -381,8 +388,8 @@ the app is a *fold* (a replay) over Iroh Rooms' signed event log.
 | `crates/jeliyad` | The resident daemon: a thin local-only WebSocket shell over the `jeliya-core` engine (see `docs/PROTOCOL.md`). |
 | `crates/jeliya-ffi` | C-ABI shim over `jeliya-core` for the mobile in-process (FFI) transport. |
 | `dart/jeliya_protocol` | Pure-Dart typed client for the protocol: typed models + wrappers for all 24 RPCs, WebSocket and in-process FFI transports (`package:jeliya_protocol/ffi.dart`), sidecar supervisor, mock client for tests. |
-| `app/` | The native Flutter app: the macOS desktop client at parity with the web UI (English + French), plus a phone bottom-tab layout below 900dp and the Android build running the protocol in-process (FFI). |
-| `ui/` | The web UI the daemon serves (`embed-ui`): Vite + React, implements `mockups/`. Still the only GUI on Windows/Linux, and the reference client the native app tracks. |
+| `app/` | The native Flutter app: macOS and Linux desktop clients at parity with the web UI (English + French), plus a phone bottom-tab layout below 900dp and the Android build running the protocol in-process (FFI). Linux is buildable from source but has no published app artifact. |
+| `ui/` | The web UI the daemon serves (`embed-ui`): Vite + React, implements `mockups/`. It remains the only GUI shipped in Windows and Linux releases, and the reference client the native app tracks. |
 | `docs/index.md` | The canonical documentation wiki: architecture, guides, operations, decisions, and proposals. |
 | `docs/PROFILE.md` | The metadata, lifecycle, navigation, linking, and CI contract for every wiki page. |
 | `docs/PROTOCOL.md` | The daemon ⇄ shell contract (the spine). |

--- a/app/.metadata
+++ b/app/.metadata
@@ -18,6 +18,9 @@ migration:
     - platform: android
       create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
       base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+    - platform: linux
+      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
 
   # User provided section
 

--- a/app/README.md
+++ b/app/README.md
@@ -1,9 +1,10 @@
 # Jeliya app (Flutter)
 
-The native shell for Jeliya on desktop and phones. On macOS it spawns (or
-adopts) the local `jeliyad` daemon as a supervised sidecar; on Android it runs
-the Rust engine in-process behind `FfiClient` (phones cannot spawn a sidecar
-subprocess). Both transports sit behind the transport-agnostic Dart client in
+The native shell for Jeliya on desktop and phones. On macOS and Linux it
+spawns (or adopts) the local `jeliyad` daemon as a supervised sidecar; on
+Android it runs the Rust engine in-process behind `FfiClient` (phones cannot
+spawn a sidecar subprocess). Both transports sit behind the
+transport-agnostic Dart client in
 [`../dart/jeliya_protocol`](../dart/jeliya_protocol). UI parity target is the
 reference web client in [`../ui`](../ui) (spec: `docs/PROTOCOL.md`): the
 three-pane desktop layout at or above 900dp, a bottom-tab mobile shell below.
@@ -14,7 +15,15 @@ runs today.
 
 - **Rust toolchain + `cargo build`** at the repo root — the app supervises the
   `jeliyad` binary; debug runs pick up `target/debug/jeliyad` automatically.
-- **Flutter** (stable channel) with macOS desktop support enabled.
+- **Flutter** (stable channel) with the desktop target for your host enabled.
+
+Linux additionally needs Flutter's GTK build toolchain. On Debian/Ubuntu:
+
+```sh
+sudo apt-get install appstream clang cmake desktop-file-utils libgtk-3-dev \
+  liblzma-dev libstdc++-12-dev ninja-build pkg-config
+flutter config --enable-linux-desktop
+```
 
 Android builds additionally need (all consumed by
 `../scripts/build-android-libs.mjs`):
@@ -37,6 +46,14 @@ cd app
 flutter run -d macos
 ```
 
+### Linux
+
+```sh
+cargo build -p jeliyad       # from the repo root
+cd app
+flutter run -d linux
+```
+
 ### Android
 
 ```sh
@@ -50,27 +67,38 @@ Gradle packages automatically — re-run the script after Rust-side changes.
 There is no daemon process on Android: the app starts the engine in-process
 and talks to it over `FfiClient`.
 
-### Daemon binary resolution (macOS)
+### Daemon binary resolution (desktop)
 
 1. `JELIYAD_BIN=/path/to/jeliyad` environment override — the dev lever; wins
    over everything.
-2. Bundled sidecar next to the app executable
-   (`Contents/Resources/jeliyad`, `Contents/Helpers/jeliyad`) — the packaged
-   path (Phase 5).
+2. Bundled sidecar next to the app executable: macOS searches
+   `Contents/Resources/jeliyad` and `Contents/Helpers/jeliyad`; Linux searches
+   the release bundle's adjacent `jeliyad` installed by CMake, then
+   `$exeDir/../lib/jeliya/jeliyad` for distro-style layouts.
 3. Debug builds only: the repo's `target/debug/jeliyad`.
+4. Linux only: an installed `jeliyad` found on `PATH`, as a last resort after
+   bundle- and repo-matched binaries.
 
 ### Data directory
 
 - `JELIYA_DATA_DIR=/path` environment override (desktop only) — test
-  automation and side-by-side profiles (takes precedence over both macOS
-  defaults below; note the sandboxed release app can only write inside its
-  container and the shared Jeliya dir, so arbitrary override paths only work
-  in debug builds).
+  automation and side-by-side profiles (takes precedence over the macOS and
+  Linux defaults below; note the sandboxed macOS release app can only write
+  inside its container and the shared Jeliya dir, so arbitrary override paths
+  only work in macOS debug builds).
 - macOS release: `~/Library/Application Support/Jeliya` — deliberately SHARED
   with a Homebrew-installed `jeliyad` (one identity and room store per user),
   reached from inside the sandbox via the exception in `Release.entitlements`.
 - macOS debug: `~/Library/Application Support/JeliyaAppDev` (dev runs never
   touch real user data)
+- Linux release: `$XDG_DATA_HOME/Jeliya` when `XDG_DATA_HOME` is absolute,
+  otherwise `$HOME/.local/share/Jeliya` — shared with a separately installed
+  `jeliyad`; a relative `XDG_DATA_HOME` is ignored per the XDG base-directory
+  contract.
+- Linux debug: `$XDG_DATA_HOME/JeliyaAppDev` when that base is absolute,
+  otherwise `$HOME/.local/share/JeliyaAppDev` (dev runs never touch real user
+  data). If neither `XDG_DATA_HOME` nor `HOME` supplies an absolute base, the
+  app fails closed instead of placing identity state in a shared temp path.
 - Android: app preferences use the platform app-support directory; the
   in-process engine (including `identity.secret`) lives under the native
   `noBackupFilesDir/engine`. The manifest disables backup and explicit API
@@ -87,19 +115,17 @@ application sandbox and no-backup storage protect the file-backed key today;
 hardware-backed Keystore wrapping requires a future Rust key-provider
 contract and is not claimed by this preview.
 
-### Loopback dev mode (macOS)
+### Desktop network mode and lifecycle
 
-The app currently starts the daemon with `--loopback`: single-machine
-networking for development. The daemon is spawned `--supervised`, so it exits
-when the app dies (stdin watch) even if graceful teardown never runs; Cmd-Q
-additionally runs the graceful order `client.stop()` →
+Linux starts its sidecar with real networking enabled (`loopback: false`);
+macOS remains loopback-only for development. Both desktop targets spawn the
+daemon with `--supervised`, so it exits when the app dies (stdin watch) even if
+graceful teardown never runs. An orderly app exit runs `client.stop()` before
 `supervisor.shutdown()`.
 
-This is a configuration asymmetry today: the Android build constructs its
-in-process engine with `loopback: false`, while the desktop sidecar stays
-loopback-only. The Android setting enables the real network path; it is not
-evidence of direct, relay, NAT, or cross-network behavior, which remains
-unverified on Android.
+The Linux setting enables the real network path; it is not by itself evidence
+of direct, relay, NAT, or cross-network behavior. The same evidence boundary
+applies to Android, whose in-process engine also uses `loopback: false`.
 
 ## Tests
 
@@ -116,7 +142,13 @@ overflow list is empty. The package suite replays the golden conformance
 corpus against the built daemon and the in-process FFI engine, and skips those
 oracles cleanly when the artifacts are missing.
 
-## Packaging (Phase 5)
+## Desktop packaging (source only)
+
+No native desktop artifact has been published. These commands produce local
+developer artifacts; the current release workflow publishes only `jeliyad`
+with its embedded browser UI.
+
+### macOS
 
 ```sh
 node scripts/package-macos.mjs        # from the repo root
@@ -142,11 +174,41 @@ Android release artifacts (the Play `.aab` and the per-ABI sideload APKs) are
 documented in [`../packaging/README.md`](../packaging/README.md) under
 "Android release builds".
 
+### Linux
+
+```sh
+node scripts/package-linux.mjs        # from the repo root; run on Linux
+```
+
+This builds a release `jeliyad` and Flutter app for the host architecture,
+installs the sidecar next to the `jeliya` executable through the CMake bundle
+contract, checks required libraries and desktop metadata, and runs a
+launch/health/authenticated-bootstrap/rendered-frame/teardown gate. The gate
+needs a display; CI supplies one with `xvfb-run`. It emits:
+
+```text
+dist/Jeliya-v<version>-linux-<x86_64|aarch64>.tar.gz
+dist/Jeliya-v<version>-linux-<x86_64|aarch64>.tar.gz.sha256
+```
+
+Use `--skip-build` only to repackage an existing release bundle, or
+`--skip-runtime-gate` when a graphical display is genuinely unavailable. The
+default path keeps the lifecycle check enabled. The archive is path-relocatable
+on a compatible GTK/glibc host, but it is an unsigned, source-built developer
+artifact: CI verifies it and does not upload or publish it. The complete
+default package gate, bundled daemon smoke, dependency checks, archive
+checksum, and reproducible repack have passed locally on Ubuntu 24.04 ARM64
+under X11/Xvfb; the x86_64 hosted result and Wayland lifecycle remain pending.
+The local daemon currently requires GLIBC 2.39, and the tarball includes the
+project licenses plus Flutter/Dart notices but not a complete Rust dependency
+license inventory. A public distribution must define a compatibility baseline
+and supply that inventory.
+
 ## Layout
 
 - `lib/main.dart` — thin entry: theme + `SessionScope` + phase routing, plus
-  the per-platform session fork (desktop spawns/adopts the sidecar; Android
-  builds the `FfiClient` session over the in-process engine).
+  the per-platform session fork (macOS/Linux spawn or adopt the sidecar;
+  Android builds the `FfiClient` session over the in-process engine).
 - `lib/src/layout.dart` — the ONE form-factor seam: `kShellBreakpoint`
   (900dp) / `isMobileWidth`; every width fork in the app routes through it.
 - `lib/src/theme.dart` — the design tokens (`JeliyaTokens`) ported from the
@@ -173,6 +235,12 @@ macOS notes: minimum window size is 960x620 (`MainFlutterWindow.swift`);
 debug builds keep the sandbox OFF so they can spawn the repo-built daemon;
 release builds are sandboxed with the co-signed bundled sidecar (see
 `Release.entitlements` / `Sidecar.entitlements`).
+
+Linux notes: application ID `com.incubtek.jeliya`; the CMake install bundle
+contains the `jeliya` executable, adjacent `jeliyad`, and freedesktop desktop
+entry, AppStream metadata, and scalable icon. Linux is source-supported on the
+host architecture; the configured hosted gate currently covers x86_64, and
+no AppImage, Flatpak, deb, rpm, or native Linux release asset is published.
 
 Android notes: applicationId `com.incubtek.jeliya`, minSdk 26, three ABIs
 (armeabi-v7a is required — real target devices run 32-bit-only Android);

--- a/app/lib/src/session/daemon_session.dart
+++ b/app/lib/src/session/daemon_session.dart
@@ -19,6 +19,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' show AppExitResponse;
 
@@ -62,31 +63,106 @@ enum BootstrapPhase { boot, noIdentity, noRooms, ready }
 typedef ClientFactory = Client Function(WsUrlResolver resolveUrl);
 
 /// Resolve the jeliyad binary: `JELIYAD_BIN` env override → bundled sidecar
-/// (next to the app executable) → debug-only repo fallback. Null when nothing
-/// is found ([DaemonSession] surfaces this as a [Boot.failed] with a hint).
-String? resolveJeliyadBinary() {
-  final env = Platform.environment['JELIYAD_BIN'];
-  if (env != null && env.isNotEmpty) return env;
-  // Bundled: Jeliya.app/Contents/MacOS/<exe> → Contents/{Resources,Helpers}.
-  final exeDir = File(Platform.resolvedExecutable).parent.path;
-  for (final candidate in [
-    '$exeDir/../Resources/jeliyad',
-    '$exeDir/../Helpers/jeliyad',
-    '$exeDir/jeliyad',
-  ]) {
-    if (File(candidate).existsSync()) return candidate;
+/// (next to the app executable) → debug-only repo fallback → an installed
+/// `jeliyad` on Linux's `PATH`. Null when nothing is found
+/// ([DaemonSession] surfaces this as a [Boot.failed] with a hint).
+String? resolveJeliyadBinary() => resolveJeliyadBinaryFrom(
+  environment: Platform.environment,
+  resolvedExecutable: Platform.resolvedExecutable,
+  currentDirectory: Directory.current.path,
+  debugMode: kDebugMode,
+  isLinux: Platform.isLinux,
+  fileExists: _isRegularFile,
+  fileIsExecutable: _isExecutableFile,
+);
+
+bool _isRegularFile(String path) {
+  try {
+    return FileStat.statSync(path).type == FileSystemEntityType.file;
+  } on FileSystemException {
+    return false;
   }
-  if (kDebugMode) {
+}
+
+bool _isExecutableFile(String path) {
+  try {
+    final stat = FileStat.statSync(path);
+    if (stat.type != FileSystemEntityType.file) return false;
+    // Linux and macOS both require at least one execute bit before exec(2) can
+    // use a candidate. Windows has no corresponding permission bits.
+    if (!Platform.isWindows && stat.mode & 0x49 == 0) return false;
+    // FileStat cannot see ownership, so exec bits alone cannot prove THIS user
+    // may run the file — a root-only 0700 binary still shows an owner-exec
+    // bit. Probing read access rejects such entries so the PATH scan keeps
+    // trying later candidates instead of returning one exec(2) must refuse.
+    File(path).openSync().closeSync();
+    return true;
+  } on FileSystemException {
+    return false;
+  }
+}
+
+/// Pure binary-resolution seam used by platform tests. The bundle candidates
+/// deliberately precede both developer and system fallbacks: a packaged app
+/// must run the sidecar it shipped and was tested with, not an unrelated
+/// `jeliyad` installed on the host. To honor that, bundle and repo candidates
+/// resolve on EXISTENCE ([fileExists]) — a shipped sidecar that lost its
+/// execute bit is still selected so the spawn failure names its exact path —
+/// while the last-resort PATH scan requires a usable file
+/// ([fileIsExecutable]) and skips entries this user cannot run.
+@visibleForTesting
+String? resolveJeliyadBinaryFrom({
+  required Map<String, String> environment,
+  required String resolvedExecutable,
+  required String currentDirectory,
+  required bool debugMode,
+  required bool isLinux,
+  required bool Function(String path) fileExists,
+  required bool Function(String path) fileIsExecutable,
+}) {
+  final env = environment['JELIYAD_BIN'];
+  if (env != null && env.isNotEmpty) return env;
+
+  // macOS: Jeliya.app/Contents/MacOS/<exe> → Contents/{Resources,Helpers}.
+  // Linux: the generated bundle puts application-owned executables beside the
+  // runner; lib/jeliya is also supported for distro-style layouts.
+  final exeDir = File(resolvedExecutable).parent.path;
+  final bundleCandidates = isLinux
+      ? ['$exeDir/jeliyad', '$exeDir/../lib/jeliya/jeliyad']
+      : [
+          '$exeDir/../Resources/jeliyad',
+          '$exeDir/../Helpers/jeliyad',
+          '$exeDir/jeliyad',
+        ];
+  for (final candidate in bundleCandidates) {
+    if (fileExists(candidate)) return candidate;
+  }
+
+  if (debugMode) {
     // Repo debug build, relative to a typical checkout — debug builds only.
     // First existing candidate wins; TAC/bantaba is the pre-rename checkout
     // directory name, kept for machines that never re-cloned.
-    final home = Platform.environment['HOME'] ?? '.';
+    final home = environment['HOME'] ?? '.';
     for (final candidate in [
       '$home/TAC/jeliya/target/debug/jeliyad',
       '$home/TAC/bantaba/target/debug/jeliyad',
-      '${Directory.current.path}/../target/debug/jeliyad',
+      '$currentDirectory/../target/debug/jeliyad',
     ]) {
-      if (File(candidate).existsSync()) return candidate;
+      if (fileExists(candidate)) return candidate;
+    }
+  }
+
+  // Linux users may already have installed the standalone daemon. This is a
+  // last resort, after the bundled and repo-matched binaries, so PATH cannot
+  // silently replace a release's tested sidecar.
+  final path = environment['PATH'];
+  if (isLinux && path != null && path.isNotEmpty) {
+    for (final directory in path.split(':')) {
+      if (directory.isEmpty) continue;
+      final candidate = directory.endsWith('/')
+          ? '${directory}jeliyad'
+          : '$directory/jeliyad';
+      if (fileIsExecutable(candidate)) return candidate;
     }
   }
   return null;
@@ -104,17 +180,108 @@ String realHomeFrom(String home) {
 }
 
 /// The daemon data dir: `JELIYA_DATA_DIR` env override (test automation and
-/// side-by-side profiles) → `~/Library/Application Support/Jeliya` in release
-/// (shared with a Homebrew-installed jeliyad — the settled data-dir decision;
-/// reachable from the sandbox via the Release.entitlements exception),
-/// `…/JeliyaAppDev` in debug (so dev runs never touch real user data).
-String defaultDataDir() {
-  final override = Platform.environment['JELIYA_DATA_DIR'];
+/// side-by-side profiles) → the platform data root. Linux follows XDG
+/// (`$XDG_DATA_HOME`, falling back to `~/.local/share`); macOS continues to
+/// use `~/Library/Application Support`. Release uses `Jeliya`, while debug
+/// uses `JeliyaAppDev` so development runs never touch real user data.
+String defaultDataDir() => defaultDataDirFrom(
+  environment: Platform.environment,
+  fallbackHome: Directory.systemTemp.path,
+  debugMode: kDebugMode,
+  isLinux: Platform.isLinux,
+);
+
+/// Why Linux data-dir resolution can fail: the XDG Base Directory spec
+/// requires an absolute base, and identity material must never land relative
+/// to the launch directory. Shared between the resolution seam's [StateError]
+/// and the boot screen's technical detail.
+@visibleForTesting
+const String linuxDataDirRequirement =
+    'Linux data directory requires an absolute XDG_DATA_HOME or HOME';
+
+/// Pure data-directory resolution seam used by platform tests.
+@visibleForTesting
+String defaultDataDirFrom({
+  required Map<String, String> environment,
+  required String fallbackHome,
+  required bool debugMode,
+  required bool isLinux,
+}) {
+  final override = environment['JELIYA_DATA_DIR'];
   if (override != null && override.isNotEmpty) return override;
-  final home = Platform.environment['HOME'] ?? Directory.systemTemp.path;
-  final name = kDebugMode ? 'JeliyaAppDev' : 'Jeliya';
+
+  final name = debugMode ? 'JeliyaAppDev' : 'Jeliya';
+  if (isLinux) {
+    final xdgDataHome = environment['XDG_DATA_HOME'];
+    // The XDG Base Directory specification requires an absolute value. Ignore
+    // a relative value rather than storing identity material relative to the
+    // app's launch directory.
+    final String base;
+    if (xdgDataHome != null && xdgDataHome.startsWith('/')) {
+      base = xdgDataHome;
+    } else {
+      final home = environment['HOME'];
+      if (home == null || !home.startsWith('/')) {
+        throw StateError(linuxDataDirRequirement);
+      }
+      base = '$home/.local/share';
+    }
+    return base.endsWith('/') ? '$base$name' : '$base/$name';
+  }
+  final configuredHome = environment['HOME'];
+  final home = configuredHome == null || configuredHome.isEmpty
+      ? fallbackHome
+      : configuredHome;
   return '${realHomeFrom(home)}/Library/Application Support/$name';
 }
+
+/// Linux desktop is a real peer-to-peer node. macOS retains its existing
+/// loopback-only sidecar policy (including its current sandbox assumptions).
+@visibleForTesting
+bool desktopSidecarUsesLoopback({required bool isLinux}) => !isLinux;
+
+/// Opt-in marker used only by the Linux source-package lifecycle gate. Keeping
+/// the path fixed under the already-isolated daemon data directory avoids an
+/// environment-controlled arbitrary write path. The marker never contains the
+/// portfile's WebSocket authentication token.
+@visibleForTesting
+const String linuxPackageReadinessFileName = 'flutter-session-ready.json';
+
+@visibleForTesting
+String? linuxPackageReadinessPathFrom({
+  required Map<String, String> environment,
+  required bool isLinux,
+  required String dataDir,
+}) {
+  if (!isLinux || environment['JELIYA_LINUX_PACKAGE_GATE'] != '1') {
+    return null;
+  }
+  return dataDir.endsWith('/')
+      ? '$dataDir$linuxPackageReadinessFileName'
+      : '$dataDir/$linuxPackageReadinessFileName';
+}
+
+@visibleForTesting
+Map<String, Object> linuxPackageReadinessPayload({
+  required String boot,
+  required String phase,
+  required String connection,
+  required String frame,
+  required int protocol,
+  required int appPid,
+  required int daemonPid,
+  required int daemonPort,
+}) => {
+  'schema': 1,
+  'boot': boot,
+  'phase': phase,
+  'connection': connection,
+  'frame': frame,
+  'protocol': protocol,
+  'app_pid': appPid,
+  'daemon_pid': daemonPid,
+  'daemon_port': daemonPort,
+};
 
 class DaemonSession extends ChangeNotifier {
   /// Production: no [client] — the session spawns/adopts jeliyad and builds a
@@ -138,9 +305,24 @@ class DaemonSession extends ChangeNotifier {
         _clientFactory = clientFactory ?? WsClient.new,
         _binaryPathOverride = binaryPath,
         _stageAndShareOverride = stageAndShare,
-        dataDir = dataDir ?? defaultDataDir(),
+        dataDir = dataDir ?? _defaultDataDirOrEmpty(),
         prefs = prefs ??
-            PrefsStore('${dataDir ?? defaultDataDir()}/app_prefs.json');
+            PrefsStore(
+              '${dataDir ?? _defaultDataDirOrEmpty()}/app_prefs.json',
+            );
+
+  /// A misconfigured environment (no absolute HOME/XDG_DATA_HOME on Linux)
+  /// must not throw out of the constructor at widget-build time; the empty
+  /// sentinel defers the failure to [start], which reports it through the
+  /// regular [Boot.failed] surface with a Retry path. PrefsStore performs no
+  /// I/O until `load`, so the sentinel never touches disk.
+  static String _defaultDataDirOrEmpty() {
+    try {
+      return defaultDataDir();
+    } on StateError {
+      return '';
+    }
+  }
 
   final Client? _injectedClient;
   final ClientFactory _clientFactory;
@@ -176,6 +358,8 @@ class DaemonSession extends ChangeNotifier {
   bool _started = false;
   bool _disposed = false;
   bool _tearingDown = false;
+  bool _linuxPackageReadinessWritten = false;
+  bool _linuxPackageReadinessScheduled = false;
   final List<StreamSubscription<Object?>> _subs = [];
 
   // -- read surface --------------------------------------------------------------
@@ -247,6 +431,17 @@ class DaemonSession extends ChangeNotifier {
           _lifecycle ??= AppLifecycleListener(onResume: _onResumed);
         }
       } else {
+        if (dataDir.isEmpty) {
+          // Constructor-time data-dir resolution failed (see
+          // [_defaultDataDirOrEmpty]); classify it like any other failed
+          // start so the boot screen renders guidance plus this cause.
+          _setBoot(
+            Boot.failed,
+            BootStage.failedStart,
+            technical: linuxDataDirRequirement,
+          );
+          return;
+        }
         _setBoot(Boot.spawning, BootStage.spawning);
         final binary = _binaryPathOverride ?? resolveJeliyadBinary();
         if (binary == null) {
@@ -256,8 +451,13 @@ class DaemonSession extends ChangeNotifier {
           _setBoot(Boot.failed, BootStage.failedBinaryMissing);
           return;
         }
-        final supervisor = _supervisor ??
-            SidecarSupervisor(binaryPath: binary, dataDir: dataDir, loopback: true);
+        final supervisor =
+            _supervisor ??
+            SidecarSupervisor(
+              binaryPath: binary,
+              dataDir: dataDir,
+              loopback: desktopSidecarUsesLoopback(isLinux: Platform.isLinux),
+            );
         Ready ready;
         try {
           ready = await supervisor.start(port: 0);
@@ -307,7 +507,10 @@ class DaemonSession extends ChangeNotifier {
         unawaited(_supervisor?.shutdown());
         return;
       }
-      _setBoot(Boot.ready, BootStage.none);
+      // Retain the supervised process facts established at daemonUp/adopted.
+      // They remain useful diagnostics after transport bring-up and let the
+      // opt-in Linux package marker bind the rendered session to its portfile.
+      _setBoot(Boot.ready, BootStage.none, pid: _bootPid, port: _bootPort);
       // If the connected transition has not been delivered through the states
       // stream yet, synthesize it so the bootstrap runs exactly once (the
       // wasConnected check in _onConnectionState dedupes the stream's copy).
@@ -353,6 +556,7 @@ class DaemonSession extends ChangeNotifier {
     _bootMismatchExpected = mismatchExpected;
     _bootTechnical = technical;
     notifyListeners();
+    _maybeScheduleLinuxPackageReadiness();
   }
 
   void _onConnectionState(ConnectionState state) {
@@ -392,6 +596,7 @@ class DaemonSession extends ChangeNotifier {
       if (status.identity == null) {
         _phase = BootstrapPhase.noIdentity;
         notifyListeners();
+        _maybeScheduleLinuxPackageReadiness();
         return;
       }
       final rooms = await client.roomList();
@@ -400,6 +605,7 @@ class DaemonSession extends ChangeNotifier {
       if (rooms.isEmpty) {
         _phase = BootstrapPhase.noRooms;
         notifyListeners();
+        _maybeScheduleLinuxPackageReadiness();
         return;
       }
       _phase = BootstrapPhase.ready;
@@ -409,6 +615,7 @@ class DaemonSession extends ChangeNotifier {
       if (active.isEmpty) {
         _closeRoomStore();
         notifyListeners();
+        _maybeScheduleLinuxPackageReadiness();
         return;
       }
       bool isActive(String? rid) =>
@@ -419,6 +626,7 @@ class DaemonSession extends ChangeNotifier {
               ? prefs.lastRoomId!
               : active.first.roomId;
       notifyListeners();
+      _maybeScheduleLinuxPackageReadiness();
       unawaited(openRoom(target));
     } on ProtocolMismatchError catch (e) {
       // Version skew is a HARD stop, not a transient: the connection stays
@@ -434,6 +642,88 @@ class DaemonSession extends ChangeNotifier {
     } catch (_) {
       // daemon.status failed (connection dropped mid-flight) — the reconnect
       // cycle re-triggers this bootstrap.
+    }
+  }
+
+  /// Emit the package gate's proof only after the real desktop supervisor,
+  /// authenticated WebSocket connection, and initial daemon.status/room-list
+  /// bootstrap have all converged. A fresh gate profile legitimately routes to
+  /// noIdentity; that is still a completed bootstrap, not a daemon-health-only
+  /// success. Atomic replacement prevents the Node gate from observing JSON
+  /// while it is being written.
+  void _maybeScheduleLinuxPackageReadiness() {
+    if (_linuxPackageReadinessWritten ||
+        _linuxPackageReadinessScheduled ||
+        _supervisor == null ||
+        _boot != Boot.ready ||
+        _phase == BootstrapPhase.boot ||
+        _conn != ConnectionState.connected ||
+        _status == null ||
+        _bootPid == null ||
+        _bootPort == null) {
+      return;
+    }
+    final path = linuxPackageReadinessPathFrom(
+      environment: Platform.environment,
+      isLinux: Platform.isLinux,
+      dataDir: dataDir,
+    );
+    if (path == null) return;
+
+    _linuxPackageReadinessScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _linuxPackageReadinessScheduled = false;
+      _writeLinuxPackageReadiness(path);
+    });
+    // addPostFrameCallback does not request a frame by itself. The gate wants
+    // positive proof that Flutter rendered the resolved bootstrap phase, so
+    // make sure this opt-in launch has a frame for the callback to follow.
+    if (!WidgetsBinding.instance.hasScheduledFrame) {
+      WidgetsBinding.instance.scheduleFrame();
+    }
+  }
+
+  void _writeLinuxPackageReadiness(String path) {
+    // State may have changed while Flutter rendered the resolved bootstrap
+    // phase. Re-check everything in the post-frame callback before writing.
+    if (_linuxPackageReadinessWritten ||
+        _disposed ||
+        _supervisor == null ||
+        _boot != Boot.ready ||
+        _phase == BootstrapPhase.boot ||
+        _conn != ConnectionState.connected ||
+        _status == null ||
+        _bootPid == null ||
+        _bootPort == null) {
+      return;
+    }
+
+    final target = File(path);
+    final temporary = File('$path.tmp.$pid');
+    try {
+      final payload = linuxPackageReadinessPayload(
+        boot: _boot.name,
+        phase: _phase.name,
+        connection: _conn.name,
+        frame: 'rendered',
+        protocol: _status!.protocol,
+        appPid: pid,
+        daemonPid: _bootPid!,
+        daemonPort: _bootPort!,
+      );
+      temporary.writeAsStringSync('${jsonEncode(payload)}\n', flush: true);
+      temporary.renameSync(target.path);
+      _linuxPackageReadinessWritten = true;
+    } catch (error) {
+      // This opt-in proof must not perturb the normal application lifecycle.
+      // The package gate captures stderr and will fail with this diagnostic if
+      // it cannot observe the marker.
+      try {
+        if (temporary.existsSync()) temporary.deleteSync();
+      } catch (_) {
+        // Best-effort cleanup of a gate-only temporary file.
+      }
+      debugPrint('Could not write Linux package readiness marker: $error');
     }
   }
 

--- a/app/linux/.gitignore
+++ b/app/linux/.gitignore
@@ -1,0 +1,2 @@
+flutter/ephemeral
+build/

--- a/app/linux/CMakeLists.txt
+++ b/app/linux/CMakeLists.txt
@@ -1,0 +1,176 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "jeliya")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.incubtek.jeliya")
+
+# Optional prebuilt daemon to include in the relocatable application bundle.
+# The environment is resolved on every configure so release packaging cannot
+# inherit an empty value from an earlier developer-build CMake cache. When the
+# environment is unset, the cache variable can be supplied with -D instead.
+set(JELIYA_SIDECAR_PATH "" CACHE FILEPATH
+  "Path to a prebuilt jeliyad executable to bundle next to Jeliya")
+if(DEFINED ENV{JELIYA_SIDECAR_PATH} AND
+   NOT "$ENV{JELIYA_SIDECAR_PATH}" STREQUAL "")
+  set(_JELIYA_SIDECAR_PATH "$ENV{JELIYA_SIDECAR_PATH}")
+else()
+  set(_JELIYA_SIDECAR_PATH "${JELIYA_SIDECAR_PATH}")
+endif()
+if(_JELIYA_SIDECAR_PATH)
+  get_filename_component(_JELIYA_SIDECAR_PATH "${_JELIYA_SIDECAR_PATH}"
+    ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
+  if(NOT EXISTS "${_JELIYA_SIDECAR_PATH}" OR
+     IS_DIRECTORY "${_JELIYA_SIDECAR_PATH}")
+    message(FATAL_ERROR
+      "JELIYA_SIDECAR_PATH does not name a prebuilt jeliyad executable: ${_JELIYA_SIDECAR_PATH}")
+  endif()
+endif()
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(INSTALL_BUNDLE_SHARE_DIR "${CMAKE_INSTALL_PREFIX}/share")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+if(_JELIYA_SIDECAR_PATH)
+  install(PROGRAMS "${_JELIYA_SIDECAR_PATH}"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}"
+    RENAME "jeliyad"
+    COMPONENT Runtime)
+endif()
+
+# Keep freedesktop integration metadata in the bundle so native packages can
+# install it without synthesizing product identity at packaging time.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/assets/com.incubtek.jeliya.desktop"
+  DESTINATION "${INSTALL_BUNDLE_SHARE_DIR}/applications"
+  COMPONENT Runtime)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/assets/com.incubtek.jeliya.metainfo.xml"
+  DESTINATION "${INSTALL_BUNDLE_SHARE_DIR}/metainfo"
+  COMPONENT Runtime)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/assets/icons/hicolor/scalable/apps/com.incubtek.jeliya.svg"
+  DESTINATION "${INSTALL_BUNDLE_SHARE_DIR}/icons/hicolor/scalable/apps"
+  COMPONENT Runtime)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../LICENSE-APACHE"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../LICENSE-MIT"
+  DESTINATION "${INSTALL_BUNDLE_SHARE_DIR}/doc/jeliya"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/app/linux/assets/com.incubtek.jeliya.desktop
+++ b/app/linux/assets/com.incubtek.jeliya.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Jeliya
+GenericName=Peer-to-peer rooms
+Comment=Connect and collaborate in local-first peer-to-peer rooms
+Exec=jeliya
+Icon=com.incubtek.jeliya
+Terminal=false
+Categories=Network;Chat;
+Keywords=chat;collaboration;peer-to-peer;rooms;
+StartupNotify=true
+StartupWMClass=com.incubtek.jeliya

--- a/app/linux/assets/com.incubtek.jeliya.metainfo.xml
+++ b/app/linux/assets/com.incubtek.jeliya.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.incubtek.jeliya</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT OR Apache-2.0</project_license>
+  <name>Jeliya</name>
+  <summary>Local-first peer-to-peer rooms</summary>
+  <developer id="com.incubtek">
+    <name>Incubtek</name>
+  </developer>
+  <description>
+    <p>
+      Jeliya is a native desktop client for private peer-to-peer rooms with
+      chat, file sharing, invitations, and agent collaboration.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.incubtek.jeliya.desktop</launchable>
+  <url type="homepage">https://github.com/kortiene/jeliya</url>
+  <url type="bugtracker">https://github.com/kortiene/jeliya/issues</url>
+  <provides>
+    <binary>jeliya</binary>
+  </provides>
+  <content_rating type="oars-1.1" />
+</component>

--- a/app/linux/assets/icons/hicolor/scalable/apps/com.incubtek.jeliya.svg
+++ b/app/linux/assets/icons/hicolor/scalable/apps/com.incubtek.jeliya.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#070d10"/>
+  <path d="M8.5 15.5 A7.5 7.5 0 0 1 23.5 15.5"
+        fill="none" stroke="#2fd6a4" stroke-width="2.6"
+        stroke-linecap="round"/>
+  <path d="M16 14 V21.5" fill="none" stroke="#2fd6a4"
+        stroke-width="2.6" stroke-linecap="round"/>
+  <circle cx="16" cy="25.5" r="2" fill="#2fd6a4"/>
+</svg>

--- a/app/linux/flutter/CMakeLists.txt
+++ b/app/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,19 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <file_selector_linux/file_selector_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+}

--- a/app/linux/flutter/generated_plugin_registrant.h
+++ b/app/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,26 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
+  url_launcher_linux
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/app/linux/runner/CMakeLists.txt
+++ b/app/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/app/linux/runner/main.cc
+++ b/app/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/app/linux/runner/my_application.cc
+++ b/app/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "Jeliya");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "Jeliya");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/app/linux/runner/my_application.h
+++ b/app/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/app/test/daemon_runtime_test.dart
+++ b/app/test/daemon_runtime_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/session/daemon_session.dart';
+
+void main() {
+  group('resolveJeliyadBinaryFrom', () {
+    String? resolve({
+      Map<String, String> environment = const {},
+      Set<String> executableFiles = const {},
+      Set<String> existingFiles = const {},
+      bool debugMode = false,
+      bool isLinux = true,
+      String executable = '/opt/jeliya/jeliya',
+      String currentDirectory = '/checkout/app',
+    }) => resolveJeliyadBinaryFrom(
+      environment: environment,
+      resolvedExecutable: executable,
+      currentDirectory: currentDirectory,
+      debugMode: debugMode,
+      isLinux: isLinux,
+      // Every executable file exists; existingFiles adds present-but-unusable
+      // candidates (e.g. a sidecar that lost its execute bit).
+      fileExists: (path) =>
+          executableFiles.contains(path) || existingFiles.contains(path),
+      fileIsExecutable: executableFiles.contains,
+    );
+
+    test('explicit override wins without probing other locations', () {
+      expect(
+        resolve(
+          environment: const {
+            'JELIYAD_BIN': '/custom/jeliyad',
+            'PATH': '/usr/bin',
+          },
+          executableFiles: const {'/opt/jeliya/jeliyad', '/usr/bin/jeliyad'},
+        ),
+        '/custom/jeliyad',
+      );
+    });
+
+    test('Linux bundle beside the runner wins over PATH', () {
+      expect(
+        resolve(
+          environment: const {'PATH': '/usr/local/bin:/usr/bin'},
+          executableFiles: const {
+            '/opt/jeliya/jeliyad',
+            '/usr/local/bin/jeliyad',
+          },
+        ),
+        '/opt/jeliya/jeliyad',
+      );
+    });
+
+    test('Linux supports an FHS lib directory beside the bin directory', () {
+      expect(
+        resolve(
+          executable: '/usr/bin/jeliya',
+          executableFiles: const {'/usr/bin/../lib/jeliya/jeliyad'},
+        ),
+        '/usr/bin/../lib/jeliya/jeliyad',
+      );
+    });
+
+    test('a bundled sidecar that exists but is unusable is still selected', () {
+      // The packaged app must run the sidecar it shipped: a present bundle
+      // binary with a broken mode is returned so the spawn failure names its
+      // exact path, instead of silently substituting a host-installed daemon.
+      expect(
+        resolve(
+          environment: const {'PATH': '/usr/local/bin:/usr/bin'},
+          existingFiles: const {'/opt/jeliya/jeliyad'},
+          executableFiles: const {'/usr/local/bin/jeliyad'},
+        ),
+        '/opt/jeliya/jeliyad',
+      );
+    });
+
+    test('an unusable PATH entry is skipped for a later usable one', () {
+      // PATH is a last resort scanned for something exec(2) will accept: an
+      // entry this user cannot run (e.g. a root-only 0700 binary) must not
+      // shadow a working install later on the PATH.
+      expect(
+        resolve(
+          environment: const {'PATH': '/usr/local/bin:/usr/bin'},
+          existingFiles: const {'/usr/local/bin/jeliyad'},
+          executableFiles: const {'/usr/bin/jeliyad'},
+        ),
+        '/usr/bin/jeliyad',
+      );
+    });
+
+    test('debug repo binary wins over PATH', () {
+      expect(
+        resolve(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': '/home/sekou',
+            'PATH': '/usr/bin',
+          },
+          executableFiles: const {
+            '/checkout/app/../target/debug/jeliyad',
+            '/usr/bin/jeliyad',
+          },
+          debugMode: true,
+        ),
+        '/checkout/app/../target/debug/jeliyad',
+      );
+    });
+
+    test('Linux can fall back to an installed PATH binary', () {
+      expect(
+        resolve(
+          environment: const {'PATH': '/missing:/usr/local/bin:/usr/bin'},
+          executableFiles: const {'/usr/local/bin/jeliyad'},
+        ),
+        '/usr/local/bin/jeliyad',
+      );
+    });
+
+    test('PATH fallback is Linux-only', () {
+      expect(
+        resolve(
+          environment: const {'PATH': '/usr/local/bin'},
+          executableFiles: const {'/usr/local/bin/jeliyad'},
+          isLinux: false,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  test('Linux uses real networking without changing macOS loopback policy', () {
+    expect(desktopSidecarUsesLoopback(isLinux: true), isFalse);
+    expect(desktopSidecarUsesLoopback(isLinux: false), isTrue);
+  });
+
+  group('Linux package readiness signal', () {
+    test('is absent from normal and non-Linux launches', () {
+      expect(
+        linuxPackageReadinessPathFrom(
+          environment: const {},
+          isLinux: true,
+          dataDir: '/tmp/profile',
+        ),
+        isNull,
+      );
+      expect(
+        linuxPackageReadinessPathFrom(
+          environment: const {'JELIYA_LINUX_PACKAGE_GATE': '1'},
+          isLinux: false,
+          dataDir: '/tmp/profile',
+        ),
+        isNull,
+      );
+    });
+
+    test('uses a fixed file inside the isolated gate data directory', () {
+      expect(
+        linuxPackageReadinessPathFrom(
+          environment: const {'JELIYA_LINUX_PACKAGE_GATE': '1'},
+          isLinux: true,
+          dataDir: '/tmp/profile',
+        ),
+        '/tmp/profile/$linuxPackageReadinessFileName',
+      );
+      expect(
+        linuxPackageReadinessPathFrom(
+          environment: const {'JELIYA_LINUX_PACKAGE_GATE': '1'},
+          isLinux: true,
+          dataDir: '/tmp/profile/',
+        ),
+        '/tmp/profile/$linuxPackageReadinessFileName',
+      );
+    });
+
+    test(
+      'payload carries matching lifecycle facts but no authentication token',
+      () {
+        final payload = linuxPackageReadinessPayload(
+          boot: 'ready',
+          phase: 'noIdentity',
+          connection:
+              'connected', // i18n-exempt: wire enum fixture value, not copy
+          frame: 'rendered',
+          protocol: 1,
+          appPid: 100,
+          daemonPid: 101,
+          daemonPort: 4242,
+        );
+        expect(payload, {
+          'schema': 1,
+          'boot': 'ready',
+          'phase': 'noIdentity',
+          'connection':
+              'connected', // i18n-exempt: wire enum fixture value, not copy
+          'frame': 'rendered',
+          'protocol': 1,
+          'app_pid': 100,
+          'daemon_pid': 101,
+          'daemon_port': 4242,
+        });
+        expect(payload, isNot(contains('auth_token')));
+      },
+    );
+  });
+}

--- a/app/test/data_dir_test.dart
+++ b/app/test/data_dir_test.dart
@@ -1,27 +1,175 @@
-// Data-dir resolution under the App Sandbox (Phase 5): $HOME points at the
-// app container, but the shared-dir exception is resolved against the REAL
-// home — realHomeFrom must unwrap the container prefix and pass everything
-// else through untouched.
+// Desktop data-dir resolution: macOS App Sandbox home unwrapping plus Linux
+// XDG data roots. The debug product-name split keeps developer runs isolated
+// from release identities on both platforms.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jeliya_app/src/session/daemon_session.dart';
 
 void main() {
-  test('realHomeFrom unwraps a sandbox container HOME', () {
-    expect(
-      realHomeFrom('/Users/sekou/Library/Containers/com.incubtek.jeliya/Data'),
-      '/Users/sekou',
-    );
+  group('realHomeFrom', () {
+    test('unwraps a sandbox container HOME', () {
+      expect(
+        realHomeFrom(
+          '/Users/sekou/Library/Containers/com.incubtek.jeliya/Data',
+        ),
+        '/Users/sekou',
+      );
+    });
+
+    test('passes a real home through untouched', () {
+      expect(realHomeFrom('/Users/sekou'), '/Users/sekou');
+      expect(realHomeFrom('/var/root'), '/var/root');
+    });
+
+    test('never returns empty for a pathological value', () {
+      // A HOME that *starts* with the marker has no user prefix to recover.
+      expect(
+        realHomeFrom('/Library/Containers/x/Data'),
+        '/Library/Containers/x/Data',
+      );
+    });
   });
 
-  test('realHomeFrom passes a real home through untouched', () {
-    expect(realHomeFrom('/Users/sekou'), '/Users/sekou');
-    expect(realHomeFrom('/var/root'), '/var/root');
-  });
+  group('defaultDataDirFrom', () {
+    test('explicit override wins on every platform and build mode', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': '/home/sekou',
+            'XDG_DATA_HOME': '/state',
+            'JELIYA_DATA_DIR': '/profiles/demo',
+          },
+          fallbackHome: '/tmp',
+          debugMode: true,
+          isLinux: true,
+        ),
+        '/profiles/demo',
+      );
+    });
 
-  test('realHomeFrom never returns empty for a pathological value', () {
-    // A HOME that *starts* with the marker has no user prefix to recover.
-    expect(realHomeFrom('/Library/Containers/x/Data'),
-        '/Library/Containers/x/Data');
+    test('Linux release uses XDG_DATA_HOME', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': '/home/sekou',
+            'XDG_DATA_HOME': '/mnt/state',
+          },
+          fallbackHome: '/tmp',
+          debugMode: false,
+          isLinux: true,
+        ),
+        '/mnt/state/Jeliya',
+      );
+    });
+
+    test('Linux debug uses an isolated product directory', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': '/home/sekou',
+          },
+          fallbackHome: '/tmp',
+          debugMode: true,
+          isLinux: true,
+        ),
+        '/home/sekou/.local/share/JeliyaAppDev',
+      );
+    });
+
+    test('Linux falls back for an invalid relative XDG_DATA_HOME', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': '/home/sekou',
+            'XDG_DATA_HOME': 'relative/state',
+          },
+          fallbackHome: '/tmp',
+          debugMode: false,
+          isLinux: true,
+        ),
+        '/home/sekou/.local/share/Jeliya',
+      );
+    });
+
+    test('Linux can use XDG_DATA_HOME when HOME is absent', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {'XDG_DATA_HOME': '/run/user/1000/data'},
+          fallbackHome: '/tmp/session',
+          debugMode: false,
+          isLinux: true,
+        ),
+        '/run/user/1000/data/Jeliya',
+      );
+    });
+
+    test('Linux fails closed when neither absolute data base is available', () {
+      for (final environment in <Map<String, String>>[
+        const {},
+        const {
+          // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+          'HOME': '',
+        },
+        const {
+          // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+          'HOME': 'relative/home',
+        },
+        const {'XDG_DATA_HOME': 'relative/data'},
+      ]) {
+        expect(
+          () => defaultDataDirFrom(
+            environment: environment,
+            fallbackHome: '/tmp/session',
+            debugMode: false,
+            isLinux: true,
+          ),
+          throwsA(isA<StateError>()),
+        );
+      }
+    });
+
+    test('macOS still uses the fallback home when HOME is absent', () {
+      expect(
+        defaultDataDirFrom(
+          environment: const {},
+          fallbackHome: '/tmp/session',
+          debugMode: false,
+          isLinux: false,
+        ),
+        '/tmp/session/Library/Application Support/Jeliya',
+      );
+    });
+
+    test('macOS keeps its shared release and isolated debug paths', () {
+      const home = '/Users/sekou/Library/Containers/com.incubtek.jeliya/Data';
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': home,
+          },
+          fallbackHome: '/tmp',
+          debugMode: false,
+          isLinux: false,
+        ),
+        '/Users/sekou/Library/Application Support/Jeliya',
+      );
+      expect(
+        defaultDataDirFrom(
+          environment: const {
+            // i18n-exempt: 'HOME' is the env-var name, not the Home nav label
+            'HOME': home,
+          },
+          fallbackHome: '/tmp',
+          debugMode: true,
+          isLinux: false,
+        ),
+        '/Users/sekou/Library/Application Support/JeliyaAppDev',
+      );
+    });
   });
 }

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -9,9 +9,10 @@ description = "Jeliya resident core: the only crate in the project that talks to
 [features]
 default = []
 # Publication gate for the diagnostic relay verifier. The reviewed upstream
-# feature is now published and pinned (iroh-room tag v0.1.0-rc.2), so this
-# forwards to it; the cfg-gated const assertion in lib.rs verifies the upstream
-# clear_ip_transports seam is actually active, failing closed otherwise.
+# feature is published and pinned (since iroh-room v0.1.0-rc.2; the pin is now
+# the v0.1.0-rc.3 tag), so this forwards to it; the cfg-gated const assertion
+# in lib.rs verifies the upstream clear_ip_transports seam is actually active,
+# failing closed otherwise.
 relay-only-test = ["iroh-rooms/relay-only-test"]
 
 [dependencies]

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -39,9 +39,9 @@ use iroh_rooms::events::{
 };
 use iroh_rooms::experimental::pipe_runtime::{is_loopback_target, PipeError, PipeForwarder};
 use iroh_rooms::experimental::session::{
-    Admission, AdmissionView, AllowlistAdmission, BlobServeConfig, ConnEvent, EndpointAddr,
-    EndpointId, JoinBootstrapAdmission, NetConfig, NetMode, Node, PeerConnState, SecretKey,
-    SnapshotAdmission, TracingAudit, DEFAULT_TICK,
+    Admission, AdmissionView, AllowlistAdmission, BlobServeConfig, BootstrapProof, ConnEvent,
+    EndpointAddr, EndpointId, JoinBootstrapAdmission, NetConfig, NetMode, Node, PeerConnState,
+    SecretKey, SnapshotAdmission, TracingAudit, DEFAULT_TICK,
 };
 use iroh_rooms::experimental::store::{EventStore, StoreOptions, StoredEvent};
 use iroh_rooms::experimental::sync::{SyncConfig, SyncEngine};
@@ -1404,13 +1404,21 @@ impl RoomSupervisor {
         let engine = SyncEngine::open(store, room_id, SyncConfig::default())
             .map_err(|e| internal("could not open the sync engine", e))?;
         let secret_key = SecretKey::from_bytes(&secret.device.to_seed());
-        let node = Node::spawn(
+        // The admin serves the membership closure only after this node proves it
+        // holds the invite (upstream issue #112); a plain `Node::spawn` joiner is
+        // never bootstrapped and times out.
+        let node = Node::spawn_join_bootstrap(
             secret_key,
             Arc::new(admission),
             Arc::new(TracingAudit),
             engine,
             self.net_config(),
             DEFAULT_TICK,
+            BootstrapProof {
+                room_id,
+                invite_id: ticket.invite_id,
+                capability_secret: ticket.capability_secret,
+            },
         )
         .await
         .map_err(|e| internal("could not bring up the join node", e))?;

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/main.rs"
 # `cargo build` stays a lean WS-only daemon with no UI-build dependency.
 embed-ui = ["dep:rust-embed"]
 # Diagnostic-only verifier binary. Off by default and never enabled for the
-# five release artifacts. jeliya-core fails this build closed until the
-# reviewed upstream relay-only feature is published and forwarded.
+# five release artifacts. jeliya-core forwards to the published upstream seam
+# and still fails this build closed if the pin ever loses it.
 relay-only-test = ["jeliya-core/relay-only-test"]
 
 [dependencies]

--- a/docs/agent-orchestration.md
+++ b/docs/agent-orchestration.md
@@ -3,7 +3,7 @@ type: "Reference"
 title: "Agent orchestration contract (v1)"
 description: "Normative contract for agent liveness, task claims, fleet reads, and UI projections."
 tags: ["agents", "fleet", "orchestration", "protocol"]
-timestamp: "2026-07-11T21:27:07Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -17,7 +17,8 @@ The pinned contract across four implementation surfaces:
 
 - **Rust daemon** (`crates/jeliyad` + `crates/jeliya-core`) — implements the
   fleet read RPCs and the liveness derivation. `jeliya-core` remains the sole
-  consumer of `iroh_rooms` (SDK pinned at rev `3cb9bfd`).
+  consumer of `iroh_rooms` (SDK pinned at published tag `v0.1.0-rc.3`,
+  rev `71fbb50`).
 - **JS runner** (`scripts/jeliya-agent.mjs`, `scripts/jeliya-fleet.mjs`)
   — implements the status-vocabulary additions and the task-claim protocol.
   Node 22 (global `WebSocket`), zero npm deps.

--- a/docs/capability-status.md
+++ b/docs/capability-status.md
@@ -3,73 +3,77 @@ type: "Status Report"
 title: "Capability status"
 description: "Evidence-aware capability matrix for the v0.5.0 technical-preview candidate and the latest public release."
 tags: ["capabilities", "release", "status", "verification"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
-release_status: "unreleased"
+release_status: "partial"
 audience: ["contributors", "maintainers", "operators", "release-engineers"]
 ---
 
 # Capability status
 
-This page separates implementation, verification, and public availability. The
-`v0.5.0` candidate is **blocked**: passing local and network tests do not make an
-unpublished revision releasable.
+This page separates implementation, verification, and public availability.
+`v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease backed by signed,
+certifying direct and forced-relay evidence. Current `main` is the
+post-release candidate: it repins `iroh-rooms` to `v0.1.0-rc.3`, and the
+certified evidence does not transfer to it.
 
 ## Snapshot boundary
 
 | Field | Value |
 |---|---|
-| Candidate milestone | `v0.5.0 — Evidence-Backed Technical Preview` |
-| Audited baseline | `1285b42037a3713840955fa518f2b81b19f2929f` |
-| Hardened implementation and network-test snapshot | `0f6769a68d783cf6a5feba0e2db6111a212affa1` on `hardening/v0.5.0-evidence-preview` before final documentation reconciliation |
-| Public Jeliya `iroh-rooms` pin | `3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020` (room-isolation defect remains) |
-| Local upstream remediation | `3702e8cbcd5ac1808791124dd6bc44068be5f822` (clean and tested, but unpublished) |
-| Current network verification | Schema 2 direct run at Jeliya `0f6769a…` with public pin `3cb9bfd…`; forced-relay build blocked because that pin lacks the test seam |
-| Historical network verification | Schema 1 direct and relay runs at Jeliya `fe870c7…` with local upstream `3702e8c…`; functional evidence only |
-| Latest public release | `v0.4.3` at `9d62c3cd98c7f21d9683815c28278b6ac8c0b97f` |
-| Status captured | 2026-07-12 23:55 UTC |
+| Released milestone | `v0.5.0 — Evidence-Backed Technical Preview`, published 2026-07-14 as a prerelease: five daemon+embedded-UI archives with `.sha256` sidecars |
+| Network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` with `iroh-rooms` pin `d0ceb0b…` (published rc.2-era remediation) |
+| Certified evidence | signed schema 2 direct (`3b86ac67`) and forced-relay (`a3c76859`) runs; `certifiable: true`; see [Verification evidence](verification-evidence.md) |
+| Candidate `iroh-rooms` pin (post-release `main`) | `71fbb5007bef4ce83631c94762ec68c2beef3d79` — published tag `v0.1.0-rc.3`; adds the join-after-conversation fix, the join-bootstrap capability gate, size-independent membership sync, and deep gap healing |
+| Candidate network verification | none yet — the certified `v0.5.0` runs bind `c5f740e` + `d0ceb0b` and do not transfer; fresh certifying runs are required before the next release |
+| Historical network verification | schema 1 runs at Jeliya `fe870c7…` with local upstream `3702e8c…`, and the schema 2 preview run at `0f6769a…` with pre-remediation pin `3cb9bfd…`; functional evidence only |
+| Status captured | 2026-07-16 15:30 UTC |
 
 See [Release versus main](release-vs-main.md) for the revision boundaries and
 [Verification evidence](verification-evidence.md) for the complete ledger.
-The current schema 2 direct run covers the hardened implementation snapshot,
-but it uses the unsafe public upstream pin and explicitly makes no
-synchronization-isolation claim. The older schema 1 direct and relay runs use
-the unpublished local remediation and remain historical functional evidence;
-they do not qualify the current implementation or a release.
+The released `v0.5.0` pins `d0ceb0b…`, which predates upstream's
+join-after-conversation fix: an invite minted after any non-admin chat cannot
+complete `room.join` on `v0.5.0` — the rc.3 repin on `main` fixes this for
+the next candidate. Mixed `v0.5.0`/candidate rooms cannot complete joins in
+either direction, so a room's members, especially its admin, must move
+together.
 
 ## Capability matrix
 
 | Capability | Implementation | Verification | Public release | Honest current claim |
 |---|---|---|---|---|
-| `jeliyad` with embedded React UI | implemented | partial | released in `v0.4.3` | Schema 2 source-bound macOS x86_64 and Linux x86_64 musl builds passed the current direct run. The matching relay-only build failed closed, and a complete five-target `v0.5.0` artifact set does not exist. |
-| Identity, room create/join/open, membership, and messages | implemented | current direct functional pass | released in `v0.4.3` | Three-peer join, message convergence, reconnect, and resynchronization passed in the current direct run. Current relay verification is blocked; the evidence is unsigned and non-certifiable. |
-| Files and BLAKE3 fetch verification | implemented | current direct functional pass | released in `v0.4.3` | Cross-network transfer, byte equality, and hash verification passed in the current direct run. |
-| Pipes | implemented | current direct functional pass | released in `v0.4.3` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in the current direct run. |
-| Direct cross-network P2P | implemented | current functional pass, not release-qualifying | released in `v0.4.3` | [Schema 2 direct run `3c938c66`](evidence/v0.5.0/preview-direct-schema2.json) passed 36/36 assertions across three distinct public egresses and two ASNs at `0f6769a…`. It is unsigned, unpublished, and does not claim synchronization isolation. |
-| Deliberately forced relay | test seam absent from the current public dependency pin | current verification blocked | runtime relay support released in `v0.4.3` | The exact public-pin relay-only build failed closed before remote execution. [Historical schema 1 run `f1d9c149`](evidence/v0.5.0/relay.json) passed only with the unpublished local upstream seam and does not qualify the current candidate. |
-| Public room-scoped RPC isolation | implemented in hardened candidate | verified locally and exercised remotely | unreleased | A centralized guard covers the public room-scoped surface. Seventeen negative RPC checks, local-file denial, and aggregate filtering passed; foreign agent projections were exercised. |
-| Room isolation in upstream synchronization | remediated only in local upstream checkout | local malicious-sync tests pass; retained runs do not claim synchronization isolation | unreleased | Jeliya still publicly pins vulnerable `3cb9bfd…`. `3702e8c…` must be reviewed, published, and pinned before qualification. |
-| Agent runner and fleet | implemented | local pass | released as source in `v0.4.3` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
+| `jeliyad` with embedded React UI | implemented | certified for `v0.5.0` | released in `v0.5.0` (prerelease) | The complete five-target daemon+embedded-UI archive set with `.sha256` sidecars is published. Signed schema 2 direct and forced-relay runs certified the released revision pair. |
+| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Three-peer join, message convergence, reconnect, and resynchronization passed in both certifying runs. Known `v0.5.0` limitation: its pin predates upstream's join-after-conversation fix, so an invite minted after non-admin chat cannot complete `room.join`; the rc.3 candidate on `main` fixes this and has no network run yet. |
+| Files and BLAKE3 fetch verification | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Cross-network transfer, byte equality, and hash verification passed in both certifying runs. |
+| Pipes | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in both certifying runs. |
+| Direct cross-network P2P | implemented | certified for `v0.5.0` | released in `v0.5.0` | [Signed schema 2 direct run `3b86ac67`](evidence/v0.5.0/direct.json) at `c5f740e…` + `d0ceb0b…` passed every recorded assertion across three distinct public egresses and two ASNs; `certifiable: true`. No run exists at the rc.3 candidate pin. |
+| Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for `v0.5.0`; no run at the rc.3 candidate | released in `v0.5.0` | [Signed schema 2 relay run `a3c76859`](evidence/v0.5.0/relay.json) with a self-attested relay-only build certified `v0.5.0`. The rc.3 candidate's verifier builds and attests `jeliya-relay-only-test-build-v1` locally; its own certifying relay run is still required before the next release. |
+| Public room-scoped RPC isolation | implemented | verified locally and in both certifying runs | released in `v0.5.0` | A centralized guard covers the public room-scoped surface. Seventeen negative RPC checks, local-file denial, and aggregate filtering passed over the public network in the certifying runs. |
+| Room isolation in upstream synchronization | remediated in the published pin certified for `v0.5.0` (`d0ceb0b…`); the rc.3 candidate keeps the fix and adds the join-bootstrap capability gate | certified by the `v0.5.0` runs; at the rc.3 tag the upstream isolation regressions and full suites pass locally (523/523 core, 232/232 net) | released in `v0.5.0` | The `v0.5.0` isolation claim is certified at `d0ceb0b…`. The rc.3 candidate is locally requalified; a fresh signed schema 2 qualification is required before the claim transfers to the next release. |
+| Agent runner and fleet | implemented | local pass | released as source through `v0.5.0` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
+| Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 release build, X11/Xvfb lifecycle, sidecar smoke, dependency, archive, and checksum gates pass locally; the equivalent x86_64 hosted gate and Wayland lifecycle have no result yet | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
 | Android in-process FFI engine | implemented | local device smoke only | unreleased | App-private identity state is excluded from cloud backup and device transfer. It is not Android Keystore-backed, and Android direct, relay, NAT, and cross-network behavior remain unverified. |
-| Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | unreleased candidate gates | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
-| CI matrix | implemented | local component gates pass; hosted proof absent | unreleased | Rust, MSRV, TypeScript, Dart, Flutter, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. A manual non-publishing dispatch exists, and Gradle is checksum-verified; two clean hosted CI runs have not occurred because nothing was pushed. |
-| Unix installer integrity | implemented | behavioral checks pass | unreleased | Unix installers fetch and verify the matching sidecar before extraction. |
-| Windows installer integrity | behavioral gate configured | hosted execution absent | unreleased | The Windows job parses and executes checksum/tamper behavior, simulates reparse-point rejection, and the release matrix runs native `jeliyad.exe --version`; those jobs have not run on `windows-latest` for this candidate. |
-| Complete asset-set visibility and version consistency | implemented locally | contract and receipt tests pass; workflow never executed | unreleased | A read-only job validates and seals the untouched complete set, a separate read-only job executes the smoke binary, and the sole writer verifies the receipt without executing candidate bytes. Its GitHub token is exposed only to the final publishing step. GitHub cannot transact the tag and release assets atomically; the finalizer instead keeps the release draft until every uploaded byte matches and requires operator inspection after an interrupted cleanup. No `v0.5.0` release has been built or published, and the absent evidence key keeps publication fail-closed. |
+| Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | release gates passed for `v0.5.0` | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
+| CI matrix | implemented | hosted runs pass on `main` | exercised for `v0.5.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined; the six pre-existing required jobs pass on hosted `main` runs, including Windows installer integrity. The new `linux-flutter` job (release binaries, integrated bundle under Xvfb, dependency/archive/checksum checks) has no hosted execution yet. |
+| Unix installer integrity | implemented | behavioral checks pass | released in `v0.5.0` | Unix installers fetch and verify the matching sidecar before extraction; `v0.5.0` installs via the version-pinned installer path. |
+| Windows installer integrity | implemented | hosted `windows-latest` job passes on `main` | released in `v0.5.0` | The Windows job executes checksum/tamper behavior, simulates reparse-point rejection, and runs native `jeliyad.exe --version`; a `v0.5.0` Windows zip and sidecar are published. |
+| Complete asset-set visibility and version consistency | implemented | executed for `v0.5.0` | released in `v0.5.0` | The publication workflow validated, sealed, smoked, and receipt-verified the complete five-archive set; the evidence key is provisioned and the signed evidence passed the release gate before publication. |
 | WCAG 2.1 AA | partial | targeted checks only | partial | WCAG is a design target, not an enforced or certified conformance claim across React and Flutter. |
-| OKF-compatible documentation | implemented | locally checked; final release reconciliation pending | unreleased | The profile separates lifecycle, implementation, verification, and release status. |
+| OKF-compatible documentation | implemented | locally checked; reconciled to the released `v0.5.0` and the rc.3 candidate | released posture documented | The profile separates lifecycle, implementation, verification, and release status. |
 
 ## Preview publication rule
 
-`v0.5.0` may publish only `jeliyad` with its embedded web UI, and only after all
-required daemon target gates pass. Native Flutter applications, DMG, APK/AAB,
-Homebrew app cask, iOS artifacts, and a separately packaged agent runner are out
-of scope.
+`v0.5.0` published only `jeliyad` with its embedded web UI, after all required
+daemon target gates passed — the rule held. Native Flutter applications, DMG,
+Linux app tarballs, APK/AAB, Homebrew app cask, iOS artifacts, and a
+separately packaged agent runner remain out of scope until their own platform
+gates are satisfied.
 
 No row becomes `verified` because code exists, and no row becomes `released`
-because it is on a branch. A public immutable dependency pin, signed retained
-evidence, passing hosted gates, matching tag, complete verified artifact set,
-and explicit release authority are still required. See
+because it is on a branch. For the next release the same bar applies to the
+rc.3 candidate: fresh signed network evidence at its pin, passing hosted gates
+(including the new `linux-flutter` job), a matching tag, a complete verified
+artifact set, and explicit release authority. See
 [Known gaps and roadmap](known-gaps-roadmap.md).

--- a/docs/gate-a-result.md
+++ b/docs/gate-a-result.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Historical Gate A result — 2026-07-04"
 description: "Historical evidence of one direct cross-network P2P run that does not certify the v0.5.0 candidate."
 tags: ["nat", "networking", "p2p", "verification"]
-timestamp: "2026-07-12T12:21:59Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "historical"
@@ -77,10 +77,11 @@ achieved on that network pair); this run achieved neither caveat.
 
 ## Applicability to v0.5.0
 
-The `v0.5.0` candidate baseline is
-`1285b42037a3713840955fa518f2b81b19f2929f` and pins `iroh-rooms` at
-`3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020`. Neither matches this historical
-run. Gate A remains **pending** for the candidate until direct and deliberately
-constrained relay runs pass with the exact candidate commit and dependency
-revision, together with the broader assertion set in
-[`verification-evidence.md`](verification-evidence.md).
+This historical run matches neither the released `v0.5.0` nor the current
+candidate. `v0.5.0` satisfied Gate A's intent through its own certifying
+signed direct and forced-relay schema 2 runs at `c5f740e…` + `d0ceb0b…` (see
+[`verification-evidence.md`](verification-evidence.md)). The post-release
+candidate on `main` repins `iroh-rooms` to published `v0.1.0-rc.3`
+(`71fbb5007bef4ce83631c94762ec68c2beef3d79`) and needs its own direct and
+deliberately constrained relay runs at that exact commit and dependency
+revision before the next release.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ CI rules for every page in this wiki.
 
 ## Current status and evidence
 
-- [Capability status](capability-status.md) - What is implemented, verified, and publicly released for the v0.5.0 candidate.
+- [Capability status](capability-status.md) - What is implemented, verified, and publicly released as of v0.5.0 and the post-release candidate.
 - [Platform matrix](platform-matrix.md) - Runtime, packaging, verification, and release status by operating system and artifact.
-- [Release versus main](release-vs-main.md) - Exact boundary between v0.4.3, the audited main baseline, and the hardening candidate.
+- [Release versus main](release-vs-main.md) - Exact boundary between released v0.5.0, its certified evidence, and the post-release candidate on main.
 - [Verification evidence](verification-evidence.md) - Revision-bound milestone ledger, remote-test record, and evidence-sanitization contract.
 - [Known gaps and roadmap](known-gaps-roadmap.md) - Release blockers, deferred risks, owners, and the NOW/NEXT/LATER boundary.
 

--- a/docs/known-gaps-roadmap.md
+++ b/docs/known-gaps-roadmap.md
@@ -3,38 +3,43 @@ type: "Status Report"
 title: "Known gaps and roadmap"
 description: "Release blockers, deferred risks, owners, and next actions for the v0.5.0 evidence-backed technical preview."
 tags: ["gaps", "release", "risks", "roadmap"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
-release_status: "unreleased"
+release_status: "partial"
 audience: ["contributors", "maintainers", "product", "release-engineers"]
 ---
 
 # Known gaps and roadmap
 
-The `NOW` phase adds no product capability. It hardens the existing engineering
-alpha and remains **blocked for release** despite substantial local progress.
+`v0.5.0` shipped on 2026-07-14: the release conditions the `NOW` phase tracked
+were met (published safe pin, signed certifying direct and relay evidence,
+hosted gates, complete verified artifact set). The table below records that
+closure and the gaps that carry forward to the post-release candidate on
+`main`, which repins `iroh-rooms` to `v0.1.0-rc.3` and must earn its own
+evidence.
 
 ## NOW — closure status
 
-| Area | Evidence now available | Remaining release condition | Owner | Status |
+| Area | Evidence now available | Remaining condition for the next release | Owner | Status |
 |---|---|---|---|---|
-| Public room-scoped authorization | centralized guard; 17 negative RPCs, local-file denial, and aggregate filtering pass; foreign agent projection exercised | preserve gates on the final public candidate | core maintainer | locally closed |
-| Accepted-room provenance | failure-injected create/join ordering, serialized concurrent updates, cached reads, owner-only Unix state, and durable Unix/Windows replacement semantics pass locally | execute the configured Windows job and preserve these tests on the final public candidate | core maintainer | locally closed; hosted Windows proof pending |
-| Upstream synchronization isolation | local `3702e8c…` remediation is clean and its malicious-sync tests pass | review and publish upstream fix, pin it immutably in Jeliya, then rerun qualification | upstream and core maintainer | **blocked** |
-| Android and agent secrets | Android cloud/device-transfer exclusions, app-private no-backup identity storage, external agent data default, ignore and tracked-secret gates pass | keep controls in final candidate; Keystore wrapping is defense-in-depth, not a current claim | mobile and agent maintainers | locally closed |
-| Dependency security | Cargo and npm report zero vulnerabilities; four unmaintained/yanked warnings have owner, mitigation, and expiry records | rerun against final lockfiles; no high/critical exception may be implicit | dependency owner | locally closed |
-| CI completeness | all required matrix jobs and fail-closed prerequisites are defined; manual dispatch does not publish; Gradle is checksum-verified before execution | push authority and two clean hosted runs on the final public commit | CI maintainer | **blocked** |
-| Agent/fleet reliability | agent E2E passes; fleet stability passed 5/5; Linux orphan/zombie cleanup verified on `demo1` under UID `65534` | repeat in final hosted gates | agent maintainer | locally closed |
-| Direct network behavior | schema 2 run `3c938c66` at `0f6769a…`: three peers, distinct egress, two ASNs, 36/36 and cleanup pass; no synchronization-isolation claim | publish and pin the safe upstream revision, then rerun from the public Jeliya commit with a valid retained-evidence signature | verification owner | current functional pass; **not certifiable** |
-| Forced relay behavior | exact public-pin relay-only build failed closed before remote execution because `3cb9bfd…` lacks the reviewed seam; older schema 1 `f1d9c149` is historical local-remediation evidence only | publish and pin the reviewed seam, then obtain a current schema 2 36/36 signed relay run paired with direct evidence from the same commit and toolchain | verification owner | **blocked; no current relay pass** |
-| Evidence authenticity | release gate validates detached Ed25519 evidence signatures | authorize key custody and commit only the canonical public key before the qualifying run; never commit the private key | release authority | **blocked, fails closed** |
-| Unix installer integrity | behavioral checksum-before-extraction tests pass | rerun against final artifacts | release maintainer | locally closed |
-| Windows installer integrity | behavioral checksum/tamper, simulated reparse rejection, and native daemon smoke jobs are configured | obtain a passing hosted Windows result on the final candidate | release maintainer | **blocked; configured, unexecuted** |
-| Complete asset-set visibility | immutable actions, verified build tools, execution-free validation and receipt sealing, isolated read-only smoke, receipt-only writer verification, draft-until-complete publication, and final-step token isolation are implemented | execute only after all gates pass and explicit release authority is granted; inspect and recover manually if cleanup is interrupted because GitHub cannot transact the tag and release assets atomically | release authority | implemented, never executed |
-| Complete artifact set | `v0.4.3` has five published archives | build and verify all five `v0.5.0` daemon-plus-embedded-UI archives and sidecars together | release maintainer | **blocked; complete set absent** |
-| Documentation alignment | status pages distinguish current schema 2 direct evidence, the failed-closed current relay build, and historical schema 1 local-remediation evidence | final reconciliation after public pins, hosted runs, signatures, and artifact verification | documentation owner | current for this snapshot; release remains blocked |
+| Public room-scoped authorization | centralized guard; 17 negative RPCs, local-file denial, and aggregate filtering passed locally and in both certifying network runs | preserve gates on the next candidate | core maintainer | closed for `v0.5.0` |
+| Accepted-room provenance | failure-injected create/join ordering, serialized concurrent updates, cached reads, owner-only Unix state, and durable replacement semantics pass; hosted Windows job passes on `main` | preserve on the next candidate | core maintainer | closed |
+| Upstream synchronization isolation | certified for `v0.5.0` at published pin `d0ceb0b…`; the rc.3 candidate keeps the fix, adds the join-bootstrap capability gate, and passes upstream store/engine isolation regressions plus the full Jeliya suites locally at `71fbb50…` | rerun signed network qualification at the rc.3 pin before the next release | upstream and core maintainer | certified for `v0.5.0`; rc.3 locally requalified |
+| Android and agent secrets | Android cloud/device-transfer exclusions, app-private no-backup identity storage, external agent data default, ignore and tracked-secret gates pass | keep controls; Keystore wrapping is defense-in-depth, not a current claim | mobile and agent maintainers | closed |
+| Dependency security | Cargo and npm report zero vulnerabilities; four unmaintained/yanked warnings have owner, mitigation, and expiry records | rerun against the next candidate's lockfiles | dependency owner | closed |
+| CI completeness | all required matrix jobs pass on hosted `main` runs; manual dispatch does not publish; Gradle is checksum-verified | hosted execution of the new `linux-flutter` job; keep two clean runs on the next final commit | CI maintainer | closed for the six pre-existing jobs |
+| Agent/fleet reliability | agent E2E passes; fleet stability passed 5/5; Linux orphan/zombie cleanup verified on `demo1` under UID `65534` | repeat in the next candidate's hosted gates | agent maintainer | closed |
+| Linux Flutter source app | Ubuntu 24.04 ARM64 release package, X11/Xvfb lifecycle, bundled daemon smoke, dependency, archive, and checksum gates pass locally; a hosted x86_64 `linux-flutter` CI job is now defined | obtain hosted x86_64 and Wayland results; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
+| Direct network behavior | signed certifying schema 2 run `3b86ac67` at `c5f740e…` + `d0ceb0b…` | rerun at the rc.3 candidate pin before the next release | verification owner | certified for `v0.5.0` |
+| Forced relay behavior | signed certifying schema 2 relay run `a3c76859` with a self-attested relay-only build at the same revision pair; the rc.3 candidate verifier builds and attests locally | rerun at the rc.3 candidate pin before the next release | verification owner | certified for `v0.5.0` |
+| Evidence authenticity | detached Ed25519 signatures over both certifying manifests verify against the committed public SPKI; private-key custody is out of band | keep custody; sign the next candidate's runs | release authority | closed |
+| Unix installer integrity | behavioral checksum-before-extraction tests pass; `v0.5.0` installs via the version-pinned installer path | rerun against the next artifacts | release maintainer | closed |
+| Windows installer integrity | hosted `windows-latest` behavioral job passes on `main`; a `v0.5.0` Windows zip and sidecar are published | rerun against the next artifacts | release maintainer | closed |
+| Complete asset-set visibility | the publication workflow executed for `v0.5.0`: validation, sealing, isolated smoke, receipt verification, and draft-until-complete publication | re-execute for the next release under explicit authority | release authority | executed for `v0.5.0` |
+| Complete artifact set | `v0.5.0` published all five daemon-plus-embedded-UI archives with sidecars | build and verify the next candidate's set together | release maintainer | closed for `v0.5.0` |
+| Documentation alignment | status pages reconciled to the released `v0.5.0`, its certified evidence, and the rc.3 candidate boundary | re-reconcile at the next release cut | documentation owner | current for this snapshot |
 
 No reachable high or critical advisory is currently unresolved. The four
 maintenance/yank warnings are tracked with mitigation and an expiry of
@@ -44,32 +49,46 @@ maintenance/yank warnings are tracked with mitigation and an expiry of
 
 - the macOS Flutter application is unpublished and its bundled sidecar remains
   loopback-only;
+- the Linux Flutter application is an unsigned, source-built developer
+  package only; no native app archive is public, its x86_64 hosted and Wayland
+  results are pending, the local ARM64 daemon requires GLIBC 2.39, the tarball
+  lacks a complete Rust dependency license inventory, and direct, relay, NAT,
+  and cross-network behavior are unverified;
 - Android has local device-smoke evidence, not direct, relay, NAT, reconnect,
   or cross-network evidence; its identity is app-private and backup-excluded,
   not Keystore-backed;
 - iOS has no application scaffold or engine build;
-- macOS arm64, Linux arm64 musl, and Windows have no complete `v0.5.0`
-  candidate artifact evidence;
 - bare daemon binaries are unsigned; macOS notarization and Windows
   Authenticode are inactive;
 - WCAG 2.1 AA remains a design target with targeted checks, not enforced or
   certified conformance;
 - member removal cannot recall data already copied by an authorized peer;
-  revocation semantics require a separate protocol and product decision.
+  revocation semantics require a separate protocol and product decision;
+- the pinned upstream `v0.1.0-rc.3` carries documented residuals: while a room
+  is accepting joins, an unproven provisionally-admitted dialer no longer
+  receives history but still receives live event fan-out until it disconnects
+  (upstream issue #121); a store hole left by a swallowed insert error heals
+  only from peers that re-serve the region (upstream issue #119); and mixed
+  pre/post-repin fleets cannot complete joins, so joiners and admins must
+  upgrade together.
 
-## Exit criteria for NOW
+## Exit criteria for the next release
 
-`v0.5.0` reaches a release-authority decision only when:
+`v0.5.0` met its exit criteria and shipped on 2026-07-14. The next release
+reaches a release-authority decision only when the same bar is met at the
+new candidate:
 
-1. upstream `3702e8c…` or its reviewed successor is published and pinned by the
-   final public Jeliya commit;
-2. the approved evidence public key predates qualification, and signed direct
-   and relay manifests pass the release gate with `certifiable: true`;
-3. every required hosted CI gate passes twice from clean environments;
+1. the candidate's published pin (`v0.1.0-rc.3` at `71fbb50…`, or its
+   reviewed successor) is carried by the final public commit;
+2. signed direct and relay manifests bound to that commit and pin pass the
+   release gate with `certifiable: true` (the `v0.5.0` evidence binds
+   `c5f740e` + `d0ceb0b` and does not transfer);
+3. every required hosted CI gate — now including `linux-flutter` — passes
+   twice from clean environments;
 4. Windows behavioral checks and the other target-specific gates pass;
-5. all five daemon-plus-embedded-UI archives and sidecars are built and
-   verified before publication begins;
-6. tag, daemon, changelog, and public names agree on `v0.5.0`;
+5. the complete archive-and-sidecar set is built and verified before
+   publication begins;
+6. tag, daemon, changelog, and public names agree on the release version;
 7. [Capability status](capability-status.md),
    [Platform matrix](platform-matrix.md),
    [Release versus main](release-vs-main.md), and

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Platform matrix"
 description: "Implementation, verification, packaging, and release status for every Jeliya runtime and target platform."
 tags: ["packaging", "platforms", "release", "verification"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -13,31 +13,37 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 
 # Platform matrix
 
-The latest public release is `v0.4.3`. The `v0.5.0` candidate remains blocked
-and has no public artifacts. A source build or passing test is not a release.
+The latest public release is `v0.5.0` (2026-07-14, daemon-only prerelease
+with certified network evidence). The post-release candidate on `main` repins
+`iroh-rooms` to `v0.1.0-rc.3` and has no network evidence of its own yet. A
+source build or passing test is not a release.
 
 ## Daemon and embedded web UI
 
 | Target | Implementation | `v0.5.0` evidence | Latest public artifact | Preview status |
 |---|---|---|---|---|
-| macOS arm64 (`aarch64-apple-darwin`) | implemented | no candidate archive or platform run | `v0.4.3` archive and sidecar | required, pending |
-| macOS x86_64 (`x86_64-apple-darwin`) | implemented | schema 2 embedded-UI source build and direct operator run pass; current relay-only build blocked; installer behavior passes | `v0.4.3` archive and sidecar | direct functional evidence only |
-| Linux arm64 musl (`aarch64-unknown-linux-musl`) | implemented | no candidate archive or platform run | `v0.4.3` archive and sidecar | required, pending |
-| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | schema 2 embedded-UI source build and direct run pass on Ubuntu 22.04 x86_64 under UID `65534`; current relay-only build blocked; installer behavior passes | `v0.4.3` archive and sidecar | direct functional evidence only |
-| Windows x86_64 MSVC (`x86_64-pc-windows-msvc`) | implemented | behavioral installer/checksum/tamper and simulated reparse gates plus native daemon smoke are configured; no hosted candidate result | `v0.4.3` archive and sidecar | required, pending execution |
+| macOS arm64 (`aarch64-apple-darwin`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
+| macOS x86_64 (`x86_64-apple-darwin`) | implemented | certifying signed schema 2 direct and relay runs pass (operator role); installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` |
+| Linux arm64 musl (`aarch64-unknown-linux-musl`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
+| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | certifying signed schema 2 direct and relay runs pass on Ubuntu 22.04 x86_64 under UID `65534`; installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` |
+| Windows x86_64 MSVC (`x86_64-pc-windows-msvc`) | implemented | hosted behavioral installer/checksum/tamper, simulated reparse, and native daemon smoke jobs pass on `main` | `v0.5.0` archive and sidecar | released; no platform network run |
 
-The current [schema 2 direct manifest](evidence/v0.5.0/preview-direct-schema2.json)
-binds macOS x86_64 and Linux x86_64 musl builds to Jeliya `0f6769a…`, the
-public Iroh Rooms pin `3cb9bfd…`, Rust `1.91.0`, Node `22.22.3`, the verified
-complete Zig `0.15.2` archive, and the embedded UI. It passed 36/36 assertions,
-is unsigned, sets `certifiable: false`, and makes no synchronization-isolation
-claim. The matching relay-only source build failed closed because the public
-pin lacks the reviewed compile-time test seam.
+The certifying [direct](evidence/v0.5.0/direct.json) and
+[relay](evidence/v0.5.0/relay.json) schema 2 manifests bind macOS x86_64 and
+Linux x86_64 musl builds to Jeliya `c5f740e…`, published Iroh Rooms pin
+`d0ceb0b…`, and the verified toolchain; both are signed and set
+`certifiable: true`. The earlier unsigned
+[preview manifest](evidence/v0.5.0/preview-direct-schema2.json) at `0f6769a…`
+with pre-remediation pin `3cb9bfd…` remains historical. The post-release
+candidate on `main` has since repinned
+to published Iroh Rooms `v0.1.0-rc.3`, which contains the seam, and fresh
+runs from the public candidate commit are still required.
 
-The older schema 1 [direct](evidence/v0.5.0/direct.json) and
-[relay](evidence/v0.5.0/relay.json) manifests use Jeliya `fe870c7…` and local
-upstream `3702e8c…`. They remain historical local-remediation evidence only
-and cannot qualify the current candidate. See
+The older schema 1
+[direct](evidence/v0.5.0/historical-schema1-direct.json) and
+[relay](evidence/v0.5.0/historical-schema1-relay.json) manifests use Jeliya
+`fe870c7…` and local upstream `3702e8c…`. They remain historical
+local-remediation evidence only. See
 [Verification evidence](verification-evidence.md).
 
 ## Native applications and source-only tools
@@ -45,6 +51,7 @@ and cannot qualify the current candidate. See
 | Surface | Implementation | Verification evidence | Release status | `v0.5.0` decision |
 |---|---|---|---|---|
 | macOS Flutter app | application and DMG pipeline exist | local tests only; current app sidecar is loopback-only; signing/notarization inactive | no DMG published | excluded |
+| Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 release build, X11/Xvfb lifecycle, sidecar smoke, dependency, archive, and checksum gates pass locally; Wayland and the equivalent x86_64 hosted gate remain unverified | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
 | Android Flutter app with in-process Rust engine | application and three-ABI build path exist | Android 13 local lifecycle/FFI smoke only; no cross-network, NAT, direct, or relay evidence | no APK/AAB published | excluded |
 | Android identity storage | app-private no-backup storage with cloud and device-transfer exclusions | rules and validation pass | unreleased | included security control; not Keystore-backed |
 | iOS app | no scaffold or engine build | none | none | excluded |
@@ -55,29 +62,28 @@ and cannot qualify the current candidate. See
 
 | Runtime | Local protocol | Cross-network direct | Forced relay | Reconnect/resync |
 |---|---|---|---|---|
-| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | current schema 2 36/36 functional pass across three distinct egresses and two ASNs | BLOCKED; exact public pin lacks the relay-only test seam; historical schema 1 pass does not transfer | current direct reconnect/resync pass; current relay unverified |
+| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | certifying signed schema 2 direct pass across three distinct egresses and two ASNs at `c5f740e…` + `d0ceb0b…` | certifying signed schema 2 relay pass with a self-attested relay-only build at the same revision pair; no run at the rc.3 candidate pin | certified direct and relay reconnect/resync pass for `v0.5.0` |
 | Other daemon targets | implemented | no candidate evidence | no candidate evidence | no candidate evidence |
 | Android in-process engine | local device-smoke evidence | unverified | unverified | local lifecycle only; cross-peer unverified |
 | macOS Flutter sidecar | loopback-only configuration | unsupported by current app configuration | unsupported by current app configuration | local sidecar lifecycle only |
+| Linux Flutter sidecar | real networking configured through the bundled daemon | unverified | unverified | local ARM64 source-package lifecycle gate passes; cross-peer unverified |
 
-The current direct run is not release-qualifying because its Jeliya commit is
-unpublished, its upstream pin remains unsafe, and its manifest is unsigned.
-The historical runs are also non-qualifying. “Real networking enabled” on
-Android means only `loopback: false`; it is not evidence of a peer path.
+The certifying runs qualify `v0.5.0` exactly; they do not transfer to the
+rc.3 candidate, whose pin differs. “Real networking enabled” on Android means
+only `loopback: false`; it is not evidence of a peer path.
 
 ## Packaging trust status
 
-`v0.4.3` contains five daemon archives and a SHA-256 sidecar for each. Its
-installers do not automatically enforce those sidecars before extraction. The
-candidate Unix installer now passes behavioral fail-closed tests for sidecar
-verification. Windows jobs now exercise the PowerShell installer, tamper
-rejection, a simulated reparse-point payload, and native daemon startup, but
-they have not run in a hosted Windows environment for this candidate.
+`v0.5.0` contains five daemon archives and a SHA-256 sidecar for each. Its
+Unix installers pass behavioral fail-closed tests for sidecar verification
+before extraction, and the hosted Windows job exercises the PowerShell
+installer, tamper rejection, a simulated reparse-point payload, and native
+daemon startup.
 
-The candidate workflow pins third-party actions, verifies downloaded Zig,
+The release workflow pins third-party actions, verifies downloaded Zig,
 keeps build jobs read-only, validates and seals the complete set without
 executing it, and runs smoke execution in a separate read-only job. The sole
 writer verifies the sealed receipt without executing candidate bytes and
-exposes its token only to the final publishing step. It has never been executed
-to publish `v0.5.0`, and no complete five-target candidate set has been built.
+exposes its token only to the final publishing step. It executed exactly this
+way to publish `v0.5.0`'s five-target set.
 See [Release versus main](release-vs-main.md).

--- a/docs/realnet-runbook.md
+++ b/docs/realnet-runbook.md
@@ -3,7 +3,7 @@ type: "Runbook"
 title: "Real-network NAT runbook"
 description: "Operator procedure for collecting revision-bound direct and forced-relay evidence across three distinct public egress paths."
 tags: ["nat", "networking", "operations", "p2p"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -20,22 +20,23 @@ a diagnostic and historical reference; it cannot qualify a `v0.5.0` release.
 
 ## Current evidence status
 
-The current hardened source snapshot is Jeliya
-`0f6769a68d783cf6a5feba0e2db6111a212affa1` with public Iroh Rooms pin
-`3cb9bfd1e43eb755c967315c37b6d4fd1c2bf020`. Its schema 2 direct run passed;
-the matching relay-only build failed closed before remote execution because
-that public pin lacks the reviewed compile-time test seam:
+The certifying `v0.5.0` runs bind the published network-qualified Jeliya
+commit `c5f740e67d043a1153cf285691e3bc5b2b9a7203` and published Iroh Rooms
+pin `d0ceb0b…`; both are signed and set `certifiable: true`:
 
-| Path | Run | UTC window | Evidence status |
-|---|---|---|---|
-| direct | `20260712T231015Z-3c938c66` | 23:10:15–23:34:46 | 36/36 functional PASS; [schema 2 manifest](evidence/v0.5.0/preview-direct-schema2.json) retained, unsigned, `certifiable: false` |
-| forced relay | no run manifest | not applicable | BLOCKED; source build failed closed; no remote execution or relay assertion occurred |
+| Path | Run | Evidence status |
+|---|---|---|
+| direct | `3b86ac67` | certifying PASS; [signed schema 2 manifest](evidence/v0.5.0/direct.json) |
+| forced relay | `a3c76859` | certifying PASS with a self-attested relay-only build; [signed schema 2 manifest](evidence/v0.5.0/relay.json) |
 
-The direct run validates direct network behavior and public-RPC
-non-disclosure. It explicitly does not claim upstream synchronization
-isolation: the public dependency pin remains unsafe, the Jeliya commit is
-unpublished, and the evidence public key is absent. It cannot qualify a
-release.
+The post-release candidate on `main` has since repinned to published Iroh
+Rooms `v0.1.0-rc.3` (`71fbb5007bef4ce83631c94762ec68c2beef3d79`). The
+certified evidence does not transfer to it: the next release's direct and
+forced-relay runs must start from the public Jeliya commit carrying the rc.3
+pin. The earlier unsigned preview run
+(`20260712T231015Z-3c938c66`,
+[manifest](evidence/v0.5.0/preview-direct-schema2.json)) at `0f6769a…` with
+pre-remediation pin `3cb9bfd…` remains historical functional evidence.
 
 Historical schema 1 direct and relay runs used unpublished Jeliya
 `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` and a local `file://` checkout of
@@ -45,9 +46,11 @@ unpublished Iroh Rooms
 public candidate. They also predate
 the isolated source-build and complete Zig-installation controls in schema 2.
 Schema 1 records remain non-certifying and cannot be promoted by adding a
-signature. The durable sanitized records are
-[`direct.json`](evidence/v0.5.0/direct.json) and
-[`relay.json`](evidence/v0.5.0/relay.json); their exact limits are documented in
+signature. Their durable sanitized records are
+[`historical-schema1-direct.json`](evidence/v0.5.0/historical-schema1-direct.json)
+and
+[`historical-schema1-relay.json`](evidence/v0.5.0/historical-schema1-relay.json);
+their exact limits are documented in
 [`verification-evidence.md`](verification-evidence.md#historical-schema-1-local-remediation-evidence).
 
 ## Safety envelope

--- a/docs/release-vs-main.md
+++ b/docs/release-vs-main.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Release versus main"
 description: "Exact boundary between the latest published Jeliya artifacts, the audited baseline, and the v0.5.0 candidate."
 tags: ["artifacts", "main", "release", "versions"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "not-applicable"
 verification_status: "verified"
@@ -14,86 +14,86 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Release versus main
 
 Git branches, test revisions, tags, and release assets answer different
-questions. The `v0.5.0` candidate is **blocked** and must not be described as
-shipped.
+questions. `v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease;
+current `main` is the post-release candidate and must not be described as
+released.
 
 ## Current boundary
 
 | Layer | Exact revision | Dependency state | Artifact/evidence state | Claim allowed |
 |---|---|---|---|---|
-| Latest public release | tag `v0.4.3` at `9d62c3cd98c7f21d9683815c28278b6ac8c0b97f` | release lockfile | five published daemon archives and five checksum sidecars | only behavior in those archives is released |
+| Latest public release | tag `v0.5.0` at `045d85cb1d066f16d564b6051363b9328063ee01` (prerelease) | pins published `iroh-rooms` `d0ceb0b…` (rc.2-era remediation) | five published daemon archives and five checksum sidecars; signed certifying direct (`3b86ac67`) and relay (`a3c76859`) manifests | behavior in those archives is released; known limitation: joins from invites minted after non-admin chat fail at this pin |
+| Network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` | pins `d0ceb0b…` | both certifying schema 2 runs bind this commit | the certified evidence speaks for this revision pair |
+| Post-release candidate | `main` | pins published `iroh-room` tag `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` (adds the join-after-conversation fix, join-bootstrap capability gate, bounded membership sync, gap healing) | no network evidence at this pin; local suites and upstream regressions pass | source behavior only; needs its own signed runs before the next release |
 | Audited baseline | `1285b42037a3713840955fa518f2b81b19f2929f` | pins vulnerable `iroh-rooms` `3cb9bfd…` | no artifact for this commit | baseline source behavior only |
-| Initial hardening checkpoint | `4d0807a42ad79f7eb1b44edab48a62bf8813dd9c` | public repository pin remains `3cb9bfd…` | historical checkpoint before provenance, cache, and protocol-contract follow-ups | historical only; not the current candidate boundary |
-| Hardened candidate and current network snapshot | `0f6769a68d783cf6a5feba0e2db6111a212affa1` on `hardening/v0.5.0-evidence-preview` before final documentation reconciliation | public repository pin remains unsafe `3cb9bfd…`; exact `atomicwrites 0.4.4` supplies durable state replacement semantics | schema 2 direct 36/36 functional pass; exact relay-only build failed closed because the public pin lacks the test seam; no public artifacts | current direct functional evidence only; relay and release readiness blocked |
-| Historical local-remediation network snapshot | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` | local Git dependency `3702e8c…` | schema 1 direct and relay functional pass; manifests retained, unsigned, `certifiable: false` | historical functional evidence only; cannot qualify current candidate or release |
-| Upstream synchronization remediation | local `iroh-room` `3702e8cbcd5ac1808791124dd6bc44068be5f822` | clean and tested, but unpublished | no immutable public dependency revision | cannot support a Jeliya release claim |
+| Initial hardening checkpoint | `4d0807a42ad79f7eb1b44edab48a62bf8813dd9c` | pinned `3cb9bfd…` at that checkpoint | historical checkpoint before provenance, cache, and protocol-contract follow-ups | historical only |
+| Pre-certification network snapshot | `0f6769a68d783cf6a5feba0e2db6111a212affa1` on `hardening/v0.5.0-evidence-preview` | pinned then-unsafe `3cb9bfd…` | schema 2 direct 36/36 functional pass ([preview manifest](evidence/v0.5.0/preview-direct-schema2.json), unsigned); its relay-only build failed closed for lack of the seam | historical functional evidence only |
+| Historical local-remediation network snapshot | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` | local Git dependency `3702e8c…` | schema 1 direct and relay functional pass; manifests retained unsigned as `historical-schema1-{direct,relay}.json` | historical functional evidence only |
 
-The current hardened implementation and schema 2 direct run share exact source
-commit `0f6769a…`. The retained
-[preview direct manifest](evidence/v0.5.0/preview-direct-schema2.json) uses the
-public dependency pin and explicitly makes no synchronization-isolation claim.
-The corresponding relay-only build did not execute remotely: the public pin
-does not contain the reviewed compile-time seam, so the build failed closed.
+The certifying [direct](evidence/v0.5.0/direct.json) and
+[relay](evidence/v0.5.0/relay.json) schema 2 manifests bind the
+network-qualified commit `c5f740e…` and published pin `d0ceb0b…`, carry
+detached Ed25519 signatures, and set `certifiable: true` — they authorized
+the `v0.5.0` prerelease. They do not transfer to the rc.3 candidate on
+`main`: its pin differs, so the next release needs fresh signed runs.
 
-The older [direct](evidence/v0.5.0/direct.json) and
-[relay](evidence/v0.5.0/relay.json) schema 1 manifests exercise the unpublished
-local upstream remediation. They predate later runtime and evidence hardening
-and remain historical only. No retained pair currently combines the hardened
-Jeliya commit, a published safe upstream pin, schema 2, signatures, and both
-direct and forced-relay passes.
+## Published `v0.5.0` artifact set
 
-## Published `v0.4.3` artifact set
-
-- `jeliyad-v0.4.3-aarch64-apple-darwin.tar.gz`
-- `jeliyad-v0.4.3-x86_64-apple-darwin.tar.gz`
-- `jeliyad-v0.4.3-aarch64-unknown-linux-musl.tar.gz`
-- `jeliyad-v0.4.3-x86_64-unknown-linux-musl.tar.gz`
-- `jeliyad-v0.4.3-x86_64-pc-windows-msvc.zip`
+- `jeliyad-v0.5.0-aarch64-apple-darwin.tar.gz`
+- `jeliyad-v0.5.0-x86_64-apple-darwin.tar.gz`
+- `jeliyad-v0.5.0-aarch64-unknown-linux-musl.tar.gz`
+- `jeliyad-v0.5.0-x86_64-unknown-linux-musl.tar.gz`
+- `jeliyad-v0.5.0-x86_64-pc-windows-msvc.zip`
 - one `.sha256` sidecar for each archive
 
-No DMG, APK/AAB, iOS application, or separately packaged agent runner is in
-`v0.4.3`. No complete `v0.5.0` five-archive set has been built or published.
+No DMG, Linux native-app tarball, APK/AAB, iOS application, or separately
+packaged agent runner is in `v0.5.0`; it is a daemon-plus-embedded-UI
+prerelease only.
 
 ## Candidate changes are not released capabilities
 
-The candidate adds room-access guards, secret and backup protections,
-dependency gates, complete CI job definitions, safer E2E process ownership,
-installer integrity checks, complete asset-set visibility controls, and
-evidence-aware documentation. It adds no product feature. Local tests and
-retained network runs demonstrate implementation progress; they do not alter
-the release boundary.
+The post-release candidate on `main` repins `iroh-rooms` to `v0.1.0-rc.3`
+(join-after-conversation fix, join-bootstrap capability proof in `room.join`,
+bounded membership sync, gap healing) and adds a source-supported Linux
+Flutter app with its packaging gate and `linux-flutter` CI job. The Linux app
+is an unsigned, unpublished developer package; it adds no released feature.
+Local tests and upstream regressions demonstrate implementation progress;
+they do not alter the release boundary — `v0.5.0` behavior is exactly what
+its archives contain, including its known join-after-chat limitation.
 
 ## Publication gate
 
-Before a `v0.5.0` tag can be published, the same public immutable commit must
-prove all of the following:
+`v0.5.0` met this gate and published. Before the next release tag can be
+published, the same public immutable commit must prove all of the following:
 
-1. a reviewed upstream room-isolation fix is public and exactly pinned;
-2. an approved evidence Ed25519 public key was committed before the qualifying
-   network run, and both retained manifests have valid detached signatures;
-3. direct and relay evidence is certifiable against published revisions;
-4. all required hosted CI gates pass twice from clean environments;
-5. all five daemon-plus-embedded-UI archives and sidecars exist and verify,
-   including Windows behavioral gates;
-6. tag, daemon version, changelog, and artifact names all say `v0.5.0`;
+1. the reviewed upstream pin (`v0.1.0-rc.3` or a reviewed successor) is
+   public and exactly pinned;
+2. the approved evidence Ed25519 public key predates the qualifying network
+   runs, and both retained manifests have valid detached signatures;
+3. direct and relay evidence is certifiable against the candidate's published
+   revisions (the `v0.5.0` evidence binds `c5f740e` + `d0ceb0b` and does not
+   transfer);
+4. all required hosted CI gates — now including `linux-flutter` — pass twice
+   from clean environments;
+5. the complete archive-and-sidecar set exists and verifies, including
+   Windows behavioral gates;
+6. tag, daemon version, changelog, and artifact names agree;
 7. only the final publishing job can write; it verifies the sealed receipt
    without executing candidate bytes, and only its final step receives the
    token after explicit release authority.
 
-The evidence key is intentionally absent today. The release check therefore
-fails closed; an unsigned local PASS cannot open publication. The publication
-workflow is implemented locally but has never been used to publish `v0.5.0`.
 GitHub does not provide one transaction spanning the Git tag and release
-assets. The workflow can guarantee complete asset-set visibility by retaining
+assets. The workflow guarantees complete asset-set visibility by retaining
 a draft until all uploaded bytes verify, but an interrupted cleanup between
 the ref and release operations requires operator inspection before retry.
 
 ## Evidence provenance
 
-This snapshot records repository and release inventory established on
-2026-07-12, the hardened/network-tested implementation at `0f6769a…`, the
-schema 2 direct manifest produced between 23:10 and 23:34 UTC, the failed-closed
-current relay build, and the older schema 1 direct/relay manifests. Neither
-tickets, tokens, identity material, nor public IP addresses are retained. See
+This snapshot records the released `v0.5.0` boundary (tag at `045d85c…`,
+certifying signed direct/relay manifests bound to `c5f740e…` + `d0ceb0b…`),
+the post-release rc.3 candidate on `main`, and the retained historical
+manifests (the unsigned schema 2 preview run at `0f6769a…` and the schema 1
+local-remediation runs). Neither tickets, tokens, identity material, nor
+public IP addresses are retained. See
 [Platform matrix](platform-matrix.md) and
 [Known gaps and roadmap](known-gaps-roadmap.md).

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -3,7 +3,7 @@ type: "Architecture"
 title: "Security and threat model"
 description: "Trust boundaries, assets, threats, controls, and residual risks for the v0.5.0 Jeliya technical preview."
 tags: ["authorization", "privacy", "security", "threat-model"]
-timestamp: "2026-07-12T23:55:23Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -20,7 +20,10 @@ complete security. The hardening implementation and functional verification
 are complete and certified: the public dependency pin now carries the
 room-scoped synchronization remediation and relay-only verification seam, the
 network-tested source is published, and the retained direct and forced-relay
-network evidence is signed and certifiable.
+network evidence is signed and certifiable. The post-release candidate on
+`main` repins `iroh-rooms` to published `v0.1.0-rc.3`, which additionally
+gates the join bootstrap on an invite capability proof; the certified
+evidence does not transfer to that pin.
 
 ## Candidate boundary
 
@@ -31,6 +34,7 @@ Security conclusions must name the source being evaluated:
 | Public Jeliya dependency | Iroh Rooms `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` (iroh-room tag `v0.1.0-rc.2`) | carries the room-scoped event-lookup isolation remediation and relay-only seam; qualified for `v0.5.0` |
 | Network-qualified Jeliya commit | Jeliya `c5f740e67d043a1153cf285691e3bc5b2b9a7203` | implements local RPC, durable provenance, secret, CI, evidence, and release controls; certifying schema 2 direct checks pass against public pin `d0ceb0b…` |
 | Forced-relay verification | Jeliya `c5f740e…` plus public Iroh Rooms `d0ceb0b…` | certifying PASS; the relay-only build self-attests and forced-relay paths hold on roles A/B/C |
+| Post-release candidate dependency (`main`) | Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (published tag `v0.1.0-rc.3`) | keeps the isolation remediation and relay seam; adds the join-after-conversation fix, the join-bootstrap capability gate (`room.join` presents a `BootstrapProof`), bounded membership sync, and gap healing; no network evidence at this pin |
 | Historical local-remediation verification | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` plus local Iroh Rooms `3702e8cbcd5ac1808791124dd6bc44068be5f822` | schema 1 direct and forced-relay checks passed, but this older unpublished pair does not qualify a release |
 
 The certifying direct and forced-relay runs bind the published network-qualified
@@ -39,7 +43,9 @@ establish direct and relay network operation, public-RPC non-disclosure, and the
 room-scoped synchronization isolation carried by the pinned remediation.
 Publication, immutable safe repinning, the direct and relay reruns, and the fresh
 signed evidence — all now complete — were security requirements, not release
-administration.
+administration. The rc.3 candidate is locally requalified only (upstream
+isolation regressions and the full Jeliya suites pass at the pinned tag);
+the next release needs fresh signed runs at that pin.
 
 ## Assets
 
@@ -75,6 +81,8 @@ implemented control.
 |---|---|---|---|
 | Foreign-room data returned through a public RPC | cross-room confidentiality breach | one accepted-room preflight guard before any room-derived read or fold; `agents.fleet` and other aggregates enumerate/filter accepted rooms | local regressions pass; the certifying schema 2 direct and forced-relay runs deny all room-scoped RPCs, local-file access, and aggregate foreign-room/agent projections at `c5f740e…` |
 | Foreign-room events served or admitted during synchronization | remote extraction or local-store contamination | room-scope `get`, `contains`, `WantEvents`, missing-parent traversal, and administrative tips; reject foreign envelopes and parents | the room-scoped remediation is published as `d0ceb0b...` (iroh-room tag v0.1.0-rc.2) and pinned; the certifying forced-relay run confirms foreign envelopes and parents are rejected over the network |
+| Uninvited dialer pulls room history during an open join window (rc.3 candidate) | pre-join history disclosure | the rc.3 pin serves the join-bootstrap membership closure only after a verified invite capability proof (upstream issue #112); Jeliya's `room.join` presents the proof from the ticket | capability-gated join covered by the upstream join e2e suite and Jeliya's loopback join tests at the pin; residual: a still-connected unproven provisional dialer keeps receiving live event fan-out until it disconnects (upstream issue #121) — accept joins only while expecting them |
+| Store hole from a swallowed insert error (rc.3 candidate) | local store/fold divergence and unhealed history | the pinned upstream re-serves unplaced regions from peers; bounded backfill retries drive from recorded missing sets | upstream issue #119 remains open: a hole in a region no peer re-serves does not heal, and fold/store can disagree until restart; no Jeliya-side control beyond restart today |
 | Invite possession treated as accepted membership | pre-join data exposure | accepted-room index is authoritative; invite-only/never-joined rooms fail closed; joined-then-left archive behavior is explicit | negative never-joined cases and positive archive behavior pass locally |
 | Android identity copied through backup or device transfer | long-lived identity disclosure outside the device | `allowBackup=false`, explicit backup/data-extraction exclusions, `noBackupFilesDir`, fail-closed migration | repository validation passes; no Keystore protection and no claim against a rooted or compromised device |
 | Agent identity or state committed from a checkout | public secret disclosure and identity reuse | platform data directory outside the checkout, per-directory deny-all `.gitignore`, repository ignore rules, tracked-secret gate | six secret-storage tests plus repository validation pass locally |

--- a/docs/signing-notarization.md
+++ b/docs/signing-notarization.md
@@ -1,9 +1,9 @@
 ---
 type: "Runbook"
 title: "Signing and notarization (Phase 2)"
-description: "Release-security plan and procedure for signing and notarizing Jeliya artifacts on macOS and Windows."
-tags: ["macos", "release", "security", "signing", "windows"]
-timestamp: "2026-07-11T21:27:07Z"
+description: "Release-security plan and procedure for signing and notarizing Jeliya desktop artifacts."
+tags: ["linux", "macos", "release", "security", "signing", "windows"]
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -25,8 +25,13 @@ Current status:
 - The `v0.5.0` workflow publishes only five unsigned `jeliyad` archives with
   their checksum sidecars. It contains no `macos-app` job, DMG upload,
   Developer ID signing, notarization, or Authenticode step.
-- Source-level macOS packaging scripts and unsigned development builds exist,
-  but they are not public release artifacts and do not satisfy a platform gate.
+- Source-level macOS packaging scripts and an unsigned Linux Flutter tarball
+  pipeline exist. The Linux ARM64 build and lifecycle gate pass locally, but
+  neither platform's native app is a public release artifact. The Linux
+  tarball has only a SHA-256 integrity sidecar; it has no publisher signature,
+  distro repository signature, or sandboxed package format. It also lacks a
+  complete Rust third-party license and notice inventory, which is required
+  before distribution.
 - Android signing is separate future distribution work. `v0.5.0` publishes no
   APK or AAB, and a debug-keystore fallback must never be treated as a
   distributable build. See

--- a/docs/verification-evidence.md
+++ b/docs/verification-evidence.md
@@ -3,11 +3,11 @@ type: "Status Report"
 title: "Verification evidence"
 description: "Revision-bound verification ledger and evidence-recording contract for the v0.5.0 technical preview."
 tags: ["evidence", "networking", "release", "testing", "verification"]
-timestamp: "2026-07-14T22:10:00Z"
+timestamp: "2026-07-16T15:30:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "verified"
-release_status: "unreleased"
+release_status: "partial"
 audience: ["contributors", "maintainers", "operators", "release-engineers"]
 ---
 
@@ -28,14 +28,14 @@ authorizes the v0.5.0 daemon prerelease.
 
 | Field | Value |
 |---|---|
-| Milestone | `v0.5.0 — Evidence-Backed Technical Preview` |
+| Milestone | `v0.5.0 — Evidence-Backed Technical Preview`, published 2026-07-14 as a prerelease |
 | Baseline commit | `1285b42037a3713840955fa518f2b81b19f2929f` |
 | Network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` |
-| Current public `iroh-rooms` pin | `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` — cross-room event-lookup isolation remediated (iroh-room tag v0.1.0-rc.2) |
-| Candidate upstream remediation revision | `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` |
+| `v0.5.0`-certified `iroh-rooms` pin | `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` — cross-room event-lookup isolation remediated (published rc.2-era revision) |
+| Post-release candidate `iroh-rooms` pin (`main`) | `71fbb5007bef4ce83631c94762ec68c2beef3d79` — published tag `v0.1.0-rc.3`; no network evidence at this pin yet |
 | Retained evidence signatures | present — detached Ed25519 over `direct.json` and `relay.json`, verified against the pinned public SPKI |
-| Release evidence gate | READY |
-| Evidence window | 2026-07-14 UTC |
+| Release evidence gate | READY for `v0.5.0` (consumed by its publication); the next release needs fresh evidence at the candidate pin |
+| Evidence window | 2026-07-14 UTC (certifying runs); candidate re-qualification 2026-07-16 |
 
 Both certifying schema 2 runs resolve the published iroh-rooms revision
 `d0ceb0b` (iroh-room tag `v0.1.0-rc.2`), which carries the reviewed cross-room
@@ -65,15 +65,15 @@ manifests are the certifying set.
 | Agent secret location | platform data directory outside the checkout, deny-all state-directory Git guard, repository ignore rules, and commit-prevention validation | local PASS |
 | Rust dependency audit | zero vulnerability advisories; three unmaintained-crate warnings and one yanked-version warning remain in the register below | PASS for vulnerability threshold |
 | npm dependency audit | zero vulnerabilities | PASS |
-| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | configured; no two hosted clean runs exist |
+| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | the six pre-existing required jobs pass on hosted `main` runs; the new `linux-flutter` job has no hosted execution yet |
 | Repeatability | two complete hosted CI executions from clean environments | satisfied by `release.yml`, which runs the complete CI gate twice on the network-qualified commit before any release build |
 | Direct different-network P2P | schema 2 run `3b86ac67`: three peers, three distinct observed egresses, two ASNs (AS11426 + AS24940), stable direct paths on roles A/B/C, all assertions pass | certifying PASS; signed and retained as `direct.json` |
 | Deliberately forced relay | schema 2 run `a3c76859`: the relay-only source build compiles against the published seam and self-attests, then proves forced-relay paths on roles A/B/C with all assertions passing | certifying PASS; signed and retained as `relay.json` |
 | Join, reconnect, and resynchronization | current direct run covered targeted joins, three-peer convergence, closed-session message, reopen, resynchronization, and settled direct reconnect | certifying PASS; direct and forced-relay both certified |
 | Messages, files, and pipes | current direct run covered bidirectional and three-peer messages, byte-identical engine-verified BLAKE3 file fetch, authorized pipe, and zero-target-connection unauthorized pipe | certifying PASS; direct and forced-relay both certified |
-| Installer integrity | Unix behavioral tests verify checksum-before-extraction; Windows jobs execute checksum/tamper behavior, simulate reparse rejection, and smoke the native daemon | Unix PASS; Windows gates configured but no hosted `windows-latest` result exists |
-| Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | contract and negative receipt tests PASS; no five-archive set built and no publication executed; GitHub tag and release operations are not one transaction |
-| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.5.0` | local PASS; public tag and artifacts are cut on release dispatch |
+| Installer integrity | Unix behavioral tests verify checksum-before-extraction; Windows jobs execute checksum/tamper behavior, simulate reparse rejection, and smoke the native daemon | Unix PASS; hosted `windows-latest` job passes on `main` |
+| Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | executed for `v0.5.0`: the five-archive set with sidecars was built, verified, and published; GitHub tag and release operations remain non-transactional |
+| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.5.0` | PASS; the public `v0.5.0` tag and artifact names agree |
 | Documentation | required OKF pages distinguish current schema 2 direct evidence, the failed-closed current relay attempt, and historical schema 1 local-remediation evidence | rerun the local docs gate on the final documentation-only commit |
 
 ## Dependency-risk exception register
@@ -297,5 +297,47 @@ The evidence gate is **READY**. Each prior blocker has been cleared:
    consistency, and the draft-until-verified publication — are executed by
    `release.yml` on release dispatch under explicit release authority.
 
-Until then, `v0.5.0` is an unreleased technical-preview candidate, regardless
-of the local functional successes recorded above.
+`v0.5.0` published through that path on 2026-07-14 with the complete
+five-archive set and sidecars.
+
+## Post-release candidate: repin to iroh-room v0.1.0-rc.3 (2026-07-16)
+
+After the `v0.5.0` release, `main` repinned `iroh-rooms` from certified
+`d0ceb0b…` to the published `v0.1.0-rc.3` tag
+(`71fbb5007bef4ce83631c94762ec68c2beef3d79`). On top of the certified pin's
+isolation fix and relay seam, rc.3 carries the join-after-conversation
+deadlock fix (upstream PR #111 — at `d0ceb0b`, and therefore in released
+`v0.5.0`, an invite minted after any non-admin chat cannot complete
+`room.join`), the join-bootstrap capability gate (PRs #117/#120, with
+`room.join` now presenting the invite's `BootstrapProof`), size-independent
+membership reconciliation (PR #118), and deep pure-chat gap healing
+(PR #116).
+
+Local re-qualification at the pinned tag on 2026-07-16 (Linux aarch64
+workstation, clean checkouts of the exact tag commit):
+
+- upstream `iroh-rooms-core --all-features`: 523/523 pass, including the
+  named isolation regressions
+  (`room_scoped_point_reads_never_match_a_foreign_room`,
+  `want_events_cannot_serve_an_id_from_another_room_in_the_shared_store`) and
+  the v1 wire/store compatibility fixtures;
+- upstream `iroh-rooms-net`: 232/232 pass, including the capability-proof
+  join end-to-end suite;
+- Jeliya at the repin: 63/63 `jeliya-core` and 8/8 `jeliyad` tests pass, and
+  the two-daemon loopback end-to-end suite passes 67/67, covering the
+  proof-presenting `room.join`;
+- the relay verifier builds against the pinned seam, prints the compile-time
+  attestation `jeliya-relay-only-test-build-v1`, and exits before touching a
+  data dir; the default build rejects the hidden flag.
+
+This is local qualification only. The certified `v0.5.0` evidence binds
+`c5f740e` + `d0ceb0b` and does not transfer; the next release requires fresh
+signed direct and forced-relay runs from the public commit carrying the rc.3
+pin. Upstream residuals at rc.3 are recorded in the
+[threat model](security-threat-model.md): live event fan-out to a
+still-connected unproven provisional dialer while joins are being accepted
+(issue #121) and store holes from swallowed insert errors (issue #119).
+Mixed-fleet caution: a `v0.5.0`-era joiner cannot bootstrap from an rc.3
+admin (it sends no capability proof), and an rc.3 joiner hard-stalls
+bootstrapping from a `v0.5.0`-era responder once it holds more than ~1k
+events — a room's members, especially its admin, must upgrade together.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -4,13 +4,15 @@ These files distribute the `jeliyad` daemon as prebuilt, per-platform binaries.
 The installer scripts and archive URLs are wired to `kortiene/jeliya` and have
 been live since `v0.3.0` (see the release-status section below). `jeliya.rb`
 is a per-release Homebrew formula: its `version` and sha256 values are
-refreshed from each release's sidecars.
+refreshed from each release's sidecars. Native-app packaging helpers also
+exist in `../scripts`, but their outputs are source-built developer artifacts,
+not public downloads.
 
 **`v0.5.0` publishes exactly five `jeliyad` archives with the embedded web UI,
 plus one checksum sidecar per archive.** It does not publish the macOS Flutter
-app or DMG, Android APK/AAB files, an iOS app, or the Homebrew app cask. Native
-build instructions below remain development references, not `v0.5.0` release
-scope.
+app or DMG, the Linux Flutter app or its tarball, Android APK/AAB files, an iOS
+app, or the Homebrew app cask. Native build instructions below remain
+development references, not `v0.5.0` release scope.
 
 ## Files
 
@@ -21,6 +23,7 @@ scope.
 | `install.ps1` | Windows PowerShell equivalent. Downloads the archive and checksum, verifies SHA-256 before extraction, installs to `%LOCALAPPDATA%\Programs\Jeliya`, and adds it to the user PATH. |
 | `jeliya.rb` | Homebrew formula template. Belongs in a tap (`kortiene/homebrew-jeliya`), not homebrew-core. |
 | `jeliya-app.rb` | Unpublished Homebrew cask template for a future desktop-app release. It is not completed, uploaded, or updated by the `v0.5.0` release. |
+| `../scripts/package-linux.mjs` | Source-only Linux Flutter packager. Builds the host-native app and `jeliyad`, installs the adjacent sidecar and freedesktop metadata, exercises the bundle, then emits a tarball and SHA-256 sidecar under `dist/`. CI checks but does not publish them. |
 
 ## How they fit together
 
@@ -138,6 +141,63 @@ attach a DMG to its release. Every release to date carries only unsigned daemon
 archives. Signing the bare daemon archives (issue #1) and Windows Authenticode
 (issue #2) are tracked in
 [`../docs/signing-notarization.md`](../docs/signing-notarization.md).
+
+## Linux native app source package
+
+The GTK/Flutter Linux app is supported as a source build. This does **not**
+make it a released Linux app: no AppImage, Flatpak, deb, rpm, or native app
+tarball is attached to a GitHub release, and the install script still installs
+only the standalone `jeliyad` daemon with its browser UI.
+
+On Debian/Ubuntu, install the native build dependencies and enable Flutter's
+Linux target:
+
+```sh
+sudo apt-get install appstream clang cmake desktop-file-utils libgtk-3-dev \
+  liblzma-dev libstdc++-12-dev ninja-build pkg-config
+flutter config --enable-linux-desktop
+```
+
+Then package from the repository root:
+
+```sh
+node scripts/package-linux.mjs
+```
+
+The default path builds release versions of both `jeliyad` and the Flutter
+app, injects the daemon through the Linux CMake sidecar contract, verifies the
+bundle, and runs the app/sidecar launch-health-teardown gate. Run it inside an
+active desktop session; the gate also requires a rendered Flutter frame and a
+completed authenticated protocol bootstrap. Headless CI uses `xvfb-run -a`.
+The result is:
+
+```text
+dist/Jeliya-v<version>-linux-<x86_64|aarch64>.tar.gz
+dist/Jeliya-v<version>-linux-<x86_64|aarch64>.tar.gz.sha256
+```
+
+The path-relocatable archive contains the `jeliya` app executable, adjacent
+`jeliyad`, Flutter libraries and data, and freedesktop desktop entry,
+AppStream, icon, project-license, and Flutter/Dart notice assets. `--skip-build`
+repackages an existing release bundle; `--skip-runtime-gate` is the explicit
+escape hatch when no display is available. The x86_64 hosted CI gate keeps the
+default lifecycle check enabled, smokes the bundled daemon, validates the
+freedesktop metadata, checks dynamic dependencies and archive contents, and
+verifies the checksum. It deliberately does not upload the result.
+
+The complete gate has also passed locally on Ubuntu 24.04 ARM64, including
+the Xvfb app/sidecar lifecycle, daemon protocol smoke, dynamic dependency
+checks, archive verification, checksum verification, and a repeat package
+with the same SHA-256 digest. This is source-build evidence, not publication;
+the x86_64 hosted result remains pending until CI runs.
+
+“Path-relocatable” does not mean distro-portable. The locally built ARM64
+daemon requires GLIBC 2.39, so a public build must declare and enforce its
+runtime baseline or use a more portable distribution format. The lifecycle
+proof above covers X11 through Xvfb; Wayland remains unverified. The archive
+also lacks a complete Rust third-party license and notice inventory for the
+linked daemon dependencies. That inventory is required before public
+distribution.
 
 ## Android release builds
 

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -395,6 +395,7 @@ test('developer documentation matches the MSRV and complete CI job matrix', () =
   assert.deepEqual(jobs, [
     'docs-ui',
     'flutter',
+    'linux-flutter',
     'rust-runtime',
     'msrv',
     'windows-installer',

--- a/scripts/package-linux.mjs
+++ b/scripts/package-linux.mjs
@@ -1,0 +1,626 @@
+#!/usr/bin/env node
+// Build and verify the native Linux Flutter app with its jeliyad sidecar, then
+// emit a relocatable, checksummed tarball.
+//
+//   node scripts/package-linux.mjs [--skip-build] [--skip-runtime-gate]
+//
+// The runtime gate needs a display. On a headless host run the script through
+// `xvfb-run -a`. The output is:
+//
+//   dist/Jeliya-v<app-version>-linux-<arch>.tar.gz
+//   dist/Jeliya-v<app-version>-linux-<arch>.tar.gz.sha256
+
+import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  readProcessIdentity,
+  recordOwnedProcess,
+} from "./e2e-process-ownership.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const appDir = join(repoRoot, "app");
+const flutterSessionReadinessFileName = "flutter-session-ready.json";
+
+const log = (message) => console.log(`package-linux: ${message}`);
+const die = (message) => {
+  throw new Error(`package-linux: ${message}`);
+};
+
+function run(command, args, options = {}) {
+  log(`$ ${command} ${args.join(" ")}`);
+  return execFileSync(command, args, {
+    stdio: ["ignore", "inherit", "inherit"],
+    ...options,
+  });
+}
+
+function capture(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    ...options,
+  }).trim();
+}
+
+export function linuxTargetFor(nodeArch) {
+  if (nodeArch === "x64") {
+    return { flutterArch: "x64", artifactArch: "x86_64" };
+  }
+  if (nodeArch === "arm64") {
+    return { flutterArch: "arm64", artifactArch: "aarch64" };
+  }
+  throw new Error(`unsupported Linux architecture: ${nodeArch}`);
+}
+
+export function appVersionFrom(pubspec) {
+  const match = pubspec.match(/^version:\s*([0-9]+(?:\.[0-9]+){2})/m);
+  if (!match) throw new Error("app/pubspec.yaml has no semantic app version");
+  return match[1];
+}
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function assertBundleLayout(bundle) {
+  const required = [
+    "jeliya",
+    "jeliyad",
+    "data/flutter_assets",
+    "lib/libapp.so",
+    "lib/libflutter_linux_gtk.so",
+    "share/applications/com.incubtek.jeliya.desktop",
+    "share/doc/jeliya/LICENSE-APACHE",
+    "share/doc/jeliya/LICENSE-MIT",
+    "share/icons/hicolor/scalable/apps/com.incubtek.jeliya.svg",
+    "share/metainfo/com.incubtek.jeliya.metainfo.xml",
+  ];
+  for (const relative of required) {
+    if (!existsSync(join(bundle, relative))) {
+      throw new Error(`Linux bundle is missing ${relative}`);
+    }
+  }
+  for (const executable of ["jeliya", "jeliyad"]) {
+    accessSync(join(bundle, executable), constants.X_OK);
+  }
+}
+
+function validateDesktopMetadata(bundle) {
+  run("desktop-file-validate", [
+    join(bundle, "share/applications/com.incubtek.jeliya.desktop"),
+  ]);
+  run("appstreamcli", [
+    "validate",
+    "--no-net",
+    join(bundle, "share/metainfo/com.incubtek.jeliya.metainfo.xml"),
+  ]);
+}
+
+function validateNativeDependencies(bundle) {
+  const binaries = [join(bundle, "jeliya")];
+  const libDir = join(bundle, "lib");
+  for (const entry of readdirSync(libDir)) {
+    if (entry.endsWith(".so")) binaries.push(join(libDir, entry));
+  }
+  for (const binary of binaries) {
+    const output = capture("ldd", [binary]);
+    if (/(^|\s)not found(\s|$)/m.test(output)) {
+      die(`unresolved native dependency in ${binary}:\n${output}`);
+    }
+  }
+}
+
+const sleep = (milliseconds) =>
+  new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+
+export async function waitForExit(child, milliseconds) {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  return await new Promise((resolvePromise) => {
+    const onExit = () => {
+      clearTimeout(timer);
+      resolvePromise(true);
+    };
+    const timer = setTimeout(() => {
+      child.off("exit", onExit);
+      resolvePromise(false);
+    }, milliseconds);
+    child.once("exit", onExit);
+    // Close the small race between the fast-path above and listener install.
+    if (child.exitCode !== null || child.signalCode !== null) {
+      child.off("exit", onExit);
+      onExit();
+    }
+  });
+}
+
+export async function terminateChildProcess(
+  child,
+  {
+    label = "child process",
+    terminateMs = 15_000,
+    killMs = 2_000,
+    waitForExitFn = waitForExit,
+  } = {},
+) {
+  if (child.exitCode !== null || child.signalCode !== null) return "already-exited";
+
+  try {
+    child.kill("SIGTERM");
+  } catch (error) {
+    if (child.exitCode === null && child.signalCode === null) {
+      throw new Error(`${label} could not be sent SIGTERM: ${error?.message ?? error}`);
+    }
+  }
+  if (await waitForExitFn(child, terminateMs)) return "sigterm";
+
+  try {
+    child.kill("SIGKILL");
+  } catch (error) {
+    if (child.exitCode === null && child.signalCode === null) {
+      throw new Error(`${label} could not be sent SIGKILL: ${error?.message ?? error}`);
+    }
+  }
+  if (await waitForExitFn(child, killMs)) return "sigkill";
+  throw new Error(`${label} did not exit within ${killMs}ms after SIGKILL`);
+}
+
+// True when a process identity's command component names commandPath. Linux
+// identities are `linux:<bootId>:<startTime>:<command>` (the command may
+// itself contain colons); other platforms embed the `ps` command line.
+export function identityRunsCommand(identity, commandPath) {
+  const command = identity.startsWith("linux:")
+    ? identity.split(":").slice(3).join(":")
+    : identity;
+  return command.includes(commandPath);
+}
+
+function ownedProcessIsAlive(record, readIdentity = readProcessIdentity) {
+  return readIdentity(record.pid) === record.identity;
+}
+
+async function waitForOwnedProcessExit(
+  record,
+  milliseconds,
+  { readIdentity = readProcessIdentity, sleepFn = sleep } = {},
+) {
+  const deadline = Date.now() + milliseconds;
+  while (ownedProcessIsAlive(record, readIdentity)) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await sleepFn(Math.min(100, remaining));
+  }
+  return true;
+}
+
+function signalOwnedProcess(record, signal, { readIdentity, signalProcess }) {
+  const identity = readIdentity(record.pid);
+  // The recorded process exited and its PID was either freed or recycled. In
+  // both cases the gate-owned process is gone; never signal the new occupant.
+  if (identity !== record.identity) return false;
+  try {
+    signalProcess(record.pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw new Error(
+      `could not send ${signal} to owned process ${record.pid}: ${error?.code ?? error}`,
+    );
+  }
+}
+
+export async function terminateOwnedProcess(
+  record,
+  {
+    label = "owned process",
+    naturalExitMs = 15_000,
+    terminateMs = 5_000,
+    killMs = 2_000,
+    readIdentity = readProcessIdentity,
+    signalProcess = process.kill,
+    waitForExitFn = waitForOwnedProcessExit,
+  } = {},
+) {
+  if (
+    await waitForExitFn(record, naturalExitMs, { readIdentity })
+  ) {
+    return "already-exited";
+  }
+
+  signalOwnedProcess(record, "SIGTERM", { readIdentity, signalProcess });
+  if (await waitForExitFn(record, terminateMs, { readIdentity })) return "sigterm";
+
+  signalOwnedProcess(record, "SIGKILL", { readIdentity, signalProcess });
+  if (await waitForExitFn(record, killMs, { readIdentity })) return "sigkill";
+  throw new Error(`${label} did not exit within ${killMs}ms after SIGKILL`);
+}
+
+export function assertFlutterSessionReadiness(marker, { appPid, portfile }) {
+  const completedPhases = new Set(["noIdentity", "noRooms", "ready"]);
+  const valid =
+    marker?.schema === 1 &&
+    marker.boot === "ready" &&
+    completedPhases.has(marker.phase) &&
+    marker.connection === "connected" &&
+    marker.frame === "rendered" &&
+    marker.protocol === portfile.protocol &&
+    marker.app_pid === appPid &&
+    marker.daemon_pid === portfile.pid &&
+    marker.daemon_port === portfile.port;
+  if (!valid) {
+    throw new Error(
+      `Flutter session readiness marker does not match the app and sidecar: ${JSON.stringify(marker)}`,
+    );
+  }
+}
+
+async function waitForJsonFile(path, child, milliseconds) {
+  const deadline = Date.now() + milliseconds;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      try {
+        return JSON.parse(readFileSync(path, "utf8"));
+      } catch {
+        // The Flutter writer uses atomic replacement, but tolerate a file from
+        // an interrupted external inspection until the timeout expires.
+      }
+    }
+    if (child.exitCode !== null || child.signalCode !== null) return null;
+    await sleep(Math.min(250, deadline - Date.now()));
+  }
+  return null;
+}
+
+async function runtimeGate(bundle) {
+  if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    die("runtime gate needs DISPLAY/WAYLAND_DISPLAY; use `xvfb-run -a node scripts/package-linux.mjs`");
+  }
+
+  const gateDir = mkdtempSync(join(tmpdir(), "jeliya-linux-package-gate-"));
+  const app = join(bundle, "jeliya");
+  const portfile = join(gateDir, "daemon.json");
+  const readinessFile = join(gateDir, flutterSessionReadinessFileName);
+  const child = spawn(app, [], {
+    // Pin the app to the packaged sidecar even when the invoking developer has
+    // a JELIYAD_BIN override in their shell. This gate must exercise the bytes
+    // that will enter the archive, not an unrelated system installation.
+    env: {
+      ...process.env,
+      JELIYA_DATA_DIR: gateDir,
+      JELIYAD_BIN: join(bundle, "jeliyad"),
+      JELIYA_LINUX_PACKAGE_GATE: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  // Accumulate raw Buffers and decode once at use: per-chunk stringification
+  // would tear multi-byte UTF-8 sequences split across chunk boundaries into
+  // U+FFFD replacement characters.
+  const outputChunks = [];
+  const output = () => Buffer.concat(outputChunks).toString("utf8");
+  child.stdout.on("data", (chunk) => outputChunks.push(chunk));
+  child.stderr.on("data", (chunk) => outputChunks.push(chunk));
+  let spawnError = null;
+  // A failed spawn emits `error`; without a listener Node treats it as an
+  // uncaught exception and bypasses the cleanup path entirely.
+  child.once("error", (error) => {
+    spawnError = error;
+  });
+
+  let daemonPid = null;
+  let daemonRecord = null;
+  let gateFailure = null;
+  try {
+    let portfileData = null;
+    for (let attempt = 0; attempt < 90 && !portfileData; attempt += 1) {
+      await sleep(500);
+      if (existsSync(portfile)) {
+        try {
+          portfileData = JSON.parse(readFileSync(portfile, "utf8"));
+        } catch {
+          // Atomic replacement makes this unlikely, but retry a torn external
+          // read rather than turning it into a false-negative package failure.
+        }
+      }
+      if (
+        spawnError ||
+        child.exitCode !== null ||
+        child.signalCode !== null
+      ) {
+        break;
+      }
+    }
+    if (!portfileData) {
+      if (spawnError) {
+        die(`native app could not be spawned: ${spawnError.message}`);
+      }
+      die(`app did not start its bundled sidecar. Last output:\n${output().slice(-3000)}`);
+    }
+    daemonPid = portfileData.pid;
+    daemonRecord = recordOwnedProcess(daemonPid);
+    const health = await fetch(`http://127.0.0.1:${portfileData.port}/api/health`, {
+      signal: AbortSignal.timeout(5_000),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      });
+    if (health.pid !== daemonPid || health.data_dir !== portfileData.data_dir) {
+      die("sidecar health response does not match its portfile");
+    }
+    log(`runtime gate sidecar healthy (pid ${daemonPid}, port ${portfileData.port})`);
+
+    const readiness = await waitForJsonFile(readinessFile, child, 30_000);
+    if (!readiness) {
+      if (spawnError) {
+        die(`native app failed after spawning: ${spawnError.message}`);
+      }
+      die(
+        `Flutter session did not complete authenticated bootstrap. Last output:\n${output().slice(-3000)}`,
+      );
+    }
+    assertFlutterSessionReadiness(readiness, {
+      appPid: child.pid,
+      portfile: portfileData,
+    });
+    log(
+      `Flutter session rendered and ready (phase ${readiness.phase}, authenticated protocol ${readiness.protocol})`,
+    );
+  } catch (error) {
+    gateFailure = error;
+  }
+
+  const cleanupFailures = [];
+  let appTermination = null;
+  try {
+    appTermination = spawnError && child.pid == null
+      ? "spawn-failed"
+      : await terminateChildProcess(child, { label: "native app" });
+    if (!gateFailure && appTermination === "sigkill") {
+      cleanupFailures.push(new Error("native app did not exit after SIGTERM"));
+    }
+  } catch (error) {
+    cleanupFailures.push(error);
+  }
+
+  // A failure can race the sidecar's portfile publication. Recover its PID
+  // after the app has stopped so cleanup can still wait and escalate safely.
+  // The identity is read AFTER the teardown window, when the kernel may have
+  // recycled the portfile's PID to an unrelated process — mere liveness is
+  // not ownership here. Adopt the occupant only when its command line proves
+  // it is running this gate's own bundled sidecar binary; anything else stays
+  // untouched even if that means reporting the sidecar as unaccounted for.
+  if (daemonRecord == null && existsSync(portfile)) {
+    try {
+      const candidate = JSON.parse(readFileSync(portfile, "utf8"));
+      if (Number.isInteger(candidate.pid) && candidate.pid > 0) {
+        const identity = readProcessIdentity(candidate.pid);
+        if (identity && identityRunsCommand(identity, join(bundle, "jeliyad"))) {
+          daemonPid = candidate.pid;
+          daemonRecord = Object.freeze({ pid: candidate.pid, identity });
+        }
+      }
+    } catch (error) {
+      cleanupFailures.push(
+        new Error(`could not recover sidecar ownership during cleanup: ${error?.message ?? error}`),
+      );
+    }
+  }
+
+  let daemonTermination = null;
+  if (daemonRecord != null) {
+    try {
+      daemonTermination = await terminateOwnedProcess(daemonRecord, {
+        label: "bundled sidecar",
+      });
+      if (!gateFailure && daemonTermination !== "already-exited") {
+        cleanupFailures.push(
+          new Error(
+            `bundled sidecar was orphaned after app exit and required ${daemonTermination}`,
+          ),
+        );
+      }
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
+
+  // Give graceful daemon teardown a brief final window to unlink its
+  // portfile. A SIGKILL fallback necessarily leaves one and must fail the gate.
+  const portfileDeadline = Date.now() + 2_000;
+  while (existsSync(portfile) && Date.now() < portfileDeadline) {
+    await sleep(100);
+  }
+  if (existsSync(portfile)) {
+    cleanupFailures.push(new Error("sidecar portfile remained after app exit"));
+  }
+
+  const appGone = child.exitCode !== null || child.signalCode !== null || spawnError;
+  let daemonGone = true;
+  if (daemonRecord != null) {
+    try {
+      daemonGone = !ownedProcessIsAlive(daemonRecord);
+    } catch (error) {
+      daemonGone = false;
+      cleanupFailures.push(error);
+    }
+  }
+  if (appGone && daemonGone) {
+    try {
+      rmSync(gateDir, { recursive: true, force: true });
+    } catch (error) {
+      cleanupFailures.push(
+        new Error(`could not remove runtime gate directory: ${error?.message ?? error}`),
+      );
+    }
+  } else {
+    cleanupFailures.push(
+      new Error(`runtime gate processes remain alive; preserving ${gateDir} for inspection`),
+    );
+  }
+
+  const failures = [gateFailure, ...cleanupFailures].filter(Boolean);
+  if (failures.length > 0) {
+    const details = failures
+      .map((error, index) => `${index + 1}. ${error?.message ?? error}`)
+      .join("\n");
+    die(`runtime gate failed:\n${details}`);
+  }
+
+  if (appTermination !== "sigterm") {
+    // The process should have remained alive until the gate deliberately
+    // requested teardown. Treat an early exit as a lifecycle regression.
+    die(`native app exited before controlled teardown (${appTermination})`);
+  }
+  if (daemonTermination !== "already-exited") {
+    die(`bundled sidecar did not exit through supervised app teardown (${daemonTermination})`);
+  }
+  log(
+    "runtime gate passed: rendered authenticated Flutter bootstrap, health, teardown, and orphan checks",
+  );
+}
+
+function reproducibleEpoch() {
+  const configured = process.env.SOURCE_DATE_EPOCH?.trim();
+  if (configured) {
+    if (/^\d+$/.test(configured)) return configured;
+    // An operator who set the variable expected it to take effect; silently
+    // substituting the commit time would undermine the reproducibility intent.
+    die(`SOURCE_DATE_EPOCH must be a non-negative integer, got: ${configured}`);
+  }
+  return capture("git", ["show", "-s", "--format=%ct", "HEAD"], {
+    cwd: repoRoot,
+  });
+}
+
+async function main() {
+  if (process.platform !== "linux") die("this packager must run on Linux");
+
+  const flags = new Set(process.argv.slice(2));
+  const supportedFlags = new Set(["--skip-build", "--skip-runtime-gate"]);
+  for (const flag of flags) {
+    if (!supportedFlags.has(flag)) die(`unknown option: ${flag}`);
+  }
+
+  const target = linuxTargetFor(process.arch);
+  const appVersion = appVersionFrom(readFileSync(join(appDir, "pubspec.yaml"), "utf8"));
+  const bundle = join(
+    appDir,
+    "build",
+    "linux",
+    target.flutterArch,
+    "release",
+    "bundle",
+  );
+
+  if (!flags.has("--skip-build")) {
+    log("building native jeliyad sidecar");
+    run("cargo", ["build", "--locked", "--release", "-p", "jeliyad"], {
+      cwd: repoRoot,
+    });
+    const cargoTargetDir = resolve(
+      repoRoot,
+      process.env.CARGO_TARGET_DIR || "target",
+    );
+    const sidecar = join(cargoTargetDir, "release", "jeliyad");
+    if (!existsSync(sidecar)) die(`cargo did not produce ${sidecar}`);
+    chmodSync(sidecar, 0o755);
+
+    log("building Flutter Linux release bundle");
+    run("flutter", ["pub", "get"], { cwd: appDir });
+    run("flutter", ["build", "linux", "--release"], {
+      cwd: appDir,
+      env: { ...process.env, JELIYA_SIDECAR_PATH: sidecar },
+    });
+  } else {
+    log("build skipped; validating the existing release bundle");
+  }
+
+  assertBundleLayout(bundle);
+  validateDesktopMetadata(bundle);
+  validateNativeDependencies(bundle);
+  const daemonVersion = capture(join(bundle, "jeliyad"), ["--version"]);
+  if (!daemonVersion.startsWith("jeliyad ")) {
+    die(`unexpected sidecar version output: ${daemonVersion}`);
+  }
+  log(`bundled ${daemonVersion}`);
+
+  if (flags.has("--skip-runtime-gate")) {
+    log("runtime gate skipped");
+  } else {
+    await runtimeGate(bundle);
+  }
+
+  const dist = join(repoRoot, "dist");
+  mkdirSync(dist, { recursive: true });
+  const staging = join(dist, `.linux-package-${process.pid}`);
+  const packageRoot = join(staging, "Jeliya");
+  rmSync(staging, { recursive: true, force: true });
+  mkdirSync(staging, { recursive: true });
+  cpSync(bundle, packageRoot, { recursive: true, preserveTimestamps: true });
+
+  const archive = join(
+    dist,
+    `Jeliya-v${appVersion}-linux-${target.artifactArch}.tar.gz`,
+  );
+  rmSync(archive, { force: true });
+  try {
+    run(
+      "tar",
+      [
+        "--sort=name",
+        `--mtime=@${reproducibleEpoch()}`,
+        "--owner=0",
+        "--group=0",
+        "--numeric-owner",
+        "--mode=u+rwX,go+rX,go-w",
+        "--pax-option=delete=atime,delete=ctime",
+        "-C",
+        staging,
+        "-czf",
+        archive,
+        "Jeliya",
+      ],
+      { cwd: repoRoot },
+    );
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+
+  if (!statSync(archive).isFile() || statSync(archive).size === 0) {
+    die("packaged archive is empty");
+  }
+  const digest = sha256File(archive);
+  const sidecarPath = `${archive}.sha256`;
+  writeFileSync(sidecarPath, `${digest}  ${basename(archive)}\n`);
+  log(`archive: ${archive}`);
+  log(`sha256: ${sidecarPath}`);
+}
+
+// import.meta.url is realpath-resolved by Node, so argv[1] must be too or an
+// invocation through a symlink silently skips main().
+const isMain =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(realpathSync(resolve(process.argv[1]))).href;
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/package-linux.test.mjs
+++ b/scripts/package-linux.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appVersionFrom,
+  assertFlutterSessionReadiness,
+  assertBundleLayout,
+  identityRunsCommand,
+  linuxTargetFor,
+  sha256File,
+  terminateChildProcess,
+  terminateOwnedProcess,
+  waitForExit,
+} from "./package-linux.mjs";
+
+test("Linux architecture names match Flutter and release conventions", () => {
+  assert.deepEqual(linuxTargetFor("x64"), {
+    flutterArch: "x64",
+    artifactArch: "x86_64",
+  });
+  assert.deepEqual(linuxTargetFor("arm64"), {
+    flutterArch: "arm64",
+    artifactArch: "aarch64",
+  });
+  assert.throws(() => linuxTargetFor("riscv64"), /unsupported Linux architecture/);
+});
+
+test("app version excludes Flutter build metadata", () => {
+  assert.equal(appVersionFrom("name: jeliya_app\nversion: 1.2.3+45\n"), "1.2.3");
+  assert.throws(() => appVersionFrom("name: jeliya_app\n"), /no semantic app version/);
+});
+
+test("sha256 sidecars use the archive bytes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "jeliya-package-test-"));
+  try {
+    const file = join(dir, "archive");
+    writeFileSync(file, "abc");
+    assert.equal(
+      sha256File(file),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bundle validation requires app, sidecar, Flutter runtime, and desktop metadata", () => {
+  const bundle = mkdtempSync(join(tmpdir(), "jeliya-bundle-test-"));
+  try {
+    const files = [
+      "jeliya",
+      "jeliyad",
+      "lib/libapp.so",
+      "lib/libflutter_linux_gtk.so",
+      "share/applications/com.incubtek.jeliya.desktop",
+      "share/doc/jeliya/LICENSE-APACHE",
+      "share/doc/jeliya/LICENSE-MIT",
+      "share/icons/hicolor/scalable/apps/com.incubtek.jeliya.svg",
+      "share/metainfo/com.incubtek.jeliya.metainfo.xml",
+    ];
+    mkdirSync(join(bundle, "data", "flutter_assets"), { recursive: true });
+    for (const relative of files) {
+      const path = join(bundle, relative);
+      mkdirSync(join(path, ".."), { recursive: true });
+      writeFileSync(path, "fixture");
+    }
+    chmodSync(join(bundle, "jeliya"), 0o755);
+    chmodSync(join(bundle, "jeliyad"), 0o755);
+    assert.doesNotThrow(() => assertBundleLayout(bundle));
+    rmSync(join(bundle, "jeliyad"));
+    assert.throws(() => assertBundleLayout(bundle), /missing jeliyad/);
+  } finally {
+    rmSync(bundle, { recursive: true, force: true });
+  }
+});
+
+test("Flutter readiness must match the rendered authenticated session", () => {
+  const portfile = { pid: 202, port: 4242, protocol: 1 };
+  const marker = {
+    schema: 1,
+    boot: "ready",
+    phase: "noIdentity",
+    connection: "connected",
+    frame: "rendered",
+    protocol: 1,
+    app_pid: 101,
+    daemon_pid: 202,
+    daemon_port: 4242,
+  };
+  assert.doesNotThrow(() =>
+    assertFlutterSessionReadiness(marker, { appPid: 101, portfile }),
+  );
+  assert.throws(
+    () =>
+      assertFlutterSessionReadiness(
+        { ...marker, connection: "connecting" },
+        { appPid: 101, portfile },
+      ),
+    /does not match/,
+  );
+  assert.throws(
+    () =>
+      assertFlutterSessionReadiness(
+        { ...marker, daemon_pid: 999 },
+        { appPid: 101, portfile },
+      ),
+    /does not match/,
+  );
+});
+
+test("late ownership recovery adopts only the gate's own sidecar command", () => {
+  const sidecar = "/repo/app/build/linux/x64/release/bundle/jeliyad";
+  // The genuine sidecar: cmdline names the bundled binary.
+  assert.equal(
+    identityRunsCommand(`linux:boot-1:12345:${sidecar} --data-dir /tmp/gate`, sidecar),
+    true,
+  );
+  // A recycled PID running something else must never be adopted, even though
+  // it is alive at the portfile's recorded PID.
+  assert.equal(
+    identityRunsCommand("linux:boot-1:99999:/usr/bin/some-unrelated-daemon", sidecar),
+    false,
+  );
+  // Colons inside the command survive the identity encoding.
+  assert.equal(
+    identityRunsCommand(`linux:boot-1:12345:${sidecar} --label a:b`, sidecar),
+    true,
+  );
+  // Non-Linux identities embed the ps command line directly.
+  assert.equal(identityRunsCommand(`Mon Jul 13 12:00:00 2026 ${sidecar}`, sidecar), true);
+  assert.equal(identityRunsCommand("Mon Jul 13 12:00:00 2026 /bin/sleep", sidecar), false);
+});
+
+test("child cleanup awaits SIGTERM and escalates to an awaited SIGKILL", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    signals: [],
+    kill(signal) {
+      this.signals.push(signal);
+      return true;
+    },
+  });
+  const waits = [false, true];
+  const result = await terminateChildProcess(child, {
+    waitForExitFn: async () => waits.shift(),
+  });
+  assert.equal(result, "sigkill");
+  assert.deepEqual(child.signals, ["SIGTERM", "SIGKILL"]);
+  assert.deepEqual(waits, []);
+});
+
+test("fast child exit cancels the wait timer and removes its listener", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+  });
+  const waiting = waitForExit(child, 10_000);
+  queueMicrotask(() => {
+    child.signalCode = "SIGTERM";
+    child.emit("exit", null, "SIGTERM");
+  });
+  assert.equal(await waiting, true);
+  assert.equal(child.listenerCount("exit"), 0);
+});
+
+test("sidecar cleanup escalates but never signals a recycled PID", async () => {
+  const record = { pid: 303, identity: "original" };
+  const signals = [];
+  const waits = [false, false, true];
+  const result = await terminateOwnedProcess(record, {
+    readIdentity: () => "original",
+    signalProcess: (pid, signal) => signals.push({ pid, signal }),
+    waitForExitFn: async () => waits.shift(),
+  });
+  assert.equal(result, "sigkill");
+  assert.deepEqual(signals, [
+    { pid: 303, signal: "SIGTERM" },
+    { pid: 303, signal: "SIGKILL" },
+  ]);
+
+  const recycledSignals = [];
+  assert.equal(
+    await terminateOwnedProcess(record, {
+      naturalExitMs: 0,
+      readIdentity: () => "recycled",
+      signalProcess: (pid, signal) => recycledSignals.push({ pid, signal }),
+    }),
+    "already-exited",
+  );
+  assert.deepEqual(recycledSignals, []);
+});


### PR DESCRIPTION
## Summary

Two commits, reviewed by a 47-agent workflow review (15 confirmed findings fixed before commit):

1. **feat(linux)** — source-supported Linux Flutter app: GTK runner + freedesktop metadata under `app/linux/`, XDG data-dir policy, Linux-aware sidecar resolution (bundle-on-existence, PATH-on-usability), real-network Linux policy (macOS keeps loopback), an opt-in package-gate readiness marker, `scripts/package-linux.mjs` + tests, and a new `linux-flutter` CI job (first hosted execution happens on this PR).
2. **feat(deps)** — repin `iroh-rooms` from the v0.5.0-certified `d0ceb0b` to the published `v0.1.0-rc.3` tag (`71fbb500…`). rc.3 fixes the join-after-conversation deadlock present in released v0.5.0, gates the join bootstrap on an invite capability proof (now presented by `room.join` via `Node::spawn_join_bootstrap` + `BootstrapProof`), removes the ~30k-event membership ceiling, and heals deep chat gaps. Status docs are reconciled to the released v0.5.0 and this candidate boundary.

## Verification

- upstream at the pinned tag: 523/523 `iroh-rooms-core --all-features`, 232/232 `iroh-rooms-net`
- Jeliya: 63/63 jeliya-core + 8/8 jeliyad; two-daemon e2e 67/67; Flutter analyze clean + 175/175 app tests; packaging + docs script tests 33/33; docs gate OK
- relay verifier builds against the pinned seam and attests `jeliya-relay-only-test-build-v1`

## Notes

- Mixed v0.5.0/rc.3 fleets cannot complete joins in either direction; rooms must upgrade together (documented in CHANGELOG and the threat model).
- The certified v0.5.0 evidence binds `c5f740e` + `d0ceb0b` and does not transfer; the next release needs fresh signed runs at the rc.3 pin.
- Suggest **rebase-merge** to keep the two scoped commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)