### PR TITLE
fix(ui): give room-open failures explicit retry and escape paths

### DIFF
--- a/ui/e2e/room-open-recovery.spec.ts
+++ b/ui/e2e/room-open-recovery.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Issue #53: a failed room.open must offer explicit Retry and Back to Rooms
+// paths, retry the same room without selecting another first, and never
+// render another room's data (or a comforting empty timeline) underneath.
+
+test('a failed room open offers Retry, and Retry restores the room', async ({
+  app,
+  page,
+  compact,
+}) => {
+  // Desktop auto-opens the room (one visible failure); on compact the reveal
+  // tap itself is the instinctive first retry, so spend two failures there.
+  await app.gotoPopulated({ mock_fail: compact ? 'room.open:2' : 'room.open:1' });
+  const surface = page.locator('.room-error-surface');
+  if (compact) {
+    // Wait for the hidden auto-open to fail before tapping, so the tap is
+    // deterministically the second (and last) injected failure.
+    await expect(surface).toHaveCount(1);
+    await app.roomItem(MOCK_ROOMS.main).click();
+  }
+
+  // The error owns the pane: real failure, recovery actions, no fake timeline.
+  await expect(surface).toBeVisible();
+  await expect(surface.getByText('Something went wrong')).toBeVisible();
+  await expect(surface.getByText('Technical details')).toBeVisible();
+  await expect(app.timeline).toHaveCount(0);
+  await expect(app.composerTextarea).toHaveCount(0);
+  await expect(page.getByText('No events yet')).toHaveCount(0);
+
+  // Retry is a real, keyboard-operable control that re-opens THIS room.
+  const retry = surface.getByRole('button', { name: 'Retry' });
+  await retry.focus();
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+  await expect(app.timeline).toBeVisible();
+  await expect(app.timeline.getByText('Kicked off the rooms protocol spec')).toBeVisible();
+  await expect(surface).toHaveCount(0);
+  await expect(app.composerTextarea).toBeVisible();
+});
+
+test('re-selecting the errored room retries instead of doing nothing', async ({
+  app,
+  page,
+  compact,
+}) => {
+  test.skip(compact, 'covered by the reveal-tap in the Retry test; the sidebar is a desktop rail here');
+  await app.gotoPopulated({ mock_fail: 'room.open:2' });
+
+  const surface = page.locator('.room-error-surface');
+  await expect(surface).toBeVisible();
+
+  // Clicking the already-selected room must issue a real second attempt —
+  // it consumes the second injected failure…
+  await app.roomItem(MOCK_ROOMS.main).click();
+  await expect(surface).toBeVisible();
+
+  // …so the next retry succeeds. Without the retry-on-reselect fix, this
+  // click would hit the second failure and the test would fail.
+  await surface.getByRole('button', { name: 'Retry' }).click();
+  await expect(app.timeline).toBeVisible();
+});
+
+test('Back to Rooms escapes a room that cannot open', async ({ app, page, compact }) => {
+  await app.gotoPopulated({ mock_fail: 'room.open:9' });
+  if (compact) {
+    await app.roomItem(MOCK_ROOMS.main).click();
+  }
+
+  const surface = page.locator('.room-error-surface');
+  await expect(surface).toBeVisible();
+  await surface.getByRole('button', { name: 'Back to Rooms' }).click();
+
+  // The failed room is fully deselected — nothing renders under it.
+  await expect(surface).toHaveCount(0);
+  await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  if (!compact) {
+    await expect(page.getByText('Select a room')).toBeVisible();
+  } else {
+    await expect(app.center).toBeHidden();
+    await expect(app.sidebar).toBeVisible();
+  }
+});
+
+test('another room\'s data never renders under a failed open', async ({ app, page }) => {
+  // First open succeeds and fills members/files/pipes; the next one fails.
+  await app.gotoPopulated({ mock_fail: 'room.open:1:1' });
+  await app.openRoom(MOCK_ROOMS.main);
+  await expect(app.timeline.getByText('Kicked off the rooms protocol spec')).toBeVisible();
+
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.roomItem(MOCK_ROOMS.design).click();
+  await expect(page.locator('.room-error-surface')).toBeVisible();
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.design })).toBeVisible();
+
+  // The main room's roster/files/pipes must not bleed into the failed room:
+  // the right panel shows empty-room truth, not another room's data.
+  await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toHaveCount(0);
+  await expect(app.rightPanel.getByText('127.0.0.1:3000')).toHaveCount(0);
+  await expect(app.rightPanel.getByText('Maya R.')).toHaveCount(0);
+});

--- a/ui/e2e/room-open-recovery.spec.ts
+++ b/ui/e2e/room-open-recovery.spec.ts
@@ -63,24 +63,36 @@ test('re-selecting the errored room retries instead of doing nothing', async ({
 });
 
 test('Back to Rooms escapes a room that cannot open', async ({ app, page, compact }) => {
-  await app.gotoPopulated({ mock_fail: 'room.open:9' });
-  if (compact) {
-    await app.roomItem(MOCK_ROOMS.main).click();
-  }
+  // The default room opens fine; every later open fails — so the failure is
+  // pinned to a deliberately selected, non-default room.
+  await app.gotoPopulated({ mock_fail: 'room.open:9:1' });
+  if (compact) await app.mobileTab('Rooms').click();
+  await app.roomItem(MOCK_ROOMS.design).click();
 
   const surface = page.locator('.room-error-surface');
   await expect(surface).toBeVisible();
-  await surface.getByRole('button', { name: 'Back to Rooms' }).click();
+  // Keyboard-operable, like Retry: focus + Enter, not a mouse click.
+  const back = surface.getByRole('button', { name: 'Back to Rooms' });
+  await back.focus();
+  await page.keyboard.press('Enter');
 
   // The failed room is fully deselected — nothing renders under it.
   await expect(surface).toHaveCount(0);
-  await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  await expect(app.roomItem(MOCK_ROOMS.design)).toBeVisible();
   if (!compact) {
     await expect(page.getByText('Select a room')).toBeVisible();
   } else {
     await expect(app.center).toBeHidden();
     await expect(app.sidebar).toBeVisible();
   }
+
+  // The escape is durable: a reload must not auto-open straight back into
+  // the failed room (its last-room memory is cleared) — the app boots into
+  // the healthy default room with no error surface.
+  await page.reload();
+  await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  await expect(app.roomItem(MOCK_ROOMS.main)).toContainText('Active', { timeout: 10_000 });
+  await expect(page.locator('.room-error-surface')).toHaveCount(0);
 });
 
 test('another room\'s data never renders under a failed open', async ({ app, page }) => {
@@ -89,14 +101,31 @@ test('another room\'s data never renders under a failed open', async ({ app, pag
   await app.openRoom(MOCK_ROOMS.main);
   await expect(app.timeline.getByText('Kicked off the rooms protocol spec')).toBeVisible();
 
+  // Positive control first — the main room's data really is on each panel
+  // tab, so the absence assertions below cannot pass vacuously.
+  await app.navigate('Files');
+  await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toBeVisible();
+  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
+  await expect(app.rightPanel.getByText('127.0.0.1:3000')).toBeVisible();
+  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await expect(app.rightPanel.getByText('Maya R.').first()).toBeVisible();
+
   if (app.compact) await app.mobileTab('Rooms').click();
   await app.roomItem(MOCK_ROOMS.design).click();
   await expect(page.locator('.room-error-surface')).toBeVisible();
   await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.design })).toBeVisible();
 
-  // The main room's roster/files/pipes must not bleed into the failed room:
-  // the right panel shows empty-room truth, not another room's data.
+  // Walk every panel tab under the failed room: nothing from the main room
+  // bleeds through — each surface shows empty-room truth.
+  await app.navigate('Files');
+  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
   await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toHaveCount(0);
+  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
   await expect(app.rightPanel.getByText('127.0.0.1:3000')).toHaveCount(0);
+  await page.getByRole('tab', { name: 'Members', exact: false }).click();
   await expect(app.rightPanel.getByText('Maya R.')).toHaveCount(0);
+  await expect(app.rightPanel.getByText('No members have synced', { exact: false })).toBeVisible();
 });

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
     // console errors — the latter attached by the fixture in e2e/fixtures.ts).
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
+    // The app honors prefers-reduced-motion (a WCAG contract, not a hint),
+    // and the suite runs under it: animations — including the timeline's
+    // jump-to-latest scroll — settle instantly, so assertions never race an
+    // in-flight animation against the mock's live-event timers.
+    contextOptions: { reducedMotion: 'reduce' },
   },
   projects: [
     {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -582,6 +582,16 @@ export default function App({ client }: { client: Client }) {
     }
   };
 
+  // The escape hatch from a room whose open failed: deselect it entirely so
+  // nothing renders under a room the daemon could not actually open.
+  const backToRooms = () => {
+    roomIdRef.current = null;
+    setRoomId(null);
+    setRoomError(null);
+    setRoomLoading(false);
+    setMobileView('rooms');
+  };
+
   const leaveCurrentRoom = () => {
     roomIdRef.current = null;
     setRoomId(null);
@@ -746,7 +756,10 @@ export default function App({ client }: { client: Client }) {
               return;
             }
             setMobileView('chat');
-            if (rid !== roomId) void openRoom(rid);
+            // Re-selecting the room whose open failed is the user's most
+            // instinctive retry — honor it instead of ignoring the click
+            // because the id is already selected.
+            if (rid !== roomId || roomError) void openRoom(rid);
           }}
           onCreateRoom={() => setCreateOpen(true)}
           onJoinRoom={() => setJoinOpen(true)}
@@ -765,38 +778,58 @@ export default function App({ client }: { client: Client }) {
                 onOpenPipe={() => openPanelTab('pipes')}
               />
               {roomError ? (
-                <div className="room-error">
+                // The open failed: the error owns the pane. Rendering the
+                // empty timeline ("No events yet") and a live composer under
+                // it would be a comforting lie about a room that isn't open.
+                <div className="room-error-surface">
                   <ErrorNote error={roomError} />
+                  <div className="room-error-actions">
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={() => {
+                        if (roomIdRef.current) void openRoom(roomIdRef.current);
+                      }}
+                    >
+                      Retry
+                    </button>
+                    <button type="button" className="btn btn-ghost" onClick={backToRooms}>
+                      Back to Rooms
+                    </button>
+                  </div>
                 </div>
-              ) : null}
-              {/* Keyed by room so the role="log" live region resets on room switch
-                  instead of announcing the whole backlog as new content. */}
-              <Timeline
-                key={roomId}
-                events={timeline}
-                pendingMessages={roomId ? (pendingMessages[roomId] ?? []) : []}
-                files={files}
-                fetches={fetches}
-                loading={roomLoading}
-                selfId={selfId}
-                savedView={roomId ? (timelineViews.current.get(roomId) ?? null) : null}
-                onSaveView={(view) => {
-                  if (!roomId) return;
-                  if (view) timelineViews.current.set(roomId, view);
-                  else timelineViews.current.delete(roomId);
-                }}
-                onFetch={fetchFile}
-                onRecheckFiles={recheckFiles}
-                onRetryPendingMessage={retryPendingMessage}
-                onShowPipes={(pipeId) => openPanelTab('pipes', pipeId)}
-              />
-              <Composer
-                roomId={currentRoom.room_id}
-                roomName={currentRoom.name ?? 'Untitled room'}
-                disabled={conn !== 'connected'}
-                onSend={sendMessage}
-                onShareFile={shareBrowserFile}
-              />
+              ) : (
+                <>
+                  {/* Keyed by room so the role="log" live region resets on room switch
+                      instead of announcing the whole backlog as new content. */}
+                  <Timeline
+                    key={roomId}
+                    events={timeline}
+                    pendingMessages={roomId ? (pendingMessages[roomId] ?? []) : []}
+                    files={files}
+                    fetches={fetches}
+                    loading={roomLoading}
+                    selfId={selfId}
+                    savedView={roomId ? (timelineViews.current.get(roomId) ?? null) : null}
+                    onSaveView={(view) => {
+                      if (!roomId) return;
+                      if (view) timelineViews.current.set(roomId, view);
+                      else timelineViews.current.delete(roomId);
+                    }}
+                    onFetch={fetchFile}
+                    onRecheckFiles={recheckFiles}
+                    onRetryPendingMessage={retryPendingMessage}
+                    onShowPipes={(pipeId) => openPanelTab('pipes', pipeId)}
+                  />
+                  <Composer
+                    roomId={currentRoom.room_id}
+                    roomName={currentRoom.name ?? 'Untitled room'}
+                    disabled={conn !== 'connected'}
+                    onSend={sendMessage}
+                    onShareFile={shareBrowserFile}
+                  />
+                </>
+              )}
             </>
           ) : (
             <div className="center-empty muted">Select a room</div>
@@ -842,7 +875,7 @@ export default function App({ client }: { client: Client }) {
               const room = rooms.find((r) => r.room_id === rid);
               if (room?.status === 'left' || room?.status === 'removed') return;
               setMobileView('chat');
-              if (rid !== roomId) void openRoom(rid);
+              if (rid !== roomId || roomError) void openRoom(rid);
             }}
           />
         ) : null}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -583,13 +583,20 @@ export default function App({ client }: { client: Client }) {
   };
 
   // The escape hatch from a room whose open failed: deselect it entirely so
-  // nothing renders under a room the daemon could not actually open.
+  // nothing renders under a room the daemon could not actually open — and
+  // forget it as the last room, or the next reload/reconnect would auto-open
+  // straight back into the same failure the user just walked away from.
   const backToRooms = () => {
     roomIdRef.current = null;
     setRoomId(null);
     setRoomError(null);
     setRoomLoading(false);
     setMobileView('rooms');
+    try {
+      localStorage.removeItem(LAST_ROOM_KEY);
+    } catch {
+      /* ignore */
+    }
   };
 
   const leaveCurrentRoom = () => {

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -487,7 +487,10 @@ export function Timeline({
   const scrollToBottom = () => {
     const el = scroller.current;
     if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+    // Reduced motion is a contract, not a hint (WCAG floor in CONTRIBUTING):
+    // the jump to the newest event lands instantly instead of animating.
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollTo({ top: el.scrollHeight, behavior: reduceMotion ? 'auto' : 'smooth' });
     stickToBottom.current = true;
     setNewItemCount(0);
   };

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -367,6 +367,32 @@ function deriveLiveness(connected: boolean, latest: TimelineEvent | null, now: n
 
 // -- the client --------------------------------------------------------------
 
+/** Deterministic failure injection for the browser regression suite:
+ *  `?mock_fail=room.open:2` fails the first two `room.open` calls with a real
+ *  `unavailable` error; `room.open:1:1` first allows one successful call.
+ *  Comma-separated entries inject for several methods. Mock-only — the
+ *  WebSocket client never reads this. */
+interface FailureSpec {
+  allowRemaining: number;
+  failRemaining: number;
+}
+
+function parseFailSpecs(raw: string | null): Map<string, FailureSpec> {
+  const specs = new Map<string, FailureSpec>();
+  if (!raw) return specs;
+  for (const entry of raw.split(',')) {
+    const [method, count, after] = entry.split(':');
+    const failRemaining = Number(count);
+    if (!method || !Number.isInteger(failRemaining) || failRemaining <= 0) continue;
+    const allowRemaining = Number(after ?? '0');
+    specs.set(method, {
+      allowRemaining: Number.isInteger(allowRemaining) && allowRemaining > 0 ? allowRemaining : 0,
+      failRemaining,
+    });
+  }
+  return specs;
+}
+
 class MockClient implements Client {
   private state: ConnectionState = 'disconnected';
   private stateHandlers = new Set<(s: ConnectionState) => void>();
@@ -379,8 +405,10 @@ class MockClient implements Client {
   private tickets = new Map<string, TicketEntry>();
   private portSeq = 41732;
   private startTimer: number | null = null;
+  private failSpecs: Map<string, FailureSpec>;
 
-  constructor(fresh: boolean) {
+  constructor(fresh: boolean, failSpecs: Map<string, FailureSpec> = new Map()) {
+    this.failSpecs = failSpecs;
     for (const p of EVERYONE) suggestedNames[p.id] = p.name;
     if (fresh) {
       this.identity = null;
@@ -674,7 +702,25 @@ class MockClient implements Client {
     };
   }
 
+  /** See parseFailSpecs: consumes one allowed call, then one injected
+   *  failure, per configured method — after that the method recovers. */
+  private maybeInjectFailure(method: MethodName): void {
+    const spec = this.failSpecs.get(method);
+    if (!spec || spec.failRemaining <= 0) return;
+    if (spec.allowRemaining > 0) {
+      spec.allowRemaining -= 1;
+      return;
+    }
+    spec.failRemaining -= 1;
+    this.err(
+      'unavailable',
+      `simulated ${method} failure (mock_fail)`,
+      'retry — the mock recovers once the requested failures are spent',
+    );
+  }
+
   private dispatch(method: MethodName, params: unknown): unknown {
+    this.maybeInjectFailure(method);
     switch (method) {
       case 'daemon.status': {
         const status: DaemonStatus = {
@@ -1032,6 +1078,7 @@ class MockClient implements Client {
 }
 
 export function createMockClient(): Client {
-  const fresh = new URLSearchParams(window.location.search).get('mock') === 'fresh';
-  return new MockClient(fresh);
+  const params = new URLSearchParams(window.location.search);
+  const fresh = params.get('mock') === 'fresh';
+  return new MockClient(fresh, parseFailSpecs(params.get('mock_fail')));
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1239,8 +1239,31 @@ button.sender-name:not(:disabled):hover {
   opacity: 0.5;
 }
 
-.room-error {
-  padding: 8px 24px 0;
+/* A failed room.open owns the whole pane (no empty timeline, no live
+   composer): the honest error with its collapsible technical details, and
+   the recovery actions right under it. */
+.room-error-surface {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 14px;
+  padding: 24px;
+}
+
+.room-error-surface .error-note {
+  max-width: 520px;
+  width: 100%;
+}
+
+.room-error-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 /* ---------- timeline ---------- */

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1248,7 +1248,9 @@ button.sender-name:not(:disabled):hover {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  /* `safe` so an error taller than a short viewport starts at the top and
+     scrolls, instead of centering with its beginning clipped unreachable. */
+  justify-content: safe center;
   align-items: center;
   gap: 14px;
   padding: 24px;


### PR DESCRIPTION
Stacked on #83. A failed `room.open` rendered an error note above an empty timeline whose "No events yet" read as a comforting lie, and re-selecting the room did nothing because its id was already selected — the only recovery was opening a different room first (#53).

- The error now owns the pane: the real failure with its collapsible technical details, plus two keyboard-operable actions. **Retry** re-invokes `room.open` for the currently selected errored room; **Back to Rooms** deselects it entirely — and clears the last-room memory, so a reload or reconnect doesn't auto-open straight back into the failure the user just walked away from (spec proves the escape survives a reload).
- Re-selecting the errored room in the sidebar or fleet dashboard issues a real retry — on mobile the reveal tap is the user's most instinctive recovery.
- `openRoom` already clears per-room state up front; with the error surface replacing timeline+composer, another room's members/events/files/pipes/endpoint data cannot render under the failure. The spec establishes a positive control (the healthy room's file/pipe/roster really visible per panel tab) then walks every tab under the failed room asserting empty-room truth — no vacuous absence checks.
- `.room-error-surface` centers with `justify-content: safe center` so an overflowing error starts at the top and scrolls instead of clipping its beginning unreachable.
- Mock gains `?mock_fail=method:count[:allowFirstN]` deterministic failure injection (mock-only, real `unavailable` errors, recovers once spent).

Ran: `cd ui && npm run build` ✓ · `npm run test:e2e` (106 passed / 18 skipped) ✓. Reverse proof: recovery specs against unfixed sources fail 7/7 runnable on desktop-1440x900 + mobile-390x844. Adversarial review round findings (escape durability, vacuous bleed-guard, missing keyboard coverage for Back) fixed in the second commit.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)