### PR TITLE
chore(release): cut the v0.6.0 candidate before network qualification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-16
+
 ### Changed
 
 - Repinned `iroh-rooms` from the `v0.5.0`-certified `d0ceb0b…` (rc.2-era) to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dirs",

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/docs/realnet-runbook.md
+++ b/docs/realnet-runbook.md
@@ -13,10 +13,10 @@ audience: ["contributors", "maintainers", "operators"]
 
 # Real-network NAT runbook
 
-This is the canonical `v0.5.0` network-evidence procedure. It drives one local
+This is the canonical `v0.6.0` network-evidence procedure. It drives one local
 operator process and two supervised remote daemons through
 `scripts/realnet-evidence.mjs`. The older `gate-a.mjs` flow is retained only as
-a diagnostic and historical reference; it cannot qualify a `v0.5.0` release.
+a diagnostic and historical reference; it cannot qualify a release.
 
 ## Current evidence status
 
@@ -58,7 +58,7 @@ their exact limits are documented in
 Apply these rules before running the harness:
 
 - begin with read-only SSH inventory and connectivity checks;
-- use only the generated `/tmp/jeliya-v050-<run-id>-<role>` directories and
+- use only the generated `/tmp/jeliya-v060-<run-id>-<role>` directories and
   dynamically allocated, loopback-only control ports;
 - do not change firewalls, routes, package repositories, SSH settings, user
   accounts, persistent services, or other system configuration;
@@ -264,7 +264,7 @@ lockfile.
 ## Interpret and retain the result
 
 The harness writes its initial sanitized record to
-`.jeliya-gatea/v0.5.0/<run-id>.json`. This local directory is gitignored. A
+`.jeliya-gatea/v0.6.0/<run-id>.json`. This local directory is gitignored. A
 successful functional result still fails release qualification when any source
 or dependency revision is local/unpublished, topology is insufficient, the
 working tree is dirty, or the build is not source-bound.
@@ -285,8 +285,9 @@ For a release candidate:
 2. review the structured record for secrets and remove all log excerpts while
    retaining per-role line count, byte count, and stream SHA-256 records;
 3. copy the final exact JSON bytes to
-   `docs/evidence/v0.5.0/direct.json` or
-   `docs/evidence/v0.5.0/relay.json`;
+   `docs/evidence/v0.6.0/direct.json` or
+   `docs/evidence/v0.6.0/relay.json` (the release gate derives this
+   directory from the daemon crate version);
 4. sign those final bytes with the approved out-of-band Ed25519 private key and
    retain the canonical base64 detached signature as the adjacent `.sig` file;
 5. never place the private key, its backup, or a private-key PEM in the
@@ -342,7 +343,7 @@ current relay build failed before remote mutation.
 `scripts/gate-a.mjs`, `scripts/realnet-host.mjs`, and
 `scripts/realnet-check.mjs` remain useful for two-host diagnosis and manual
 connectivity exploration. Their records are not source-bound to the complete
-`v0.5.0` candidate and cannot satisfy the three-peer topology, forced-relay,
+release candidate and cannot satisfy the three-peer topology, forced-relay,
 authorization, retained-signature, or release-ancestry gates.
 
 The 2026-07-04 result is historical only. See

--- a/scripts/check-secret-storage.mjs
+++ b/scripts/check-secret-storage.mjs
@@ -140,6 +140,7 @@ for (const candidate of [
   "release/evidence-ed25519-private.pem",
   "release/evidence-operator.key",
   "docs/evidence/v0.5.0/direct.private.pem",
+  "docs/evidence/v0.6.0/direct.private.pem",
 ]) {
   const ignored = spawnSync("git", ["check-ignore", "--no-index", "--quiet", candidate], {
     cwd: repoRoot,

--- a/scripts/realnet-evidence.mjs
+++ b/scripts/realnet-evidence.mjs
@@ -68,7 +68,7 @@ const DEFAULT_LOCAL_BIN = join(REPO_ROOT, "target", "release", "jeliyad");
 const DEFAULT_DEBUG_BIN = join(REPO_ROOT, "target", "debug", "jeliyad");
 const EVIDENCE_ROOT = process.env.JELIYA_EVIDENCE_ROOT
   ? resolve(process.env.JELIYA_EVIDENCE_ROOT)
-  : join(REPO_ROOT, ".jeliya-gatea", "v0.5.0");
+  : join(REPO_ROOT, ".jeliya-gatea", "v0.6.0");
 const WAIT_MS = 120_000;
 const LINUX_TARGET = "x86_64-unknown-linux-musl";
 const REQUIRED_RUST_TOOLCHAIN = "1.91.0";
@@ -177,7 +177,7 @@ export function remoteRunDir(runId, role) {
   if (!validRunId(runId) || !/^[abc]$/.test(role)) {
     throw new Error("invalid generated run id or role");
   }
-  return `/tmp/jeliya-v050-${runId}-${role}`;
+  return `/tmp/jeliya-v060-${runId}-${role}`;
 }
 
 function validateRemoteRunDir(runId, runDir) {
@@ -219,7 +219,7 @@ export function remoteCleanupCommand(runId, runDir) {
     `run_dir='${validated}'`,
     `pid_file='${pidFile}'`,
     `expected_exe='${expectedExe}'`,
-    `case "$run_dir" in '/tmp/jeliya-v050-${runId}-'[abc]) ;; *) exit 90 ;; esac`,
+    `case "$run_dir" in '/tmp/jeliya-v060-${runId}-'[abc]) ;; *) exit 90 ;; esac`,
     '[ ! -e "$run_dir" ] && exit 0',
     `owner=$(cat -- '${validated}/.jeliya-run-owner' 2>/dev/null) || exit 97`,
     `[ "$owner" = '${runId}' ] || exit 97`,
@@ -250,7 +250,7 @@ export function remoteOwnedDirectoryCleanupCommand(runId, runDir) {
   const validated = validateRemoteRunDir(runId, runDir);
   return [
     `run_dir='${validated}'`,
-    `case "$run_dir" in '/tmp/jeliya-v050-${runId}-'[abc]) ;; *) exit 90 ;; esac`,
+    `case "$run_dir" in '/tmp/jeliya-v060-${runId}-'[abc]) ;; *) exit 90 ;; esac`,
     '[ ! -e "$run_dir" ] && exit 0',
     '[ -d "$run_dir" ] || exit 97',
     `owner=$(cat -- '${validated}/.jeliya-run-owner' 2>/dev/null) || exit 97`,
@@ -1377,7 +1377,7 @@ export function createIsolatedSourceArchive({
 
 export function validBuildDirectory(path, runId) {
   if (!validRunId(runId) || typeof path !== "string") return false;
-  const prefix = join(tmpdir(), `jeliya-v050-${runId}-build-`);
+  const prefix = join(tmpdir(), `jeliya-v060-${runId}-build-`);
   return path.startsWith(prefix)
     && /^[A-Za-z0-9]{6}$/.test(path.slice(prefix.length));
 }
@@ -1416,7 +1416,7 @@ function buildCandidateFromSource({
   // receives a minimal environment, while unlisted credentials remain
   // available to the later SSH phase but never reach build subprocesses.
   validateSourceBuildAmbient(process.env);
-  const targetDir = mkdtempSync(join(tmpdir(), `jeliya-v050-${runId}-build-`));
+  const targetDir = mkdtempSync(join(tmpdir(), `jeliya-v060-${runId}-build-`));
   const sourceRoot = join(targetDir, "source");
   const cargoTargetDir = join(targetDir, "target");
   const discoveryHome = join(targetDir, "tool-discovery-home");
@@ -1814,7 +1814,7 @@ async function sessionToken(baseHttp) {
 }
 
 async function startLocalPeer({ role, binary, loopback, runId, resources, secrets }) {
-  const dataDir = mkdtempSync(join(tmpdir(), `jeliya-v050-${runId}-${role}-`));
+  const dataDir = mkdtempSync(join(tmpdir(), `jeliya-v060-${runId}-${role}-`));
   const args = ["--no-open", "--port", "0", "--data-dir", dataDir];
   if (loopback) args.unshift("--loopback");
   const proc = spawn(binary, args, { stdio: ["pipe", "pipe", "pipe"] });
@@ -2242,7 +2242,7 @@ async function runFlow({ peers, expectedPath, runId, resources, record }) {
   }
 
   const room = await record("A: room created", () => a.client.call("room.create", {
-    name: `v0.5.0 network evidence ${runId}`,
+    name: `v0.6.0 network evidence ${runId}`,
   }));
   const roomId = room.room_id;
   const openedA = await record("A: room opened", async () => {
@@ -2325,7 +2325,7 @@ async function runFlow({ peers, expectedPath, runId, resources, record }) {
   }
 
   const payload = Buffer.concat([
-    Buffer.from(`jeliya-v0.5.0-${runId}\n`),
+    Buffer.from(`jeliya-v0.6.0-${runId}\n`),
     randomBytes(256 * 1024),
   ]);
   const payloadPath = join(a.dataDir, `payload-${runId}.bin`);
@@ -2638,7 +2638,7 @@ async function stopResources(resources) {
   }
   for (const peer of resources.peers) {
     if (peer.kind === "local") {
-      if (peer.dataDir.includes(`jeliya-v050-${resources.runId}-`)) {
+      if (peer.dataDir.includes(`jeliya-v060-${resources.runId}-`)) {
         if (!stoppedPeers.get(peer)) {
           failures.push(`${peer.role}:local-artifact-preserved`);
           continue;
@@ -2781,7 +2781,7 @@ export function parseCli(argv) {
     withThird: localDryrun ? Boolean(args["with-third"]) : true,
     allowDirty: Boolean(args["allow-dirty"] || localDryrun),
     allowSharedEgress: Boolean(args["allow-shared-egress"] || args["allow-same-network"] || localDryrun),
-    expectedVersion: String(args["expected-version"] ?? "0.5.0"),
+    expectedVersion: String(args["expected-version"] ?? "0.6.0"),
     localBin: String(args["local-bin"] ?? (localDryrun ? DEFAULT_DEBUG_BIN : DEFAULT_LOCAL_BIN)),
     linuxBin: args["linux-bin"] ? String(args["linux-bin"]) : null,
     linuxSha256: args["linux-sha256"] ? String(args["linux-sha256"]) : null,

--- a/scripts/realnet-evidence.test.mjs
+++ b/scripts/realnet-evidence.test.mjs
@@ -74,7 +74,7 @@ test("SSH targets and generated run directories reject shell syntax", () => {
   assert.equal(validSshTarget("user@host;touch /tmp/pwned"), false);
   const runId = "20260712T120000Z-0123abcd";
   assert.equal(validRunId(runId), true);
-  assert.equal(remoteRunDir(runId, "b"), `/tmp/jeliya-v050-${runId}-b`);
+  assert.equal(remoteRunDir(runId, "b"), `/tmp/jeliya-v060-${runId}-b`);
   assert.throws(() => remoteRunDir("../bad", "b"));
 });
 
@@ -109,7 +109,7 @@ test("remote cleanup verifies the exact PID executable before signals and deleti
   assert.ok(deletion > confirmedStop);
   assert.match(command, /readlink "\/proc\/\$pid\/exe"/);
   assert.match(command, /kill -KILL "\$pid"/);
-  assert.throws(() => remoteCleanupCommand(runId, "/tmp/jeliya-v050-other-b"));
+  assert.throws(() => remoteCleanupCommand(runId, "/tmp/jeliya-v060-other-b"));
 });
 
 function freshRemoteFixture(role = "b") {
@@ -324,7 +324,7 @@ test("local dependency sources and build directories are never release provenanc
   assert.equal(isPublicGitSource("https://github.com/example/repo#credential"), false);
   assert.equal(isPublicGitSource("git@github.com:example/repo.git?token=secret"), false);
   const runId = "20260712T120000Z-0123abcd";
-  assert.equal(validBuildDirectory(join(tmpdir(), `jeliya-v050-${runId}-build-abc123`), runId), true);
+  assert.equal(validBuildDirectory(join(tmpdir(), `jeliya-v060-${runId}-build-abc123`), runId), true);
   assert.equal(validBuildDirectory("/tmp/unrelated", runId), false);
 });
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version cut for the next release, landing **before** the schema-2 network qualification (only documentation may change after it):

- daemon + core crates, `Cargo.lock`, and UI package/lock → **0.6.0**; CHANGELOG section dated.
- Network-evidence milestone markers retargeted to v0.6.0: harness run-dir prefixes (`jeliya-v060-`), manifest name, runbook procedure/paths, and the secret-storage guard for `docs/evidence/v0.6.0/`. The release gate derives the evidence path from the daemon crate version, so the certifying manifests land under `docs/evidence/v0.6.0/`.
- Why 0.6.0 and not 0.5.1: the rc.3 capability-proof bootstrap is a compatibility-affecting behavior change (v0.5.0 peers and v0.6.0 peers cannot join each other's rooms).

## Verification

- `node scripts/check-release.mjs --source` → `source versions match v0.6.0`
- harness suite 37/37; release/secret/docs/packaging suites 41/41; docs gate OK; secret-storage PASS
- Rust 63/63 + 8/8; two-daemon e2e 67/67

## After this merges

The remaining human step for the release: the operator schema-2 **direct + forced-relay runs** at this public commit (macOS x86_64, demo1/demo2, evidence key), then certification docs + release dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)