### PR TITLE
test(ui): add responsive Playwright UX regression harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,48 @@ jobs:
         working-directory: ui
         run: npm run build
 
+  ui-e2e:
+    name: UI browser regression (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.22.3'
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install TypeScript dependencies
+        working-directory: ui
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        working-directory: ui
+        run: npx playwright install --with-deps chromium
+
+      # The responsive UX regression suite (ui/e2e) drives the real app against
+      # the VITE_MOCK=1 fixture client across desktop and compact viewports —
+      # no daemon required, so this gate cannot silently skip one.
+      - name: Browser regression suite
+        working-directory: ui
+        run: npm run test:e2e
+
+      - name: Preserve failure evidence (screenshots, traces, console logs)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-failure-evidence
+          path: |
+            ui/playwright-report
+            ui/test-results
+          retention-days: 14
+
   flutter:
     name: Flutter app + i18n
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /dist/
 node_modules/
 ui/dist/
+ui/test-results/
+ui/playwright-report/
 .jeliya-data*/
 .jeliya-demo*/
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,20 @@ declined kindly.
   the contract.
 - **Prove it runs.** `node scripts/agent-e2e.mjs` proves the agent flow
   end-to-end with no network and no AI; `scripts/demo.sh` runs the full
-  two-daemon demo. Say in the PR what you ran. CI runs seven required jobs on
-  every PR and push to main: `docs-ui`, `flutter`, `linux-flutter`,
+  two-daemon demo. Say in the PR what you ran. CI runs eight required jobs on
+  every PR and push to main: `docs-ui`, `ui-e2e`, `flutter`, `linux-flutter`,
   `rust-runtime`, `msrv`, `windows-installer`, and `dependency-security`.
-  Together they cover docs, UI, Flutter/i18n, the native Linux bundle and its
-  supervised sidecar, Rust and Dart, smoke/E2E/protocol conformance, the
-  1.91.0 MSRV, Windows installer integrity, and Cargo/npm security audits.
+  Together they cover docs, UI, browser-level responsive UX regressions,
+  Flutter/i18n, the native Linux bundle and its supervised sidecar, Rust and
+  Dart, smoke/E2E/protocol conformance, the 1.91.0 MSRV, Windows installer
+  integrity, and Cargo/npm security audits.
   The same complete matrix can be dispatched manually without publishing a release.
+- **UI regressions are browser-tested.** `cd ui && npm run test:e2e` runs the
+  Playwright suite (`ui/e2e/`) against the `VITE_MOCK=1` fixture client — no
+  daemon needed — across desktop (1440×900, 920×800) and compact (390×844,
+  320×568) viewports. Changes to responsive flows (pane navigation, timeline,
+  composer, dialogs) must keep it green and should extend it; keep the suite
+  deterministic — web-first assertions only, never arbitrary sleeps.
 - **Documentation is a contract.** `docs/PROFILE.md` defines metadata,
   lifecycle, navigation, and linking rules. Every page must remain reachable
   from `docs/index.md`; run `node scripts/check-docs.mjs` after editing the

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -394,6 +394,7 @@ test('developer documentation matches the MSRV and complete CI job matrix', () =
     .map((match) => match[1]);
   assert.deepEqual(jobs, [
     'docs-ui',
+    'ui-e2e',
     'flutter',
     'linux-flutter',
     'rust-runtime',

--- a/ui/e2e/compose.spec.ts
+++ b/ui/e2e/compose.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Composing and sending messages through the mock daemon.
+
+test('sends a message and renders it as a delivered event', async ({ app }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const body = 'Hello from the regression harness';
+  await app.composerTextarea.fill(body);
+  await app.composerTextarea.press('Enter');
+
+  // The message appears (optimistic pending first), then settles once the
+  // mock daemon echoes the signed event — no "Sending…" residue remains.
+  await expect(app.timeline.getByText(body)).toBeVisible();
+  await expect(app.timeline.locator('.pending-line')).toHaveCount(0);
+  await expect(app.composerTextarea).toHaveValue('');
+});
+
+test('Shift+Enter makes a new line instead of sending', async ({ app }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  await app.composerTextarea.fill('first line');
+  await app.composerTextarea.press('Shift+Enter');
+  await app.composerTextarea.pressSequentially('second line');
+
+  await expect(app.composerTextarea).toHaveValue('first line\nsecond line');
+  // Nothing was sent.
+  await expect(app.timeline.getByText('first line')).toHaveCount(0);
+});

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -1,0 +1,143 @@
+import { expect, test as base } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/** The compact breakpoint from styles.css (`@media (max-width: 900px)`). */
+export const COMPACT_MAX_WIDTH = 900;
+
+/** Room names from the populated mock fixture (ui/src/lib/mock.ts). */
+export const MOCK_ROOMS = {
+  main: 'Build Iroh Rooms MVP',
+  workspace: 'Agent Workspace',
+  review: 'Product Review',
+  design: 'Design System',
+  research: 'Research Lab',
+} as const;
+
+interface AppFixtures {
+  /** True when this project's viewport is in the compact (phone) layout. */
+  compact: boolean;
+  app: AppDriver;
+}
+
+/** Small driver for flows every spec needs, breakpoint-aware so the same
+ *  spec runs unchanged across all four viewport projects. */
+export class AppDriver {
+  constructor(
+    readonly page: Page,
+    readonly compact: boolean,
+  ) {}
+
+  /** Load the app and wait for the shell (populated fixture) to be ready. */
+  async gotoPopulated(params: Record<string, string> = {}): Promise<void> {
+    await this.goto(params);
+    // Ready = the room list has fixture rooms (boot + room.list resolved).
+    await expect(this.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  }
+
+  /** Load the app with the fresh-onboarding fixture (`?mock=fresh`). */
+  async gotoFresh(): Promise<void> {
+    await this.goto({ mock: 'fresh' });
+    await expect(this.page.getByRole('heading', { name: 'Create your identity' })).toBeVisible();
+  }
+
+  private async goto(params: Record<string, string>): Promise<void> {
+    const search = new URLSearchParams(params).toString();
+    await this.page.goto(search ? `/?${search}` : '/');
+  }
+
+  roomItem(name: string) {
+    return this.page
+      .getByRole('navigation', { name: 'Rooms' })
+      .getByRole('button', { name, exact: false });
+  }
+
+  /** The single-pane containers (visibility differs per breakpoint). */
+  get sidebar() {
+    return this.page.locator('.sidebar');
+  }
+  get center() {
+    return this.page.locator('.center');
+  }
+  get rightPanel() {
+    return this.page.locator('.right-panel');
+  }
+  get timeline() {
+    return this.page.locator('.timeline');
+  }
+  get composerTextarea() {
+    return this.page.locator('.composer-bar textarea');
+  }
+  get tabBar() {
+    return this.page.getByRole('navigation', { name: 'Primary (mobile)' });
+  }
+
+  mobileTab(label: 'Rooms' | 'Agents' | 'Pipes' | 'Files' | 'Settings') {
+    return this.tabBar.getByRole('button', { name: label });
+  }
+
+  /** Open a room so its chat pane is visible, whatever the breakpoint.
+   *  On desktop all columns are visible; on compact this taps through the
+   *  Rooms pane. */
+  async openRoom(name: string): Promise<void> {
+    if (this.compact) {
+      // The Rooms pane is the compact landing view; get back to it first so
+      // the room item is tappable from any pane.
+      await this.mobileTab('Rooms').click();
+    }
+    await this.roomItem(name).click();
+    await expect(this.page.getByRole('heading', { level: 1, name })).toBeVisible();
+    await expect(this.timeline).toBeVisible();
+  }
+
+  /** Navigate to a primary destination (desktop left rail / mobile tab bar). */
+  async navigate(label: 'Rooms' | 'Agents' | 'Pipes' | 'Files' | 'Settings'): Promise<void> {
+    if (this.compact) {
+      await this.mobileTab(label).click();
+    } else {
+      await this.page
+        .getByRole('navigation', { name: 'Primary', exact: true })
+        .getByRole('button', { name: label })
+        .click();
+    }
+  }
+
+  /** Distance of the timeline scroller from its bottom edge, in px. */
+  async timelineBottomOffset(): Promise<number> {
+    return this.timeline.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
+  }
+}
+
+export const test = base.extend<AppFixtures>({
+  compact: [
+    async ({ viewport }, use) => {
+      await use((viewport?.width ?? 1280) <= COMPACT_MAX_WIDTH);
+    },
+    { auto: false },
+  ],
+  app: async ({ page, compact }, use, testInfo) => {
+    // Console-error trail: collected for the whole test, attached on failure
+    // alongside Playwright's screenshot + trace so a broken viewport ships
+    // with everything needed to diagnose it.
+    const consoleErrors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('pageerror', (error) => consoleErrors.push(`pageerror: ${error.message}`));
+
+    await use(new AppDriver(page, compact));
+
+    if (testInfo.status !== testInfo.expectedStatus) {
+      const viewport = page.viewportSize();
+      await testInfo.attach('failing-viewport', {
+        body: `${testInfo.project.name} (${viewport?.width}x${viewport?.height})`,
+        contentType: 'text/plain',
+      });
+      await testInfo.attach('console-errors', {
+        body: consoleErrors.length > 0 ? consoleErrors.join('\n') : '(no console errors)',
+        contentType: 'text/plain',
+      });
+    }
+  },
+});
+
+export { expect };

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -43,6 +43,15 @@ export class AppDriver {
   private async goto(params: Record<string, string>): Promise<void> {
     const search = new URLSearchParams(params).toString();
     await this.page.goto(search ? `/?${search}` : '/');
+    // Refuse to drive anything but the VITE_MOCK=1 fixture build. With
+    // reuseExistingServer enabled locally, attaching to a stray non-mock
+    // server would at best fail every spec confusingly and at worst drive a
+    // REAL daemon (the onboarding spec creates a real, irreversible
+    // identity). main.tsx stamps the transport on <html> for exactly this.
+    await expect(
+      this.page.locator('html'),
+      'the server on the harness port is not the VITE_MOCK=1 build — refusing to run against a non-mock transport',
+    ).toHaveAttribute('data-jeliya-transport', /mock fixtures \(VITE_MOCK=1\)/);
   }
 
   roomItem(name: string) {

--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -10,10 +10,22 @@ test('shows the agent fleet with honest liveness', async ({ app, page }) => {
   await expect(fleet).toBeVisible();
   await expect(fleet.getByRole('heading', { level: 1, name: 'Agents' })).toBeVisible();
 
-  // Fixture agents are aggregated across rooms.
-  await expect(fleet.getByText('Backend Agent').first()).toBeVisible();
-  await expect(fleet.getByText('QA Agent').first()).toBeVisible();
-  await expect(fleet.getByText('Research Agent').first()).toBeVisible();
+  // Each fixture agent gets exactly one aggregated card, not one per room.
+  const card = (name: string) => fleet.locator('.fleet-card', { hasText: name });
+  for (const name of ['Backend Agent', 'QA Agent', 'Research Agent']) {
+    await expect(card(name)).toHaveCount(1);
+  }
+
+  // The honesty rule this dashboard exists for (§1.2): a crashed runner whose
+  // latest label is working-class but whose peer is gone must read Stale,
+  // never Working — the mock builds exactly that fixture for Research Agent.
+  // Backend has a connected peer and a fresh working status: really Working.
+  await expect(card('Research Agent').locator('.live-pill')).toHaveText(/Stale/);
+  // Working needs the auto-opened main room's live peer; the dashboard polls
+  // agents.fleet every 4s, so allow one full cycle beyond the default.
+  await expect(card('Backend Agent').locator('.live-pill')).toHaveText(/Working/, {
+    timeout: 10_000,
+  });
 });
 
 test('searching filters the fleet list', async ({ app, page }) => {

--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from './fixtures';
+
+// The top-level Agent Fleet dashboard.
+
+test('shows the agent fleet with honest liveness', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.navigate('Agents');
+
+  const fleet = page.getByRole('region', { name: 'Agents fleet' });
+  await expect(fleet).toBeVisible();
+  await expect(fleet.getByRole('heading', { level: 1, name: 'Agents' })).toBeVisible();
+
+  // Fixture agents are aggregated across rooms.
+  await expect(fleet.getByText('Backend Agent').first()).toBeVisible();
+  await expect(fleet.getByText('QA Agent').first()).toBeVisible();
+  await expect(fleet.getByText('Research Agent').first()).toBeVisible();
+});
+
+test('searching filters the fleet list', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.navigate('Agents');
+
+  const fleet = page.getByRole('region', { name: 'Agents fleet' });
+  await fleet.getByLabel('Search agents').fill('Research');
+  await expect(fleet.getByText('Research Agent').first()).toBeVisible();
+  await expect(fleet.getByText('Backend Agent')).toHaveCount(0);
+});

--- a/ui/e2e/onboarding.spec.ts
+++ b/ui/e2e/onboarding.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from './fixtures';
+
+// Fresh-daemon onboarding (`?mock=fresh`): identity creation, then the
+// create-or-join rooms step, through to the ready shell.
+
+test('creates an identity and a first room', async ({ app, page }) => {
+  await app.gotoFresh();
+
+  await page.getByRole('button', { name: 'Create identity' }).click();
+
+  // Rooms step: both cards and the identity handoff panel are shown.
+  await expect(page.getByRole('heading', { name: 'Create a room' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Join with a ticket' })).toBeVisible();
+  await expect(page.getByText('Your identity id')).toBeVisible();
+
+  await page.getByLabel('Room name').fill('Harness Test Room');
+  await page.getByRole('button', { name: 'Create room' }).click();
+
+  // Ready shell: the new room is in the rooms list on every breakpoint
+  // (compact lands on the Rooms pane; desktop shows the sidebar).
+  await expect(app.roomItem('Harness Test Room')).toBeVisible();
+
+  // And it opens into a working chat pane.
+  await app.openRoom('Harness Test Room');
+  await expect(app.composerTextarea).toBeVisible();
+});
+
+test('surfaces a join failure honestly', async ({ app, page }) => {
+  await app.gotoFresh();
+  await page.getByRole('button', { name: 'Create identity' }).click();
+  await expect(page.getByRole('heading', { name: 'Join with a ticket' })).toBeVisible();
+
+  // A well-formed ticket nobody minted must fail with a real error — the
+  // mock enforces the same contract as the daemon (no fabricated rooms).
+  await page.getByLabel('Ticket').fill(`roomtkt1${'a'.repeat(90)}`);
+  await page.getByRole('button', { name: 'Join room' }).click();
+
+  await expect(page.locator('.error-note')).toBeVisible();
+  // Still on the rooms step — no comforting fake transition.
+  await expect(page.getByRole('heading', { name: 'Create a room' })).toBeVisible();
+});

--- a/ui/e2e/panels.spec.ts
+++ b/ui/e2e/panels.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Files and Pipes entry points. On desktop these are right-panel tabs; on
+// compact they are standalone panes reached from the bottom tab bar.
+
+test('opens the Files surface with the shared-file inventory', async ({ app, page, compact }) => {
+  await app.gotoPopulated();
+  await app.navigate('Files');
+
+  await expect(app.rightPanel).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  // The default room's five fixture files. Scoped to the panel: the same
+  // file names also render inside timeline event cards.
+  await expect(app.rightPanel.getByRole('heading', { name: '5 shared files' })).toBeVisible();
+  await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toBeVisible();
+
+  if (compact) {
+    // Standalone pane: the room context label is the only room name on screen.
+    await expect(page.locator('.panel-room-context')).toHaveText(MOCK_ROOMS.main);
+    await expect(app.center).toBeHidden();
+  }
+});
+
+test('opens the Pipes surface with live pipes and the expose form', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.navigate('Pipes');
+
+  await expect(app.rightPanel).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+  // The two fixture pipes for the default room (scoped: pipe targets also
+  // render inside timeline event cards).
+  await expect(app.rightPanel.getByText('127.0.0.1:3000')).toBeVisible();
+  await expect(app.rightPanel.getByText('127.0.0.1:4000')).toBeVisible();
+});
+
+test('desktop right-panel tabs switch between members, files, and pipes', async ({
+  app,
+  page,
+  compact,
+}) => {
+  test.skip(compact, 'the tab strip is a desktop-only affordance; compact uses the tab bar');
+  await app.gotoPopulated();
+
+  await expect(page.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+  await page.getByRole('tab', { name: 'Files', exact: false }).click();
+  await expect(page.getByRole('heading', { name: '5 shared files' })).toBeVisible();
+  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
+  await expect(page.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await expect(page.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+});

--- a/ui/e2e/rooms.spec.ts
+++ b/ui/e2e/rooms.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Room list + selecting/opening rooms, on the populated fixture.
+
+test('lists every fixture room with membership metadata', async ({ app }) => {
+  await app.gotoPopulated();
+  for (const name of Object.values(MOCK_ROOMS)) {
+    await expect(app.roomItem(name)).toBeVisible();
+  }
+  await expect(app.roomItem(MOCK_ROOMS.main)).toContainText('members');
+});
+
+test('opens the default room into a populated timeline', async ({ app, page, compact }) => {
+  await app.gotoPopulated();
+
+  if (compact) {
+    // Compact lands on the Rooms pane; the chat pane must stay hidden until
+    // the user picks a room.
+    await expect(app.center).toBeHidden();
+    await app.openRoom(MOCK_ROOMS.main);
+  } else {
+    // Desktop auto-opens the default room in the center column.
+    await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+  }
+
+  await expect(
+    app.timeline.getByText('Kicked off the rooms protocol spec', { exact: false }),
+  ).toBeVisible();
+  await expect(app.timeline.getByText('created the room', { exact: false })).toBeVisible();
+});
+
+test('switches rooms and shows the selected room content', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.design);
+  await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeVisible();
+
+  await app.openRoom(MOCK_ROOMS.review);
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.review })).toBeVisible();
+  await expect(
+    app.timeline.getByText('Weekly product review — drop artifacts before Friday.'),
+  ).toBeVisible();
+});

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from './fixtures';
+
+// The Settings pane (compact tab / desktop overlay).
+
+test('shows identity, endpoint, daemon state, and diagnostics', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.navigate('Settings');
+
+  const settings = page.getByRole('region', { name: 'Settings' });
+  await expect(settings).toBeVisible();
+  await expect(settings.getByText('P2P Identity')).toBeVisible();
+  // The real 64-hex identity id, not a placeholder.
+  await expect(settings.locator('.settings-val').first()).toHaveText(/^[0-9a-f]{64}$/);
+  // Honest daemon state: mock mode reports loopback + live connection state.
+  await expect(settings.getByText('loopback · connected')).toBeVisible();
+  await expect(settings.getByRole('button', { name: 'Copy diagnostics' })).toBeEnabled();
+  await expect(settings.getByRole('button', { name: 'Report issue' })).toBeVisible();
+});

--- a/ui/e2e/tsconfig.json
+++ b/ui/e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": [".", "../playwright.config.ts"]
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^26.1.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -930,6 +931,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2410,6 +2427,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,13 +8,15 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:conformance": "vitest run src/lib/conformance"
+    "test:conformance": "vitest run src/lib/conformance",
+    "test:e2e": "tsc --noEmit -p e2e && playwright test"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^26.1.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Browser-level UX regression harness (issue #51). Runs the real app against
+// the VITE_MOCK=1 fixture client — no daemon, no network — so every flow is
+// deterministic. Four viewport projects cover the responsive contract:
+// the two desktop grids (wide + narrowed columns) and the two compact
+// (max-width: 900px) phone layouts the mockups target.
+//
+// Run with `npm run test:e2e` (boots its own dev server on 4173).
+
+const PORT = 4173;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  // No retries: a test that only passes on retry is a regression this harness
+  // exists to catch, not to paper over.
+  retries: 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    // Failures must preserve the full evidence trail (screenshot, trace,
+    // console errors — the latter attached by the fixture in e2e/fixtures.ts).
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-1440x900',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
+    {
+      name: 'desktop-920x800',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 920, height: 800 } },
+    },
+    {
+      name: 'mobile-390x844',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 390, height: 844 }, hasTouch: true },
+    },
+    {
+      name: 'mobile-320x568',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 320, height: 568 }, hasTouch: true },
+    },
+  ],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT} --strictPort`,
+    url: `http://127.0.0.1:${PORT}`,
+    env: { VITE_MOCK: '1' },
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -6,9 +6,16 @@ import { defineConfig, devices } from '@playwright/test';
 // the two desktop grids (wide + narrowed columns) and the two compact
 // (max-width: 900px) phone layouts the mockups target.
 //
-// Run with `npm run test:e2e` (boots its own dev server on 4173).
+// Run with `npm run test:e2e` (boots its own dev server).
+//
+// The port is deliberately NOT a default of any other tool (vite dev's 5173,
+// vite preview's 4173): with reuseExistingServer enabled locally, a colliding
+// port would let the suite silently attach to a non-mock server — worst case
+// driving a real daemon, where the onboarding spec would create a real,
+// irreversible identity. Belt and braces: every spec also refuses to run
+// unless the app under test reports the mock transport (see e2e/fixtures.ts).
 
-const PORT = 4173;
+const PORT = 43117;
 
 export default defineConfig({
   testDir: './e2e',

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,4 +6,10 @@ import './styles.css';
 // One client for the whole app lifetime (WebSocket or VITE_MOCK=1 fixtures).
 const client = createClient();
 
+// Surface which transport this build runs against (the same honest string
+// diagnostics reports). The browser regression suite refuses to drive
+// anything but the mock transport — this is its guard rail against silently
+// attaching to a dev server that talks to a real daemon.
+document.documentElement.dataset.jeliyaTransport = client.describe();
+
 createRoot(document.getElementById('root')!).render(<App client={client} />);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,6 +1,11 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    // Vitest owns src/**/*.test.ts only; ui/e2e/*.spec.ts belongs to
+    // Playwright (npm run test:e2e) and must not be collected here.
+    include: ['src/**/*.test.ts'],
+  },
 });


### PR DESCRIPTION
The React suite validates protocol conformance but never exercises rendered workflows, so mobile layout/navigation regressions ship green (#51). This is the regression foundation the rest of UX 0 builds on — first PR of the stack (merge order: this → #52/#54/#57 → #53 → #56; the Flutter PR for #55 is independent).

- `cd ui && npm run test:e2e` — typechecks `ui/e2e`, boots its own Vite dev server with `VITE_MOCK=1` (no daemon), runs Chromium across four viewport projects: 1440×900, 920×800, 390×844, 320×568.
- Fixtures: populated rooms (default mock) and fresh onboarding (`?mock=fresh`).
- Initial specs: onboarding (identity → first room → honest join failure), room list/select/open, compose/send, Files/Pipes entry points, Agent Fleet (including the crashed-runner honesty rule: working-class label + dead peer must read **Stale**), Settings.
- Failures preserve screenshot, trace, console errors (custom fixture), and the failing viewport. Zero retries, zero sleeps — web-first assertions only.
- Safety: the harness port (43117) is no tool's default, and every navigation refuses to run unless the app reports the mock transport (`main.tsx` stamps `client.describe()` on `<html>`) — with `reuseExistingServer`, silently attaching to a non-mock dev server would at worst drive a **real daemon**, where the onboarding spec would create a real, irreversible identity. Demonstrated: a non-mock server on the harness port fails immediately with "refusing to run against a non-mock transport".
- CI: new `ui-e2e` job (eighth required gate) with failure artifacts; CONTRIBUTING documents the command and determinism rules. `ui/vite.config.ts` scopes vitest to `src/**/*.test.ts` so `npm test` and Playwright don't collect each other's files.

Ran:
- `cd ui && npm run build` ✓ · `npm test` (13 passed) ✓ · `npm run test:e2e` (50 passed / 2 skipped) ✓ · `npm audit --audit-level=high` (0) ✓
- Intentional-failure demonstration: a compact-only breakage (mv-chat pane never shown) fails 10 tests on exactly the two mobile projects; a desktop-only breakage (nav rail hidden >900px) fails 10 tests on exactly the two desktop projects.
- The stack was additionally reviewed by an adversarial multi-agent pass; its confirmed findings against this PR (port/reuse hazard, vacuous fleet-liveness assertions) are fixed in the second commit.

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)