### PR TITLE
fix(flutter): contain in-flight dialogs and give the leave modal safe initial focus

### DIFF
--- a/app/lib/src/screens/modals/add_agent.dart
+++ b/app/lib/src/screens/modals/add_agent.dart
@@ -6,7 +6,8 @@
 ///
 /// Generate: `room.open` first (solely to obtain the room session's dialable
 /// `endpoint.addr`, docs §5 step 2), then `invite.create` with role 'agent'.
-/// Pops void — the ✕ / Escape / backdrop close it.
+/// Pops void — the ✕ / Escape / backdrop close it, except while minting is
+/// in flight (#55, ModalScaffold busy contains the route).
 library;
 
 import 'package:flutter/material.dart';
@@ -128,6 +129,7 @@ class _AddAgentModalState extends State<AddAgentModal> {
     return ModalScaffold(
       title: s.addAgentTitle,
       wide: true,
+      busy: _busy,
       child: ownedRooms.isEmpty
           ? _NoOwnedRooms()
           : _result == null

--- a/app/lib/src/screens/modals/create_room.dart
+++ b/app/lib/src/screens/modals/create_room.dart
@@ -4,9 +4,10 @@
 /// busy or blank, ErrorNote. Submit → `client.roomCreate(name.trim())`; on
 /// success pops with the new room id (the shell refreshes rooms and opens
 /// it); failures are recorded to diagnostics as context 'room.create'.
+/// While the create is in flight the modal is CONTAINED (#55, ModalScaffold
+/// busy): no dismissal path can pop it, so the result applies exactly once,
+/// while the modal is still up.
 library;
-
-import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:jeliya_protocol/jeliya_protocol.dart' show JeliyaMethods, RequestError;
@@ -54,22 +55,23 @@ class _CreateRoomModalState extends State<CreateRoomModal> {
     });
     try {
       final roomId = await client.roomCreate(name);
-      if (mounted) {
-        Navigator.of(context).pop(roomId);
-        // Stays busy until the pop lands (web keeps the button disabled too).
-      } else {
-        // Dismissed mid-flight: the create still happened — apply the
-        // success effects the shell's pop-consumer would have (web parity).
-        unawaited(session.refreshRooms());
-        unawaited(session.openRoom(roomId));
-      }
+      // Containment (ModalScaffold busy → PopScope) holds the route up
+      // while the create is in flight, so this state is still mounted.
+      // Defensively, if it somehow isn't: apply NOTHING — a result must
+      // never mutate navigation or room state after the user believes the
+      // action was abandoned.
+      if (!mounted) return;
+      Navigator.of(context).pop(roomId);
+      // Stays busy until the pop lands (web keeps the button disabled too).
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = session.recordError('room.create', e);
-          _busy = false;
-        });
-      }
+      // Record BEFORE the mounted check: a failure must reach diagnostics
+      // even if the modal was somehow dismissed mid-flight.
+      final err = session.recordError('room.create', e);
+      if (!mounted) return;
+      setState(() {
+        _error = err;
+        _busy = false;
+      });
     }
   }
 
@@ -80,6 +82,7 @@ class _CreateRoomModalState extends State<CreateRoomModal> {
     final canSubmit = !_busy && _name.text.trim().isNotEmpty;
     return ModalScaffold(
       title: s.modalCreateRoomTitle,
+      busy: _busy,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/app/lib/src/screens/modals/invite.dart
+++ b/app/lib/src/screens/modals/invite.dart
@@ -114,6 +114,9 @@ class _InviteModalState extends State<InviteModal> {
     return ModalScaffold(
       title: s.inviteTitle,
       wide: true,
+      // Ticket generation publishes a signed member_invited event — contain
+      // the route while it is in flight (#55).
+      busy: _busy,
       child: ListenableBuilder(
         listenable: liveStore ?? Listenable.merge(const []),
         builder: (context, _) {

--- a/app/lib/src/screens/modals/join_room.dart
+++ b/app/lib/src/screens/modals/join_room.dart
@@ -5,10 +5,10 @@
 /// `splitInvite` + `joinRoomWithRetry` (5 attempts, retries ONLY
 /// peer_unreachable); on success pops with the joined room id (the shell then
 /// refreshes rooms and opens it); failures are recorded to diagnostics as
-/// context 'room.join'.
+/// context 'room.join'. While the join is in flight the modal is CONTAINED
+/// (#55, ModalScaffold busy): no dismissal path can pop it, so the result
+/// applies exactly once, while the modal is still up.
 library;
-
-import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:jeliya_protocol/jeliya_protocol.dart'
@@ -71,23 +71,24 @@ class _JoinRoomModalState extends State<JoinRoomModal> {
           if (mounted) setState(() => _progress = progress);
         },
       );
-      if (mounted) {
-        Navigator.of(context).pop(roomId);
-        // Stays busy until the pop lands (web keeps the button disabled too).
-      } else {
-        // Dismissed mid-retry: the join still happened — apply the success
-        // effects the shell's pop-consumer would have (web parity).
-        unawaited(session.refreshRooms());
-        unawaited(session.openRoom(roomId));
-      }
+      // Containment (ModalScaffold busy → PopScope) holds the route up
+      // while the join is in flight, so this state is still mounted.
+      // Defensively, if it somehow isn't: apply NOTHING — a result must
+      // never mutate navigation or room state after the user believes the
+      // action was abandoned.
+      if (!mounted) return;
+      Navigator.of(context).pop(roomId);
+      // Stays busy until the pop lands (web keeps the button disabled too).
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = session.recordError('room.join', e);
-          _progress = null;
-          _busy = false;
-        });
-      }
+      // Record BEFORE the mounted check: a failure must reach diagnostics
+      // even if the modal was somehow dismissed mid-retry.
+      final err = session.recordError('room.join', e);
+      if (!mounted) return;
+      setState(() {
+        _error = err;
+        _progress = null;
+        _busy = false;
+      });
     }
   }
 
@@ -99,6 +100,7 @@ class _JoinRoomModalState extends State<JoinRoomModal> {
     final progress = _progress;
     return ModalScaffold(
       title: s.modalJoinRoomTitle,
+      busy: _busy,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/app/lib/src/screens/modals/leave_room.dart
+++ b/app/lib/src/screens/modals/leave_room.dart
@@ -1,11 +1,13 @@
-/// Leave Room modal — exact port of ui/src/App.tsx `LeaveRoomModal` per
+/// Leave Room modal — port of ui/src/App.tsx `LeaveRoomModal` per
 /// phase3-features.json: copy 'Leaving {roomName} publishes a signed
 /// membership departure…' (room name bold), danger submit 'Leave room'/
-/// 'Leaving…' (autofocus), ghost Cancel (disabled while busy), ErrorNote.
-/// Submit → `client.roomLeave(roomId)`; on success pops with true — the shell
-/// then runs `session.leaveCurrentRoom()` (full room-state reset, pref
-/// cleared, rooms + daemon.status refreshed). Failures are recorded to
-/// diagnostics as context 'room.leave'.
+/// 'Leaving…', ghost Cancel (autofocus — safe initial focus, so an
+/// immediate Enter can never confirm the destructive action; disabled while
+/// busy), ErrorNote. Submit → `client.roomLeave(roomId)`; on success pops
+/// with true — the shell then runs `session.leaveCurrentRoom()` (full
+/// room-state reset, pref cleared, rooms + daemon.status refreshed).
+/// Failures are recorded to diagnostics as context 'room.leave'. While the
+/// leave is in flight the modal is CONTAINED (#55, ModalScaffold busy).
 library;
 
 import 'package:flutter/material.dart';
@@ -48,21 +50,22 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
     });
     try {
       await client.roomLeave(widget.roomId);
-      if (mounted) {
-        Navigator.of(context).pop(true);
-        // Stays busy until the pop lands (web keeps the button disabled too).
-      } else {
-        // Dismissed mid-flight: the leave still happened — run the cleanup
-        // the shell's pop-consumer would have (web parity).
-        session.leaveCurrentRoom();
-      }
+      // Containment (ModalScaffold busy → PopScope) holds the route up
+      // while the leave is in flight, so this state is still mounted.
+      // Defensively, if it somehow isn't: apply NOTHING — never run the
+      // room-state reset after the user believes the action was abandoned.
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+      // Stays busy until the pop lands (web keeps the button disabled too).
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _error = session.recordError('room.leave', e);
-          _busy = false;
-        });
-      }
+      // Record BEFORE the mounted check: a failure must reach diagnostics
+      // even if the modal was somehow dismissed mid-flight.
+      final err = session.recordError('room.leave', e);
+      if (!mounted) return;
+      setState(() {
+        _error = err;
+        _busy = false;
+      });
     }
   }
 
@@ -72,6 +75,7 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
     final tokens = JeliyaTokens.of(context);
     return ModalScaffold(
       title: s.modalLeaveRoomTitle,
+      busy: _busy,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -103,9 +107,6 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
                   label: _busy ? s.modalLeavingRoom : s.modalLeaveRoom,
                   variant: JeliyaButtonVariant.danger,
                   busy: _busy,
-                  // The reference autofocuses the danger submit so Enter
-                  // confirms.
-                  autofocus: true,
                   onPressed: _busy ? null : _leave,
                 ),
               ),
@@ -114,6 +115,11 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
                 child: JeliyaButton(
                   label: s.modalCancel,
                   variant: JeliyaButtonVariant.ghost,
+                  // Safe initial focus (#55): Cancel takes focus, never the
+                  // danger submit, so an immediate Enter abandons instead of
+                  // confirming. The web reference adopted the same contract
+                  // in #56.
+                  autofocus: true,
                   onPressed:
                       _busy ? null : () => Navigator.of(context).maybePop(),
                 ),

--- a/app/lib/src/screens/modals/rename_peer.dart
+++ b/app/lib/src/screens/modals/rename_peer.dart
@@ -26,6 +26,12 @@ class RenamePeerModal extends StatefulWidget {
 class _RenamePeerModalState extends State<RenamePeerModal> {
   TextEditingController? _alias;
 
+  /// Save has two synchronous affordances (the button and Enter in the
+  /// field) and the field keeps focus during the exit transition, so a
+  /// repeated commit would pop the route BELOW the dialog. Only the first
+  /// commit may pop (#55).
+  bool _popped = false;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -43,12 +49,16 @@ class _RenamePeerModalState extends State<RenamePeerModal> {
   }
 
   void _save() {
+    if (_popped) return;
+    _popped = true;
     // setAlias trims and deletes on blank — the reference Save semantics.
     SessionScope.of(context).setAlias(widget.identityId, _alias?.text);
     Navigator.of(context).pop();
   }
 
   void _clear() {
+    if (_popped) return;
+    _popped = true;
     SessionScope.of(context).setAlias(widget.identityId, null);
     Navigator.of(context).pop();
   }

--- a/app/lib/src/widgets/buttons.dart
+++ b/app/lib/src/widgets/buttons.dart
@@ -36,8 +36,8 @@ class JeliyaButton extends StatelessWidget {
   /// Shows a small spinner before the label (Sending…/Joining…/etc).
   final bool busy;
 
-  /// Initial focus (the reference autofocuses e.g. the Leave-room danger
-  /// submit so Enter confirms).
+  /// Initial focus (e.g. the Leave-room modal focuses its Cancel button so
+  /// an immediate Enter can never confirm the destructive action, #55).
   final bool autofocus;
 
   final String? semanticLabel;

--- a/app/lib/src/widgets/modal_scaffold.dart
+++ b/app/lib/src/widgets/modal_scaffold.dart
@@ -3,6 +3,11 @@
 /// bgRaise, borderStrong, header with title + ✕). Flutter's dialog route
 /// supplies the reference keyboard/focus contract for free: Escape closes,
 /// focus is trapped in the route, and focus returns to the opener on close.
+/// While a modal reports [ModalScaffold.busy] its route is CONTAINED (#55):
+/// barrier tap, Escape, the ✕ and system/predictive back all refuse to
+/// dismiss until the in-flight operation settles — a result must never
+/// mutate navigation or room state after the user believes the action was
+/// abandoned.
 library;
 
 import 'package:flutter/material.dart';
@@ -63,6 +68,7 @@ class ModalScaffold extends StatelessWidget {
     required this.title,
     required this.child,
     this.wide = false,
+    this.busy = false,
     this.onClose,
   });
 
@@ -71,6 +77,14 @@ class ModalScaffold extends StatelessWidget {
 
   /// Wide variant: max-width 560 instead of 440.
   final bool wide;
+
+  /// True while the modal's async operation is in flight. The route refuses
+  /// to pop — one PopScope covers barrier tap, Escape, and system/predictive
+  /// back, because they all route through `Navigator.maybePop` — and the ✕
+  /// disables so the containment is visible. The success path's imperative
+  /// `Navigator.pop(result)` bypasses PopScope, so submitting stays able to
+  /// close the modal while it is still marked busy.
+  final bool busy;
 
   /// Defaults to popping the enclosing dialog route.
   final VoidCallback? onClose;
@@ -90,7 +104,9 @@ class ModalScaffold extends StatelessWidget {
             ),
           ),
           IconButton(
-            onPressed: close,
+            // Disabled while busy: containment must be visible, not a
+            // silently swallowed tap. The tooltip stays either way.
+            onPressed: busy ? null : close,
             tooltip: context.strings.commonClose,
             icon: Text(Tokens.closeGlyph,
                 style: TextStyle(fontSize: 14, color: tokens.textDim)),
@@ -105,11 +121,12 @@ class ModalScaffold extends StatelessWidget {
         ],
       ),
     );
+    final Widget presentation;
     if (_ModalScreenScope.of(context)) {
       // Full-screen presentation (showJeliyaModalScreen): same header/body
       // anatomy as the dialog, page-sized, with safe-area insets. The
       // Scaffold keeps the form above the soft keyboard.
-      return Scaffold(
+      presentation = Scaffold(
         backgroundColor: tokens.bgRaise,
         body: SafeArea(
           child: Column(
@@ -127,30 +144,37 @@ class ModalScaffold extends StatelessWidget {
           ),
         ),
       );
-    }
-    return Dialog(
-      backgroundColor: tokens.bgRaise,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(JeliyaRadii.modal),
-        side: BorderSide(color: tokens.borderStrong),
-      ),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: wide ? 560 : 440),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            header,
-            Divider(height: 1, color: tokens.border),
-            Flexible(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(18, 16, 18, 20),
-                child: child,
-              ),
-            ),
-          ],
+    } else {
+      presentation = Dialog(
+        backgroundColor: tokens.bgRaise,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(JeliyaRadii.modal),
+          side: BorderSide(color: tokens.borderStrong),
         ),
-      ),
-    );
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: wide ? 560 : 440),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              header,
+              Divider(height: 1, color: tokens.border),
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(18, 16, 18, 20),
+                  child: child,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    // Containment (#55): while busy, refuse every dismissal path. Barrier
+    // taps, Escape (routes.dart _DismissModalAction) and system/predictive
+    // back all route through Navigator.maybePop, so this single PopScope —
+    // registered on whichever route hosts the modal (DialogRoute or the
+    // full-screen MaterialPageRoute) — covers all of them.
+    return PopScope(canPop: !busy, child: presentation);
   }
 }

--- a/app/test/dialog_containment_test.dart
+++ b/app/test/dialog_containment_test.dart
@@ -1,0 +1,536 @@
+/// Dialog containment and safe initial focus (issue #55). While a modal's
+/// async submit is in flight, its route must refuse EVERY dismissal path —
+/// barrier tap, Escape, system back — the ✕ must disable, and a second
+/// submit must issue no second wire request; the result then applies exactly
+/// once, while the modal is still up (never after the user believes the
+/// action was abandoned). Failures restore interaction (ErrorNote, submit
+/// re-enabled) and normal dismissal returns once the operation settles. The
+/// Leave dialog's initial focus is Cancel, never the danger submit, so an
+/// immediate Enter can never leave the room. A not-busy modal keeps the
+/// normal dismissal UX untouched.
+///
+/// System back is simulated with `tester.binding.handlePopRoute()` — the
+/// same mechanism predictive_back_test uses (a widget test cannot drive the
+/// real OS gesture). Barrier tap, Escape and back all route through
+/// `Navigator.maybePop`, but each path is proven here, not assumed.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/l10n/error_display.dart';
+import 'package:jeliya_app/src/l10n/tokens.dart';
+import 'package:jeliya_app/src/screens/modals/create_room.dart';
+import 'package:jeliya_app/src/screens/modals/join_room.dart';
+import 'package:jeliya_app/src/screens/modals/leave_room.dart';
+import 'package:jeliya_app/src/screens/right_panel.dart';
+import 'package:jeliya_app/src/widgets/buttons.dart';
+import 'package:jeliya_app/src/widgets/modal_scaffold.dart';
+import 'package:jeliya_protocol/jeliya_protocol.dart'
+    show JeliyaMethods, RequestError, Roles;
+
+import 'helpers.dart';
+import 'member_self_seam.dart';
+
+/// The error every gated failure resolves with — built by a function so the
+/// assertion side derives the SAME friendly copy the modal renders.
+RequestError _gateError() =>
+    // i18n-exempt: wire error fixture, not copy
+    RequestError('internal', 'gated wire failure', hint: 'try again');
+
+/// Holds calls to [gateMethod] on completers the test releases by hand, so
+/// the submit stays genuinely in flight while every dismissal path is
+/// exercised. Records every wire method so a test can prove exactly one
+/// request per submitted action.
+mixin _GateMixin on DelegatingClient {
+  final List<String> calls = [];
+  String? gateMethod;
+  final List<Completer<void>> gates = [];
+
+  /// Let the single pending gated call proceed to the mock (success).
+  void releaseSuccess() => gates.single.complete();
+
+  /// Fail the single pending gated call with [_gateError].
+  void releaseFailure() => gates.single.completeError(_gateError());
+
+  @override
+  Future<dynamic> call(String method, [Map<String, dynamic>? params]) {
+    calls.add(method);
+    if (method == gateMethod) {
+      final gate = Completer<void>();
+      gates.add(gate);
+      return gate.future.then((_) => super.call(method, params));
+    }
+    return super.call(method, params);
+  }
+}
+
+class _GatedClient extends DelegatingClient with _GateMixin {
+  _GatedClient(super.inner);
+}
+
+/// The leave flow needs both seams: self as a plain member (so Leave
+/// renders and succeeds at the wire) AND the gate.
+class _GatedMemberSelfClient extends MemberSelfClient with _GateMixin {
+  _GatedMemberSelfClient(super.inner);
+}
+
+/// How many times [method] was called at or past [mark].
+int _callCount(List<String> calls, int mark, String method) =>
+    calls.sublist(mark).where((m) => m == method).length;
+
+/// The modal's ✕ close button (scoped to the one open [ModalScaffold]).
+IconButton _closeButton(WidgetTester tester) =>
+    tester.widget<IconButton>(find.descendant(
+        of: find.byType(ModalScaffold),
+        matching: find.widgetWithText(IconButton, Tokens.closeGlyph)));
+
+/// The TextButton inside the [JeliyaButton] whose label is [label], scoped
+/// to the open modal so same-labeled affordances behind the barrier never
+/// collide.
+TextButton _modalButton(WidgetTester tester, Finder modal, String label) =>
+    tester.widget<TextButton>(find.descendant(
+        of: find.descendant(
+            of: modal, matching: find.widgetWithText(JeliyaButton, label)),
+        matching: find.byType(TextButton)));
+
+/// True when the primary focus sits inside [finder]'s subtree.
+bool _hasPrimaryFocus(WidgetTester tester, Finder finder) {
+  final context = tester.binding.focusManager.primaryFocus?.context;
+  if (context == null) return false;
+  final focused = context as Element;
+  final targets = finder.evaluate().toSet();
+  if (targets.contains(focused)) return true;
+  var within = false;
+  focused.visitAncestorElements((ancestor) {
+    if (targets.contains(ancestor)) {
+      within = true;
+      return false;
+    }
+    return true;
+  });
+  return within;
+}
+
+/// Exercises every dismissal path while the gated submit is pending — the
+/// modal must survive all of them and the ✕ must be disabled. [barrier] is
+/// false for the full-screen presentation, which has no tappable barrier.
+Future<void> _expectContained(WidgetTester tester, Finder modal,
+    {required bool barrier}) async {
+  if (barrier) {
+    await tester.tapAt(const Offset(8, 8)); // outside the dialog card
+    await tester.pump();
+    expect(modal, findsOneWidget,
+        reason: 'a barrier tap must not dismiss a busy modal');
+  }
+  await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+  await tester.pump();
+  expect(modal, findsOneWidget,
+      reason: 'Escape must not dismiss a busy modal');
+  await tester.binding.handlePopRoute(); // system back
+  await tester.pump();
+  expect(modal, findsOneWidget,
+      reason: 'system back must not dismiss a busy modal');
+  expect(_closeButton(tester).onPressed, isNull,
+      reason: 'the ✕ must be visibly disabled while busy');
+}
+
+/// Opens the create-room dialog from the mobile rooms screen.
+Future<void> _openCreate(WidgetTester tester) async {
+  await tester.tap(find.text(en.modalCreateRoom).hitTestable());
+  await pumpSteps(tester, steps: 3);
+  expect(find.byType(CreateRoomModal), findsOneWidget);
+  expect(find.byType(Dialog), findsOneWidget); // dialog, even on phones
+}
+
+/// Types a name and submits with the gate installed; returns the calls mark
+/// taken just before the submit tap.
+Future<int> _submitCreateGated(WidgetTester tester, _GatedClient client,
+    {required String name}) async {
+  await tester.enterText(
+      find.widgetWithText(TextField, en.modalRoomNamePlaceholder), name);
+  await tester.pump();
+  client.gateMethod = 'room.create'; // i18n-exempt: wire method, not copy
+  final mark = client.calls.length;
+  await tester
+      .tap(find.widgetWithText(JeliyaButton, en.modalCreateRoom).hitTestable());
+  await tester.pump();
+  expect(client.gates, hasLength(1),
+      reason: 'the submit must have issued exactly one request');
+  return mark;
+}
+
+/// Navigates chat → Members and opens the leave dialog (member-self seam).
+Future<void> _openLeave(
+    WidgetTester tester, _GatedMemberSelfClient client) async {
+  // i18n-exempt: fixture room name, not copy
+  await tester.tap(find.text('Product Review').hitTestable());
+  await pumpSteps(tester, steps: 6);
+  await tester.tap(find.text(en.panelTabMembers).hitTestable().first);
+  await pumpSteps(tester, steps: 6);
+  expect(find.byType(RightPanel).hitTestable(), findsOneWidget);
+  await tester
+      .tap(find.widgetWithText(JeliyaButton, en.panelLeave).hitTestable());
+  await pumpSteps(tester, steps: 3);
+  expect(find.byType(LeaveRoomModal), findsOneWidget);
+  expect(find.byType(Dialog), findsOneWidget);
+}
+
+void main() {
+  // i18n-exempt: wire method names, not copy — used across the suite.
+  const roomCreate = 'room.create';
+  const roomJoin = 'room.join';
+  const roomLeave = 'room.leave';
+  const roomOpen = 'room.open';
+  const roomList = 'room.list';
+  const daemonStatus = 'daemon.status';
+
+  testWidgets(
+      'create: contained while pending — barrier/Escape/back refused, ✕ '
+      'disabled, no second request; success applies exactly once',
+      (tester) async {
+    final client = _GatedClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final roomsBefore = session.rooms.length;
+
+    await _openCreate(tester);
+    final mark =
+        await _submitCreateGated(tester, client, name: 'Contained Lane');
+
+    // A second submit tap while pending issues no second request (the
+    // button is disabled and shows the busy label).
+    await tester.tap(find.widgetWithText(JeliyaButton, en.modalCreatingRoom),
+        warnIfMissed: false);
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+    expect(_callCount(client.calls, mark, roomCreate), 1);
+
+    await _expectContained(tester, find.byType(CreateRoomModal),
+        barrier: true);
+
+    client.releaseSuccess();
+    await pumpSteps(tester);
+
+    // Pops once; the shell applies the transition once.
+    expect(find.byType(CreateRoomModal), findsNothing);
+    expect(_callCount(client.calls, mark, roomCreate), 1);
+    expect(_callCount(client.calls, mark, roomOpen), 1,
+        reason: 'the popped roomId must drive openRoom exactly once');
+    expect(session.rooms, hasLength(roomsBefore + 1));
+    expect(session.currentRoomId,
+        session.rooms.firstWhere((r) => r.name == 'Contained Lane').roomId);
+    expect(ready.overflows, isEmpty);
+  });
+
+  testWidgets(
+      'create: failure keeps the dialog up with an actionable ErrorNote, '
+      'restores interaction, and normal dismissal works again',
+      (tester) async {
+    final client = _GatedClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final roomsBefore = session.rooms.length;
+    final openedBefore = session.currentRoomId;
+
+    await _openCreate(tester);
+    final mark =
+        await _submitCreateGated(tester, client, name: 'Doomed Lane');
+
+    client.releaseFailure();
+    await pumpSteps(tester, steps: 3);
+
+    // Still open, error surfaced with the friendly (actionable) copy, and
+    // the failure reached diagnostics.
+    expect(find.byType(CreateRoomModal), findsOneWidget);
+    final friendly = en.friendlyError(_gateError());
+    expect(find.text(friendly.title), findsOneWidget);
+    expect(session.lastDiagnosticError?.context, roomCreate);
+    // Interaction restored: idle label back, submit enabled again.
+    expect(
+        _modalButton(tester, find.byType(CreateRoomModal), en.modalCreateRoom)
+            .onPressed,
+        isNotNull);
+    expect(_closeButton(tester).onPressed, isNotNull);
+
+    // Once settled, normal dismissal works again.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsNothing);
+    // The abandoned failure applied nothing.
+    expect(_callCount(client.calls, mark, roomOpen), 0);
+    expect(session.rooms, hasLength(roomsBefore));
+    expect(session.currentRoomId, openedBefore);
+    expect(ready.overflows, isEmpty);
+  });
+
+  testWidgets(
+      'join (full screen): contained while pending — Escape/back refused, ✕ '
+      'disabled, no second request; success applies exactly once',
+      (tester) async {
+    final client = _GatedClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final review = session.rooms.firstWhere((r) => r.name == 'Product Review');
+    final minted = client.inviteCreate(
+        roomId: review.roomId, identityId: 'b' * 64, role: Roles.member);
+    await pumpSteps(tester, steps: 2);
+    final ticket = await minted;
+
+    await tester.tap(find.text(en.modalJoinRoomTitle).hitTestable());
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(JoinRoomModal), findsOneWidget);
+    expect(find.byType(Dialog), findsNothing); // full screen on phones
+
+    await tester.enterText(
+        find.widgetWithText(TextField, en.modalTicketPlaceholder), ticket);
+    await tester.pump();
+    client.gateMethod = roomJoin;
+    final mark = client.calls.length;
+    await tester
+        .tap(find.widgetWithText(JeliyaButton, en.modalJoinRoom).hitTestable());
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+
+    await tester.tap(find.widgetWithText(JeliyaButton, en.modalJoiningRoom),
+        warnIfMissed: false);
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+    expect(_callCount(client.calls, mark, roomJoin), 1);
+
+    // No barrier exists on the full-screen presentation; Escape and system
+    // back are its dismissal surface.
+    await _expectContained(tester, find.byType(JoinRoomModal), barrier: false);
+
+    client.releaseSuccess();
+    await pumpSteps(tester);
+
+    expect(find.byType(JoinRoomModal), findsNothing);
+    expect(_callCount(client.calls, mark, roomJoin), 1);
+    expect(_callCount(client.calls, mark, roomOpen), 1,
+        reason: 'the popped roomId must drive openRoom exactly once');
+    expect(session.currentRoomId, review.roomId);
+    expect(ready.overflows, isEmpty);
+  });
+
+  testWidgets(
+      'join: failure keeps the screen up with an actionable ErrorNote and '
+      'system back dismisses again once settled', (tester) async {
+    final client = _GatedClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final review = session.rooms.firstWhere((r) => r.name == 'Product Review');
+    final minted = client.inviteCreate(
+        roomId: review.roomId, identityId: 'b' * 64, role: Roles.member);
+    await pumpSteps(tester, steps: 2);
+    final ticket = await minted;
+    final openedBefore = session.currentRoomId;
+
+    await tester.tap(find.text(en.modalJoinRoomTitle).hitTestable());
+    await pumpSteps(tester, steps: 3);
+    await tester.enterText(
+        find.widgetWithText(TextField, en.modalTicketPlaceholder), ticket);
+    await tester.pump();
+    client.gateMethod = roomJoin;
+    final mark = client.calls.length;
+    await tester
+        .tap(find.widgetWithText(JeliyaButton, en.modalJoinRoom).hitTestable());
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+
+    client.releaseFailure();
+    await pumpSteps(tester, steps: 3);
+
+    expect(find.byType(JoinRoomModal), findsOneWidget);
+    final friendly = en.friendlyError(_gateError());
+    expect(find.text(friendly.title), findsOneWidget);
+    expect(session.lastDiagnosticError?.context, roomJoin);
+    expect(
+        _modalButton(tester, find.byType(JoinRoomModal), en.modalJoinRoom)
+            .onPressed,
+        isNotNull);
+
+    await tester.binding.handlePopRoute();
+    await pumpSteps(tester, steps: 6); // full-screen exit transition
+    expect(find.byType(JoinRoomModal), findsNothing);
+    expect(_callCount(client.calls, mark, roomOpen), 0);
+    expect(session.currentRoomId, openedBefore);
+    expect(ready.overflows, isEmpty);
+  });
+
+  testWidgets(
+      'leave: contained while pending — barrier/Escape/back refused, ✕ and '
+      'both buttons disabled; success applies exactly once', (tester) async {
+    final client = _GatedMemberSelfClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    client.memberRoomId =
+        session.rooms.firstWhere((r) => r.name == 'Product Review').roomId;
+
+    await _openLeave(tester, client);
+    // Chat/members surfaces own their pixel budget elsewhere
+    // (mobile_flow_layout_test); this suite pins that the LEAVE FLOW adds
+    // no overflow reports from here on.
+    final overflowMark = ready.overflows.length;
+
+    client.gateMethod = roomLeave;
+    final mark = client.calls.length;
+    await tester
+        .tap(find.widgetWithText(JeliyaButton, en.modalLeaveRoom).hitTestable());
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+
+    // Second submit tap while pending: no second request.
+    await tester.tap(find.widgetWithText(JeliyaButton, en.modalLeavingRoom),
+        warnIfMissed: false);
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+    expect(_callCount(client.calls, mark, roomLeave), 1);
+    // Containment is visible: Cancel is disabled too while busy.
+    expect(
+        _modalButton(tester, find.byType(LeaveRoomModal), en.modalCancel)
+            .onPressed,
+        isNull);
+
+    await _expectContained(tester, find.byType(LeaveRoomModal), barrier: true);
+
+    client.releaseSuccess();
+    await pumpSteps(tester);
+
+    // Pops once with true; the shell runs leaveCurrentRoom exactly once.
+    expect(find.byType(LeaveRoomModal), findsNothing);
+    expect(_callCount(client.calls, mark, roomLeave), 1);
+    expect(session.currentRoomId, isNull);
+    expect(session.prefs.lastRoomId, isNull);
+    final after = client.calls.sublist(mark);
+    expect(after, contains(roomList));
+    expect(after, contains(daemonStatus));
+    expect(ready.overflows.sublist(overflowMark), isEmpty);
+  });
+
+  testWidgets(
+      'leave: failure keeps the dialog up with an actionable ErrorNote, '
+      'restores interaction, and barrier dismissal works again — with the '
+      'room left intact', (tester) async {
+    final client = _GatedMemberSelfClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final roomId =
+        session.rooms.firstWhere((r) => r.name == 'Product Review').roomId;
+    client.memberRoomId = roomId;
+
+    await _openLeave(tester, client);
+    final overflowMark = ready.overflows.length;
+
+    client.gateMethod = roomLeave;
+    await tester
+        .tap(find.widgetWithText(JeliyaButton, en.modalLeaveRoom).hitTestable());
+    await tester.pump();
+    expect(client.gates, hasLength(1));
+
+    client.releaseFailure();
+    await pumpSteps(tester, steps: 3);
+
+    expect(find.byType(LeaveRoomModal), findsOneWidget);
+    final friendly = en.friendlyError(_gateError());
+    expect(find.text(friendly.title), findsOneWidget);
+    expect(session.lastDiagnosticError?.context, roomLeave);
+    expect(
+        _modalButton(tester, find.byType(LeaveRoomModal), en.modalLeaveRoom)
+            .onPressed,
+        isNotNull);
+    expect(
+        _modalButton(tester, find.byType(LeaveRoomModal), en.modalCancel)
+            .onPressed,
+        isNotNull);
+
+    // Once settled, the barrier dismisses again — and the failed leave
+    // applied nothing.
+    await tester.tapAt(const Offset(8, 8));
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(LeaveRoomModal), findsNothing);
+    expect(client.leftRoomId, isNull);
+    expect(session.currentRoomId, roomId);
+    expect(ready.overflows.sublist(overflowMark), isEmpty);
+  });
+
+  testWidgets(
+      'leave: initial focus is Cancel, never the danger submit — an '
+      'immediate Enter does not leave the room', (tester) async {
+    final client = _GatedMemberSelfClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+    final session = ready.session;
+    final roomId =
+        session.rooms.firstWhere((r) => r.name == 'Product Review').roomId;
+    client.memberRoomId = roomId;
+
+    await _openLeave(tester, client);
+
+    final danger = find.descendant(
+        of: find.byType(LeaveRoomModal),
+        matching: find.widgetWithText(JeliyaButton, en.modalLeaveRoom));
+    final cancel = find.descendant(
+        of: find.byType(LeaveRoomModal),
+        matching: find.widgetWithText(JeliyaButton, en.modalCancel));
+    expect(_hasPrimaryFocus(tester, danger), isFalse,
+        reason: 'the danger submit must never take initial focus');
+    expect(_hasPrimaryFocus(tester, cancel), isTrue,
+        reason: 'Cancel is the safe initial focus');
+
+    final mark = client.calls.length;
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await pumpSteps(tester, steps: 3);
+
+    expect(_callCount(client.calls, mark, roomLeave), 0,
+        reason: 'Enter right after open must never confirm the leave');
+    expect(client.leftRoomId, isNull);
+    expect(session.currentRoomId, roomId,
+        reason: 'the room must still be open');
+    // Enter activated Cancel: the dialog closed without leaving.
+    expect(find.byType(LeaveRoomModal), findsNothing);
+  });
+
+  testWidgets(
+      'not busy: modals still dismiss via barrier, Escape, system back and '
+      'the ✕ (no regression of the normal dismissal UX)', (tester) async {
+    final client = _GatedClient(newMockClient());
+    final ready = await pumpReadyMobileApp(tester, client);
+
+    // Barrier tap.
+    await _openCreate(tester);
+    await tester.tapAt(const Offset(8, 8));
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsNothing);
+
+    // Escape.
+    await _openCreate(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsNothing);
+
+    // System back.
+    await _openCreate(tester);
+    await tester.binding.handlePopRoute();
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsNothing);
+
+    // The ✕ stays enabled and closes.
+    await _openCreate(tester);
+    expect(_closeButton(tester).onPressed, isNotNull);
+    await tester.tap(find.byTooltip(en.commonClose).hitTestable());
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsNothing);
+
+    // The full-screen presentation dismisses via system back too.
+    await tester.tap(find.text(en.modalJoinRoomTitle).hitTestable());
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(JoinRoomModal), findsOneWidget);
+    await tester.binding.handlePopRoute();
+    await pumpSteps(tester, steps: 6); // full-screen exit transition
+    expect(find.byType(JoinRoomModal), findsNothing);
+
+    expect(ready.overflows, isEmpty);
+  });
+}


### PR DESCRIPTION
Independent of the web stack (based on main). Flutter's dialogs shared the web UI's asynchronous dismissal risk (#55) — and went further: create/join/leave deliberately REPLAYED their success effects (`refreshRooms`/`openRoom`/`leaveCurrentRoom`) after being dismissed mid-flight, and the leave modal autofocused the danger submit so an immediate Enter left the room.

- `ModalScaffold` gains `busy`: both presentations (Dialog and the full-screen route) return through one `PopScope(canPop: !busy)` — barrier tap, Escape, and system/predictive back all route through `Navigator.maybePop`, so a single scope contains every dismissal path (each path proven by widget test, not assumed) — and the ✕ disables while busy so the containment is visible. The success path's imperative `Navigator.pop(result)` bypasses PopScope, so submitting still closes the modal.
- Create/join/leave pass `busy` and their dismissed-mid-flight replay branches are removed: results apply exactly once, while the modal is up; the defensive unmounted path applies NOTHING, and failures now reach diagnostics via `recordError` even when unmounted (they used to be silently swallowed). Add-agent and invite ticket generation are contained the same way; the synchronous rename modal gets a first-commit-only pop guard. Success pop contracts (String room id for create/join, `true` for leave) are unchanged and stay pinned by `mobile_modal_flows_test`.
- The leave modal's initial focus moves from the danger submit to Cancel; the stale "reference autofocuses the danger submit" parity comments are rewritten to the contract the web reference adopts in #56.
- New `app/test/dialog_containment_test.dart` (8 tests, completer-gated fake client) per house rules (strict surface, no `pumpAndSettle`, catalog copy): one request + one applied transition per submit; failure keeps the modal actionable; barrier/Escape/system-back refused while pending and working again once settled; ✕ disabled while busy; leave focus order + immediate Enter never calls `room.leave`; a not-busy modal still dismisses through every normal path.

Ran (Flutter 3.44.6 locally; no `gen-l10n` run, nothing under `l10n/gen` or ARBs touched):
- `flutter analyze` — No issues found
- `flutter test` — 183 passed (175 pre-existing + 8 new), including the pinned `predictive_back_test`, `mobile_modal_flows_test`, `mobile_back_policy_test`, `mobile_flow_layout_test`
- `node scripts/i18n-gate.mjs` — OK
- Reverse proof: with `app/lib` stashed (tests kept), the three contained-while-pending tests and the leave focus test fail (4/8); the failure-recovery and not-busy-dismissal tests still pass.

Follow-up candidate found during the work (out of scope here): `add_agent` and `invite` shape errors with `errorShape` but never call `session.recordError`, so their failures never reach the Settings diagnostics surface.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)