### PR TITLE
fix(ui): compact pane reveals measure correctly; room actions land visibly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 ui/dist/
 ui/test-results/
 ui/playwright-report/
+/test-results/
 .jeliya-data*/
 .jeliya-demo*/
 *.log

--- a/ui/e2e/composer-height.spec.ts
+++ b/ui/e2e/composer-height.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Issue #57: the composer initializes while its pane is hidden on compact —
+// it must still present a full one-line textarea on first reveal, grow
+// multiline drafts to the 150px cap, keep drafts across hide/show, and
+// re-measure on viewport changes.
+
+const MULTILINE_DRAFT = Array.from({ length: 8 }, (_, i) => `draft line ${i + 1}`).join('\n');
+
+test('the untouched composer shows a full one-line field before any keystroke', async ({
+  app,
+}) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const textarea = app.composerTextarea;
+  await expect(textarea).toBeVisible();
+  await expect(textarea).toHaveAttribute('placeholder', `Message ${MOCK_ROOMS.main}`);
+  // Nonzero content area before the first keystroke — the regression was a
+  // clipped 0px strip measured inside the hidden pane.
+  const box = await textarea.boundingBox();
+  expect(box, 'composer textarea must be laid out').not.toBeNull();
+  expect(box!.height).toBeGreaterThanOrEqual(24);
+});
+
+test('mobile: a multiline draft survives hide/show with its height restored', async ({
+  app,
+  compact,
+}) => {
+  test.skip(!compact, 'panes are only hidden on compact');
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const textarea = app.composerTextarea;
+  await textarea.fill(MULTILINE_DRAFT);
+  const grownBox = await textarea.boundingBox();
+  expect(grownBox!.height).toBeGreaterThan(80);
+
+  // Hide the room pane, then reveal it again.
+  await app.mobileTab('Rooms').click();
+  await expect(app.center).toBeHidden();
+  await app.roomItem(MOCK_ROOMS.main).click();
+
+  // Draft preserved, height re-measured for the real layout — not a strip.
+  await expect(textarea).toHaveValue(MULTILINE_DRAFT);
+  await expect
+    .poll(async () => (await textarea.boundingBox())!.height)
+    .toBeGreaterThan(80);
+});
+
+test('multiline drafts grow to the cap without hiding the timeline', async ({ app }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const textarea = app.composerTextarea;
+  await textarea.fill(Array.from({ length: 40 }, (_, i) => `long line ${i + 1}`).join('\n'));
+
+  // The textarea grows but stops at the 150px cap…
+  const box = await textarea.boundingBox();
+  expect(box!.height).toBeGreaterThan(100);
+  expect(box!.height).toBeLessThanOrEqual(150);
+  // …and its content stays reachable by scrolling inside the field.
+  expect(await textarea.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true);
+  // The timeline is squeezed, never evicted (short viewports leave it only
+  // a sliver, but it must stay laid out and visible).
+  await expect(app.timeline).toBeVisible();
+  const timelineBox = await app.timeline.boundingBox();
+  expect(timelineBox!.height).toBeGreaterThan(0);
+});
+
+test('mobile: rotating the viewport recalculates the composer layout', async ({
+  app,
+  page,
+  compact,
+}) => {
+  test.skip(!compact, 'rotation is a phone concern');
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const textarea = app.composerTextarea;
+  await textarea.fill(MULTILINE_DRAFT);
+  await expect.poll(async () => (await textarea.boundingBox())!.height).toBeGreaterThan(80);
+
+  const viewport = page.viewportSize()!;
+  await page.setViewportSize({ width: viewport.height, height: viewport.width });
+
+  await expect(textarea).toBeVisible();
+  await expect(textarea).toHaveValue(MULTILINE_DRAFT);
+  // Still a real, correctly measured field in the new geometry: taller than
+  // one line, no taller than the cap.
+  await expect
+    .poll(async () => (await textarea.boundingBox())!.height)
+    .toBeGreaterThan(40);
+  expect((await textarea.boundingBox())!.height).toBeLessThanOrEqual(150);
+});

--- a/ui/e2e/room-actions.spec.ts
+++ b/ui/e2e/room-actions.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Issue #54: Share File, Open Pipe, and Open in Pipes must land on a VISIBLE
+// surface on compact viewports — the released bug updated the hidden
+// right-panel tab and appeared to do nothing.
+
+test('room-header Share File opens a visible Files surface', async ({ app, page, compact }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  await page.getByRole('button', { name: 'Share File' }).click();
+
+  await expect(app.rightPanel).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(app.rightPanel.getByRole('heading', { name: '5 shared files' })).toBeVisible();
+
+  if (compact) {
+    // Pane, panel tab, and bottom navigation may never contradict each other.
+    await expect(app.center).toBeHidden();
+    await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
+    // Repeating the destination while already on it is idempotent.
+    await app.mobileTab('Files').click();
+    await expect(app.rightPanel).toBeVisible();
+    await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
+  }
+});
+
+test('room-header Open Pipe opens a visible Pipes surface', async ({ app, page, compact }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  await page.getByRole('button', { name: 'Open Pipe' }).click();
+
+  await expect(app.rightPanel).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+
+  if (compact) {
+    await expect(app.center).toBeHidden();
+    await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  }
+});
+
+test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
+  app,
+  page,
+  compact,
+}) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  // The fixture's first pipe event is the logs pipe on 127.0.0.1:4000.
+  await app.timeline.getByRole('button', { name: 'Open in Pipes' }).first().click();
+
+  await expect(app.rightPanel).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  if (compact) {
+    await expect(app.center).toBeHidden();
+    await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  }
+
+  // The referenced pipe row is identified: transiently marked, and durably
+  // focused + on screen (focus outlives the 1.6s visual marker).
+  await expect(app.rightPanel.locator('.pipe-row-flash')).toContainText('127.0.0.1:4000');
+  const row = app.rightPanel.locator('.pipe-row', { hasText: '127.0.0.1:4000' });
+  await expect(row).toBeFocused();
+  await expect(row).toBeInViewport();
+});
+
+test('desktop: repeating Open in Pipes stays idempotent', async ({ app, compact }) => {
+  test.skip(compact, 'on compact the source button lives in the hidden chat pane');
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  const openInPipes = app.timeline.getByRole('button', { name: 'Open in Pipes' }).first();
+  await openInPipes.click();
+  await expect(app.rightPanel.locator('.pipe-row-flash')).toContainText('127.0.0.1:4000');
+  await openInPipes.click();
+  // Same destination, same identified row — no toggling, no stacking.
+  await expect(app.rightPanel.locator('.pipe-row-flash')).toContainText('127.0.0.1:4000');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+});

--- a/ui/e2e/room-actions.spec.ts
+++ b/ui/e2e/room-actions.spec.ts
@@ -76,6 +76,29 @@ test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
   await expect(row).toBeInViewport();
 });
 
+test('mobile: the panel tab strip keeps the bottom navigation truthful', async ({
+  app,
+  page,
+  compact,
+}) => {
+  test.skip(!compact, 'the bottom bar only exists on compact');
+  await app.gotoPopulated();
+  await app.navigate('Files');
+  await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
+
+  // Switching to Pipes inside the panel's own tab strip must move the bottom
+  // navigation with it — a Files highlight over Pipes content is a lie.
+  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
+  await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+
+  // Members is a sub-view of the current pane (it has no bottom-nav
+  // destination): the pane and its highlight stay put.
+  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+});
+
 test('desktop: repeating Open in Pipes stays idempotent', async ({ app, compact }) => {
   test.skip(compact, 'on compact the source button lives in the hidden chat pane');
   await app.gotoPopulated();

--- a/ui/e2e/timeline-position.spec.ts
+++ b/ui/e2e/timeline-position.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// Issue #52: mobile rooms must open at the newest timeline event even though
+// the room is auto-opened while its pane is display:none, and a deliberate
+// reading position must survive pane hiding and room switches.
+
+// The newest fixture event in the main room (mock.ts anchors it near "now").
+const NEWEST_MAIN_EVENT = 'Sync convergence suite running (14/24 green).';
+
+test('mobile: the auto-opened default room reveals at the newest event', async ({
+  app,
+  compact,
+}) => {
+  test.skip(!compact, 'desktop mounts the timeline visible; this is the hidden-mount path');
+  await app.gotoPopulated();
+
+  // The room was opened while the chat pane was hidden; first reveal must
+  // land within 140px of the bottom with the newest event exposed. On very
+  // short viewports the newest card can be taller than the visible timeline,
+  // so the contract is: its row intersects the viewport and the scroller sits
+  // at the bottom.
+  await app.openRoom(MOCK_ROOMS.main);
+  await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeVisible();
+  await expect(app.timeline.locator('.timeline-row').last()).toBeInViewport();
+  expect(await app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+});
+
+test('selecting a different room opens its latest activity', async ({ app }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+  await app.openRoom(MOCK_ROOMS.design);
+
+  await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeVisible();
+  await expect(app.timeline.locator('.timeline-row').last()).toBeInViewport();
+  expect(await app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+});
+
+test('mobile: hiding and revealing the room pane keeps the reading position', async ({
+  app,
+  compact,
+}) => {
+  test.skip(!compact, 'panes are only hidden on compact');
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  // Scroll deliberately away from the bottom (display:none will wipe this).
+  await app.timeline.evaluate((el) => {
+    el.scrollTop = 300;
+  });
+  await expect.poll(() => app.timeline.evaluate((el) => el.scrollTop)).toBe(300);
+
+  await app.mobileTab('Rooms').click();
+  await expect(app.center).toBeHidden();
+  await app.roomItem(MOCK_ROOMS.main).click();
+  await expect(app.timeline).toBeVisible();
+
+  // Reinstated, not reset to the top and not jumped to the bottom.
+  await expect
+    .poll(() => app.timeline.evaluate((el) => Math.abs(el.scrollTop - 300)))
+    .toBeLessThan(2);
+});
+
+test('returning to a scrolled-up room preserves the position and offers new activity', async ({
+  app,
+}) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  // Deliberately read from the top…
+  await app.timeline.evaluate((el) => {
+    el.scrollTop = 0;
+  });
+  await expect.poll(() => app.timeline.evaluate((el) => el.scrollTop)).toBe(0);
+
+  // …leave for another room, then come back.
+  await app.openRoom(MOCK_ROOMS.design);
+  await app.openRoom(MOCK_ROOMS.main);
+
+  // Wait for the reloaded backlog (the oldest event is on screen only if the
+  // reading position was really preserved), then confirm: top, not bottom.
+  await expect(app.timeline.getByText('created the room', { exact: false })).toBeInViewport();
+  await expect.poll(() => app.timeline.evaluate((el) => el.scrollTop)).toBe(0);
+  expect(await app.timelineBottomOffset()).toBeGreaterThan(140);
+
+  // New activity surfaces as a control, not a jump.
+  await app.composerTextarea.fill('note to self while reading history');
+  await app.composerTextarea.press('Enter');
+  const newMessages = app.page.locator('.new-messages');
+  await expect(newMessages).toBeVisible();
+  await expect.poll(() => app.timeline.evaluate((el) => el.scrollTop)).toBe(0);
+
+  // The control takes the reader to the newest event on demand.
+  await newMessages.click();
+  await expect(newMessages).toBeHidden();
+  await expect.poll(() => app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+});
+
+test('desktop: stick-to-bottom keeps following new events', async ({ app, compact }) => {
+  test.skip(compact, 'desktop invariant — must not regress while fixing mobile');
+  await app.gotoPopulated();
+  await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeInViewport();
+
+  // Own sends stay pinned to the bottom…
+  await app.composerTextarea.fill('following the live conversation');
+  await app.composerTextarea.press('Enter');
+  await expect(app.timeline.getByText('following the live conversation')).toBeInViewport();
+  expect(await app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+
+  // …and so does the next simulated live event from the mock daemon.
+  await expect(app.timeline.getByText('Integration tests passing (17/24)')).toBeInViewport({
+    timeout: 15_000,
+  });
+  expect(await app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -805,7 +805,14 @@ export default function App({ client }: { client: Client }) {
 
         <RightPanel
           tab={tab}
-          onTab={setTab}
+          onTab={(next) => {
+            // The panel's own tab strip must keep the bottom navigation
+            // truthful on compact: switching to Files/Pipes there moves the
+            // active pane too (Members/Agents are sub-views of whichever
+            // pane is showing and have no bottom-nav destination).
+            if (next === 'files' || next === 'pipes') openPanelTab(next);
+            else setTab(next);
+          }}
           roomName={currentRoom?.name ?? null}
           members={members}
           timeline={timeline}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,7 +31,7 @@ import type { NavKey } from './components/Sidebar';
 import { MobileTabBar } from './components/MobileTabBar';
 import { RoomHeader } from './components/RoomHeader';
 import { Timeline } from './components/Timeline';
-import type { PendingMessage } from './components/Timeline';
+import type { PendingMessage, TimelineView } from './components/Timeline';
 import { Composer } from './components/Composer';
 import { RightPanel } from './components/RightPanel';
 import type { PanelTab, PipeConnState } from './components/RightPanel';
@@ -131,6 +131,10 @@ export default function App({ client }: { client: Client }) {
     return t === 'members' || t === 'files' || t === 'pipes' || t === 'agents' ? t : 'members';
   });
   const [mobileView, setMobileView] = useState<MobileView>('rooms');
+  const [pipeFocus, setPipeFocus] = useState<string | null>(null);
+  // Deliberate per-room reading positions (see TimelineView); a ref because
+  // saving one on room switch must not re-render the outgoing timeline.
+  const timelineViews = useRef(new Map<string, TimelineView>());
   const [inviteOpen, setInviteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [joinOpen, setJoinOpen] = useState(false);
@@ -655,6 +659,16 @@ export default function App({ client }: { client: Client }) {
               ? 'home'
               : 'rooms';
 
+  // The one route from in-room actions to the Files/Pipes surfaces. Setting
+  // only the right-panel tab is invisible on compact (the panel is a hidden
+  // pane there) — the active pane must move with it, exactly as the primary
+  // navigation does, so pane, panel tab, and bottom bar can never contradict.
+  const openPanelTab = useCallback((which: 'files' | 'pipes', pipeId?: string) => {
+    setTab(which);
+    setMobileView(which);
+    setPipeFocus(which === 'pipes' ? (pipeId ?? null) : null);
+  }, []);
+
   const navigate = useCallback((key: NavKey) => {
     if (key === 'agents') {
       // Top-level fleet dashboard — distinct from the in-room Agents tab, which
@@ -747,8 +761,8 @@ export default function App({ client }: { client: Client }) {
                 members={members}
                 peers={peers}
                 onInvite={() => setInviteOpen(true)}
-                onShareFile={() => setTab('files')}
-                onOpenPipe={() => setTab('pipes')}
+                onShareFile={() => openPanelTab('files')}
+                onOpenPipe={() => openPanelTab('pipes')}
               />
               {roomError ? (
                 <div className="room-error">
@@ -765,10 +779,16 @@ export default function App({ client }: { client: Client }) {
                 fetches={fetches}
                 loading={roomLoading}
                 selfId={selfId}
+                savedView={roomId ? (timelineViews.current.get(roomId) ?? null) : null}
+                onSaveView={(view) => {
+                  if (!roomId) return;
+                  if (view) timelineViews.current.set(roomId, view);
+                  else timelineViews.current.delete(roomId);
+                }}
                 onFetch={fetchFile}
                 onRecheckFiles={recheckFiles}
                 onRetryPendingMessage={retryPendingMessage}
-                onShowPipes={() => setTab('pipes')}
+                onShowPipes={(pipeId) => openPanelTab('pipes', pipeId)}
               />
               <Composer
                 roomId={currentRoom.room_id}
@@ -793,6 +813,8 @@ export default function App({ client }: { client: Client }) {
           pipes={pipes}
           selfId={selfId}
           fetches={fetches}
+          focusPipeId={pipeFocus}
+          onFocusPipeHandled={() => setPipeFocus(null)}
           onFetch={fetchFile}
           onRecheckFiles={recheckFiles}
           onSharePath={shareFilePath}

--- a/ui/src/components/Composer.tsx
+++ b/ui/src/components/Composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DaemonErrorShape } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
 import { ErrorNote } from './ui';
@@ -32,12 +32,41 @@ export function Composer({
     }
   }, [draftKey]);
 
-  useEffect(() => {
+  const autosize = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = '0px';
+    if (el.scrollHeight === 0) {
+      // Inside a display:none pane (compact keeps inactive panes unlaid-out)
+      // every measurement reads 0 — writing that would clip the composer to a
+      // strip. Fall back to the stylesheet's one-line height; the observer
+      // below re-measures the moment the pane is actually laid out.
+      el.style.height = '';
+      return;
+    }
     el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
-  }, [draft]);
+  }, []);
+
+  useEffect(() => {
+    autosize();
+  }, [draft, autosize]);
+
+  // Re-measure when the textarea's laid-out width changes: the hidden→visible
+  // transition (0→w), viewport resize, and rotation. Keying on width ignores
+  // the height changes autosize itself causes, so the observer cannot loop.
+  const lastWidth = useRef(-1);
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[entries.length - 1].contentRect.width;
+      if (width === lastWidth.current) return;
+      lastWidth.current = width;
+      if (width > 0) autosize();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [autosize]);
 
   const updateDraft = (value: string) => {
     setDraft(value);

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { DaemonErrorShape, FileEntry, Member, PipeEntry, TimelineEvent } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
@@ -491,6 +491,8 @@ function PipesTab({
   selfId,
   conns,
   closing,
+  focusPipeId = null,
+  onFocusPipeHandled,
   onConnect,
   onClose,
   onExpose,
@@ -500,6 +502,8 @@ function PipesTab({
   selfId: string | null;
   conns: Record<string, PipeConnState>;
   closing: Set<string>;
+  focusPipeId?: string | null;
+  onFocusPipeHandled?(): void;
   onConnect(pipeId: string): void;
   onClose(pipeId: string): void;
   onExpose(target: string, peerIdentity: string): Promise<void>;
@@ -510,6 +514,28 @@ function PipesTab({
   const [peer, setPeer] = useState('');
   const [exposing, setExposing] = useState(false);
   const [exposeError, setExposeError] = useState<DaemonErrorShape | null>(null);
+
+  // "Open in Pipes" lands here with the pipe it came from: move focus to that
+  // row and mark it so the destination identifies the relevant item instead
+  // of appearing unchanged (the row may be far down a long list).
+  const rowRefs = useRef(new Map<string, HTMLDivElement>());
+  const [flashPipeId, setFlashPipeId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!focusPipeId) return;
+    const row = rowRefs.current.get(focusPipeId);
+    if (row) {
+      row.scrollIntoView({ block: 'nearest' });
+      row.focus({ preventScroll: true });
+      setFlashPipeId(focusPipeId);
+    }
+    // Consume the request either way (an unknown id must not re-fire forever).
+    onFocusPipeHandled?.();
+  }, [focusPipeId, onFocusPipeHandled]);
+  useEffect(() => {
+    if (flashPipeId === null) return;
+    const timer = window.setTimeout(() => setFlashPipeId(null), 1600);
+    return () => window.clearTimeout(timer);
+  }, [flashPipeId]);
 
   const expose = async () => {
     const t = target.trim();
@@ -535,7 +561,17 @@ function PipesTab({
       {pipes.map((pipe) => {
         const conn = conns[pipe.pipe_id];
         return (
-          <div key={pipe.pipe_id} className={`pipe-row${pipe.state === 'closed' ? ' closed' : ''}`}>
+          <div
+            key={pipe.pipe_id}
+            ref={(el) => {
+              if (el) rowRefs.current.set(pipe.pipe_id, el);
+              else rowRefs.current.delete(pipe.pipe_id);
+            }}
+            tabIndex={-1}
+            className={`pipe-row${pipe.state === 'closed' ? ' closed' : ''}${
+              flashPipeId === pipe.pipe_id ? ' pipe-row-flash' : ''
+            }`}
+          >
             <div className="pipe-row-head">
               <span className="pipe-icon" aria-hidden="true">
                 ⤳
@@ -649,6 +685,8 @@ export function RightPanel({
   pipes,
   selfId,
   fetches,
+  focusPipeId = null,
+  onFocusPipeHandled,
   onFetch,
   onRecheckFiles,
   onSharePath,
@@ -669,6 +707,8 @@ export function RightPanel({
   pipes: PipeEntry[];
   selfId: string | null;
   fetches: Record<string, FetchState>;
+  focusPipeId?: string | null;
+  onFocusPipeHandled?(): void;
   onFetch(fileId: string): void;
   onRecheckFiles(): void;
   onSharePath(path: string): Promise<void>;
@@ -753,6 +793,8 @@ export function RightPanel({
             selfId={selfId}
             conns={pipeConns}
             closing={closingPipes}
+            focusPipeId={focusPipeId}
+            onFocusPipeHandled={onFocusPipeHandled}
             onConnect={onPipeConnect}
             onClose={onPipeClose}
             onExpose={onPipeExpose}

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -527,10 +527,16 @@ function PipesTab({
       row.scrollIntoView({ block: 'nearest' });
       row.focus({ preventScroll: true });
       setFlashPipeId(focusPipeId);
+      onFocusPipeHandled?.();
+    } else if (pipes.length > 0 && !pipes.some((p) => p.pipe_id === focusPipeId)) {
+      // The list is in and the pipe genuinely isn't there (closed/unknown):
+      // consume so a dead id can't re-fire forever.
+      onFocusPipeHandled?.();
     }
-    // Consume the request either way (an unknown id must not re-fire forever).
-    onFocusPipeHandled?.();
-  }, [focusPipeId, onFocusPipeHandled]);
+    // Otherwise pipe.list is still loading — keep the request pending; the
+    // effect re-runs when `pipes` arrives. Consuming here would silently
+    // drop the identification the user just asked for.
+  }, [focusPipeId, pipes, onFocusPipeHandled]);
   useEffect(() => {
     if (flashPipeId === null) return;
     const timer = window.setTimeout(() => setFlashPipeId(null), 1600);

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -363,6 +363,10 @@ export function Timeline({
   const stickToBottom = useRef(savedView === null);
   const previousItemCount = useRef(0);
   const restorePending = useRef<TimelineView | null>(savedView);
+  // Seen-count baseline across a wholesale backlog reload (openRoom clears
+  // then refills the same room, e.g. on reconnect) — without it the whole
+  // reloaded backlog would be announced as new activity.
+  const reloadBaseline = useRef<number | null>(null);
   const lastScrollTop = useRef(savedView?.scrollTop ?? 0);
   const [newItemCount, setNewItemCount] = useState(0);
 
@@ -373,11 +377,16 @@ export function Timeline({
   newItemCountRef.current = newItemCount;
   const onSaveViewRef = useRef(onSaveView);
   onSaveViewRef.current = onSaveView;
+  const itemCountRef = useRef(0);
 
   const items: TimelineItem[] = [
     ...events.map((event) => ({ type: 'event' as const, event })),
     ...pendingMessages.map((pending) => ({ type: 'pending' as const, pending })),
   ].sort((a, b) => itemTs(a) - itemTs(b));
+  // Updated during render, not in the effect: the ResizeObserver path can run
+  // syncScroll between a commit and its effect, and must see this render's
+  // count, never the previous one.
+  itemCountRef.current = items.length;
 
   // The one place scroll position is written. Compact keeps inactive panes
   // display:none, which zeroes every measurement and (on reveal) wipes
@@ -395,7 +404,7 @@ export function Timeline({
       // Everything beyond what the reader had seen when they left is "new" —
       // counted here, once the backlog is really in, because the brief empty
       // render while room.open reloads must not be mistaken for churn.
-      setNewItemCount(Math.max(0, previousItemCount.current - restorePending.current.itemCount));
+      setNewItemCount(Math.max(0, itemCountRef.current - restorePending.current.itemCount));
       restorePending.current = null;
       return;
     }
@@ -413,11 +422,27 @@ export function Timeline({
     const previous = previousItemCount.current;
     previousItemCount.current = items.length;
     if (!scroller.current) return;
+    if (items.length === 0 && previous > 0 && loadingRef.current) {
+      // openRoom emptied the backlog for a reload of the same room (e.g. a
+      // reconnect re-running bootstrap). Remember how much the reader had
+      // actually seen — announcing the whole reloaded backlog as new would
+      // be a lie.
+      reloadBaseline.current = previous - newItemCountRef.current;
+    }
     // Live deltas only — while a restore is pending the backlog is being
     // reloaded wholesale and syncScroll derives the count from the saved view.
     if (!stickToBottom.current && restorePending.current === null) {
-      const delta = Math.max(0, items.length - previous);
-      if (delta > 0) setNewItemCount((count) => count + delta);
+      if (reloadBaseline.current !== null) {
+        if (items.length > 0) {
+          setNewItemCount(Math.max(0, items.length - reloadBaseline.current));
+          reloadBaseline.current = null;
+        }
+      } else {
+        const delta = Math.max(0, items.length - previous);
+        if (delta > 0) setNewItemCount((count) => count + delta);
+      }
+    } else {
+      reloadBaseline.current = null;
     }
     syncScroll();
   }, [items.length, syncScroll]);
@@ -445,7 +470,7 @@ export function Timeline({
       } else {
         save({
           scrollTop: lastScrollTop.current,
-          itemCount: previousItemCount.current - newItemCountRef.current,
+          itemCount: itemCountRef.current - newItemCountRef.current,
         });
       }
     };

--- a/ui/src/components/Timeline.tsx
+++ b/ui/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { DaemonErrorShape, FileEntry, FileRef, TimelineEvent } from '../lib/protocol';
 import { dayLabel, extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel, shortId } from '../lib/format';
@@ -12,6 +12,15 @@ export interface PendingMessage {
   phase: 'sending' | 'syncing' | 'failed';
   eventId?: string;
   error?: DaemonErrorShape;
+}
+
+/** A deliberate reading position, persisted across the keyed remount when the
+ *  user comes back to a room they had scrolled up in. `itemCount` is how many
+ *  items they had actually seen — the difference against the reloaded backlog
+ *  feeds the "N new messages" control instead of a silent jump. */
+export interface TimelineView {
+  scrollTop: number;
+  itemCount: number;
 }
 
 type TimelineItem = { type: 'event'; event: TimelineEvent } | { type: 'pending'; pending: PendingMessage };
@@ -84,7 +93,7 @@ function EventCard({
   compact: boolean;
   onFetch(fileId: string): void;
   onRecheckFiles(): void;
-  onShowPipes(): void;
+  onShowPipes(pipeId?: string): void;
 }) {
   const senderId = event.sender.identity_id;
   const time = formatTime(event.ts);
@@ -237,7 +246,7 @@ function EventCard({
                   {event.pipe.authorized_peer ? <SenderName id={event.pipe.authorized_peer} /> : '—'}
                 </span>
               </span>
-              <button type="button" className="btn btn-sm" onClick={onShowPipes}>
+              <button type="button" className="btn btn-sm" onClick={() => onShowPipes(event.pipe?.pipe_id)}>
                 Open in Pipes
               </button>
             </div>
@@ -330,6 +339,8 @@ export function Timeline({
   fetches,
   loading,
   selfId,
+  savedView = null,
+  onSaveView,
   onFetch,
   onRecheckFiles,
   onRetryPendingMessage,
@@ -341,39 +352,109 @@ export function Timeline({
   fetches: Record<string, FetchState>;
   loading: boolean;
   selfId: string | null;
+  savedView?: TimelineView | null;
+  onSaveView?(view: TimelineView | null): void;
   onFetch(fileId: string): void;
   onRecheckFiles(): void;
   onRetryPendingMessage(clientId: string): void;
-  onShowPipes(): void;
+  onShowPipes(pipeId?: string): void;
 }) {
   const scroller = useRef<HTMLDivElement | null>(null);
-  const stickToBottom = useRef(true);
+  const stickToBottom = useRef(savedView === null);
   const previousItemCount = useRef(0);
+  const restorePending = useRef<TimelineView | null>(savedView);
+  const lastScrollTop = useRef(savedView?.scrollTop ?? 0);
   const [newItemCount, setNewItemCount] = useState(0);
+
+  // Render-time mirrors so the stable callbacks below never go stale.
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
+  const newItemCountRef = useRef(newItemCount);
+  newItemCountRef.current = newItemCount;
+  const onSaveViewRef = useRef(onSaveView);
+  onSaveViewRef.current = onSaveView;
 
   const items: TimelineItem[] = [
     ...events.map((event) => ({ type: 'event' as const, event })),
     ...pendingMessages.map((pending) => ({ type: 'pending' as const, pending })),
   ].sort((a, b) => itemTs(a) - itemTs(b));
 
+  // The one place scroll position is written. Compact keeps inactive panes
+  // display:none, which zeroes every measurement and (on reveal) wipes
+  // scrollTop — so this must run not only when items change but whenever the
+  // scroller is laid out again (the ResizeObserver below): first reveal of an
+  // auto-opened room, hide/show cycles, rotation, and composer growth.
+  const syncScroll = useCallback(() => {
+    const el = scroller.current;
+    if (!el || el.clientHeight === 0) return; // hidden — nothing measurable
+    if (restorePending.current !== null) {
+      if (loadingRef.current) return; // wait for the reloaded backlog
+      const max = el.scrollHeight - el.clientHeight;
+      el.scrollTop = Math.min(restorePending.current.scrollTop, Math.max(0, max));
+      lastScrollTop.current = el.scrollTop;
+      // Everything beyond what the reader had seen when they left is "new" —
+      // counted here, once the backlog is really in, because the brief empty
+      // render while room.open reloads must not be mistaken for churn.
+      setNewItemCount(Math.max(0, previousItemCount.current - restorePending.current.itemCount));
+      restorePending.current = null;
+      return;
+    }
+    if (stickToBottom.current) {
+      el.scrollTop = el.scrollHeight;
+      lastScrollTop.current = el.scrollTop;
+      setNewItemCount(0);
+    } else if (el.scrollTop === 0 && lastScrollTop.current > 0) {
+      // display:none reset the position under us — reinstate the reading spot.
+      el.scrollTop = Math.min(lastScrollTop.current, el.scrollHeight - el.clientHeight);
+    }
+  }, []);
+
+  useEffect(() => {
+    const previous = previousItemCount.current;
+    previousItemCount.current = items.length;
+    if (!scroller.current) return;
+    // Live deltas only — while a restore is pending the backlog is being
+    // reloaded wholesale and syncScroll derives the count from the saved view.
+    if (!stickToBottom.current && restorePending.current === null) {
+      const delta = Math.max(0, items.length - previous);
+      if (delta > 0) setNewItemCount((count) => count + delta);
+    }
+    syncScroll();
+  }, [items.length, syncScroll]);
+
   useEffect(() => {
     const el = scroller.current;
-    const previous = previousItemCount.current;
-    const delta = Math.max(0, items.length - previous);
-    if (el) {
+    if (!el) return;
+    const observer = new ResizeObserver(() => syncScroll());
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [syncScroll]);
+
+  // Persist a deliberate reading position across the keyed remount; a room
+  // left at the bottom re-opens at its newest event instead.
+  useEffect(() => {
+    return () => {
+      const save = onSaveViewRef.current;
+      if (!save) return;
       if (stickToBottom.current) {
-        el.scrollTop = el.scrollHeight;
-        setNewItemCount(0);
-      } else if (delta > 0) {
-        setNewItemCount((count) => count + delta);
+        save(null);
+      } else if (restorePending.current !== null) {
+        // Never revealed on this visit — carry the original view forward
+        // untouched so the seen-count stays honest.
+        save(restorePending.current);
+      } else {
+        save({
+          scrollTop: lastScrollTop.current,
+          itemCount: previousItemCount.current - newItemCountRef.current,
+        });
       }
-    }
-    previousItemCount.current = items.length;
-  }, [items.length]);
+    };
+  }, []);
 
   const onScroll = () => {
     const el = scroller.current;
-    if (!el) return;
+    if (!el || el.clientHeight === 0) return;
+    lastScrollTop.current = el.scrollTop;
     stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 140;
     if (stickToBottom.current) setNewItemCount(0);
   };

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2390,6 +2390,16 @@ button.sender-name:not(:disabled):hover {
   border: 1px solid var(--border);
 }
 
+/* "Open in Pipes" landing marker: identifies the row the timeline action
+   referred to. A brightened border, not the emerald accent — green is
+   reserved for verified live state, and arriving here is navigation, not
+   health. The class is removed again moments later (RightPanel). */
+.pipe-row.pipe-row-flash {
+  border-color: var(--text-dim);
+  outline: 1px solid var(--text-dim);
+  outline-offset: 0;
+}
+
 /* Closed pipes recede via a muted ground + dimmed icon only — blanket
    opacity would composite the 12px info text below the AA floor. */
 .pipe-row.closed {


### PR DESCRIPTION
Replaces #83 (closed by GitHub when its merged base branch was deleted; identical content, now based on main). #82 is merged. One root cause, three released defects (#52, #54, #57): compact keeps inactive panes `display:none`, so components measuring at mount record zeros, and actions that only mutate a hidden pane's state look dead.

- **#52 Timeline**: one `syncScroll` path driven by item changes AND a ResizeObserver on the scroller — auto-opened rooms land at the newest event on first reveal; hide/show reinstates the position `display:none` wiped; rotation re-measures; a deliberate reading position survives the keyed remount (per-room `TimelineView`), with the reloaded backlog's excess feeding the existing "N new messages" control instead of a jump. A reconnect's wholesale backlog reload is detected and counted against what the reader had actually seen — never announced wholesale as new. Desktop stick-to-bottom/pending behavior unchanged (invariant test included).
- **#57 Composer**: autosize skips the zero-measurement case (never writes `0px`; the stylesheet's one-line height holds) and a width-keyed ResizeObserver re-measures on reveal/resize/rotation without observer loops. Drafts already persist per room.
- **#54 Room actions**: Share File / Open Pipe / timeline Open in Pipes route through `openPanelTab`, moving the active pane together with the right-panel tab — and the panel's own tab strip now routes its Files/Pipes switches the same way, so pane, panel tab, and bottom navigation can never contradict. Open in Pipes passes the pipe id; the Pipes surface scrolls to, focuses, and transiently marks that row (neutral border — the emerald accent stays reserved for verified health). The focus request survives a still-loading pipe list instead of being silently dropped.

Ran:
- `cd ui && npm run build` ✓ · `npm test` ✓ · `npm run test:e2e` (92 passed / 16 skipped) ✓ (and `--repeat-each=2` at the stack tip: 300 passed, zero flake)
- Reverse proof: the new specs against the unfixed sources fail 6/11 on mobile-390x844 (invisible destinations ×3, timeline position ×2, zero-height composer ×1).
- Adversarial review round: confirmed findings (pipe-focus request dropped while `pipe.list` loading — reproduced 8/8 in review; panel-strip/bottom-nav desync; reload count lie; a ResizeObserver-path stale-count hazard) are fixed in the second commit.

Closes #52. Closes #54. Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
