### PR TITLE
fix(ui): contain in-flight modal operations; leave dialog focuses Cancel

### DIFF
--- a/ui/e2e/modal-containment.spec.ts
+++ b/ui/e2e/modal-containment.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test, MOCK_ROOMS, AppDriver } from './fixtures';
+import type { Page } from '@playwright/test';
+
+// Issue #56: create/join/leave dialogs must contain their in-flight
+// operation — no dismissal path (Escape, backdrop, ✕, re-submit) may hide a
+// pending non-cancellable request whose result would later mutate state —
+// and destructive dialogs must never give the destructive action first focus.
+
+const TICKET_SUFFIX = 'e2econtainmentticket00000000000000000000';
+
+function modal(page: Page) {
+  return page.getByRole('dialog');
+}
+
+async function openLeaveDialog(app: AppDriver, page: Page, room: string): Promise<void> {
+  await app.openRoom(room);
+  // The Members surface hosts Leave; its tab strip is part of the panel on
+  // every breakpoint (compact reaches the panel through Files).
+  await app.navigate('Files');
+  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await app.rightPanel.getByRole('button', { name: 'Leave', exact: true }).click();
+  await expect(modal(page)).toBeVisible();
+}
+
+test('create: success creates exactly one room and navigates once', async ({ app, page }) => {
+  await app.gotoPopulated();
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Create Room', exact: true }).click();
+
+  await modal(page).getByLabel('Room name').fill('Containment Test Room');
+  await modal(page).getByRole('button', { name: 'Create room' }).click();
+
+  await expect(modal(page)).toHaveCount(0);
+  // Exactly one room of that name exists (no duplicate request fired) and it
+  // was opened exactly once (compact stays on the rooms pane by design).
+  await expect(app.roomItem('Containment Test Room')).toHaveCount(1);
+  await expect(app.roomItem('Containment Test Room')).toContainText('Active');
+  if (!app.compact) {
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Containment Test Room' }),
+    ).toBeVisible();
+  }
+});
+
+test('create: a pending request cannot be dismissed or duplicated', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_delay: 'room.create:1500' });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Create Room', exact: true }).click();
+
+  await modal(page).getByLabel('Room name').fill('Pending Room');
+  const submit = modal(page).getByRole('button', { name: 'Create room' });
+  await submit.click();
+
+  // In flight: submit reflects it and every dismissal path is contained.
+  await expect(modal(page).getByRole('button', { name: 'Creating…' })).toBeDisabled();
+  await page.keyboard.press('Escape');
+  await expect(modal(page)).toBeVisible();
+  await page.locator('.modal-backdrop').click({ position: { x: 5, y: 5 } });
+  await expect(modal(page)).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Close' })).toBeDisabled();
+
+  // Success still lands exactly once.
+  await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(app.roomItem('Pending Room')).toHaveCount(1);
+});
+
+test('create: failure keeps an actionable error in the dialog', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_fail: 'room.create:1' });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Create Room', exact: true }).click();
+
+  await modal(page).getByLabel('Room name').fill('Doomed Room');
+  await modal(page).getByRole('button', { name: 'Create room' }).click();
+
+  // The failure surfaces inside the dialog and interaction is restored.
+  await expect(modal(page).locator('.error-note')).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Create room' })).toBeEnabled();
+  await expect(app.roomItem('Doomed Room')).toHaveCount(0);
+
+  // No longer busy: Escape dismisses again.
+  await page.keyboard.press('Escape');
+  await expect(modal(page)).toHaveCount(0);
+});
+
+test('join: a pending join is contained, then applies its transition once', async ({
+  app,
+  page,
+}) => {
+  await app.gotoPopulated({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:1500' });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Join with a ticket' }).click();
+
+  await modal(page).getByLabel('Ticket').fill(`roomtkt1${TICKET_SUFFIX}`);
+  await modal(page).getByRole('button', { name: 'Join room' }).click();
+
+  await expect(modal(page).getByRole('button', { name: 'Joining…' })).toBeDisabled();
+  await page.keyboard.press('Escape');
+  await expect(modal(page)).toBeVisible();
+  await page.locator('.modal-backdrop').click({ position: { x: 5, y: 5 } });
+  await expect(modal(page)).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Close' })).toBeDisabled();
+
+  // Success: the dialog closes and the joined room opens, exactly once.
+  await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  if (app.compact) {
+    await app.roomItem(MOCK_ROOMS.main).click();
+  }
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+  await expect(app.timeline).toBeVisible();
+});
+
+test('join: failure restores interaction with a real error', async ({ app, page }) => {
+  await app.gotoPopulated();
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Join with a ticket' }).click();
+
+  await modal(page).getByLabel('Ticket').fill(`roomtkt1${'x'.repeat(90)}`);
+  await modal(page).getByRole('button', { name: 'Join room' }).click();
+
+  await expect(modal(page).locator('.error-note')).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Join room' })).toBeEnabled();
+  await page.keyboard.press('Escape');
+  await expect(modal(page)).toHaveCount(0);
+});
+
+test('leave: initial focus is Cancel and immediate Enter cannot leave', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await openLeaveDialog(app, page, MOCK_ROOMS.review);
+
+  // Safe initial focus: Cancel, never the destructive submit.
+  await expect(modal(page).getByRole('button', { name: 'Cancel' })).toBeFocused();
+  await page.keyboard.press('Enter');
+
+  // Enter activated Cancel: dialog closed, membership untouched.
+  await expect(modal(page)).toHaveCount(0);
+  await expect(app.rightPanel.getByRole('button', { name: 'Leave', exact: true })).toBeVisible();
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await expect(app.roomItem(MOCK_ROOMS.review)).not.toContainText('Left');
+});
+
+test('leave: a pending leave is contained, then applies once', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_delay: 'room.leave:1500' });
+  await openLeaveDialog(app, page, MOCK_ROOMS.review);
+
+  await modal(page).getByRole('button', { name: 'Leave room' }).click();
+  await expect(modal(page).getByRole('button', { name: 'Leaving…' })).toBeDisabled();
+  await expect(modal(page).getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  await page.keyboard.press('Escape');
+  await expect(modal(page)).toBeVisible();
+  await page.locator('.modal-backdrop').click({ position: { x: 5, y: 5 } });
+  await expect(modal(page)).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Close' })).toBeDisabled();
+
+  // The departure lands exactly once: dialog closed, room marked Left,
+  // navigation reset to the rooms surface.
+  await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(app.roomItem(MOCK_ROOMS.review)).toBeDisabled();
+  await expect(app.roomItem(MOCK_ROOMS.review)).toContainText('Left');
+  if (!app.compact) {
+    await expect(page.getByText('Select a room')).toBeVisible();
+  } else {
+    await expect(app.sidebar).toBeVisible();
+  }
+});
+
+test('leave: failure keeps the dialog actionable', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_fail: 'room.leave:1' });
+  await openLeaveDialog(app, page, MOCK_ROOMS.review);
+
+  await modal(page).getByRole('button', { name: 'Leave room' }).click();
+
+  await expect(modal(page).locator('.error-note')).toBeVisible();
+  await expect(modal(page).getByRole('button', { name: 'Leave room' })).toBeEnabled();
+  await modal(page).getByRole('button', { name: 'Cancel' }).click();
+  await expect(modal(page)).toHaveCount(0);
+  // Still a member — the failure was real, nothing was applied.
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await expect(app.roomItem(MOCK_ROOMS.review)).not.toContainText('Left');
+});

--- a/ui/e2e/modal-containment.spec.ts
+++ b/ui/e2e/modal-containment.spec.ts
@@ -100,13 +100,58 @@ test('join: a pending join is contained, then applies its transition once', asyn
   await expect(modal(page)).toBeVisible();
   await expect(modal(page).getByRole('button', { name: 'Close' })).toBeDisabled();
 
-  // Success: the dialog closes and the joined room opens, exactly once.
+  // Success: the dialog closes and the join lands exactly once — a room this
+  // identity had never joined appears and opens (a real state transition,
+  // not a re-open of something already there).
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(app.roomItem('Invited Workspace')).toHaveCount(1);
+  await expect(app.roomItem('Invited Workspace')).toContainText('Active');
   if (app.compact) {
-    await app.roomItem(MOCK_ROOMS.main).click();
+    await app.roomItem('Invited Workspace').click();
   }
-  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
-  await expect(app.timeline).toBeVisible();
+  await expect(page.getByRole('heading', { level: 1, name: 'Invited Workspace' })).toBeVisible();
+  await expect(app.timeline.getByText('You joined as member', { exact: false })).toBeVisible();
+});
+
+test('create: a keyboard double-submit fires exactly one request', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_delay: 'room.create:800' });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Create Room', exact: true }).click();
+
+  const name = modal(page).getByLabel('Room name');
+  await name.fill('Double Submit Room');
+  // Enter submits the form; the second Enter lands inside the busy window
+  // (the mock holds room.create for 800ms) and must be swallowed.
+  await name.press('Enter');
+  await name.press('Enter');
+
+  await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  // Wait for the full success transition (open flag applied), then count:
+  // a duplicated request would have produced a second same-named room.
+  await expect(app.roomItem('Double Submit Room')).toContainText('Active');
+  await expect(app.roomItem('Double Submit Room')).toHaveCount(1);
+});
+
+test('join: a keyboard double-submit consumes the single-use ticket once', async ({
+  app,
+  page,
+}) => {
+  await app.gotoPopulated({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:800' });
+  if (app.compact) await app.mobileTab('Rooms').click();
+  await page.getByRole('button', { name: 'Join with a ticket' }).click();
+
+  await modal(page).getByLabel('Ticket').fill(`roomtkt1${TICKET_SUFFIX}`);
+  // Enter in the peer-address input submits the form; tickets are single-use
+  // in the mock, so a duplicated request would fail loudly with bad_ticket.
+  const peerAddr = modal(page).getByLabel('Peer address', { exact: false });
+  await peerAddr.press('Enter');
+  await peerAddr.press('Enter');
+
+  await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(app.roomItem('Invited Workspace')).toHaveCount(1);
+  // No stray failure from a second redemption anywhere.
+  await expect(page.locator('.error-note')).toHaveCount(0);
 });
 
 test('join: failure restores interaction with a real error', async ({ app, page }) => {

--- a/ui/e2e/room-actions.spec.ts
+++ b/ui/e2e/room-actions.spec.ts
@@ -76,6 +76,25 @@ test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
   await expect(row).toBeInViewport();
 });
 
+test('Open in Pipes identifies the pipe even while pipe.list is still loading', async ({
+  app,
+  page,
+}) => {
+  // Hold every pipe.list response so the action fires into an empty list —
+  // the focus request must survive until the list arrives, not be dropped.
+  await app.gotoPopulated({ mock_delay: 'pipe.list:1200' });
+  await app.openRoom(MOCK_ROOMS.main);
+  await app.timeline.getByRole('button', { name: 'Open in Pipes' }).first().click();
+
+  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  const row = app.rightPanel.locator('.pipe-row', { hasText: '127.0.0.1:4000' });
+  await expect(row).toBeFocused({ timeout: 10_000 });
+  await expect(row).toBeInViewport();
+});
+
 test('mobile: the panel tab strip keeps the bottom navigation truthful', async ({
   app,
   page,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -900,12 +900,19 @@ export default function App({ client }: { client: Client }) {
         <MobileTabBar active={activeNav} onNav={navigate} />
 
         {inviteOpen && roomId ? (
-          <InviteModal client={client} roomId={roomId} endpointAddr={endpointAddr} onClose={() => setInviteOpen(false)} />
+          <InviteModal
+            client={client}
+            roomId={roomId}
+            endpointAddr={endpointAddr}
+            connected={conn === 'connected'}
+            onClose={() => setInviteOpen(false)}
+          />
         ) : null}
 
         {createOpen ? (
           <CreateRoomModal
             client={client}
+            connected={conn === 'connected'}
             onDiagnosticError={rememberError}
             onClose={() => setCreateOpen(false)}
             onCreated={(rid) => {
@@ -919,6 +926,7 @@ export default function App({ client }: { client: Client }) {
         {joinOpen ? (
           <JoinRoomModal
             client={client}
+            connected={conn === 'connected'}
             onDiagnosticError={rememberError}
             onClose={() => setJoinOpen(false)}
             onJoined={(rid) => {
@@ -932,6 +940,7 @@ export default function App({ client }: { client: Client }) {
         {leaveOpen && roomId && currentRoom ? (
           <LeaveRoomModal
             client={client}
+            connected={conn === 'connected'}
             roomId={roomId}
             roomName={currentRoom.name ?? 'Untitled room'}
             onDiagnosticError={rememberError}
@@ -960,11 +969,17 @@ export default function App({ client }: { client: Client }) {
 
 function JoinRoomModal({
   client,
+  connected,
   onDiagnosticError,
   onClose,
   onJoined,
 }: {
   client: Client;
+  /** Submits are gated on a live daemon connection: a request queued while
+   *  disconnected would keep the dialog busy — and undismissable — for as
+   *  long as the reconnect takes. In-flight requests are safe either way
+   *  (the client rejects them with connection_lost when the socket drops). */
+  connected: boolean;
   onDiagnosticError: DiagnosticErrorRecorder;
   onClose(): void;
   onJoined(roomId: string): void;
@@ -976,7 +991,7 @@ function JoinRoomModal({
   const [progress, setProgress] = useState<JoinProgress | null>(null);
 
   const join = async () => {
-    if (!ticket.trim() || busy) return;
+    if (!ticket.trim() || busy || !connected) return;
     setBusy(true);
     setError(null);
     setProgress(null);
@@ -1028,8 +1043,8 @@ function JoinRoomModal({
             spellCheck={false}
           />
         </label>
-        <button type="submit" className="btn btn-primary" disabled={busy || !ticket.trim()}>
-          {busy ? 'Joining…' : 'Join room'}
+        <button type="submit" className="btn btn-primary" disabled={busy || !ticket.trim() || !connected}>
+          {busy ? 'Joining…' : connected ? 'Join room' : 'Reconnecting…'}
         </button>
         {progress ? (
           <div className="join-progress" role="status">
@@ -1048,11 +1063,14 @@ function JoinRoomModal({
 
 function CreateRoomModal({
   client,
+  connected,
   onDiagnosticError,
   onClose,
   onCreated,
 }: {
   client: Client;
+  /** See JoinRoomModal.connected. */
+  connected: boolean;
   onDiagnosticError: DiagnosticErrorRecorder;
   onClose(): void;
   onCreated(roomId: string): void;
@@ -1062,7 +1080,7 @@ function CreateRoomModal({
   const [error, setError] = useState<DaemonErrorShape | null>(null);
 
   const create = async () => {
-    if (!name.trim() || busy) return;
+    if (!name.trim() || busy || !connected) return;
     setBusy(true);
     setError(null);
     try {
@@ -1086,8 +1104,8 @@ function CreateRoomModal({
           <span>Room name</span>
           <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Build Iroh Rooms MVP" autoFocus />
         </label>
-        <button type="submit" className="btn btn-primary" disabled={busy || !name.trim()}>
-          {busy ? 'Creating…' : 'Create room'}
+        <button type="submit" className="btn btn-primary" disabled={busy || !name.trim() || !connected}>
+          {busy ? 'Creating…' : connected ? 'Create room' : 'Reconnecting…'}
         </button>
         <ErrorNote error={error} />
       </form>
@@ -1097,6 +1115,7 @@ function CreateRoomModal({
 
 function LeaveRoomModal({
   client,
+  connected,
   roomId,
   roomName,
   onDiagnosticError,
@@ -1104,6 +1123,8 @@ function LeaveRoomModal({
   onLeft,
 }: {
   client: Client;
+  /** See JoinRoomModal.connected. */
+  connected: boolean;
   roomId: string;
   roomName: string;
   onDiagnosticError: DiagnosticErrorRecorder;
@@ -1114,7 +1135,7 @@ function LeaveRoomModal({
   const [error, setError] = useState<DaemonErrorShape | null>(null);
 
   const leave = async () => {
-    if (busy) return;
+    if (busy || !connected) return;
     setBusy(true);
     setError(null);
     try {
@@ -1139,8 +1160,8 @@ function LeaveRoomModal({
           the local session; you’ll need a new invite to join again.
         </p>
         <div className="field-row">
-          <button type="submit" className="btn btn-danger" disabled={busy}>
-            {busy ? 'Leaving…' : 'Leave room'}
+          <button type="submit" className="btn btn-danger" disabled={busy || !connected}>
+            {busy ? 'Leaving…' : connected ? 'Leave room' : 'Reconnecting…'}
           </button>
           {/* Initial focus lands on Cancel, never the destructive action —
               Enter right after opening must not publish a departure. */}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -995,7 +995,7 @@ function JoinRoomModal({
   };
 
   return (
-    <Modal title="Join with a ticket" onClose={onClose}>
+    <Modal title="Join with a ticket" onClose={onClose} busy={busy}>
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -1075,7 +1075,7 @@ function CreateRoomModal({
   };
 
   return (
-    <Modal title="Create a room" onClose={onClose}>
+    <Modal title="Create a room" onClose={onClose} busy={busy}>
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -1127,7 +1127,7 @@ function LeaveRoomModal({
   };
 
   return (
-    <Modal title="Leave room" onClose={onClose}>
+    <Modal title="Leave room" onClose={onClose} busy={busy}>
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -1139,10 +1139,12 @@ function LeaveRoomModal({
           the local session; you’ll need a new invite to join again.
         </p>
         <div className="field-row">
-          <button type="submit" className="btn btn-danger" disabled={busy} autoFocus>
+          <button type="submit" className="btn btn-danger" disabled={busy}>
             {busy ? 'Leaving…' : 'Leave room'}
           </button>
-          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+          {/* Initial focus lands on Cancel, never the destructive action —
+              Enter right after opening must not publish a departure. */}
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy} autoFocus>
             Cancel
           </button>
         </div>

--- a/ui/src/components/InviteModal.tsx
+++ b/ui/src/components/InviteModal.tsx
@@ -9,11 +9,16 @@ export function InviteModal({
   client,
   roomId,
   endpointAddr,
+  connected,
   onClose,
 }: {
   client: Client;
   roomId: string;
   endpointAddr: string | null;
+  /** Ticket generation is gated on a live daemon connection: a request
+   *  queued while disconnected would keep the dialog busy — and
+   *  undismissable — for as long as the reconnect takes. */
+  connected: boolean;
   onClose(): void;
 }) {
   const [identityId, setIdentityId] = useState('');
@@ -25,7 +30,7 @@ export function InviteModal({
 
   const generate = async () => {
     const invitee = identityId.trim();
-    if (!invitee || busy) return;
+    if (!invitee || busy || !connected) return;
     setBusy(true);
     setError(null);
     setTicket(null);
@@ -106,8 +111,8 @@ export function InviteModal({
               />
             </label>
           </div>
-          <button type="submit" className="btn btn-primary" disabled={busy || !identityId.trim()}>
-            {busy ? 'Generating…' : 'Generate ticket'}
+          <button type="submit" className="btn btn-primary" disabled={busy || !identityId.trim() || !connected}>
+            {busy ? 'Generating…' : connected ? 'Generate ticket' : 'Reconnecting…'}
           </button>
           <ErrorNote error={error} />
         </form>

--- a/ui/src/components/InviteModal.tsx
+++ b/ui/src/components/InviteModal.tsx
@@ -56,7 +56,7 @@ export function InviteModal({
   };
 
   return (
-    <Modal title="Invite to room" onClose={onClose} wide>
+    <Modal title="Invite to room" onClose={onClose} wide busy={busy}>
       {!ticket ? (
         <form
           onSubmit={(e) => {

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -147,15 +147,23 @@ export function Modal({
   onClose,
   children,
   wide = false,
+  busy = false,
 }: {
   title: string;
   onClose(): void;
   children: ReactNode;
   wide?: boolean;
+  /** A non-cancellable operation is in flight: Escape, backdrop, and the ✕
+   *  cannot dismiss the dialog until it settles. Dismissal would only hide
+   *  the request — its result would still mutate state after the user
+   *  believed the action was abandoned. */
+  busy?: boolean;
 }) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
 
   // Real modal semantics for `aria-modal="true"`: Escape closes, Tab is trapped
   // inside the dialog (so focus never lands on the obscured room UI), and focus
@@ -182,7 +190,7 @@ export function Modal({
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.stopPropagation();
-        onCloseRef.current();
+        if (!busyRef.current) onCloseRef.current();
         return;
       }
       if (e.key !== 'Tab' || !dialog) return;
@@ -215,7 +223,7 @@ export function Modal({
     <div
       className="modal-backdrop"
       onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (e.target === e.currentTarget && !busy) onClose();
       }}
     >
       <div
@@ -224,11 +232,12 @@ export function Modal({
         role="dialog"
         aria-modal="true"
         aria-label={title}
+        aria-busy={busy || undefined}
         tabIndex={-1}
       >
         <header className="modal-head">
           <h2>{title}</h2>
-          <button type="button" className="icon-btn" onClick={onClose} aria-label="Close">
+          <button type="button" className="icon-btn" onClick={onClose} aria-label="Close" disabled={busy}>
             ✕
           </button>
         </header>

--- a/ui/src/lib/join.test.ts
+++ b/ui/src/lib/join.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+//
+// joinRoomWithRetry retries only peer_unreachable — and must abort honestly
+// if the daemon connection drops during a retry backoff: issuing the next
+// attempt while disconnected would queue it until reconnect, pinning the
+// caller's busy state (and the contained join dialog) indefinitely.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { joinRoomWithRetry } from './join';
+import type { Client, ConnectionState } from './protocol';
+import { RequestError } from './protocol';
+
+function fakeClient(overrides: {
+  call: Client['call'];
+  getState?: () => ConnectionState;
+}): Client {
+  return {
+    describe: () => 'fake',
+    start: () => undefined,
+    stop: () => undefined,
+    getState: overrides.getState ?? (() => 'connected'),
+    onState: () => () => undefined,
+    on: () => () => undefined,
+    call: overrides.call,
+  };
+}
+
+const peerUnreachable = () =>
+  new RequestError({ code: 'peer_unreachable', message: 'no path to inviter', hint: null });
+
+describe('joinRoomWithRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries peer_unreachable and succeeds while the connection holds', async () => {
+    let calls = 0;
+    const client = fakeClient({
+      call: (async () => {
+        calls += 1;
+        if (calls === 1) throw peerUnreachable();
+        return { room_id: 'room-1' };
+      }) as Client['call'],
+    });
+
+    const result = joinRoomWithRetry(client, { ticket: 'roomtkt1'.padEnd(24, 'x') });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(result).resolves.toEqual({ room_id: 'room-1' });
+    expect(calls).toBe(2);
+  });
+
+  it('aborts with connection_lost if the daemon drops during the backoff', async () => {
+    let calls = 0;
+    let state: ConnectionState = 'connected';
+    const client = fakeClient({
+      getState: () => state,
+      call: (async () => {
+        calls += 1;
+        throw peerUnreachable();
+      }) as Client['call'],
+    });
+
+    const result = joinRoomWithRetry(client, { ticket: 'roomtkt1'.padEnd(24, 'x') });
+    // Guard against an unhandled-rejection blip while timers advance.
+    const settled = result.catch((e: unknown) => e);
+    state = 'reconnecting'; // the daemon goes away while we wait to retry
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const error = await settled;
+    expect(error).toBeInstanceOf(RequestError);
+    expect((error as RequestError).code).toBe('connection_lost');
+    // The queued-forever second attempt never fires.
+    expect(calls).toBe(1);
+  });
+});

--- a/ui/src/lib/join.ts
+++ b/ui/src/lib/join.ts
@@ -1,5 +1,5 @@
 import type { Client, DaemonErrorShape } from './protocol';
-import { errorShape } from './protocol';
+import { errorShape, RequestError } from './protocol';
 
 export type JoinPhase = 'connecting' | 'retrying';
 
@@ -53,6 +53,18 @@ export async function joinRoomWithRetry(
         lastError: err,
       });
       await sleep(delay);
+      // The daemon connection can drop during the backoff. Issuing the next
+      // attempt then would QUEUE it until reconnect (WsClient keeps unsent
+      // requests), pinning the caller's busy state — and the contained join
+      // dialog with it — for as long as the daemon stays down. Fail honestly
+      // instead: the dialog surfaces the real error and dismissal returns.
+      if (client.getState() !== 'connected') {
+        throw new RequestError({
+          code: 'connection_lost',
+          message: 'the daemon connection dropped while waiting to retry the join',
+          hint: 'reconnect, then paste the same invite again',
+        });
+      }
     }
   }
 

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -307,18 +307,24 @@ function buildMainRoom(): MockRoom {
 function buildSideRoom(seed: string, name: string, people: Person[], myRole: Role, blurb: string): MockRoom {
   const r = `blake3:${hex(`room-${seed}`, 64)}`;
   const owner = people[0];
+  // Roles are per-room: the creator owns the room, and my own role is the
+  // declared myRole — the global Person.role only describes the default
+  // (Alex owns the MVP room, not every room he's merely a member of).
+  const roleHere = (p: Person): Role => (p.id === owner.id ? 'owner' : p.id === ALEX.id ? myRole : p.role);
   const timeline: TimelineEvent[] = [
-    ev(r, at(8, 30), owner, 'room_created'),
+    ev(r, at(8, 30), { ...owner, role: 'owner' }, 'room_created'),
     ...people.slice(1).map((p, i) =>
-      ev(r, at(8, 32 + i), p, 'member_joined', { member: { identity_id: p.id, role: p.role } }),
+      ev(r, at(8, 32 + i), { ...p, role: roleHere(p) }, 'member_joined', {
+        member: { identity_id: p.id, role: roleHere(p) },
+      }),
     ),
-    ev(r, at(9, 5), owner, 'message', { body: blurb }),
+    ev(r, at(9, 5), { ...owner, role: 'owner' }, 'message', { body: blurb }),
   ];
   return {
     room_id: r,
     name,
     myRole,
-    members: people.map((p) => member(p)),
+    members: people.map((p) => member({ ...p, role: roleHere(p) })),
     timeline,
     files: [],
     pipes: [],
@@ -393,6 +399,21 @@ function parseFailSpecs(raw: string | null): Map<string, FailureSpec> {
   return specs;
 }
 
+/** Deterministic per-method extra latency for the browser regression suite:
+ *  `?mock_delay=room.create:1200` holds every room.create response for an
+ *  extra 1.2s so a test can exercise the in-flight (busy) window. Mock-only. */
+function parseDelaySpecs(raw: string | null): Map<string, number> {
+  const specs = new Map<string, number>();
+  if (!raw) return specs;
+  for (const entry of raw.split(',')) {
+    const [method, ms] = entry.split(':');
+    const delay = Number(ms);
+    if (!method || !Number.isFinite(delay) || delay <= 0) continue;
+    specs.set(method, delay);
+  }
+  return specs;
+}
+
 class MockClient implements Client {
   private state: ConnectionState = 'disconnected';
   private stateHandlers = new Set<(s: ConnectionState) => void>();
@@ -406,9 +427,16 @@ class MockClient implements Client {
   private portSeq = 41732;
   private startTimer: number | null = null;
   private failSpecs: Map<string, FailureSpec>;
+  private delaySpecs: Map<string, number>;
 
-  constructor(fresh: boolean, failSpecs: Map<string, FailureSpec> = new Map()) {
+  constructor(
+    fresh: boolean,
+    failSpecs: Map<string, FailureSpec> = new Map(),
+    delaySpecs: Map<string, number> = new Map(),
+    presetTicket: string | null = null,
+  ) {
     this.failSpecs = failSpecs;
+    this.delaySpecs = delaySpecs;
     for (const p of EVERYONE) suggestedNames[p.id] = p.name;
     if (fresh) {
       this.identity = null;
@@ -467,6 +495,17 @@ class MockClient implements Client {
         }),
       );
       for (const room of [workspace, review, design, research]) this.rooms.set(room.room_id, room);
+      // Regression-suite hook (`?mock_ticket=<suffix>`): a pre-minted,
+      // redeemable ticket for the main room, so a join success path can be
+      // driven end-to-end without first walking the invite flow.
+      if (presetTicket) {
+        this.tickets.set(`roomtkt1${presetTicket}`, {
+          room_id: MAIN_ID,
+          identity_id: ALEX.id,
+          role: 'member',
+          expiresAt: null,
+        });
+      }
     }
   }
 
@@ -511,7 +550,7 @@ class MockClient implements Client {
         } catch (e) {
           reject(e);
         }
-      }, 60 + Math.random() * 120);
+      }, 60 + Math.random() * 120 + (this.delaySpecs.get(method) ?? 0));
     });
   }
 
@@ -1080,5 +1119,10 @@ class MockClient implements Client {
 export function createMockClient(): Client {
   const params = new URLSearchParams(window.location.search);
   const fresh = params.get('mock') === 'fresh';
-  return new MockClient(fresh, parseFailSpecs(params.get('mock_fail')));
+  return new MockClient(
+    fresh,
+    parseFailSpecs(params.get('mock_fail')),
+    parseDelaySpecs(params.get('mock_delay')),
+    params.get('mock_ticket'),
+  );
 }

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -172,6 +172,11 @@ const fid = (seed: string) => `file_${hex(seed, 32)}`;
 const pid = (seed: string) => hex(seed, 32);
 
 const MAIN_ID = `blake3:${hex('room-build-iroh-rooms-mvp', 64)}`;
+// The room a `?mock_ticket=` preset ticket admits into. Deliberately NOT
+// seeded into the room map: you cannot list a room you have not joined, so
+// redeeming the ticket materializes it — the way a real join bootstraps a
+// room this daemon has never seen — and the join is a real state transition.
+const INVITED_ID = `blake3:${hex('room-invited-workspace', 64)}`;
 
 const F_RELEASE = fid('release-notes.txt');
 const F_PROTOCOL = fid('room-protocol.md');
@@ -496,11 +501,12 @@ class MockClient implements Client {
       );
       for (const room of [workspace, review, design, research]) this.rooms.set(room.room_id, room);
       // Regression-suite hook (`?mock_ticket=<suffix>`): a pre-minted,
-      // redeemable ticket for the main room, so a join success path can be
-      // driven end-to-end without first walking the invite flow.
+      // redeemable ticket into a room this identity has NOT joined yet (see
+      // INVITED_ID), so a join success path exercises a real membership and
+      // navigation transition instead of landing in an already-open room.
       if (presetTicket) {
         this.tickets.set(`roomtkt1${presetTicket}`, {
-          room_id: MAIN_ID,
+          room_id: INVITED_ID,
           identity_id: ALEX.id,
           role: 'member',
           expiresAt: null,
@@ -920,13 +926,37 @@ class MockClient implements Client {
           this.tickets.delete(ticket);
           this.err('ticket_expired', 'this ticket has expired', 'ask the inviter to generate a fresh one');
         }
-        const room = this.rooms.get(entry.room_id);
+        let room = this.rooms.get(entry.room_id);
+        if (!room && entry.room_id === INVITED_ID) {
+          // First redemption of the preset regression-suite ticket:
+          // materialize the room locally, like a real join bootstrapping a
+          // room this daemon has never seen.
+          room = buildSideRoom(
+            'invited-workspace',
+            'Invited Workspace',
+            [MAYA, SAM],
+            'member',
+            'Welcome — this room reached you as a ticket.',
+          );
+          this.rooms.set(room.room_id, room);
+        }
         if (!room) this.err('room_unknown', 'the invited room no longer exists on this daemon', 'ask the inviter for a fresh ticket');
         // Single-use: redeeming the same ticket twice should fail like a real
         // spent one, not silently succeed again.
         this.tickets.delete(ticket);
-        if (!room.members.some((m) => m.identity_id === identity.identity_id)) {
+        const existing = room.members.find((m) => m.identity_id === identity.identity_id);
+        if (!existing) {
           room.members.push({ identity_id: identity.identity_id, role: entry.role, status: 'active' });
+          this.ingest(room, ev(room.room_id, Date.now(), { ...ALEX, id: identity.identity_id, dev: identity.device_id, role: entry.role }, 'member_joined', {
+            member: { identity_id: identity.identity_id, role: entry.role },
+          }));
+        } else if (existing.status !== 'active') {
+          // A fresh ticket re-admits an identity that left or was removed;
+          // keeping status 'left' after a successful join would strand the
+          // UI in a departed room (the real daemon publishes a new
+          // member_joined on re-admission).
+          existing.status = 'active';
+          existing.role = entry.role;
           this.ingest(room, ev(room.room_id, Date.now(), { ...ALEX, id: identity.identity_id, dev: identity.device_id, role: entry.role }, 'member_joined', {
             member: { identity_id: identity.identity_id, role: entry.role },
           }));


### PR DESCRIPTION
Stacked on the #53 PR. Create/join/leave/invite dialogs could be dismissed while their non-cancellable request was still in flight — the result then mutated navigation or room state after the user believed the action was abandoned — and the leave dialog gave the DESTRUCTIVE submit initial focus, so Enter right after opening published a signed membership departure (#56).

- `Modal` gains `busy`: while a request is pending, Escape, backdrop mousedown, and the ✕ (visibly disabled, `aria-busy` on the dialog) cannot dismiss it; submits were already single-fire, so exactly one request fires per submitted action. Success applies its transition exactly once; failure restores interaction with the real error inside the dialog.
- Containment stays escapable: submits are gated on a live daemon connection ("Reconnecting…" meanwhile) — a request queued while disconnected would otherwise pin the dialog busy and undismissable for as long as the reconnect takes; in-flight requests already reject with `connection_lost` when the socket drops.
- The leave dialog's initial focus moves to Cancel — immediate Enter cancels, never confirms.
- Mock hooks for the suite (mock-only): `?mock_delay=method:ms` (deterministic pending windows) and `?mock_ticket=<suffix>` — the preset ticket admits into a room that is deliberately absent until redeemed ("Invited Workspace" materializes on join, like a real join bootstrapping an unknown room), so the join success spec proves a genuine membership+navigation transition. The mock also re-admits a 'left' membership on a fresh ticket, and the side-room fixture stops giving every person their global role (the creator owns the room; self takes the declared `myRole`) — before that, "Leave" could never render anywhere in mock and `room.leave` always failed as owner.
- Tests cover success, failure, Escape, backdrop, ✕, and REAL keyboard double-submits (create counts exactly one resulting room; join relies on the single-use ticket to fail loudly if a second redemption fired), plus Enter-immediately-after-open on leave.

Ran: `cd ui && npm run build` ✓ · `npm test` (13) ✓ · `npm run test:e2e` (150 passed / 18 skipped) ✓ · `--repeat-each=2` (300 passed, zero flake) ✓ · `npm audit --audit-level=high` (0) ✓. Reverse proof: with containment reverted (mock hooks kept), 8/16 containment specs fail — exactly the pending-window and initial-focus tests. Adversarial review round findings (disconnect keyboard trap, vacuous join spec, indirect double-submit coverage, mock rejoin hole) fixed in the second commit.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)