### PR TITLE
docs(ux): decide the Room Workbench IA, route contract, and status vocabulary

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -281,15 +281,41 @@ spinners with text.
   none is always paired with a replacement affordance)
 
 ### Navigation
-- **Sidebar:** chrome layer; items are full-width rounded (10px) rows in dim
-  ink; hover = card surface + ink; active = emerald tint + emerald line +
-  emerald glyph
+Structure — which destinations exist, what scope each has, and the routes
+that name them — is decided in `docs/room-workbench.md`. This section styles
+that structure; it does not define it.
+
+- **Room rail:** chrome layer; items are full-width rounded (10px) rows in
+  dim ink; hover = card surface + ink; active = emerald tint + emerald line
+  + emerald glyph
 - **Panel tabs:** bare buttons with a 2px transparent underline; the emerald
   underline is the single active-tab affordance; count badges as nested pills
-- **Mobile tab bar:** 58px-minimum bottom bar — 58px is the base height, not
+- **Compact tab bar:** 58px-minimum bottom bar — 58px is the base height, not
   a cap: the bar grows with the OS accessibility font scale rather than clamp
-  or clip its labels — five glyph+label tabs, active = emerald text,
-  `aria-current="page"`
+  or clip its labels — glyph+label tabs for the global destinations only,
+  active = emerald text, `aria-current="page"`. It gives way to the room's
+  own header once a room is open.
+
+### Responsive shells
+Three shells, one information architecture. Only the mechanics change.
+
+| Shell | Width | Layout |
+|---|---|---|
+| **Compact** | `< 900px` | One pane; global destinations in the bottom bar, room destinations via nested navigation |
+| **Medium** | `900–1279px` | Room rail + workspace; the inspector is a dismissible drawer |
+| **Wide** | `>= 1280px` | Room rail + workspace + persistent inspector |
+
+- **The workspace is what the width is for.** A third column is only paid
+  for when one fits: at 901px a three-column grid leaves the workspace
+  narrower than the phone layout it just left. Medium exists to prevent that.
+- **Panes hide, they do not unmount.** Scroll and selection survive a shell
+  change, an inspector toggle, and a destination switch.
+- **Connection status reserves space.** It never overlays Back, a header, or
+  list content, and a transition is announced once through one live region.
+- **Touch targets:** ≥44px/44dp on touch and compact viewports. The desktop
+  26px icon buttons stand only where a pointer is the input.
+- Coverage: 360, 899, 900, 920, 1280 logical px, plus safe-area insets and
+  200% text; Flutter covers English and French.
 
 ### Identity Marks (signature)
 The brand mark is the flat single-accent meeting tree (`TreeMark` — see

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,8 +302,12 @@ Three shells, one information architecture. Only the mechanics change.
 | Shell | Width | Layout |
 |---|---|---|
 | **Compact** | `< 900px` | One pane; global destinations in the bottom bar, room destinations via nested navigation |
-| **Medium** | `900–1279px` | Room rail + workspace; the inspector is a dismissible drawer |
-| **Wide** | `>= 1280px` | Room rail + workspace + persistent inspector |
+| **Medium** | `900–1279px` | Room rail + workspace; the inspector is a dismissible drawer over the workspace |
+| **Wide** | `>= 1280px` | Room rail + workspace + inspector, the inspector in flow as a third column |
+
+The workspace is always the room's Activity; the inspector is where its
+tools (People, Agents & Runs, Files, Pipes) render, and the route decides
+whether it is open — collapsing it *is* navigating to Activity.
 
 - **The workspace is what the width is for.** A third column is only paid
   for when one fits: at 901px a three-column grid leaves the workspace

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -10,10 +10,18 @@ Small teams of humans and their AI agents working together in private
 peer-to-peer rooms. The humans are technical operators — they run daemons,
 invite peers, watch agent fleets, open pipes to local ports. The agents are
 full participants: they post statuses, artifacts, and results into the same
-timeline. Primary context is a desktop working session (three-pane shell);
-mobile is for checking in on rooms, agents, files, and pipes on the go
-(bottom tab bar). The user is always mid-task: chatting, sharing a file,
-reviewing an agent run, connecting a pipe.
+timeline. Primary context is a desktop working session (the wide shell:
+room rail, workspace, inspector); mobile is for checking in on rooms and
+agent runs on the go, then stepping into a room's workbench. The user is
+always mid-task: chatting, sharing a file, reviewing an agent run,
+connecting a pipe.
+
+Work is organized the same way on every screen: a few **global**
+destinations (Rooms, Agent Fleet, Settings), and a **room's** workbench
+(Activity, People, Agents & Runs, Files, Pipes) that exists once a room is
+selected — files and pipes are always about one room, so they live in one.
+The hierarchy, its routes, its responsive shells, and its status vocabulary
+are recorded in `docs/room-workbench.md`.
 
 ## Product Purpose
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ CI rules for every page in this wiki.
 ## Architecture and protocols
 
 - [Daemon protocol](PROTOCOL.md) - Normative transport-neutral contract between `jeliya-core` and every Jeliya client.
+- [Room Workbench](room-workbench.md) - Decision record for the global-versus-room hierarchy, canonical routes, responsive shells, and status vocabulary.
 - [Agent orchestration](agent-orchestration.md) - Normative contract for agent liveness, task claims, fleet reads, and UI projections.
 - [Security and threat model](security-threat-model.md) - Assets, trust boundaries, threats, controls, and residual risks for the technical preview.
 

--- a/docs/room-workbench.md
+++ b/docs/room-workbench.md
@@ -1,0 +1,311 @@
+---
+type: "Decision"
+title: "Room Workbench — information architecture, routes, and status vocabulary"
+description: "Decision record defining Jeliya's global-versus-room hierarchy, the canonical navigation state for every client, the wide/medium/compact shell contract, and the status vocabulary that keeps each surface bound to one provable fact."
+tags: ["architecture", "ia", "navigation", "ux"]
+timestamp: "2026-07-17T12:29:12Z"
+status: "canonical"
+implementation_status: "planned"
+verification_status: "unverified"
+release_status: "unreleased"
+audience: ["contributors", "maintainers", "product"]
+---
+
+# Room Workbench — information architecture, routes, and status vocabulary
+
+**Status: DECIDED 2026-07-17.** Jeliya adopts the *Room Workbench*
+hierarchy: a small set of global destinations, and a workbench of
+room-scoped tools that only exists once a room is selected. This record
+defines that hierarchy, the canonical navigation state every client must
+keep, the responsive shell contract, and the status vocabulary each
+surface may use. It is the contract the UX 1 implementation issues test
+against.
+
+This document is normative for clients. It changes no protocol method and
+no wire value; `docs/PROTOCOL.md` remains the daemon contract.
+
+## Why
+
+Two problems forced a decision.
+
+**Scope was ambiguous.** Files and Pipes sat in global navigation, but
+neither tool can do anything without a room — the daemon requires a
+`room_id` for `file.list`, `file.share`, `pipe.list`, `pipe.expose`, and
+`pipe.connect`. A global Files destination is therefore a destination that
+is always secretly about one room, chosen elsewhere. Meanwhile the in-room
+Agents tab and the global fleet dashboard both called themselves "Agents"
+while answering different questions.
+
+**One word described five incompatible facts.** "Active" meant, depending
+on the surface: this daemon has a live session for the room
+(`room.list.open`); this identity's signed roster status is not left or
+removed (`room.list.status`); a member's signed roster status
+(`room.members[].status`); an agent is live (`FleetAgent.liveness`); or a
+count that silently falls back to the room's *total* member count when the
+roster has not loaded. The last one is not a wording problem — it is the
+screen asserting a fact it does not have.
+
+## Decision 1 — the hierarchy
+
+**Global destinations** (no room required):
+
+| Destination | Job |
+|---|---|
+| **Rooms** | Choose or create a room; see every room this identity holds. |
+| **Agent Fleet** | See agent liveness and runs across every authorized room at once. |
+| **Settings** | Identity, daemon, diagnostics. |
+
+**Room destinations** (a room is selected; the Room Workbench):
+
+| Destination | Job |
+|---|---|
+| **Activity** | The signed timeline and the composer. The room's home. |
+| **People** | The signed roster: members, invites, roles. |
+| **Agents & Runs** | Agents *in this room* and their latest signed status. |
+| **Files** | Files shared into this room. |
+| **Pipes** | Pipes exposed and connected in this room. |
+
+Consequences, each of which an implementation issue must satisfy:
+
+- **Files and Pipes leave global navigation.** They are room tools; they
+  are reachable only inside a room. This is not a demotion — it is where
+  they always were.
+- **Global Agent Fleet and room Agents & Runs are different
+  destinations** with different names. "Agent Fleet" answers *are my
+  agents alive, anywhere*; "Agents & Runs" answers *what has run here*.
+- **Calls is hidden** until it supports a real workflow. A navigation entry
+  that only says "Soon" is a promise the product has not earned.
+- **Home is removed.** It duplicated Rooms. When it has a distinct user
+  job it can come back with one.
+- **Each destination has exactly one scope and one canonical entry path.**
+  If a surface is reachable two ways, both ways resolve to the same route.
+
+## Decision 2 — the canonical route contract
+
+**The route is the navigation state.** Not a mirror of it, not a
+serialization of it: the route *is* it. A client may not keep a second
+state machine (a `tab`, a `mobileView`, a selected-pane enum) that can
+disagree with the route. Where a client needs derived values, they are
+derived from the route on read.
+
+The route family, identical on every client:
+
+| Route | Destination |
+|---|---|
+| `/rooms` | Rooms (no room selected) |
+| `/rooms/:roomId/activity` | Room → Activity |
+| `/rooms/:roomId/people` | Room → People |
+| `/rooms/:roomId/agents` | Room → Agents & Runs |
+| `/rooms/:roomId/files` | Room → Files |
+| `/rooms/:roomId/pipes` | Room → Pipes |
+| `/fleet` | Agent Fleet |
+| `/settings` | Settings |
+
+Rules:
+
+1. **`/` resolves to `/rooms`.** The bare root is not a destination.
+2. **`/rooms/:roomId` resolves to `/rooms/:roomId/activity`.** A room's
+   canonical landing surface is its timeline.
+3. **`:roomId` is the protocol `room_id`** (`blake3:…`), verbatim and
+   percent-encoded. It is never a name, an index, or a short id.
+4. **The web keeps these as URL paths.** `crates/jeliyad/src/serve.rs`
+   already falls back to `index.html` for extensionless unknown paths, so
+   deep links work in production without a daemon change.
+5. **Flutter uses the same strings as named routes.** One spelling, two
+   clients; a route in this table means the same destination in both.
+6. **Query and fragment are not navigation state.** `?daemon=`, `?mock…`
+   are transport and fixture inputs. Any canonicalizing redirect
+   **must preserve `location.search`** — dropping it silently unfixtures
+   the e2e suite and re-points the client at a different daemon.
+
+### Unreachable and invalid rooms
+
+A route naming a room this identity cannot open is not an error page and
+not a blank panel. It resolves to a **recoverable state** that says which
+fact is true:
+
+| Condition | Resolution |
+|---|---|
+| Room id not in `room.list` | Stay on the route; show "That room isn't on this device", with Rooms as the way out. |
+| `status` is `left` or `removed` | Show the signed fact ("You left this room" / "You were removed from this room"); do not open it. |
+| `room.open` fails | Keep the route, surface the daemon's real error code and hint, offer Retry and Rooms. |
+| Session still booting | Show the route's loading state — never an empty timeline, which reads as "no messages". |
+
+### Legacy links
+
+`?tab=members|agents|files|pipes` was read once at startup and never
+written back. It migrates: the value maps onto the corresponding room
+destination of the restored room (`members` → `people`), or to `/rooms`
+when no room can be restored. It is a shipped URL surface, so it redirects
+rather than 404s, and the redirect preserves the rest of the query string.
+
+### Restoration
+
+`localStorage['jeliya.lastRoom']` (web) and `prefs.lastRoomId` (Flutter)
+restore *which room*, and only when the route does not already name one.
+**An explicit route always wins over a restored room.** A bootstrap that
+re-picks the last room while the URL names a different one is a race, and
+the URL is the authority.
+
+## Decision 3 — the responsive shell contract
+
+Three shells, one topology. The same information architecture; only the
+mechanics change.
+
+| Shell | Width | Layout |
+|---|---|---|
+| **Compact** | `< 900px` | One pane at a time. Global destinations in a bottom bar; room destinations via nested navigation inside Rooms. |
+| **Medium** | `900px – 1279px` | Room rail + workspace. The inspector opens as a dismissible drawer. |
+| **Wide** | `>= 1280px` | Room rail + workspace + persistent inspector. |
+
+Why 1280 and not the current 901: at 901px the shipped three-column grid
+(`232px` rail + `1fr` + `300px` inspector) leaves the workspace **369px** —
+narrower than the phone layout it just graduated from. The medium shell
+exists precisely to stop paying for a third column before there is room for
+one. At 900px the medium workspace is 668px; at 1280px the wide workspace
+is 648px with the inspector present.
+
+Binding rules:
+
+- **The inspector is a view, never a second source of truth.** It renders
+  the room destination it was opened for. Collapsing it changes what is
+  visible, never what is selected.
+- **Selecting an item, and opening or closing the inspector, preserves
+  list and timeline position.** Panes are hidden, not unmounted.
+- **Connection status reserves layout space.** It never overlays Back, a
+  header, or list content. Today's absolutely-positioned banner violates
+  this and changes.
+- **A connection transition is announced once**, through one live region.
+  Long descriptions wrap or truncate accessibly; they do not push chrome
+  off-screen.
+- **The compact bottom bar carries only global destinations.** Room
+  destinations are never bottom-bar tabs — that is the ambiguity this
+  record exists to remove.
+- **Room context stays visible on every room-scoped surface**, on every
+  shell.
+- **Back is truthful on every client.** Room destination → Activity →
+  Rooms → leave the app. Back never mutates state the user cannot see.
+
+Coverage: 360, 899, 900, 920, and 1280 logical pixels, plus safe-area
+insets and 200% text. Flutter runs its coverage in English and French,
+because French copy is longer and is where overflow shows up first.
+
+The existing 44px/44dp touch floor and the 58px/58dp tab-bar *minimum*
+(a minimum, not a cap — it grows with text scale) are unchanged.
+
+## Decision 4 — the status vocabulary
+
+**Every status label names exactly one fact, and that fact is one the
+daemon proves.** These five are distinct and may never share a word.
+
+| Fact | Source of truth | Vocabulary |
+|---|---|---|
+| **Room session** — this daemon has a live session for the room | `room.list.open`, `daemon.status.rooms_open` | **Open** / **Closed** |
+| **Signed membership** — this identity's roster status | `room.list.status` (`active\|left\|removed`) | **Member** / **Left** / **Removed** |
+| **Roster** — a member's signed status and role | `room.members[].status`, `.role` | **Member** / **Invited**; roles **Owner** / **Member** / **Agent** |
+| **Peer reachability** — an observed transport path | `PeerStatus.state` (`connected\|connecting\|offline`) + `.path` (`direct\|relay\|null`) | **Direct** / **Relay** / **Connecting** / **Offline**; in aggregate **No peers connected** |
+| **Agent liveness** — a fold over signed status events plus live peer state | `FleetAgent.liveness` (`online-idle\|working\|offline\|stale`) | **Idle** / **Working** / **Offline** / **Stale** |
+| **Pipe connection** — a local forwarding session | `pipe.list` state, `pipe.connect` result | **Connected** / **Closed** |
+
+### Retired words
+
+- **"Active" is retired as a display label.** It described a live local
+  session on one surface and signed membership on another. Room session
+  state reads **Open**/**Closed**; membership reads **Member**.
+- **"Alone in this room" is retired.** It rendered whenever zero peer
+  connections were observed — including a five-member room whose peers are
+  merely offline. Absence of an observed connection is not evidence of
+  solitude. The honest label is **No peers connected**, which is what the
+  daemon actually reported.
+- **"N active" in the room header is retired**, and so is its fallback.
+  It counted signed-active members but silently substituted the room's
+  *total* member count whenever the roster had not loaded — asserting a
+  fact from data it did not have. The header shows the roster count only
+  once the roster is loaded, and its loading state until then.
+
+### The wire is not the display
+
+`room.list.status` carries the wire value `active`, and `agents.fleet`
+returns a field literally named `active`. **This record renames no wire
+value.** Display labels and wire values are never the same constant
+(`docs/i18n.md`, rule 3); wire tokens route through the existing
+`wire*`/`WireDisplay` seam. Renaming a label does not change
+`labelTone` — tone still keys off the wire word, and the documented
+long-term fix (a typed severity field on the agent-status event,
+`docs/glossary-fr.md` decision 3) remains out of scope here.
+
+### French
+
+"Room Workbench" is an internal architecture name, not shipped copy — no
+translation is owed. The shipped destination names follow
+`docs/glossary-fr.md`: Tier 1 nouns translate (Rooms → Salons, Files →
+Fichiers, People → Personnes, Activity → Activité); Tier 2 wire tokens
+(`direct`, `relay`, `unavailable`, `unauthorized`, `hash_mismatch`,
+`daemon`, `jeliyad`, `pipe`) never translate. New French copy follows the
+existing typography decisions (U+202F before `; ! ?`, U+00A0 before `:`,
+U+2019 apostrophe, sentence case, vouvoiement).
+
+## Decision 5 — truthful states per destination
+
+Every destination defines all six. A destination that renders its empty
+state while it is actually loading, offline, or unauthorized is lying, and
+the empty state is the most common such lie: "No files yet" and "we have
+not asked yet" are different sentences.
+
+| State | Rule |
+|---|---|
+| **Empty** | The daemon answered, and the answer was zero. Never shown before the answer arrives. |
+| **Loading** | Asked, no answer yet. Distinct from empty on every surface. |
+| **Offline** | No daemon connection. Reads as *unknown*, not as zero; last-known data is labelled stale, not presented as current. |
+| **Stale** | Data whose freshness cannot be vouched for — a disconnected peer's last signed status. Labelled, never silently aged. |
+| **Failed** | The daemon's real error code and hint (`unavailable`, `unauthorized`, `hash_mismatch`), plus a way forward. Never a silent partial result. |
+| **Unauthorized** | The room is not this identity's to open. Says so; does not render an empty room. |
+
+## Decision 6 — room identity and homonyms
+
+**`room_id` is identity; `name` is a label.** The name is daemon-local
+metadata, is `null` until the genesis event syncs, and carries no
+uniqueness guarantee — `room.join { name? }` even lets two members label
+the same room differently. Two rooms may share a name, and this record
+does not change that.
+
+Because the name cannot identify a room, any surface where acting on the
+wrong room matters must show a **disambiguator**: the short room id, via
+the existing `shortId` helper — the same primitive already used for
+unbound peer endpoints, not a second id-shortening rule. Rules:
+
+- Homonymous rooms (including two rooms both rendering the untitled
+  placeholder, the most likely case for a new user) show the
+  disambiguator wherever they are listed.
+- **Destructive and sensitive actions always repeat it**, homonym or not.
+  Leaving the wrong room publishes a signed departure that cannot be taken
+  back.
+- Creating a room whose name collides locally **warns and proceeds**. The
+  name is a label; the product does not own the user's vocabulary.
+- Room search accepts the name and the short id.
+- Both clients use the same rule and the same facts.
+
+## What this record does not decide
+
+- **No protocol change.** No method, field, or wire value moves.
+- **No new dependency.** The web router is the History API; Flutter stays
+  on Navigator 1.0 with an explicit route model. Adding a routing library
+  to a project whose entire runtime dependency set is `react` +
+  `react-dom` would need its own decision, with the rationale and
+  provenance that `app/pubspec.yaml` records for Flutter plugins.
+- **`labelTone`'s dependence on wire prose.** Recorded above as a known
+  residual, not fixed here.
+- **Calls.** Hidden, not designed.
+
+## Implementation
+
+| Issue | Slice |
+|---|---|
+| #59 | Web: routes become canonical navigation state. |
+| #61 | Web: scoped compact navigation and the room app bar. |
+| #60 | Flutter: the nested Room Workbench. |
+| #62 | Both: adaptive wide/medium/compact shells. |
+| #49 | Both: homonymous room disambiguation. |
+
+Each slice tests against this record. Where an implementation and this
+document disagree, one of them is a bug — say which in the pull request.

--- a/docs/room-workbench.md
+++ b/docs/room-workbench.md
@@ -155,8 +155,21 @@ mechanics change.
 | Shell | Width | Layout |
 |---|---|---|
 | **Compact** | `< 900px` | One pane at a time. Global destinations in a bottom bar; room destinations via nested navigation inside Rooms. |
-| **Medium** | `900px – 1279px` | Room rail + workspace. The inspector opens as a dismissible drawer. |
-| **Wide** | `>= 1280px` | Room rail + workspace + persistent inspector. |
+| **Medium** | `900px – 1279px` | Room rail + workspace. The inspector opens as a dismissible drawer over the workspace. |
+| **Wide** | `>= 1280px` | Room rail + workspace + inspector, the inspector in flow as a third column. |
+
+**The workspace is always Activity**; the inspector is where a room's tools
+render. So the route decides the inspector, at every width:
+
+| Route | Compact | Medium | Wide |
+|---|---|---|---|
+| `/rooms/:id/activity` | The room pane | Inspector closed | Inspector closed |
+| `/rooms/:id/people` (and `agents`, `files`, `pipes`) | A pane pushed over the room | Inspector open as a drawer | Inspector open as a column |
+
+Collapsing the inspector *is* navigating to `activity`, and opening it *is*
+navigating to a tool. That is what makes one destination mean one thing on
+all three shells, and it is why `activity` is a real destination rather
+than a synonym for "a room is selected".
 
 Why 1280 and not the current 901: at 901px the shipped three-column grid
 (`232px` rail + `1fr` + `300px` inspector) leaves the workspace **369px** —
@@ -204,14 +217,17 @@ daemon proves.** These five are distinct and may never share a word.
 | **Signed membership** — this identity's roster status | `room.list.status` (`active\|left\|removed`) | **Member** / **Left** / **Removed** |
 | **Roster** — a member's signed status and role | `room.members[].status`, `.role` | **Member** / **Invited**; roles **Owner** / **Member** / **Agent** |
 | **Peer reachability** — an observed transport path | `PeerStatus.state` (`connected\|connecting\|offline`) + `.path` (`direct\|relay\|null`) | **Direct** / **Relay** / **Connecting** / **Offline**; in aggregate **No peers connected** |
-| **Agent liveness** — a fold over signed status events plus live peer state | `FleetAgent.liveness` (`online-idle\|working\|offline\|stale`) | **Idle** / **Working** / **Offline** / **Stale** |
-| **Pipe connection** — a local forwarding session | `pipe.list` state, `pipe.connect` result | **Connected** / **Closed** |
+| **Agent liveness** — a fold over signed status events plus live peer state | `FleetAgent.liveness` (`online-idle\|working\|offline\|stale`) | **Working** / **Online** / **Stale** / **Offline**; the fleet filter spanning the first two is **Live** |
+| **Pipe connection** — a local forwarding session | `pipe.list` `state` + `connected` | **Connected** (exposed, forwarding) / **Open** (exposed, nothing connected) / **Closed** |
 
 ### Retired words
 
-- **"Active" is retired as a display label.** It described a live local
-  session on one surface and signed membership on another. Room session
-  state reads **Open**/**Closed**; membership reads **Member**.
+- **"Active" is retired as a display label**, on every surface that used it.
+  It described a live local session in the room rail, signed membership in
+  the roster (which title-cased the wire value straight onto the screen), a
+  live forwarding session on a pipe chip, and reachable agents in the fleet
+  filter. Room session state reads **Open**/**Closed**; roster status reads
+  **Member**; a pipe reads **Connected**; the fleet filter reads **Live**.
 - **"Alone in this room" is retired.** It rendered whenever zero peer
   connections were observed — including a five-member room whose peers are
   merely offline. Absence of an observed connection is not evidence of

--- a/docs/room-workbench.md
+++ b/docs/room-workbench.md
@@ -127,9 +127,24 @@ fact is true:
 | Condition | Resolution |
 |---|---|
 | Room id not in `room.list` | Stay on the route; show "That room isn't on this device", with Rooms as the way out. |
-| `status` is `left` or `removed` | Show the signed fact ("You left this room" / "You were removed from this room"); do not open it. |
+| `status` is `left` or `removed` | Show the signed fact ("You left this room" / "You were removed from this room"); do not open it. See the note below — this is a choice, not a limit. |
 | `room.open` fails | Keep the route, surface the daemon's real error code and hint, offer Retry and Rooms. |
 | Session still booting | Show the route's loading state — never an empty timeline, which reads as "no messages". |
+
+**The archive is readable, and we are choosing not to read it.** A departure
+keeps the subject in the member set, so `require_local_room_access` still
+passes and `room.open` on a left or removed room is authorized — it returns
+the roster and the full local timeline (`supervisor.rs`; `room.list`
+deliberately keeps "joined-then-left archives"). Both clients nonetheless
+stop at the signed fact, which is what shipped before this record and what
+it keeps.
+
+That is a product decision, not a protocol constraint, and it is worth
+naming as one: reading an archive needs a surface that cannot lie about
+what you may still do in it — no composer, no invite, no leave — and that
+surface does not exist yet. Until it does, the honest thing is to state the
+departure rather than open a room whose every action would fail. Filed as
+follow-up work rather than smuggled in here.
 
 ### Legacy links
 
@@ -142,10 +157,21 @@ rather than 404s, and the redirect preserves the rest of the query string.
 ### Restoration
 
 `localStorage['jeliya.lastRoom']` (web) and `prefs.lastRoomId` (Flutter)
-restore *which room*, and only when the route does not already name one.
+restore *which room*, and **only from the bare root** — `/` on the web,
+a cold start with no route on Flutter. Every route in the table above is an
+explicit destination and is honored as one: `/rooms`, `/fleet`, and
+`/settings` name no room *on purpose*, and restoring one into them would
+make a direct link to Settings open a room, and a deliberate "Back to Rooms"
+undo itself.
+
 **An explicit route always wins over a restored room.** A bootstrap that
-re-picks the last room while the URL names a different one is a race, and
-the URL is the authority.
+re-picks the last room while the route names a different one — or names none
+— is a race, and the route is the authority. Restoration therefore happens
+**once per launch**, not on every reconnect: re-running it is how a client
+drags the user back into the room they just left.
+
+The restored room is *pushed* on top of Rooms rather than replacing it, so
+Back leaves the room for the rooms list instead of leaving the app.
 
 ## Decision 3 — the responsive shell contract
 
@@ -215,8 +241,8 @@ daemon proves.** These five are distinct and may never share a word.
 |---|---|---|
 | **Room session** — this daemon has a live session for the room | `room.list.open`, `daemon.status.rooms_open` | **Open** / **Closed** |
 | **Signed membership** — this identity's roster status | `room.list.status` (`active\|left\|removed`) | **Member** / **Left** / **Removed** |
-| **Roster** — a member's signed status and role | `room.members[].status`, `.role` | **Member** / **Invited**; roles **Owner** / **Member** / **Agent** |
-| **Peer reachability** — an observed transport path | `PeerStatus.state` (`connected\|connecting\|offline`) + `.path` (`direct\|relay\|null`) | **Direct** / **Relay** / **Connecting** / **Offline**; in aggregate **No peers connected** |
+| **Roster** — a member's signed status and role | `room.members[].status` (`active\|invited\|left\|removed`), `.role` | **Member** / **Invited** / **Left** / **Removed**, and **Unknown** for a status this client does not recognize; roles **Owner** / **Member** / **Agent** |
+| **Peer reachability** — an observed transport path | `PeerStatus.state` (`connected\|connecting\|offline`) + `.path` (`direct\|relay\|null`) | **Direct** / **Relay** / **Connected** / **Connecting** / **Offline**; in aggregate **No peers connected** |
 | **Agent liveness** — a fold over signed status events plus live peer state | `FleetAgent.liveness` (`online-idle\|working\|offline\|stale`) | **Working** / **Online** / **Stale** / **Offline**; the fleet filter spanning the first two is **Live** |
 | **Pipe connection** — a local forwarding session | `pipe.list` `state` + `connected` | **Connected** (exposed, forwarding) / **Open** (exposed, nothing connected) / **Closed** |
 
@@ -233,6 +259,13 @@ daemon proves.** These five are distinct and may never share a word.
   merely offline. Absence of an observed connection is not evidence of
   solitude. The honest label is **No peers connected**, which is what the
   daemon actually reported.
+
+`PeerStatus.path` is nullable **while `state` is `connected`** — the SDK
+knows the peer is reachable before it knows how. That is why the peer
+vocabulary carries a bare **Connected**: a connected peer with no path yet
+is not a relay peer, and labelling it one would invent the very fact
+(`direct` vs `relay`) the honesty rules exist to protect. Green is earned
+here — the link is real — but the path is not claimed until it is known.
 - **"N active" in the room header is retired**, and so is its fallback.
   It counted signed-active members but silently substituted the room's
   *total* member count whenever the roster had not loaded — asserting a

--- a/mockups/README.md
+++ b/mockups/README.md
@@ -1,7 +1,18 @@
 # Mockups
 
-These are the original product mockups the UI is built to — **layout and
-information-architecture reference only, not identity reference**.
+These are the original product mockups the UI is built to — **layout
+reference only, not identity reference, and no longer the
+information-architecture reference**.
+
+Their navigation inventory is **superseded** by the Room Workbench decision
+(`docs/room-workbench.md`): the sidebar's Home and Calls entries are gone,
+and Files and Pipes are room-scoped tools rather than global destinations.
+Where these images and that record disagree about *which destinations exist
+or what scope they have*, the record wins. They remain accurate about
+composition — the three-pane desktop shell, the room header over timeline
+and composer, the underline-active room tab strip, and (the mobile
+triptych) the bottom bar giving way to the room's own header once a room is
+open.
 
 Their visual identity predates the brand definition and contradicts it in
 places (cube/hexagon logo, multi-hue glowing badges — see the anti-references


### PR DESCRIPTION
Closes #58. First slice of milestone [UX 1 — Room Workbench foundation](https://github.com/kortiene/jeliya/milestone/2); every other issue in the milestone tests against this record.

## What this decides

**The hierarchy.** Global: **Rooms / Agent Fleet / Settings**. Inside a room: **Activity / People / Agents & Runs / Files / Pipes**.

Files and Pipes leave global navigation because neither can answer a question without a `room_id` — a global Files destination was always secretly about one room, chosen elsewhere. Calls is hidden until it supports a real workflow; Home is removed until it has a job Rooms doesn't already do.

**The routes are the navigation state** — not a mirror of it. `/rooms`, `/rooms/:roomId/{activity,people,agents,files,pipes}`, `/fleet`, `/settings`; one spelling, both clients. No client may keep a second state machine that can disagree with the route (today `App.tsx` keeps three: `tab`, `mobileView`, `roomId`). `crates/jeliyad/src/serve.rs` already falls back to `index.html` for extensionless unknown paths, so path routing needs no daemon change.

**The shells:** compact `< 900`, medium `900–1279`, wide `>= 1280`.

The medium band is the whole point. At 901px today's grid (`232px` rail + `1fr` + `300px` inspector) leaves the workspace **369px** — narrower than the phone layout it just graduated from. Medium drops to rail + workspace (668px at 900px) and makes the inspector a drawer; wide restores the third column at 1280px, where it fits (648px workspace).

**The vocabulary** binds each label to one provable fact — room session, signed membership, roster, peer reachability, agent liveness, pipe connection.

## Three honesty fixes this record commits us to

These aren't wording problems:

- **"Active"** meant a live local session in `Sidebar.tsx:115` (`room.open ? 'Active' : 'Idle'`) and signed membership on the wire (`room.list.status`). Same word, two facts.
- **"Alone in this room"** (`RoomHeader.tsx:50`) renders whenever zero peer connections are observed — including a five-member room whose peers are merely offline. Absence of an observed connection is not evidence of solitude. The daemon reported "no peers connected"; that's what the screen should say.
- **"N active"** (`RoomHeader.tsx:39`) falls back to the room's *total* member count when the roster hasn't loaded — the screen asserting a fact it does not have.

No wire value is renamed. Display labels and wire values stay separate constants (`docs/i18n.md` rule 3), and `labelTone`'s dependence on wire prose is recorded as a known residual, not fixed here.

## Docs reconciled

- `DESIGN.md` documented **no breakpoints, no column widths, and no touch-target rule**, while `docs/index.md` advertised it as the source for "responsive behavior" — an unbacked promise. Now backed, and it defers structure to the record rather than duplicating it.
- `mockups/README.md` declared the PNGs the normative **information-architecture** reference while showing the superseded nav (Home, Calls, global Files/Pipes). Now scoped to layout, with the nav inventory explicitly superseded. They stay accurate about composition — including the mobile triptych's bottom bar giving way to the room header inside a room, which #61 implements.

## Verification

- `node scripts/check-docs.mjs` → OK
- `node --test scripts/check-docs.test.mjs` → 15/15

## Notes for review

- No protocol change, no dependency change. The web router will be the History API; Flutter stays on Navigator 1.0. Adding a routing library to a project whose entire runtime dependency set is `react` + `react-dom` would need its own decision.
- The `900` breakpoint is unchanged, so `desktop-920x800` in the e2e suite moves from the three-column shell to **medium** — deliberate, and the reason the AC names 899/900/920 explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)