### PR TITLE
feat(ui): build the React Room Workbench on canonical routes

### DIFF
--- a/ui/e2e/compact-room.spec.ts
+++ b/ui/e2e/compact-room.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// The compact room app bar (issue #61; docs/room-workbench.md, decision 3).
+//
+// The budget at 320x568 is the point of this file: the app bar may not exceed
+// 150px, and the timeline must keep at least 180px above the composer. The old
+// header spent that budget on a wrapping action row and a peer-chip strip that
+// grew with the room, so the height depended on how many peers happened to be
+// connected — a layout you cannot make a promise about.
+
+test.describe('the 320x568 budget', () => {
+  test.skip(({ viewport }) => (viewport?.width ?? 0) !== 320, 'the budget is a 320px promise');
+
+  test('the app bar stays under 150px and leaves the timeline 180px', async ({ app, page }) => {
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+
+    const bar = await page.locator('.room-appbar').evaluate((el) => el.getBoundingClientRect().height);
+    expect(bar).toBeLessThanOrEqual(150);
+
+    const timeline = await app.timeline.evaluate((el) => el.getBoundingClientRect().height);
+    expect(timeline).toBeGreaterThanOrEqual(180);
+  });
+
+  test('the room with the most peers does not cost the timeline its height', async ({ app, page }) => {
+    // The height must be a constant, not a function of room contents.
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+    const withPeers = await page.locator('.room-appbar').evaluate((el) => el.getBoundingClientRect().height);
+
+    await app.openRoom(MOCK_ROOMS.design);
+    const other = await page.locator('.room-appbar').evaluate((el) => el.getBoundingClientRect().height);
+    expect(other).toBe(withPeers);
+  });
+
+  test('no action or status chip overflows horizontally', async ({ app, page }) => {
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1),
+    ).toBe(false);
+
+    // Including once the room-information disclosure is open, which is where
+    // the peer paths and the room's own actions now live.
+    await page.getByRole('button', { name: 'Room information' }).click();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1),
+    ).toBe(false);
+  });
+});
+
+test.describe('compact room navigation', () => {
+  test.skip(({ compact }) => !compact, 'the compact shell only');
+
+  test('title, connectivity, Invite, Back, and the disclosure are all reachable', async ({ app, page }) => {
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+
+    await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to Rooms' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Invite' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Room information' })).toBeVisible();
+    await expect(page.locator('.appbar-sub')).toContainText(/member|Loading/);
+  });
+
+  test('peer-path detail lives behind the room-information disclosure', async ({ app, page }) => {
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+
+    // Diagnostic detail is reachable, but it does not compete with the app bar
+    // for a 320px phone's vertical budget.
+    await expect(page.locator('.peer-strip')).toBeHidden();
+    await page.getByRole('button', { name: 'Room information' }).click();
+    await expect(page.locator('.appbar-info')).toBeVisible();
+    await expect(page.locator('.room-info-facts')).toContainText('Session');
+  });
+
+  test('the bottom bar gives way to the room, and Back brings it back', async ({ app, page }) => {
+    await app.gotoRoomsList();
+    await expect(app.tabBar).toBeVisible();
+
+    await app.roomItem(MOCK_ROOMS.main).click();
+    await expect(app.timeline).toBeVisible();
+    // Inside a room the global bar is gone — the room's app bar is the chrome.
+    await expect(app.tabBar).toBeHidden();
+
+    await page.getByRole('button', { name: 'Back to Rooms' }).click();
+    await expect(app.tabBar).toBeVisible();
+    await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  });
+
+  test('the bottom bar carries only the global destinations', async ({ app }) => {
+    await app.gotoRoomsList();
+    // Files and Pipes are room tools: a bottom-bar tab for them would say you
+    // can stand there without a room, and you cannot.
+    await expect(app.tabBar.getByRole('button')).toHaveCount(3);
+    await expect(app.mobileTab('Rooms')).toBeVisible();
+    await expect(app.mobileTab('Agent Fleet')).toBeVisible();
+    await expect(app.mobileTab('Settings')).toBeVisible();
+  });
+
+  test('Back walks room tool -> Activity -> Rooms before leaving Jeliya', async ({ app, page }) => {
+    await app.gotoRoomsList();
+    await app.roomItem(MOCK_ROOMS.main).click();
+    await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity$/);
+
+    await app.goToRoomDest('Files');
+    await expect(page).toHaveURL(/\/rooms\/[^/]+\/files$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity$/);
+    await expect(app.timeline).toBeVisible();
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/rooms$/);
+    await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  });
+
+  test('room context stays visible on every room destination', async ({ app, page }) => {
+    await app.gotoPopulated();
+    await app.openRoom(MOCK_ROOMS.main);
+
+    // A room tool takes the whole screen here, so it must say which room it is
+    // about — the room header is off in the hidden workspace pane.
+    await app.goToRoomDest('Files');
+    await expect(page.locator('.panel-room-context')).toContainText(MOCK_ROOMS.main);
+    await app.goToRoomDest('Pipes');
+    await expect(page.locator('.panel-room-context')).toContainText(MOCK_ROOMS.main);
+  });
+});

--- a/ui/e2e/compose.spec.ts
+++ b/ui/e2e/compose.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test, MOCK_ROOMS } from './fixtures';
 
 // Composing and sending messages through the mock daemon.
+//
+// Boot restores the last room, so `gotoPopulated()` already lands on a room's
+// Activity — but *which* room follows from the mock's ordering. Both tests
+// still open the room explicitly, so the composer under test is pinned to a
+// known room's timeline rather than to whichever room boot happened to
+// restore; reordering the fixture must not silently retarget these specs.
 
 test('sends a message and renders it as a delivered event', async ({ app }) => {
   await app.gotoPopulated();

--- a/ui/e2e/composer-height.spec.ts
+++ b/ui/e2e/composer-height.spec.ts
@@ -36,12 +36,46 @@ test('mobile: a multiline draft survives hide/show with its height restored', as
   const grownBox = await textarea.boundingBox();
   expect(grownBox!.height).toBeGreaterThan(80);
 
-  // Hide the room pane, then reveal it again.
-  await app.mobileTab('Rooms').click();
+  // Hide the room pane, then reveal it again. Opening a room tool is what
+  // hides the workspace on compact, and the room stays selected across it, so
+  // the composer keeps its draft in state rather than reloading it — the same
+  // mounted-but-unlaid-out round trip the bottom tab bar used to produce.
+  await app.goToRoomDest('Files');
   await expect(app.center).toBeHidden();
-  await app.roomItem(MOCK_ROOMS.main).click();
+  await app.goToRoomDest('Activity');
 
   // Draft preserved, height re-measured for the real layout — not a strip.
+  await expect(textarea).toHaveValue(MULTILINE_DRAFT);
+  await expect
+    .poll(async () => (await textarea.boundingBox())!.height)
+    .toBeGreaterThan(80);
+});
+
+// Boot used to land compact on the rooms list, which is what made the very
+// first composer mount happen inside a display:none pane. Boot now restores
+// straight into the room, so that path is gone — but the condition it exercised
+// is not: a room tool route renders the workspace hidden with the room still
+// selected, so a composer restoring a stored draft there measures itself at 0
+// with no laid-out box to correct it. The reveal is the only chance to size it.
+test('mobile: a composer that boots into a hidden pane is sized on first reveal', async ({
+  app,
+  page,
+  compact,
+}) => {
+  test.skip(!compact, 'panes are only hidden on compact');
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+  await app.composerTextarea.fill(MULTILINE_DRAFT);
+
+  // The route wins over the restored room, so this reloads onto the tool with
+  // the workspace — and the composer in it — mounted but never laid out.
+  await app.goToRoomDest('Files');
+  await page.reload();
+  await expect(app.rightPanel).toBeVisible();
+  await expect(app.center).toBeHidden();
+
+  await app.goToRoomDest('Activity');
+  const textarea = app.composerTextarea;
   await expect(textarea).toHaveValue(MULTILINE_DRAFT);
   await expect
     .poll(async () => (await textarea.boundingBox())!.height)

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -1,8 +1,24 @@
 import { expect, test as base } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
-/** The compact breakpoint from styles.css (`@media (max-width: 900px)`). */
-export const COMPACT_MAX_WIDTH = 900;
+/** The shell boundaries (docs/room-workbench.md, decision 3; ui/src/lib/shell.ts).
+ *  Compact stops just below 900 — 900 itself is the first medium width, which
+ *  is why issue #62 names 899 and 900 as separate cases. */
+export const COMPACT_MAX_WIDTH = 899;
+export const WIDE_MIN_WIDTH = 1280;
+
+export type Shell = 'compact' | 'medium' | 'wide';
+
+export function shellForWidth(width: number): Shell {
+  if (width <= COMPACT_MAX_WIDTH) return 'compact';
+  return width >= WIDE_MIN_WIDTH ? 'wide' : 'medium';
+}
+
+/** The global destinations — the only three (docs/room-workbench.md). */
+export type GlobalDest = 'Rooms' | 'Agent Fleet' | 'Settings';
+
+/** The room destinations, as they are labelled. */
+export type RoomDestLabel = 'Activity' | 'People' | 'Agents & Runs' | 'Files' | 'Pipes';
 
 /** Room names from the populated mock fixture (ui/src/lib/mock.ts). */
 export const MOCK_ROOMS = {
@@ -16,6 +32,8 @@ export const MOCK_ROOMS = {
 interface AppFixtures {
   /** True when this project's viewport is in the compact (phone) layout. */
   compact: boolean;
+  /** Which of the three shells this project's viewport renders. */
+  shell: Shell;
   app: AppDriver;
 }
 
@@ -25,12 +43,44 @@ export class AppDriver {
   constructor(
     readonly page: Page,
     readonly compact: boolean,
+    readonly shell: Shell = compact ? 'compact' : 'wide',
   ) {}
 
-  /** Load the app and wait for the shell (populated fixture) to be ready. */
+  /** Load the app and wait for the shell (populated fixture) to be ready.
+   *
+   *  Boot restores the last room, so `/` settles on `/rooms/:id/activity` with
+   *  Rooms pushed behind it. On compact that means the room pane, not the
+   *  rooms list — so readiness is the room being open, which is the one signal
+   *  every shell shares. Use `gotoRoomsList()` when the list itself is the
+   *  subject. */
   async gotoPopulated(params: Record<string, string> = {}): Promise<void> {
     await this.goto(params);
-    // Ready = the room list has fixture rooms (boot + room.list resolved).
+    await expect(this.page).toHaveURL(/\/rooms\/[^/]+\/activity/);
+    await expect(this.timeline).toBeVisible();
+  }
+
+  /** Load the app and land on the rooms list on every shell. */
+  async gotoRoomsList(params: Record<string, string> = {}): Promise<void> {
+    await this.gotoPopulated(params);
+    await this.showRoomsList();
+  }
+
+  /** The shell the page is ACTUALLY in right now.
+   *
+   *  `compact`/`shell` come from the project's viewport, which is right for
+   *  every spec that keeps it — but responsive.spec.ts resizes the page, and a
+   *  driver that trusted the project would take the desktop branch at 320px
+   *  and click a rail that isn't there. */
+  currentShell(): Shell {
+    return shellForWidth(this.page.viewportSize()?.width ?? 0);
+  }
+
+  /** Show the rooms list. On compact it is a pane of its own; on medium and
+   *  wide the rail is always visible, so this is already true there. */
+  async showRoomsList(): Promise<void> {
+    if (this.currentShell() === 'compact' && !(await this.sidebar.isVisible())) {
+      await this.navigate('Rooms');
+    }
     await expect(this.roomItem(MOCK_ROOMS.main)).toBeVisible();
   }
 
@@ -80,32 +130,52 @@ export class AppDriver {
     return this.page.getByRole('navigation', { name: 'Primary (mobile)' });
   }
 
-  mobileTab(label: 'Rooms' | 'Agents' | 'Pipes' | 'Files' | 'Settings') {
-    return this.tabBar.getByRole('button', { name: label });
+  /** The room's nested navigation — visible under the room header, and inside
+   *  the inspector on compact. Exactly one of the two is on screen at a time,
+   *  so this stays unambiguous on every shell. */
+  roomTab(label: RoomDestLabel) {
+    // Not exact: a tab's accessible name absorbs its count badge ("Files5").
+    // The five labels share no prefix, so a substring match stays unambiguous.
+    return this.page.getByRole('tab', { name: label, exact: false });
   }
 
-  /** Open a room so its chat pane is visible, whatever the breakpoint.
-   *  On desktop all columns are visible; on compact this taps through the
-   *  Rooms pane. */
+  mobileTab(label: GlobalDest) {
+    return this.tabBar.getByRole('button', { name: label, exact: true });
+  }
+
+  /** Open a room so its Activity is visible, whatever the shell. */
   async openRoom(name: string): Promise<void> {
-    if (this.compact) {
-      // The Rooms pane is the compact landing view; get back to it first so
-      // the room item is tappable from any pane.
-      await this.mobileTab('Rooms').click();
-    }
+    await this.showRoomsList();
     await this.roomItem(name).click();
     await expect(this.page.getByRole('heading', { level: 1, name })).toBeVisible();
     await expect(this.timeline).toBeVisible();
   }
 
-  /** Navigate to a primary destination (desktop left rail / mobile tab bar). */
-  async navigate(label: 'Rooms' | 'Agents' | 'Pipes' | 'Files' | 'Settings'): Promise<void> {
-    if (this.compact) {
+  /** Go to a room destination. Activity closes the inspector; a tool opens it —
+   *  a column on wide, a drawer on medium, the whole pane on compact, and one
+   *  navigation on all three. */
+  async goToRoomDest(label: RoomDestLabel): Promise<void> {
+    await this.roomTab(label).click();
+    if (label === 'Activity') {
+      await expect(this.timeline).toBeVisible();
+    } else {
+      await expect(this.rightPanel).toBeVisible();
+    }
+  }
+
+  /** Navigate to a global destination (room rail / compact tab bar). */
+  async navigate(label: GlobalDest): Promise<void> {
+    if (this.currentShell() === 'compact') {
+      // Inside a room the bar gives way to the room's app bar; Back returns to
+      // it, exactly as a user would have to.
+      if (!(await this.tabBar.isVisible())) {
+        await this.page.getByRole('button', { name: 'Back to Rooms' }).click();
+      }
       await this.mobileTab(label).click();
     } else {
       await this.page
         .getByRole('navigation', { name: 'Primary', exact: true })
-        .getByRole('button', { name: label })
+        .getByRole('button', { name: label, exact: true })
         .click();
     }
   }
@@ -123,7 +193,13 @@ export const test = base.extend<AppFixtures>({
     },
     { auto: false },
   ],
-  app: async ({ page, compact }, use, testInfo) => {
+  shell: [
+    async ({ viewport }, use) => {
+      await use(shellForWidth(viewport?.width ?? 1280));
+    },
+    { auto: false },
+  ],
+  app: async ({ page, compact, shell }, use, testInfo) => {
     // Console-error trail: collected for the whole test, attached on failure
     // alongside Playwright's screenshot + trace so a broken viewport ships
     // with everything needed to diagnose it.
@@ -133,7 +209,7 @@ export const test = base.extend<AppFixtures>({
     });
     page.on('pageerror', (error) => consoleErrors.push(`pageerror: ${error.message}`));
 
-    await use(new AppDriver(page, compact));
+    await use(new AppDriver(page, compact, shell));
 
     if (testInfo.status !== testInfo.expectedStatus) {
       const viewport = page.viewportSize();

--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -1,14 +1,25 @@
 import { expect, test } from './fixtures';
 
-// The top-level Agent Fleet dashboard.
+// The Agent Fleet dashboard — one of the three global destinations
+// (docs/room-workbench.md, decision 1). It answers "are my agents alive,
+// anywhere"; a room's "Agents & Runs" tab answers "what has run here". Two
+// destinations, two names, two scopes — this spec drives the global one, so it
+// always arrives through global navigation, never through a room's tab strip.
 
 test('shows the agent fleet with honest liveness', async ({ app, page }) => {
   await app.gotoPopulated();
-  await app.navigate('Agents');
+  await app.navigate('Agent Fleet');
 
-  const fleet = page.getByRole('region', { name: 'Agents fleet' });
+  // The route is the navigation state (decision 2), so arriving at a global
+  // destination means standing on its route. Worth pinning here because the
+  // compact path to it is indirect: boot lands inside the restored room, where
+  // the bottom bar gives way to the room's app bar, and the bar only comes back
+  // once Back to Rooms has left the room.
+  await expect(page).toHaveURL(/\/fleet$/);
+
+  const fleet = page.getByRole('region', { name: 'Agent Fleet' });
   await expect(fleet).toBeVisible();
-  await expect(fleet.getByRole('heading', { level: 1, name: 'Agents' })).toBeVisible();
+  await expect(fleet.getByRole('heading', { level: 1, name: 'Agent Fleet' })).toBeVisible();
 
   // Each fixture agent gets exactly one aggregated card, not one per room.
   const card = (name: string) => fleet.locator('.fleet-card', { hasText: name });
@@ -21,8 +32,12 @@ test('shows the agent fleet with honest liveness', async ({ app, page }) => {
   // never Working — the mock builds exactly that fixture for Research Agent.
   // Backend has a connected peer and a fresh working status: really Working.
   await expect(card('Research Agent').locator('.live-pill')).toHaveText(/Stale/);
-  // Working needs the auto-opened main room's live peer; the dashboard polls
-  // agents.fleet every 4s, so allow one full cycle beyond the default.
+  // Working needs a live peer in an OPEN room, which the room restored at boot
+  // supplies: leaving that room for a global destination stops rendering it, it
+  // does not close its session — so the evidence behind Working outlives the
+  // navigation on every shell, including the compact Back to Rooms detour. The
+  // dashboard polls agents.fleet every 4s, so allow one full cycle beyond the
+  // default.
   await expect(card('Backend Agent').locator('.live-pill')).toHaveText(/Working/, {
     timeout: 10_000,
   });
@@ -30,9 +45,9 @@ test('shows the agent fleet with honest liveness', async ({ app, page }) => {
 
 test('searching filters the fleet list', async ({ app, page }) => {
   await app.gotoPopulated();
-  await app.navigate('Agents');
+  await app.navigate('Agent Fleet');
 
-  const fleet = page.getByRole('region', { name: 'Agents fleet' });
+  const fleet = page.getByRole('region', { name: 'Agent Fleet' });
   await fleet.getByLabel('Search agents').fill('Research');
   await expect(fleet.getByText('Research Agent').first()).toBeVisible();
   await expect(fleet.getByText('Backend Agent')).toHaveCount(0);

--- a/ui/e2e/modal-containment.spec.ts
+++ b/ui/e2e/modal-containment.spec.ts
@@ -12,39 +12,47 @@ function modal(page: Page) {
   return page.getByRole('dialog');
 }
 
+/** Leave is published from the room's People roster — the room tool that names
+ *  the membership it ends (docs/room-workbench.md, decision 1). One tab click
+ *  reaches it from Activity on every shell, so the dialog is opened the same
+ *  way a user opens it. */
 async function openLeaveDialog(app: AppDriver, page: Page, room: string): Promise<void> {
   await app.openRoom(room);
-  // The Members surface hosts Leave; its tab strip is part of the panel on
-  // every breakpoint (compact reaches the panel through Files).
-  await app.navigate('Files');
-  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await app.goToRoomDest('People');
   await app.rightPanel.getByRole('button', { name: 'Leave', exact: true }).click();
   await expect(modal(page)).toBeVisible();
 }
 
+/** Back to the rooms list from a room tool, the way a user walks there:
+ *  Activity closes the tool, then Rooms. On medium and wide the rail never
+ *  left the screen, so only the first step moves anything. */
+async function returnToRoomsList(app: AppDriver): Promise<void> {
+  await app.goToRoomDest('Activity');
+  await app.showRoomsList();
+}
+
 test('create: success creates exactly one room and navigates once', async ({ app, page }) => {
-  await app.gotoPopulated();
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList();
   await page.getByRole('button', { name: 'Create Room', exact: true }).click();
 
   await modal(page).getByLabel('Room name').fill('Containment Test Room');
   await modal(page).getByRole('button', { name: 'Create room' }).click();
 
   await expect(modal(page)).toHaveCount(0);
-  // Exactly one room of that name exists (no duplicate request fired) and it
-  // was opened exactly once (compact stays on the rooms pane by design).
+  // The create landed once: the route names the new room, on every shell.
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Containment Test Room' })).toBeVisible();
+  // Then the rail — a pane of its own on compact, so reading the row means
+  // stepping back to it. Exactly one room of that name exists (no duplicate
+  // request fired), and the session the create opened is reported as the
+  // session it is (docs/room-workbench.md, decision 4).
+  await app.showRoomsList();
   await expect(app.roomItem('Containment Test Room')).toHaveCount(1);
-  await expect(app.roomItem('Containment Test Room')).toContainText('Active');
-  if (!app.compact) {
-    await expect(
-      page.getByRole('heading', { level: 1, name: 'Containment Test Room' }),
-    ).toBeVisible();
-  }
+  await expect(app.roomItem('Containment Test Room')).toContainText('Open');
 });
 
 test('create: a pending request cannot be dismissed or duplicated', async ({ app, page }) => {
-  await app.gotoPopulated({ mock_delay: 'room.create:1500' });
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList({ mock_delay: 'room.create:1500' });
   await page.getByRole('button', { name: 'Create Room', exact: true }).click();
 
   await modal(page).getByLabel('Room name').fill('Pending Room');
@@ -61,12 +69,12 @@ test('create: a pending request cannot be dismissed or duplicated', async ({ app
 
   // Success still lands exactly once.
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await app.showRoomsList();
   await expect(app.roomItem('Pending Room')).toHaveCount(1);
 });
 
 test('create: failure keeps an actionable error in the dialog', async ({ app, page }) => {
-  await app.gotoPopulated({ mock_fail: 'room.create:1' });
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList({ mock_fail: 'room.create:1' });
   await page.getByRole('button', { name: 'Create Room', exact: true }).click();
 
   await modal(page).getByLabel('Room name').fill('Doomed Room');
@@ -86,8 +94,7 @@ test('join: a pending join is contained, then applies its transition once', asyn
   app,
   page,
 }) => {
-  await app.gotoPopulated({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:1500' });
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:1500' });
   await page.getByRole('button', { name: 'Join with a ticket' }).click();
 
   await modal(page).getByLabel('Ticket').fill(`roomtkt1${TICKET_SUFFIX}`);
@@ -104,18 +111,14 @@ test('join: a pending join is contained, then applies its transition once', asyn
   // identity had never joined appears and opens (a real state transition,
   // not a re-open of something already there).
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
-  await expect(app.roomItem('Invited Workspace')).toHaveCount(1);
-  await expect(app.roomItem('Invited Workspace')).toContainText('Active');
-  if (app.compact) {
-    await app.roomItem('Invited Workspace').click();
-  }
   await expect(page.getByRole('heading', { level: 1, name: 'Invited Workspace' })).toBeVisible();
   await expect(app.timeline.getByText('You joined as member', { exact: false })).toBeVisible();
+  await app.showRoomsList();
+  await expect(app.roomItem('Invited Workspace')).toHaveCount(1);
 });
 
 test('create: a keyboard double-submit fires exactly one request', async ({ app, page }) => {
-  await app.gotoPopulated({ mock_delay: 'room.create:800' });
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList({ mock_delay: 'room.create:800' });
   await page.getByRole('button', { name: 'Create Room', exact: true }).click();
 
   const name = modal(page).getByLabel('Room name');
@@ -126,10 +129,11 @@ test('create: a keyboard double-submit fires exactly one request', async ({ app,
   await name.press('Enter');
 
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
-  if (app.compact) await app.mobileTab('Rooms').click();
-  // Wait for the full success transition (open flag applied), then count:
-  // a duplicated request would have produced a second same-named room.
-  await expect(app.roomItem('Double Submit Room')).toContainText('Active');
+  await expect(page.getByRole('heading', { level: 1, name: 'Double Submit Room' })).toBeVisible();
+  // Wait for the full success transition (the session the create opened), then
+  // count: a duplicated request would have produced a second same-named room.
+  await app.showRoomsList();
+  await expect(app.roomItem('Double Submit Room')).toContainText('Open');
   await expect(app.roomItem('Double Submit Room')).toHaveCount(1);
 });
 
@@ -137,8 +141,7 @@ test('join: a keyboard double-submit consumes the single-use ticket once', async
   app,
   page,
 }) => {
-  await app.gotoPopulated({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:800' });
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList({ mock_ticket: TICKET_SUFFIX, mock_delay: 'room.join:800' });
   await page.getByRole('button', { name: 'Join with a ticket' }).click();
 
   await modal(page).getByLabel('Ticket').fill(`roomtkt1${TICKET_SUFFIX}`);
@@ -149,14 +152,14 @@ test('join: a keyboard double-submit consumes the single-use ticket once', async
   await peerAddr.press('Enter');
 
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await app.showRoomsList();
   await expect(app.roomItem('Invited Workspace')).toHaveCount(1);
   // No stray failure from a second redemption anywhere.
   await expect(page.locator('.error-note')).toHaveCount(0);
 });
 
 test('join: failure restores interaction with a real error', async ({ app, page }) => {
-  await app.gotoPopulated();
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await app.gotoRoomsList();
   await page.getByRole('button', { name: 'Join with a ticket' }).click();
 
   await modal(page).getByLabel('Ticket').fill(`roomtkt1${'x'.repeat(90)}`);
@@ -179,7 +182,7 @@ test('leave: initial focus is Cancel and immediate Enter cannot leave', async ({
   // Enter activated Cancel: dialog closed, membership untouched.
   await expect(modal(page)).toHaveCount(0);
   await expect(app.rightPanel.getByRole('button', { name: 'Leave', exact: true })).toBeVisible();
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await returnToRoomsList(app);
   await expect(app.roomItem(MOCK_ROOMS.review)).not.toContainText('Left');
 });
 
@@ -196,15 +199,16 @@ test('leave: a pending leave is contained, then applies once', async ({ app, pag
   await expect(modal(page)).toBeVisible();
   await expect(modal(page).getByRole('button', { name: 'Close' })).toBeDisabled();
 
-  // The departure lands exactly once: dialog closed, room marked Left,
-  // navigation reset to the rooms surface.
+  // The departure lands exactly once: dialog closed, room marked Left, and the
+  // route left the room it published a departure from — a room tool cannot
+  // stay open over a room this identity is no longer in.
   await expect(modal(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(page).toHaveURL(/\/rooms(\?|$)/);
   await expect(app.roomItem(MOCK_ROOMS.review)).toBeDisabled();
   await expect(app.roomItem(MOCK_ROOMS.review)).toContainText('Left');
+  await expect(app.sidebar).toBeVisible();
   if (!app.compact) {
     await expect(page.getByText('Select a room')).toBeVisible();
-  } else {
-    await expect(app.sidebar).toBeVisible();
   }
 });
 
@@ -219,6 +223,6 @@ test('leave: failure keeps the dialog actionable', async ({ app, page }) => {
   await modal(page).getByRole('button', { name: 'Cancel' }).click();
   await expect(modal(page)).toHaveCount(0);
   // Still a member — the failure was real, nothing was applied.
-  if (app.compact) await app.mobileTab('Rooms').click();
+  await returnToRoomsList(app);
   await expect(app.roomItem(MOCK_ROOMS.review)).not.toContainText('Left');
 });

--- a/ui/e2e/onboarding.spec.ts
+++ b/ui/e2e/onboarding.spec.ts
@@ -2,6 +2,11 @@ import { expect, test } from './fixtures';
 
 // Fresh-daemon onboarding (`?mock=fresh`): identity creation, then the
 // create-or-join rooms step, through to the ready shell.
+//
+// This spec drives the one fixture with no rooms, so it cannot use the
+// driver's `showRoomsList`/`openRoom` — both assert a room from the populated
+// fixture. It reaches the rooms list through `navigate('Rooms')`, which is
+// shell-agnostic and asserts nothing about which rooms exist.
 
 test('creates an identity and a first room', async ({ app, page }) => {
   await app.gotoFresh();
@@ -16,13 +21,21 @@ test('creates an identity and a first room', async ({ app, page }) => {
   await page.getByLabel('Room name').fill('Harness Test Room');
   await page.getByRole('button', { name: 'Create room' }).click();
 
-  // Ready shell: the new room is in the rooms list on every breakpoint
-  // (compact lands on the Rooms pane; desktop shows the sidebar).
-  await expect(app.roomItem('Harness Test Room')).toBeVisible();
-
-  // And it opens into a working chat pane.
-  await app.openRoom('Harness Test Room');
+  // The ready shell restores the only room there is, so a first-run user
+  // lands *inside* the room they just named — on every shell, compact
+  // included — instead of on a rooms list or an empty "Select a room" pane.
+  // Naming a room is the act of choosing it; making the user pick it again
+  // would be the shell forgetting what it was just told.
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Harness Test Room' })).toBeVisible();
+  await expect(app.timeline).toBeVisible();
   await expect(app.composerTextarea).toBeVisible();
+
+  // And the room is really in the rooms list: landing in a room proves the
+  // client navigated, not that `room.create` produced a room the list can
+  // hand back (issue #54 — an action must land on a visible surface).
+  await app.navigate('Rooms');
+  await expect(app.roomItem('Harness Test Room')).toBeVisible();
 });
 
 test('surfaces a join failure honestly', async ({ app, page }) => {
@@ -36,6 +49,9 @@ test('surfaces a join failure honestly', async ({ app, page }) => {
   await page.getByRole('button', { name: 'Join room' }).click();
 
   await expect(page.locator('.error-note')).toBeVisible();
-  // Still on the rooms step — no comforting fake transition.
+  // Still on the rooms step — no comforting fake transition. A failed join
+  // must not advance onboarding, and must not route into a room that the
+  // daemon never admitted this identity to.
   await expect(page.getByRole('heading', { name: 'Create a room' })).toBeVisible();
+  await expect(page).not.toHaveURL(/\/rooms\/[^/]+/);
 });

--- a/ui/e2e/panels.spec.ts
+++ b/ui/e2e/panels.spec.ts
@@ -1,38 +1,49 @@
 import { expect, test, MOCK_ROOMS } from './fixtures';
 
-// Files and Pipes entry points. On desktop these are right-panel tabs; on
-// compact they are standalone panes reached from the bottom tab bar.
+// The Files and Pipes room tools (docs/room-workbench.md, decision 1). Neither
+// can answer anything without a room_id — the daemon requires one for
+// file.list, file.share, pipe.list and pipe.expose — so both are reached from
+// inside a room, through the room's tab strip, on every shell. What the shell
+// changes is only where the chosen tool renders: a third column on wide, a
+// drawer over the workspace on medium, the whole screen on compact.
 
-test('opens the Files surface with the shared-file inventory', async ({ app, page, compact }) => {
+test('opens the Files surface with the shared-file inventory', async ({ app, page, shell }) => {
+  // Boot restores the last room, so the strip is already on screen.
   await app.gotoPopulated();
-  await app.navigate('Files');
+  await app.goToRoomDest('Files');
 
+  // The tool is in the URL, not in a second state machine beside it: the
+  // surface survives a reload and a paste into a colleague's window.
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/files$/);
   await expect(app.rightPanel).toBeVisible();
-  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await expect(app.roomTab('Files')).toHaveAttribute('aria-selected', 'true');
+
   // The default room's five fixture files. Scoped to the panel: the same
   // file names also render inside timeline event cards.
   await expect(app.rightPanel.getByRole('heading', { name: '5 shared files' })).toBeVisible();
   await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toBeVisible();
 
-  if (compact) {
-    // Standalone pane: the room context label is the only room name on screen.
-    await expect(page.locator('.panel-room-context')).toHaveText(MOCK_ROOMS.main);
+  // Room context stays visible on every room-scoped surface, on every shell
+  // (decision 3) — but each shell owes it from a different element.
+  if (shell === 'compact') {
+    // One pane at a time: the workspace and its header are gone, so the
+    // panel's own label is the only room name left in the accessible tree.
     await expect(app.center).toBeHidden();
+    await expect(page.locator('.panel-room-context')).toHaveText(MOCK_ROOMS.main);
+  } else {
+    // The workspace keeps its header behind the inspector, so the panel does
+    // not repeat the name.
+    await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
   }
 });
 
 test('opens the Pipes surface with live pipes and the expose form', async ({ app, page }) => {
   await app.gotoPopulated();
-  await app.navigate('Pipes');
+  await app.goToRoomDest('Pipes');
 
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/pipes$/);
   await expect(app.rightPanel).toBeVisible();
-  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
   await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
   // The two fixture pipes for the default room (scoped: pipe targets also
   // render inside timeline event cards).
@@ -40,19 +51,55 @@ test('opens the Pipes surface with live pipes and the expose form', async ({ app
   await expect(app.rightPanel.getByText('127.0.0.1:4000')).toBeVisible();
 });
 
-test('desktop right-panel tabs switch between members, files, and pipes', async ({
-  app,
-  page,
-  compact,
-}) => {
-  test.skip(compact, 'the tab strip is a desktop-only affordance; compact uses the tab bar');
+test('the room tab strip moves between every room tool', async ({ app, page }) => {
+  // This no longer skips the phone viewports. The strip used to be a
+  // desktop-only affordance that compact replaced with bottom-bar tabs; it is
+  // now the room's one navigation at every width, which is what lets a room
+  // destination mean the same thing on all three shells (decision 3). On
+  // compact the inspector renders the same strip itself.
   await app.gotoPopulated();
 
-  await expect(page.getByRole('heading', { name: 'Room roster' })).toBeVisible();
-  await page.getByRole('tab', { name: 'Files', exact: false }).click();
-  await expect(page.getByRole('heading', { name: '5 shared files' })).toBeVisible();
-  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
-  await expect(page.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
-  await page.getByRole('tab', { name: 'Members', exact: false }).click();
-  await expect(page.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+  // Activity is a destination like the others — the room with no tool open —
+  // rather than a synonym for "a room is selected".
+  await expect(app.roomTab('Activity')).toHaveAttribute('aria-selected', 'true');
+  await expect(app.rightPanel).toBeHidden();
+
+  await app.goToRoomDest('People');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+
+  // The fixture room's four agent members. "Agents & Runs" is this room's
+  // agents; the global Agent Fleet answers a different question and is a
+  // different destination (decision 1).
+  await app.goToRoomDest('Agents & Runs');
+  await expect(app.rightPanel.locator('.agent-card')).toHaveCount(4);
+
+  await app.goToRoomDest('Files');
+  await expect(app.rightPanel.getByRole('heading', { name: '5 shared files' })).toBeVisible();
+
+  await app.goToRoomDest('Pipes');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+
+  // Selecting Activity closes the inspector: collapsing it IS navigating, so
+  // "which tool" and "is it open" have nothing left to disagree about.
+  await app.goToRoomDest('Activity');
+  await expect(app.rightPanel).toBeHidden();
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity$/);
+});
+
+test('Files and Pipes are room tools, not global destinations', async ({ app, page, shell }) => {
+  // Both surfaces used to be reachable from global navigation, which made a
+  // room-scoped tool look like a place you could stand without a room — the
+  // destination was always secretly about one room, chosen elsewhere. The
+  // reachability this file asserts above is only honest if the global bar has
+  // stopped offering the same tools roomlessly, so pin the absence.
+  await app.gotoRoomsList();
+
+  const primary =
+    shell === 'compact'
+      ? app.tabBar
+      : page.getByRole('navigation', { name: 'Primary', exact: true });
+
+  await expect(primary.getByRole('button')).toHaveCount(3);
+  await expect(primary.getByRole('button', { name: 'Files' })).toHaveCount(0);
+  await expect(primary.getByRole('button', { name: 'Pipes' })).toHaveCount(0);
 });

--- a/ui/e2e/peer-status.spec.ts
+++ b/ui/e2e/peer-status.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, MOCK_ROOMS } from './fixtures';
+
+// The room header's connectivity summary states what the daemon reported about
+// peer reachability, and nothing else (docs/room-workbench.md, decision 4).
+// It is the surface most tempted to round a fact up: it has one line to
+// describe a whole room's worth of peers.
+
+test('a connected peer with no known path yet is Connected, never Relay', async ({ app, page }) => {
+  // PeerStatus.path is nullable while state is already `connected` — the SDK
+  // knows a peer is reachable before it knows how. Guessing `relay` there
+  // invents the exact fact (direct vs relay) the honesty rules protect.
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.design);
+
+  const badge = page.locator('.p2p-badge');
+  await expect(badge).toContainText('Connected');
+  await expect(badge).not.toContainText('Relay');
+  await expect(badge).not.toContainText('Direct');
+});
+
+test('a direct path is named, and a relay path is never hidden behind it', async ({ app, page, compact }) => {
+  // The main fixture room has both a direct and a relay peer. Direct wins the
+  // summary because it is the best real path the room has — but relay is still
+  // reported as relay wherever it is the truth, which is the per-peer chips.
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+
+  await expect(page.locator('.p2p-badge')).toContainText('Direct');
+
+  // Compact keeps the chips behind the room-information disclosure, so the app
+  // bar can hold a constant height; above compact the strip is already on
+  // screen. Either way the relay peer is reachable and reads as relay.
+  if (compact) await page.getByRole('button', { name: 'Room information' }).click();
+  await expect(page.locator('.peer-chip.peer-path-relay').first()).toContainText('relay');
+});
+
+test('no peers connected says exactly that', async ({ app, page }) => {
+  // Absence of an observed connection is not evidence of solitude: this room
+  // has members whose peers are simply not connected.
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.research);
+
+  const badge = page.locator('.p2p-badge');
+  await expect(badge).toContainText('No peers connected');
+  await expect(badge).not.toContainText('Alone');
+});

--- a/ui/e2e/responsive.spec.ts
+++ b/ui/e2e/responsive.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test, MOCK_ROOMS, shellForWidth } from './fixtures';
+import type { Page } from '@playwright/test';
+
+// The responsive contract (docs/room-workbench.md, decision 3; issue #62).
+//
+// The four viewport projects fix one size each; this spec walks the widths the
+// contract actually names — 360, 899, 900, 920, 1280 — inside one project, so
+// the boundaries are pinned rather than sampled. It runs on the wide project
+// only: every case sets its own viewport, so running the same assertions again
+// under three more projects would just be the same test four times.
+//
+// On text scaling: the design sizes text in px, so the browser-faithful model
+// of "the user made everything bigger" is page zoom, and page zoom is
+// mathematically a narrower viewport. WCAG 1.4.10 fixes the target at 320 CSS
+// px — which is 1280 at 400% — so the 320 cases below ARE the zoom coverage.
+// Real text-scale coverage (textScale 2.0, EN and FR) lives in the Flutter
+// suite, where the platform exposes it faithfully.
+
+test.skip(({ viewport }) => (viewport?.width ?? 0) !== 1440, 'viewport-driven: one project is enough');
+
+const WIDTHS = [360, 899, 900, 920, 1280] as const;
+
+/** iPhone-class insets. The app reads every inset through these custom
+ *  properties, so overriding them exercises the real mechanism — headless
+ *  Chromium reports no insets of its own. */
+async function withSafeAreas(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: ':root { --safe-top: 44px; --safe-bottom: 34px; --safe-left: 12px; --safe-right: 12px; }',
+  });
+}
+
+async function hasHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1);
+}
+
+test.describe('the shell each width renders', () => {
+  for (const width of WIDTHS) {
+    const shell = shellForWidth(width);
+
+    test(`${width}px is the ${shell} shell`, async ({ app, page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await app.gotoPopulated();
+
+      // The room rail: a pane of its own on compact (hidden while in a room),
+      // always present beside the workspace above it.
+      if (shell === 'compact') {
+        await expect(app.sidebar).toBeHidden();
+        await expect(app.center).toBeVisible();
+      } else {
+        await expect(app.sidebar).toBeVisible();
+        await expect(app.center).toBeVisible();
+      }
+
+      // The inspector is closed on Activity at every width — that is what
+      // `activity` means (decision 3).
+      await expect(app.rightPanel).toBeHidden();
+    });
+  }
+});
+
+test.describe('the workspace is never squeezed', () => {
+  for (const width of WIDTHS) {
+    test(`${width}px leaves the workspace usable`, async ({ app, page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await app.gotoPopulated();
+
+      // The regression this band exists to prevent: at 901px the old grid
+      // (232 rail + 1fr + 300 inspector) left the workspace 369px — narrower
+      // than the phone layout it had just graduated from.
+      const centerWidth = await app.center.evaluate((el) => el.getBoundingClientRect().width);
+      expect(centerWidth).toBeGreaterThan(340);
+
+      await expect(app.timeline).toBeVisible();
+      await expect(app.composerTextarea).toBeVisible();
+      expect(await hasHorizontalOverflow(page)).toBe(false);
+    });
+  }
+});
+
+test('medium floats the inspector over the workspace; wide gives it a column', async ({ app, page }) => {
+  // 920: medium. The inspector must not take a column from a workspace this
+  // narrow, so it floats — and the workspace keeps its width while it is open.
+  await page.setViewportSize({ width: 920, height: 800 });
+  await app.gotoPopulated();
+  const centerBefore = await app.center.evaluate((el) => el.getBoundingClientRect().width);
+
+  await app.goToRoomDest('People');
+  const centerAfter = await app.center.evaluate((el) => el.getBoundingClientRect().width);
+  expect(centerAfter).toBe(centerBefore);
+  const drawer = await app.rightPanel.evaluate((el) => el.getBoundingClientRect());
+  const centerBox = await app.center.evaluate((el) => el.getBoundingClientRect());
+  // A drawer: it overlaps the workspace and pins to its right edge.
+  expect(Math.round(drawer.right)).toBe(Math.round(centerBox.right));
+  expect(drawer.left).toBeLessThan(centerBox.right);
+  expect(drawer.left).toBeGreaterThan(centerBox.left);
+
+  // 1280: wide. The inspector stops overlapping and takes its own column,
+  // which the workspace pays for.
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await expect(app.rightPanel).toBeVisible();
+  const wideCenter = await app.center.evaluate((el) => el.getBoundingClientRect());
+  const wideInspector = await app.rightPanel.evaluate((el) => el.getBoundingClientRect());
+  expect(Math.round(wideInspector.left)).toBeGreaterThanOrEqual(Math.round(wideCenter.right) - 1);
+  expect(await hasHorizontalOverflow(page)).toBe(false);
+});
+
+test('the inspector is collapsible, and collapsing it is navigating to Activity', async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await app.gotoPopulated();
+
+  await app.goToRoomDest('Files');
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/files$/);
+
+  await page.getByRole('button', { name: 'Close inspector' }).click();
+  await expect(app.rightPanel).toBeHidden();
+  // The inspector's openness is not a second state: it IS the route.
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity$/);
+});
+
+test('selecting a room tool preserves the timeline position', async ({ app, page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await app.gotoPopulated();
+  await expect(app.timeline).toBeVisible();
+
+  // Scroll away from the bottom, then open and close the inspector. Panes hide,
+  // they do not unmount (decision 3) — the reading position is the user's, and
+  // toggling a side panel is not a request to move it.
+  await app.timeline.evaluate((el) => el.scrollTo({ top: 0 }));
+  const before = await app.timelineBottomOffset();
+  expect(before).toBeGreaterThan(0);
+
+  await app.goToRoomDest('People');
+  await app.goToRoomDest('Activity');
+  await expect(app.timeline).toBeVisible();
+  expect(await app.timelineBottomOffset()).toBe(before);
+});
+
+test.describe('safe areas', () => {
+  for (const width of [360, 320] as const) {
+    test(`${width}px reserves the insets without clipping`, async ({ app, page }) => {
+      await page.setViewportSize({ width, height: 568 });
+      await app.gotoPopulated();
+      await withSafeAreas(page);
+
+      // Inside a room the bottom bar is gone, so the composer owes the home
+      // indicator its inset and nothing else.
+      await expect(app.composerTextarea).toBeVisible();
+      expect(await hasHorizontalOverflow(page)).toBe(false);
+
+      const composer = await app.composerTextarea.evaluate((el) => el.getBoundingClientRect());
+      expect(composer.bottom).toBeLessThanOrEqual(568);
+
+      // The rooms pane owes the tab bar its height plus the inset, so that its
+      // last row is never hidden behind the bottom chrome. Asserted on the
+      // pane's own last element rather than on a room row: the room list is a
+      // scroller, and a row below its fold is legitimately off-screen.
+      await app.navigate('Rooms');
+      await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+      expect(await hasHorizontalOverflow(page)).toBe(false);
+
+      const bar = await app.tabBar.evaluate((el) => el.getBoundingClientRect());
+      const paneEnd = await app.sidebar.evaluate((el) => {
+        const style = getComputedStyle(el);
+        return el.getBoundingClientRect().bottom - parseFloat(style.paddingBottom);
+      });
+      expect(paneEnd).toBeLessThanOrEqual(bar.top + 1);
+    });
+  }
+});
+
+test('the connection banner reserves space instead of covering the room', async ({ app, page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  // Hold room.open long enough to still be reconnecting-free but give the
+  // banner a reason to exist: drop the socket after boot.
+  await app.gotoPopulated();
+  await expect(app.timeline).toBeVisible();
+
+  const backBefore = await page.getByRole('button', { name: 'Back to Rooms' }).evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { top: r.top, left: r.left };
+  });
+
+  await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+  const banner = page.locator('.conn-banner');
+  if (await banner.isVisible()) {
+    const back = page.getByRole('button', { name: 'Back to Rooms' });
+    // Reserved, not overlaid: the banner pushes the app bar down rather than
+    // covering the one control the user needs in order to leave.
+    const backAfter = await back.evaluate((el) => el.getBoundingClientRect().top);
+    expect(backAfter).toBeGreaterThanOrEqual(backBefore.top);
+    const bannerBox = await banner.evaluate((el) => el.getBoundingClientRect());
+    const backBox = await back.evaluate((el) => el.getBoundingClientRect());
+    expect(bannerBox.bottom).toBeLessThanOrEqual(backBox.top + 1);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  }
+});

--- a/ui/e2e/room-actions.spec.ts
+++ b/ui/e2e/room-actions.spec.ts
@@ -1,30 +1,49 @@
 import { expect, test, MOCK_ROOMS } from './fixtures';
+import type { AppDriver } from './fixtures';
 
 // Issue #54: Share File, Open Pipe, and Open in Pipes must land on a VISIBLE
-// surface on compact viewports — the released bug updated the hidden
-// right-panel tab and appeared to do nothing.
+// surface — the released bug selected the hidden right-panel tab and appeared
+// to do nothing. The mechanics now differ per shell (the tool takes the pane on
+// compact, floats as a drawer on medium, opens a column on wide), but the
+// guarantee does not: the surface an action names is the surface the user is
+// looking at afterwards. Each action is one navigation, so the route it lands
+// on is asserted alongside the surface — a route that says `files` while the
+// user is looking at something else is the same lie in a new place.
+
+/** Fire one of the room header's own actions, the way a user of that shell has
+ *  to. On compact they live behind the app bar's ⋮ disclosure: an action row on
+ *  the bar itself is what pushed the timeline under 180px at 320x568 (issue
+ *  #61). On medium and wide they sit on the header directly. */
+async function fireRoomAction(app: AppDriver, name: 'Share File' | 'Open Pipe') {
+  if (app.compact) {
+    await app.page.getByRole('button', { name: 'Room information' }).click();
+  }
+  await app.page.getByRole('button', { name }).click();
+}
 
 test('room-header Share File opens a visible Files surface', async ({ app, page, compact }) => {
   await app.gotoPopulated();
   await app.openRoom(MOCK_ROOMS.main);
 
-  await page.getByRole('button', { name: 'Share File' }).click();
+  await fireRoomAction(app, 'Share File');
 
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/files(\?|$)/);
   await expect(app.rightPanel).toBeVisible();
-  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await expect(app.roomTab('Files')).toHaveAttribute('aria-selected', 'true');
   await expect(app.rightPanel.getByRole('heading', { name: '5 shared files' })).toBeVisible();
 
   if (compact) {
-    // Pane, panel tab, and bottom navigation may never contradict each other.
+    // One pane at a time: the room gives way to the tool it opened, so there is
+    // no second surface left for the action to have updated instead.
     await expect(app.center).toBeHidden();
-    await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
-    // Repeating the destination while already on it is idempotent.
-    await app.mobileTab('Files').click();
+
+    // Repeating the destination while already on it is idempotent — the route
+    // is already `files`, so re-selecting it must neither toggle the surface
+    // shut nor stack an entry the user has to press Back twice to undo.
+    await app.roomTab('Files').click();
+    await expect(page).toHaveURL(/\/rooms\/[^/]+\/files(\?|$)/);
     await expect(app.rightPanel).toBeVisible();
-    await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
+    await expect(app.roomTab('Files')).toHaveAttribute('aria-selected', 'true');
   }
 });
 
@@ -32,19 +51,14 @@ test('room-header Open Pipe opens a visible Pipes surface', async ({ app, page, 
   await app.gotoPopulated();
   await app.openRoom(MOCK_ROOMS.main);
 
-  await page.getByRole('button', { name: 'Open Pipe' }).click();
+  await fireRoomAction(app, 'Open Pipe');
 
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/pipes(\?|$)/);
   await expect(app.rightPanel).toBeVisible();
-  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
   await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
 
-  if (compact) {
-    await expect(app.center).toBeHidden();
-    await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
-  }
+  if (compact) await expect(app.center).toBeHidden();
 });
 
 test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
@@ -58,15 +72,10 @@ test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
   // The fixture's first pipe event is the logs pipe on 127.0.0.1:4000.
   await app.timeline.getByRole('button', { name: 'Open in Pipes' }).first().click();
 
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/pipes(\?|$)/);
   await expect(app.rightPanel).toBeVisible();
-  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
-  if (compact) {
-    await expect(app.center).toBeHidden();
-    await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
-  }
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
+  if (compact) await expect(app.center).toBeHidden();
 
   // The referenced pipe row is identified: transiently marked, and durably
   // focused + on screen (focus outlives the 1.6s visual marker).
@@ -78,7 +87,6 @@ test('timeline Open in Pipes opens Pipes and identifies the pipe', async ({
 
 test('Open in Pipes identifies the pipe even while pipe.list is still loading', async ({
   app,
-  page,
 }) => {
   // Hold every pipe.list response so the action fires into an empty list —
   // the focus request must survive until the list arrives, not be dropped.
@@ -86,36 +94,75 @@ test('Open in Pipes identifies the pipe even while pipe.list is still loading', 
   await app.openRoom(MOCK_ROOMS.main);
   await app.timeline.getByRole('button', { name: 'Open in Pipes' }).first().click();
 
-  await expect(page.getByRole('tab', { name: 'Pipes', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
   const row = app.rightPanel.locator('.pipe-row', { hasText: '127.0.0.1:4000' });
   await expect(row).toBeFocused({ timeout: 10_000 });
   await expect(row).toBeInViewport();
 });
 
-test('mobile: the panel tab strip keeps the bottom navigation truthful', async ({
+// Replaces 'mobile: the panel tab strip keeps the bottom navigation truthful'.
+// That test pinned "the pane, the panel tab, and the bottom navigation may
+// never contradict each other" — an invariant no implementation can break any
+// more. Files and Pipes are room tools, so the bottom bar has no Files
+// highlight left to hang over Pipes content, and the pane and the strip are
+// both read off the one route (docs/room-workbench.md, decision 2) rather than
+// tracked separately. The invariant that replaced it is between the three
+// things that still exist: the route, the strip's selection, and the pane on
+// screen. Those can only agree by construction if nothing re-derives them, so
+// this pins that they do.
+test('the room tab strip, the visible pane, and the route agree', async ({
   app,
   page,
   compact,
 }) => {
-  test.skip(!compact, 'the bottom bar only exists on compact');
   await app.gotoPopulated();
-  await app.navigate('Files');
-  await expect(app.mobileTab('Files')).toHaveAttribute('aria-current', 'page');
+  await app.openRoom(MOCK_ROOMS.main);
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity(\?|$)/);
+  await expect(app.roomTab('Activity')).toHaveAttribute('aria-selected', 'true');
 
-  // Switching to Pipes inside the panel's own tab strip must move the bottom
-  // navigation with it — a Files highlight over Pipes content is a lie.
-  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
-  await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  await app.goToRoomDest('Pipes');
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/pipes(\?|$)/);
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
+  await expect(app.roomTab('Activity')).toHaveAttribute('aria-selected', 'false');
   await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
+  if (compact) await expect(app.center).toBeHidden();
 
-  // Members is a sub-view of the current pane (it has no bottom-nav
-  // destination): the pane and its highlight stay put.
-  await page.getByRole('tab', { name: 'Members', exact: false }).click();
-  await expect(app.mobileTab('Pipes')).toHaveAttribute('aria-current', 'page');
+  // Every tool moves all three together — People is not a sub-view of whatever
+  // was open, it is a destination like the rest.
+  await app.goToRoomDest('People');
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/people(\?|$)/);
+  await expect(app.roomTab('People')).toHaveAttribute('aria-selected', 'true');
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'false');
   await expect(app.rightPanel.getByRole('heading', { name: 'Room roster' })).toBeVisible();
+
+  // Activity is a destination too, so closing the inspector is the same
+  // navigation as any other — and it leaves the room's own surface on screen.
+  await app.goToRoomDest('Activity');
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity(\?|$)/);
+  await expect(app.roomTab('Activity')).toHaveAttribute('aria-selected', 'true');
+  await expect(app.rightPanel).toBeHidden();
+  await expect(app.center).toBeVisible();
+  await expect(app.timeline).toBeVisible();
+});
+
+// The strip is the only pointer route between room tools, so opening one must
+// not put it out of reach. Compact and wide each have an answer — the inspector
+// carries the strip itself on compact, and on wide the tool opens beside it in
+// a column of its own. Medium is the shell with neither: the drawer floats over
+// the very workspace the strip lives in, and a tab that is visible, enabled,
+// and announced as selected while a pointer lands on something else is the
+// issue #54 lie told from the other side.
+test('opening a room tool leaves the room tab strip usable', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.main);
+  await app.goToRoomDest('Files');
+
+  // Moving between tools is one click from wherever the user already is — not
+  // "dismiss the tool you opened, then pick another off the strip underneath".
+  await app.goToRoomDest('Pipes');
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/pipes(\?|$)/);
+  await expect(app.roomTab('Pipes')).toHaveAttribute('aria-selected', 'true');
+  await expect(app.rightPanel.getByRole('heading', { name: 'Expose a pipe' })).toBeVisible();
 });
 
 test('desktop: repeating Open in Pipes stays idempotent', async ({ app, compact }) => {

--- a/ui/e2e/room-nav-strip.spec.ts
+++ b/ui/e2e/room-nav-strip.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from './fixtures';
+
+// The room's tab strip carries hard-coded ids (`room-tab-*`) for its
+// roving-tabindex keyboard handler. Exactly one strip may be live at a time —
+// two would duplicate the ids, and getElementById would move focus into the
+// hidden copy (docs/room-workbench.md, decision 3).
+
+test.describe('exactly one room-nav strip is ever live', () => {
+  for (const width of [920, 1280] as const) {
+    test(`${width}px keeps one #room-tab-people while the inspector is open`, async ({ app, page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await app.gotoPopulated();
+
+      // Closed: only the workspace strip.
+      await expect(page.locator('#room-tab-people')).toHaveCount(1);
+
+      // Open a tool — medium floats a drawer, wide adds a column, and both
+      // carry their own strip. The workspace copy must stand down.
+      await app.goToRoomDest('Files');
+      await expect(page.locator('#room-tab-people')).toHaveCount(1);
+      await expect(page.locator('#room-tab-files')).toHaveCount(1);
+    });
+  }
+});
+
+test('keyboard arrows move focus between visible tabs, never into a hidden copy', async ({ app, page }) => {
+  await page.setViewportSize({ width: 920, height: 800 });
+  await app.gotoPopulated();
+  await app.goToRoomDest('People');
+
+  // Focus the live People tab and arrow to the next: focus must land on a
+  // visible element (the drawer's own strip), not a display:none duplicate.
+  await page.locator('#room-tab-people').focus();
+  await page.keyboard.press('ArrowRight');
+
+  const focused = page.locator('*:focus');
+  await expect(focused).toBeVisible();
+  await expect(focused).toHaveAttribute('role', 'tab');
+});

--- a/ui/e2e/room-open-recovery.spec.ts
+++ b/ui/e2e/room-open-recovery.spec.ts
@@ -3,24 +3,27 @@ import { expect, test, MOCK_ROOMS } from './fixtures';
 // Issue #53: a failed room.open must offer explicit Retry and Back to Rooms
 // paths, retry the same room without selecting another first, and never
 // render another room's data (or a comforting empty timeline) underneath.
+//
+// Every case here pins the failure to a deliberately selected room via
+// `mock_fail=room.open:<fails>:1`: boot restores the last room and opens it
+// (docs/room-workbench.md, decision 2), so the one allowed call is spent
+// there and the next selection is what breaks. That is also why none of these
+// tests branch on the shell any more — compact boots into the room too, so the
+// failure arrives the same way on all three.
 
-test('a failed room open offers Retry, and Retry restores the room', async ({
-  app,
-  page,
-  compact,
-}) => {
-  // Desktop auto-opens the room (one visible failure); on compact the reveal
-  // tap itself is the instinctive first retry, so spend two failures there.
-  await app.gotoPopulated({ mock_fail: compact ? 'room.open:2' : 'room.open:1' });
-  const surface = page.locator('.room-error-surface');
-  if (compact) {
-    // Wait for the hidden auto-open to fail before tapping, so the tap is
-    // deterministically the second (and last) injected failure.
-    await expect(surface).toHaveCount(1);
-    await app.roomItem(MOCK_ROOMS.main).click();
-  }
+test('a failed room open offers Retry, and Retry restores the room', async ({ app, page }) => {
+  await app.gotoPopulated({ mock_fail: 'room.open:1:1' });
+  await app.showRoomsList();
+  await app.roomItem(MOCK_ROOMS.design).click();
+
+  // The route keeps naming the room whose open failed. A daemon error is a
+  // state of that room, not a reason to bounce the user somewhere else
+  // (decision 2: keep the route, surface the real error, offer Retry).
+  await expect(page).toHaveURL(/\/rooms\/[^/]+\/activity/);
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.design })).toBeVisible();
 
   // The error owns the pane: real failure, recovery actions, no fake timeline.
+  const surface = page.locator('.room-error-surface');
   await expect(surface).toBeVisible();
   await expect(surface.getByText('Something went wrong')).toBeVisible();
   await expect(surface.getByText('Technical details')).toBeVisible();
@@ -33,9 +36,9 @@ test('a failed room open offers Retry, and Retry restores the room', async ({
   await retry.focus();
   await page.keyboard.press('Enter');
 
-  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.design })).toBeVisible();
   await expect(app.timeline).toBeVisible();
-  await expect(app.timeline.getByText('Kicked off the rooms protocol spec')).toBeVisible();
+  await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeVisible();
   await expect(surface).toHaveCount(0);
   await expect(app.composerTextarea).toBeVisible();
 });
@@ -45,15 +48,23 @@ test('re-selecting the errored room retries instead of doing nothing', async ({
   page,
   compact,
 }) => {
-  test.skip(compact, 'covered by the reveal-tap in the Retry test; the sidebar is a desktop rail here');
-  await app.gotoPopulated({ mock_fail: 'room.open:2' });
+  // Compact never puts the rooms list and the failed room's pane on screen
+  // together, so re-selecting the selected room is not a gesture it has: the
+  // only way back to the list is Back to Rooms, which moves the route off the
+  // room and clears its session state — the next tap is then an ordinary open,
+  // already covered above.
+  test.skip(compact, 'the rooms list and the room pane are never co-visible on compact');
+  await app.gotoPopulated({ mock_fail: 'room.open:2:1' });
+  await app.roomItem(MOCK_ROOMS.design).click();
 
   const surface = page.locator('.room-error-surface');
   await expect(surface).toBeVisible();
 
-  // Clicking the already-selected room must issue a real second attempt —
-  // it consumes the second injected failure…
-  await app.roomItem(MOCK_ROOMS.main).click();
+  // Clicking the already-selected room must issue a real second attempt. The
+  // route cannot change (it already names this room), so nothing about the
+  // navigation can carry the intent — it consumes the second injected
+  // failure…
+  await app.roomItem(MOCK_ROOMS.design).click();
   await expect(surface).toBeVisible();
 
   // …so the next retry succeeds. Without the retry-on-reselect fix, this
@@ -63,10 +74,10 @@ test('re-selecting the errored room retries instead of doing nothing', async ({
 });
 
 test('Back to Rooms escapes a room that cannot open', async ({ app, page, compact }) => {
-  // The default room opens fine; every later open fails — so the failure is
+  // The restored room opens fine; every later open fails — so the failure is
   // pinned to a deliberately selected, non-default room.
   await app.gotoPopulated({ mock_fail: 'room.open:9:1' });
-  if (compact) await app.mobileTab('Rooms').click();
+  await app.showRoomsList();
   await app.roomItem(MOCK_ROOMS.design).click();
 
   const surface = page.locator('.room-error-surface');
@@ -76,56 +87,71 @@ test('Back to Rooms escapes a room that cannot open', async ({ app, page, compac
   await back.focus();
   await page.keyboard.press('Enter');
 
-  // The failed room is fully deselected — nothing renders under it.
+  // The failed room is fully deselected — and because the route *is* the
+  // selection, that is one fact rather than two that could disagree.
+  await expect(page).toHaveURL(/\/rooms(\?|$)/);
   await expect(surface).toHaveCount(0);
   await expect(app.roomItem(MOCK_ROOMS.design)).toBeVisible();
-  if (!compact) {
-    await expect(page.getByText('Select a room')).toBeVisible();
-  } else {
+  if (compact) {
     await expect(app.center).toBeHidden();
     await expect(app.sidebar).toBeVisible();
+  } else {
+    await expect(page.getByText('Select a room')).toBeVisible();
   }
 
-  // The escape is durable: a reload must not auto-open straight back into
-  // the failed room (its last-room memory is cleared) — the app boots into
-  // the healthy default room with no error surface.
+  // The escape is durable (issue #88). Reloading holds `/rooms`, because
+  // `/rooms` is an explicit destination and restoration only fills in a route
+  // that named no room: nothing re-opens, so the failed room's error cannot
+  // come back. The reload used to be expected to land in the healthy default
+  // room instead — that is gone, and asserting it would now be asserting a
+  // restore this route never asks for.
   await page.reload();
+  await expect(page).toHaveURL(/\/rooms(\?|$)/);
   await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
-  await expect(app.roomItem(MOCK_ROOMS.main)).toContainText('Active', { timeout: 10_000 });
+  await expect(app.roomItem(MOCK_ROOMS.design)).toContainText('Closed');
+  await expect(page.locator('.room-error-surface')).toHaveCount(0);
+
+  // The other half of #88, which the route model does not fix by itself: the
+  // last-room memory was cleared too, so even a load of `/` — which *does*
+  // restore — comes back to the healthy default room and not to the one the
+  // user just escaped.
+  await app.gotoPopulated({ mock_fail: 'room.open:9:1' });
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
   await expect(page.locator('.room-error-surface')).toHaveCount(0);
 });
 
-test('another room\'s data never renders under a failed open', async ({ app, page }) => {
-  // First open succeeds and fills members/files/pipes; the next one fails.
+test("another room's data never renders under a failed open", async ({ app, page }) => {
+  // The restored room opens and fills people/files/pipes; the next one fails.
   await app.gotoPopulated({ mock_fail: 'room.open:1:1' });
-  await app.openRoom(MOCK_ROOMS.main);
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
   await expect(app.timeline.getByText('Kicked off the rooms protocol spec')).toBeVisible();
 
-  // Positive control first — the main room's data really is on each panel
-  // tab, so the absence assertions below cannot pass vacuously.
-  await app.navigate('Files');
+  // Positive control first — the main room's data really is on each room tool,
+  // so the absence assertions below cannot pass vacuously.
+  await app.goToRoomDest('Files');
   await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toBeVisible();
-  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
+  await app.goToRoomDest('Pipes');
   await expect(app.rightPanel.getByText('127.0.0.1:3000')).toBeVisible();
-  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await app.goToRoomDest('People');
   await expect(app.rightPanel.getByText('Maya R.').first()).toBeVisible();
 
-  if (app.compact) await app.mobileTab('Rooms').click();
+  // Leave by the room's own Back chain — tool → Activity → Rooms (decision 3).
+  // On compact the inspector is the whole screen, so the rooms list is not
+  // reachable from under it; above compact both steps are already true.
+  await app.goToRoomDest('Activity');
+  await app.showRoomsList();
   await app.roomItem(MOCK_ROOMS.design).click();
   await expect(page.locator('.room-error-surface')).toBeVisible();
   await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.design })).toBeVisible();
 
-  // Walk every panel tab under the failed room: nothing from the main room
+  // Walk every room tool under the failed room: nothing from the main room
   // bleeds through — each surface shows empty-room truth.
-  await app.navigate('Files');
-  await expect(page.getByRole('tab', { name: 'Files', exact: false })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
+  await app.goToRoomDest('Files');
+  await expect(app.roomTab('Files')).toHaveAttribute('aria-selected', 'true');
   await expect(app.rightPanel.getByText('PRD_v0.2.pdf')).toHaveCount(0);
-  await page.getByRole('tab', { name: 'Pipes', exact: false }).click();
+  await app.goToRoomDest('Pipes');
   await expect(app.rightPanel.getByText('127.0.0.1:3000')).toHaveCount(0);
-  await page.getByRole('tab', { name: 'Members', exact: false }).click();
+  await app.goToRoomDest('People');
   await expect(app.rightPanel.getByText('Maya R.')).toHaveCount(0);
   await expect(app.rightPanel.getByText('No members have synced', { exact: false })).toBeVisible();
 });

--- a/ui/e2e/room-recovery-routes.spec.ts
+++ b/ui/e2e/room-recovery-routes.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from './fixtures';
+
+// Deep links and tool routes to rooms the daemon cannot open must resolve to a
+// visible recovery state, not a blank pane (docs/room-workbench.md, decision 2)
+// — including when the route names a tool, where the naive derivation would
+// open an empty inspector over a hidden recovery surface.
+
+const MISSING = 'blake3:0000000000000000000000000000000000000000000000000000000000000000';
+
+test('a tool route to a room not on this device shows the recovery surface, not an empty inspector', async ({
+  app,
+  page,
+}) => {
+  // The recovery UI lives in .center. A tool route (…/files) derives an
+  // inspector pane, and compact CSS hides .center for it — so without the
+  // guard the user lands in an empty tool with no way out, and file/pipe
+  // actions would fire against a room that isn't open.
+  await app.gotoPopulated();
+  await page.goto(`/rooms/${encodeURIComponent(MISSING)}/files`);
+
+  await expect(page.locator('.room-gone-title')).toBeVisible();
+  await expect(page.locator('.center')).toBeVisible();
+  await expect(app.rightPanel).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Back to Rooms' })).toBeVisible();
+});
+
+test('Back to Rooms escapes a tool route to a missing room', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await page.goto(`/rooms/${encodeURIComponent(MISSING)}/pipes`);
+  await expect(page.locator('.room-gone-title')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Back to Rooms' }).click();
+  await expect(page).toHaveURL(/\/rooms$/);
+  await expect(app.sidebar).toBeVisible();
+});

--- a/ui/e2e/rooms.spec.ts
+++ b/ui/e2e/rooms.spec.ts
@@ -2,41 +2,65 @@ import { expect, test, MOCK_ROOMS } from './fixtures';
 
 // Room list + selecting/opening rooms, on the populated fixture.
 
-test('lists every fixture room with membership metadata', async ({ app }) => {
-  await app.gotoPopulated();
+test('lists every fixture room with membership metadata', async ({ app, page }) => {
+  await app.gotoRoomsList();
+
   for (const name of Object.values(MOCK_ROOMS)) {
-    await expect(app.roomItem(name)).toBeVisible();
+    // A row states two facts and names each one exactly (docs/room-workbench.md,
+    // decision 4): how many members the room has, and whether this daemon holds
+    // a session for it.
+    await expect(app.roomItem(name)).toContainText(/\d+ members? · (Open|Closed)/);
   }
-  await expect(app.roomItem(MOCK_ROOMS.main)).toContainText('members');
+
+  // A room this daemon has never opened reads Closed — the session word, which
+  // is a different fact from the membership count beside it.
+  await expect(app.roomItem(MOCK_ROOMS.design)).toContainText(/\d+ members · Closed/);
+
+  // "Active" is retired as a display label. On this row it meant a live local
+  // session while meaning signed membership on the wire, and one word cannot
+  // honestly be both.
+  await expect(page.getByRole('navigation', { name: 'Rooms' })).not.toContainText('Active');
 });
 
-test('opens the default room into a populated timeline', async ({ app, page, compact }) => {
+test('restores the default room into a populated timeline', async ({ app, page }) => {
   await app.gotoPopulated();
 
-  if (compact) {
-    // Compact lands on the Rooms pane; the chat pane must stay hidden until
-    // the user picks a room.
-    await expect(app.center).toBeHidden();
-    await app.openRoom(MOCK_ROOMS.main);
-  } else {
-    // Desktop auto-opens the default room in the center column.
-    await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
-  }
-
-  await expect(
-    app.timeline.getByText('Kicked off the rooms protocol spec', { exact: false }),
-  ).toBeVisible();
+  // Loading `/` restores the last room, so the app lands *inside* it on every
+  // shell — on compact that is the room pane, not the rooms list.
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeVisible();
+  await expect(app.timeline.getByText('Kicked off the rooms protocol spec', { exact: false })).toBeVisible();
   await expect(app.timeline.getByText('created the room', { exact: false })).toBeVisible();
+});
+
+// Boot used to leave compact on the rooms list, and the guard that mattered was
+// "the chat pane stays hidden until the user picks a room". It cannot be
+// violated any more — boot lands in the room by design. What replaces it is the
+// obligation the restore now carries: `/` is *replaced* with /rooms and the room
+// is *pushed* on top, so the first Back press leaves the room the user never
+// chose to stand in, rather than leaving Jeliya (decision 3 — Back is truthful:
+// room destination → Activity → Rooms → out).
+test('back from the restored room lands on the rooms list', async ({ app, page }) => {
+  await app.gotoPopulated();
+
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/rooms$/);
+  await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
+  // And it stays left: nothing may re-restore the room behind an explicit
+  // escape (issue #88).
+  await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.main })).toBeHidden();
 });
 
 test('switches rooms and shows the selected room content', async ({ app, page }) => {
   await app.gotoPopulated();
+
   await app.openRoom(MOCK_ROOMS.design);
   await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeVisible();
 
   await app.openRoom(MOCK_ROOMS.review);
   await expect(page.getByRole('heading', { level: 1, name: MOCK_ROOMS.review })).toBeVisible();
-  await expect(
-    app.timeline.getByText('Weekly product review — drop artifacts before Friday.'),
-  ).toBeVisible();
+  await expect(app.timeline.getByText('Weekly product review — drop artifacts before Friday.')).toBeVisible();
+  // The outgoing room's events may not linger under the incoming room's title:
+  // a message rendered under the wrong room name misstates who can read it.
+  await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeHidden();
 });

--- a/ui/e2e/settings.spec.ts
+++ b/ui/e2e/settings.spec.ts
@@ -1,18 +1,45 @@
-import { expect, test } from './fixtures';
+import { expect, test, MOCK_ROOMS } from './fixtures';
 
-// The Settings pane (compact tab / desktop overlay).
+// Settings — one of the three global destinations (docs/room-workbench.md,
+// decision 1), at `/settings`. It is a pane of its own on compact and an
+// overlay over the workspace on medium and wide.
 
 test('shows identity, endpoint, daemon state, and diagnostics', async ({ app, page }) => {
   await app.gotoPopulated();
   await app.navigate('Settings');
 
+  // The route is the navigation state (decision 2), so the destination being
+  // reached is a fact about the URL, not only about what happens to be painted.
+  await expect(page).toHaveURL(/\/settings$/);
+
   const settings = page.getByRole('region', { name: 'Settings' });
   await expect(settings).toBeVisible();
   await expect(settings.getByText('P2P Identity')).toBeVisible();
-  // The real 64-hex identity id, not a placeholder.
+  await expect(settings.getByText('Endpoint')).toBeVisible();
+  // The real 64-hex identity and endpoint ids, not the '-' the panel renders
+  // before daemon.status answers: a placeholder shown as a value would be the
+  // screen asserting a fact it does not have (decision 5).
   await expect(settings.locator('.settings-val').first()).toHaveText(/^[0-9a-f]{64}$/);
+  await expect(settings.locator('.settings-val').nth(1)).toHaveText(/^[0-9a-f]{64}$/);
   // Honest daemon state: mock mode reports loopback + live connection state.
   await expect(settings.getByText('loopback · connected')).toBeVisible();
   await expect(settings.getByRole('button', { name: 'Copy diagnostics' })).toBeEnabled();
   await expect(settings.getByRole('button', { name: 'Report issue' })).toBeVisible();
+});
+
+test('Settings keeps a way back out on every shell', async ({ app, page, compact }) => {
+  // Boot lands inside a room, where the compact bottom bar gives way to the
+  // room's app bar. Settings has no Back of its own, so the bar has to return
+  // here or a phone user is stranded on a destination they cannot leave; the
+  // rail plays the same part on medium and wide.
+  await app.gotoPopulated();
+  await app.navigate('Settings');
+  await expect(page.getByRole('region', { name: 'Settings' })).toBeVisible();
+
+  if (compact) await expect(app.tabBar).toBeVisible();
+  else await expect(app.sidebar).toBeVisible();
+
+  await app.navigate('Rooms');
+  await expect(page).toHaveURL(/\/rooms$/);
+  await expect(app.roomItem(MOCK_ROOMS.main)).toBeVisible();
 });

--- a/ui/e2e/timeline-position.spec.ts
+++ b/ui/e2e/timeline-position.spec.ts
@@ -1,33 +1,53 @@
 import { expect, test, MOCK_ROOMS } from './fixtures';
 
-// Issue #52: mobile rooms must open at the newest timeline event even though
-// the room is auto-opened while its pane is display:none, and a deliberate
-// reading position must survive pane hiding and room switches.
+// Issue #52: a room must open at its newest timeline event, and a deliberate
+// reading position must survive the pane being hidden and rooms being switched.
+//
+// Two mechanisms carry that, and both are load-bearing here. The compact shell
+// hides panes with display:none instead of unmounting them
+// (docs/room-workbench.md, decision 3): a hidden element measures zero and
+// loses scrollTop, so the timeline has to reinstate its position the moment it
+// is laid out again. Switching rooms genuinely unmounts it (the timeline is
+// keyed by room), so there the position rides across on a saved view.
 
 // The newest fixture event in the main room (mock.ts anchors it near "now").
 const NEWEST_MAIN_EVENT = 'Sync convergence suite running (14/24 green).';
 
-test('mobile: the auto-opened default room reveals at the newest event', async ({
-  app,
-  compact,
-}) => {
-  test.skip(!compact, 'desktop mounts the timeline visible; this is the hidden-mount path');
+test('mobile: the room pane reveals at the newest event', async ({ app, compact }) => {
+  test.skip(!compact, 'medium and wide keep the room pane laid out; this is the hidden-pane path');
   await app.gotoPopulated();
 
-  // The room was opened while the chat pane was hidden; first reveal must
-  // land within 140px of the bottom with the newest event exposed. On very
-  // short viewports the newest card can be taller than the visible timeline,
-  // so the contract is: its row intersects the viewport and the scroller sits
-  // at the bottom.
-  await app.openRoom(MOCK_ROOMS.main);
+  // Boot restores the room and lands inside it (decision 2), so the auto-opened
+  // room is on screen from its first paint and cannot mount hidden. The zeroed
+  // measurements that mount had to survive are still reached, though — every
+  // room tool display:none's the pane behind it — so this walks that cycle
+  // instead.
+  //
+  // The baseline first: the restored room opens at its newest event. On very
+  // short viewports the newest card can be taller than the visible timeline, so
+  // the contract is: its row intersects the viewport and the scroller sits at
+  // the bottom.
   await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeVisible();
   await expect(app.timeline.locator('.timeline-row').last()).toBeInViewport();
   expect(await app.timelineBottomOffset()).toBeLessThanOrEqual(140);
+
+  // A room tool owns the whole screen on compact, so the room pane goes
+  // display:none — every measurement it had is now zero.
+  await app.goToRoomDest('People');
+  await expect(app.center).toBeHidden();
+
+  // Revealed again, it must re-derive the bottom rather than sit at the
+  // scrollTop that display:none reset for it.
+  await app.goToRoomDest('Activity');
+  await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeVisible();
+  await expect(app.timeline.locator('.timeline-row').last()).toBeInViewport();
+  await expect.poll(() => app.timelineBottomOffset()).toBeLessThanOrEqual(140);
 });
 
 test('selecting a different room opens its latest activity', async ({ app }) => {
+  // Boot restores the main room on every shell, so this is a switch between two
+  // rooms and not a first open.
   await app.gotoPopulated();
-  await app.openRoom(MOCK_ROOMS.main);
   await app.openRoom(MOCK_ROOMS.design);
 
   await expect(app.timeline.getByText('Tokens v2 exploration lives here.')).toBeVisible();
@@ -41,7 +61,11 @@ test('mobile: hiding and revealing the room pane keeps the reading position', as
 }) => {
   test.skip(!compact, 'panes are only hidden on compact');
   await app.gotoPopulated();
-  await app.openRoom(MOCK_ROOMS.main);
+
+  // The backlog has to be in before a reading position means anything: the
+  // timeline renders (as skeletons) while room.open is still in flight, and a
+  // scroll offset set against that empty scroller is silently dropped.
+  await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeVisible();
 
   // Scroll deliberately away from the bottom (display:none will wipe this).
   await app.timeline.evaluate((el) => {
@@ -49,9 +73,12 @@ test('mobile: hiding and revealing the room pane keeps the reading position', as
   });
   await expect.poll(() => app.timeline.evaluate((el) => el.scrollTop)).toBe(300);
 
-  await app.mobileTab('Rooms').click();
+  // A room tool hides the room pane without unmounting it, so the timeline
+  // keeps its state and loses only its layout — the exact case decision 3
+  // promises the reader will not notice.
+  await app.goToRoomDest('People');
   await expect(app.center).toBeHidden();
-  await app.roomItem(MOCK_ROOMS.main).click();
+  await app.goToRoomDest('Activity');
   await expect(app.timeline).toBeVisible();
 
   // Reinstated, not reset to the top and not jumped to the bottom.
@@ -64,7 +91,13 @@ test('returning to a scrolled-up room preserves the position and offers new acti
   app,
 }) => {
   await app.gotoPopulated();
-  await app.openRoom(MOCK_ROOMS.main);
+
+  // The room must really be open at its newest event before the reader scrolls
+  // away from it. room.open is still in flight when the timeline first renders,
+  // and scrolling an empty scroller sets nothing — the room would then be
+  // remembered as stuck-to-bottom and this would assert against a position the
+  // test never actually established.
+  await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeVisible();
 
   // Deliberately read from the top…
   await app.timeline.evaluate((el) => {
@@ -95,8 +128,8 @@ test('returning to a scrolled-up room preserves the position and offers new acti
   await expect.poll(() => app.timelineBottomOffset()).toBeLessThanOrEqual(140);
 });
 
-test('desktop: stick-to-bottom keeps following new events', async ({ app, compact }) => {
-  test.skip(compact, 'desktop invariant — must not regress while fixing mobile');
+test('stick-to-bottom keeps following new events', async ({ app, compact }) => {
+  test.skip(compact, 'medium and wide invariant — must not regress while fixing mobile');
   await app.gotoPopulated();
   await expect(app.timeline.getByText(NEWEST_MAIN_EVENT)).toBeInViewport();
 

--- a/ui/node_modules
+++ b/ui/node_modules
@@ -1,0 +1,1 @@
+/home/sekou/AGI/jeliya/ui/node_modules

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,10 @@ import { shortId } from './lib/format';
 import { splitInvite } from './lib/invite';
 import { joinRoomWithRetry } from './lib/join';
 import type { JoinProgress } from './lib/join';
+import { useRoute } from './lib/history';
+import { inspectorDest, legacyTabDest, routeRoomId } from './lib/routes';
+import type { InspectorDest, RoomDest } from './lib/routes';
+import { useShell } from './lib/shell';
 import uiPackage from '../package.json';
 import { NamesContext } from './components/names';
 import type { NameApi } from './components/names';
@@ -30,20 +34,17 @@ import { Sidebar } from './components/Sidebar';
 import type { NavKey } from './components/Sidebar';
 import { MobileTabBar } from './components/MobileTabBar';
 import { RoomHeader } from './components/RoomHeader';
+import { RoomNav } from './components/RoomNav';
 import { Timeline } from './components/Timeline';
 import type { PendingMessage, TimelineView } from './components/Timeline';
 import { Composer } from './components/Composer';
 import { RightPanel } from './components/RightPanel';
-import type { PanelTab, PipeConnState } from './components/RightPanel';
+import type { PipeConnState } from './components/RightPanel';
 import { InviteModal } from './components/InviteModal';
 import { FleetDashboard } from './components/FleetDashboard';
 import { SettingsPanel } from './components/SettingsPanel';
 
 type Phase = 'boot' | 'no-identity' | 'no-rooms' | 'ready';
-
-/** Which single pane is shown on a narrow (mobile) viewport; ignored on desktop
- *  where all three columns are visible at once. */
-type MobileView = 'rooms' | 'chat' | 'agents' | 'pipes' | 'files' | 'settings';
 
 const LAST_ROOM_KEY = 'jeliya.lastRoom';
 const ISSUE_URL = 'https://github.com/kortiene/jeliya/issues/new';
@@ -126,11 +127,12 @@ export default function App({ client }: { client: Client }) {
   const [pipeConns, setPipeConns] = useState<Record<string, PipeConnState>>({});
   const [closingPipes, setClosingPipes] = useState<Set<string>>(new Set());
 
-  const [tab, setTab] = useState<PanelTab>(() => {
-    const t = new URLSearchParams(window.location.search).get('tab');
-    return t === 'members' || t === 'files' || t === 'pipes' || t === 'agents' ? t : 'members';
-  });
-  const [mobileView, setMobileView] = useState<MobileView>('rooms');
+  // The route is the navigation state (docs/room-workbench.md, decision 2).
+  // This replaced three fields — `tab`, `mobileView`, and a `roomId` the
+  // bootstrap picked independently — that could, and did, contradict each
+  // other. Everything below derives from `route`; nothing mirrors it.
+  const [route, navigate] = useRoute();
+  const shell = useShell();
   const [pipeFocus, setPipeFocus] = useState<string | null>(null);
   // Deliberate per-room reading positions (see TimelineView); a ref because
   // saving one on room switch must not re-render the outgoing timeline.
@@ -204,6 +206,23 @@ export default function App({ client }: { client: Client }) {
     }
   }, [client]);
 
+  /** Everything that belongs to one room's open session. Cleared whenever the
+   *  route moves off a room, and before opening the next one — a stale
+   *  endpoint address or member list under a different room is a lie. */
+  const resetRoomState = useCallback(() => {
+    setMembers([]);
+    setTimeline([]);
+    setFiles([]);
+    setPipes([]);
+    setPeers([]);
+    setEndpointAddr(null);
+    setRoomError(null);
+    setRoomLoading(false);
+    setFetches({});
+    setPipeConns({});
+    setClosingPipes(new Set());
+  }, []);
+
   const openRoom = useCallback(
     async (rid: string) => {
       roomIdRef.current = rid;
@@ -228,6 +247,12 @@ export default function App({ client }: { client: Client }) {
       setPipeConns({});
       try {
         const opened = await client.call('room.open', { room_id: rid });
+        // The daemon's open flag changed, and room.list is global state — not
+        // this room's session. Refresh it before the guard below drops
+        // everything that belongs to a room the user has already left, or the
+        // rail goes on calling a live session "Closed" until something else
+        // happens to refresh it.
+        void refreshRooms();
         if (roomIdRef.current !== rid) return;
         setMembers(opened.members);
         setTimeline(opened.timeline);
@@ -253,7 +278,6 @@ export default function App({ client }: { client: Client }) {
         setFetches((current) => mergeFetchedFiles(current, rid, f.files));
         setPipes(p.pipes);
         setPeers(ps.peers);
-        void refreshRooms(); // open flag changed
       } catch (e) {
         if (roomIdRef.current === rid) {
           setRoomError(rememberError('room.open', e));
@@ -317,6 +341,11 @@ export default function App({ client }: { client: Client }) {
   }, [client, refreshFiles, refreshPipes, refreshMembers, refreshRooms]);
 
   // -- bootstrap: runs on every (re)connect and after onboarding steps ---------
+  //
+  // It no longer picks a room. The route does (decision 2: an explicit route
+  // always wins over a restored room) — a bootstrap that re-picked
+  // `lastRoom` on every reconnect fought the URL, and dragged the user back
+  // into the very room they had just escaped (issue #88).
 
   useEffect(() => {
     if (conn !== 'connected') return;
@@ -333,28 +362,7 @@ export default function App({ client }: { client: Client }) {
         const { rooms } = await client.call('room.list', {});
         if (cancelled) return;
         setRooms(rooms);
-        if (rooms.length === 0) {
-          setPhase('no-rooms');
-          return;
-        }
-        setPhase('ready');
-        const activeRooms = rooms.filter((r) => r.status !== 'left' && r.status !== 'removed');
-        if (activeRooms.length === 0) {
-          roomIdRef.current = null;
-          setRoomId(null);
-          return;
-        }
-        let saved: string | null = null;
-        try {
-          saved = localStorage.getItem(LAST_ROOM_KEY);
-        } catch {
-          /* ignore */
-        }
-        const target =
-          (roomIdRef.current && activeRooms.some((r) => r.room_id === roomIdRef.current) && roomIdRef.current) ||
-          (saved && activeRooms.some((r) => r.room_id === saved) && saved) ||
-          activeRooms[0].room_id;
-        void openRoom(target);
+        setPhase(rooms.length === 0 ? 'no-rooms' : 'ready');
       } catch {
         // daemon.status failed (connection dropped mid-flight) — the
         // reconnect cycle will re-trigger this effect.
@@ -363,7 +371,57 @@ export default function App({ client }: { client: Client }) {
     return () => {
       cancelled = true;
     };
-  }, [conn, bootNonce, client, openRoom]);
+  }, [conn, bootNonce, client]);
+
+  // -- route -> session -------------------------------------------------------
+
+  // Restore the last room, at most once, and only when the URL expressed no
+  // opinion. `/` is no opinion; `/rooms` is the Rooms destination and is
+  // honored as one — which is what keeps an explicit "Back to Rooms" from
+  // being undone by the next reconnect.
+  const initialPath = useRef(window.location.pathname);
+  const restored = useRef(false);
+  useEffect(() => {
+    if (phase !== 'ready' || restored.current) return;
+    restored.current = true;
+    if (initialPath.current !== '/') return;
+    const activeRooms = rooms.filter((r) => r.status !== 'left' && r.status !== 'removed');
+    if (activeRooms.length === 0) return;
+    let saved: string | null = null;
+    try {
+      saved = localStorage.getItem(LAST_ROOM_KEY);
+    } catch {
+      /* ignore */
+    }
+    const target = (saved && activeRooms.some((r) => r.room_id === saved) && saved) || activeRooms[0].room_id;
+    // A legacy `?tab=` link names a destination but no room; honor it on the
+    // room we restored, and let the redirect strip the key.
+    const dest = legacyTabDest(window.location.search) ?? 'activity';
+    // Two steps on purpose. `/` is replaced (the user never stood on it), but
+    // the restored room is *pushed* on top of Rooms — so Back leaves the room
+    // for the rooms list instead of leaving Jeliya. Restoring straight into
+    // the room with a replace would make the first Back press exit the app.
+    navigate({ kind: 'rooms' }, { replace: true });
+    navigate({ kind: 'room', roomId: target, dest });
+  }, [phase, rooms, navigate]);
+
+  // The open room follows the route, and this is the only place that opens
+  // one: a rail click, a fleet card, and a pasted URL all just navigate.
+  useEffect(() => {
+    if (phase !== 'ready') return;
+    const rid = routeRoomId(route);
+    if (rid === roomIdRef.current) return;
+    roomIdRef.current = rid;
+    setRoomId(rid);
+    resetRoomState();
+    if (rid === null) return;
+    // `phase === 'ready'` means room.list has answered, so an id that is not
+    // in it is genuinely not on this device — a recoverable state the render
+    // resolves, not a reason to call room.open and surface a daemon error.
+    const room = rooms.find((r) => r.room_id === rid);
+    if (!room || room.status === 'left' || room.status === 'removed') return;
+    void openRoom(rid);
+  }, [phase, route, rooms, openRoom, resetRoomState]);
 
   // -- names api ----------------------------------------------------------------
 
@@ -582,16 +640,10 @@ export default function App({ client }: { client: Client }) {
     }
   };
 
-  // The escape hatch from a room whose open failed: deselect it entirely so
-  // nothing renders under a room the daemon could not actually open — and
-  // forget it as the last room, or the next reload/reconnect would auto-open
-  // straight back into the same failure the user just walked away from.
-  const backToRooms = () => {
-    roomIdRef.current = null;
-    setRoomId(null);
-    setRoomError(null);
-    setRoomLoading(false);
-    setMobileView('rooms');
+  /** Forget the restored room. Both escapes below use it so that the next
+   *  load of `/` does not drop the user back into the room they just left —
+   *  the route effect handles clearing the session state itself. */
+  const forgetLastRoom = () => {
     try {
       localStorage.removeItem(LAST_ROOM_KEY);
     } catch {
@@ -599,30 +651,38 @@ export default function App({ client }: { client: Client }) {
     }
   };
 
+  // The escape hatch from a room whose open failed: navigating away is all it
+  // takes now — nothing can render under a room the route no longer names.
+  const backToRooms = () => {
+    forgetLastRoom();
+    navigate({ kind: 'rooms' });
+  };
+
   const leaveCurrentRoom = () => {
-    roomIdRef.current = null;
-    setRoomId(null);
-    setMembers([]);
-    setTimeline([]);
-    setFiles([]);
-    setPipes([]);
-    setPeers([]);
-    setEndpointAddr(null);
-    setRoomError(null);
-    setRoomLoading(false);
-    setFetches({});
-    setPipeConns({});
-    setClosingPipes(new Set());
-    setMobileView('rooms');
-    try {
-      localStorage.removeItem(LAST_ROOM_KEY);
-    } catch {
-      /* ignore */
-    }
+    forgetLastRoom();
+    navigate({ kind: 'rooms' });
     void refreshRooms();
     void client.call('daemon.status', {}).then(setStatus).catch(() => {
       /* transient */
     });
+  };
+
+  /** Room-row and fleet-card taps. Selecting a room is a navigation, not a
+   *  state write. */
+  const selectRoom = (rid: string) => {
+    const room = rooms.find((r) => r.room_id === rid);
+    if (room?.status === 'left' || room?.status === 'removed') {
+      navigate({ kind: 'rooms' });
+      return;
+    }
+    // Re-selecting the room whose open failed is the user's most instinctive
+    // retry. The route is already this room, so navigating is a no-op —
+    // honor the intent instead of ignoring the click.
+    if (rid === roomIdRef.current && roomError) {
+      void openRoom(rid);
+      return;
+    }
+    navigate({ kind: 'room', roomId: rid, dest: 'activity' });
   };
 
   const currentRoom = rooms.find((r) => r.room_id === roomId) ?? null;
@@ -661,47 +721,74 @@ export default function App({ client }: { client: Client }) {
     window.open(`${ISSUE_URL}?${params.toString()}`, '_blank', 'noopener,noreferrer');
   }, [copyDiagnostics]);
 
-  // -- primary navigation (desktop left rail + mobile bottom bar) ----------------
+  // -- derived navigation (all of it, from the route) ---------------------------
 
-  const activeNav: NavKey =
-    mobileView === 'settings'
-      ? 'settings'
-      : mobileView === 'agents'
-        ? 'agents'
-        : mobileView === 'pipes'
-          ? 'pipes'
-          : mobileView === 'files'
-            ? 'files'
-            : mobileView === 'chat'
-              ? 'home'
-              : 'rooms';
+  // A room route highlights Rooms: the workbench is somewhere you stand
+  // *inside* Rooms, not a fourth global destination.
+  const activeNav: NavKey = route.kind === 'fleet' ? 'fleet' : route.kind === 'settings' ? 'settings' : 'rooms';
 
-  // The one route from in-room actions to the Files/Pipes surfaces. Setting
-  // only the right-panel tab is invisible on compact (the panel is a hidden
-  // pane there) — the active pane must move with it, exactly as the primary
-  // navigation does, so pane, panel tab, and bottom bar can never contradict.
-  const openPanelTab = useCallback((which: 'files' | 'pipes', pipeId?: string) => {
-    setTab(which);
-    setMobileView(which);
-    setPipeFocus(which === 'pipes' ? (pipeId ?? null) : null);
-  }, []);
+  /** Which single surface the compact shell shows. Derived — so the bar, the
+   *  pane, and the inspector's own tab strip cannot disagree, because there is
+   *  nothing left for them to disagree *with*. */
+  const pane: 'rooms' | 'room' | 'inspector' | 'fleet' | 'settings' =
+    route.kind === 'rooms'
+      ? 'rooms'
+      : route.kind === 'fleet'
+        ? 'fleet'
+        : route.kind === 'settings'
+          ? 'settings'
+          : inspectorDest(route)
+            ? 'inspector'
+            : 'room';
 
-  const navigate = useCallback((key: NavKey) => {
-    if (key === 'agents') {
-      // Top-level fleet dashboard — distinct from the in-room Agents tab, which
-      // stays reachable via the right-panel tab strip.
-      setMobileView('agents');
-    } else if (key === 'pipes' || key === 'files') {
-      setTab(key);
-      setMobileView(key);
-    } else if (key === 'settings') {
-      setMobileView('settings');
-    } else if (key === 'home') {
-      setMobileView(roomIdRef.current ? 'chat' : 'rooms');
-    } else if (key === 'rooms') {
-      setMobileView('rooms');
-    }
-  }, []);
+  const inspector: InspectorDest | null = inspectorDest(route);
+  const roomDest: RoomDest = route.kind === 'room' ? route.dest : 'activity';
+
+  /** Tab counts — facts the daemon has answered with, so they are only shown
+   *  once it has. */
+  const roomNavCounts: Partial<Record<RoomDest, number>> = {
+    people: members.length,
+    agents: members.filter((m) => m.role === 'agent').length,
+    files: files.length,
+    pipes: pipes.filter((p) => p.state === 'open').length,
+  };
+
+  /** Navigate to a room tool. On compact this pushes a pane over the room; on
+   *  medium it opens the drawer; on wide it opens the column. One route, three
+   *  mechanics — and Back undoes it on all three. */
+  const openRoomDest = useCallback(
+    (dest: InspectorDest, pipeId?: string) => {
+      const rid = roomIdRef.current;
+      if (!rid) return;
+      setPipeFocus(dest === 'pipes' ? (pipeId ?? null) : null);
+      navigate({ kind: 'room', roomId: rid, dest });
+    },
+    [navigate],
+  );
+
+  /** Closing the inspector *is* navigating to Activity (decision 3). */
+  const closeInspector = useCallback(() => {
+    const rid = roomIdRef.current;
+    if (!rid) return;
+    navigate({ kind: 'room', roomId: rid, dest: 'activity' });
+  }, [navigate]);
+
+  /** The room nav's single handler: Activity closes the inspector, a tool
+   *  opens it, and both are the same navigation. */
+  const goToDest = useCallback(
+    (dest: RoomDest) => {
+      if (dest === 'activity') closeInspector();
+      else openRoomDest(dest);
+    },
+    [closeInspector, openRoomDest],
+  );
+
+  const navToGlobal = useCallback(
+    (key: NavKey) => {
+      navigate(key === 'fleet' ? { kind: 'fleet' } : key === 'settings' ? { kind: 'settings' } : { kind: 'rooms' });
+    },
+    [navigate],
+  );
 
   // -- render -----------------------------------------------------------------------
 
@@ -737,17 +824,24 @@ export default function App({ client }: { client: Client }) {
   return (
     <NamesContext.Provider value={names}>
       <div
-        className={`app mv-${mobileView}${activeNav === 'agents' ? ' app-fleet' : ''}${
-          activeNav === 'settings' ? ' app-settings' : ''
-        }`}
+        className={`app pane-${pane}${route.kind === 'fleet' ? ' app-fleet' : ''}${
+          route.kind === 'settings' ? ' app-settings' : ''
+        }${inspector ? ' inspector-open' : ''}`}
       >
-        {conn !== 'connected' ? (
-          <div className={`conn-banner conn-${conn}`} role="status">
-            {conn === 'reconnecting' || conn === 'connecting'
-              ? `Connection to daemon lost — reconnecting… (${client.describe()})`
-              : 'Disconnected from daemon.'}
-          </div>
-        ) : null}
+        {/* Reserved, not overlaid (decision 3): the banner is a grid row above
+            every pane, so it can never cover Back, a header, or list content.
+            One live region, announced once — `aria-live="polite"` on a node
+            that stays mounted, rather than a node that appears and re-announces
+            its whole content on every reconnect attempt. */}
+        <div className="conn-region" role="status" aria-live="polite">
+          {conn !== 'connected' ? (
+            <div className={`conn-banner conn-${conn}`}>
+              {conn === 'reconnecting' || conn === 'connecting'
+                ? `Connection to daemon lost — reconnecting… (${client.describe()})`
+                : 'Disconnected from daemon.'}
+            </div>
+          ) : null}
+        </div>
 
         <Sidebar
           rooms={rooms}
@@ -755,35 +849,67 @@ export default function App({ client }: { client: Client }) {
           status={status}
           conn={conn}
           activeNav={activeNav}
-          onNav={navigate}
-          onSelectRoom={(rid) => {
-            const room = rooms.find((r) => r.room_id === rid);
-            if (room?.status === 'left' || room?.status === 'removed') {
-              setMobileView('rooms');
-              return;
-            }
-            setMobileView('chat');
-            // Re-selecting the room whose open failed is the user's most
-            // instinctive retry — honor it instead of ignoring the click
-            // because the id is already selected.
-            if (rid !== roomId || roomError) void openRoom(rid);
-          }}
+          onNav={navToGlobal}
+          onSelectRoom={selectRoom}
           onCreateRoom={() => setCreateOpen(true)}
           onJoinRoom={() => setJoinOpen(true)}
         />
 
         <main className="center">
-          {currentRoom ? (
+          {roomId && !currentRoom ? (
+            // The route names a room room.list does not have. Not an error
+            // page and not a blank panel — say which fact is true, and offer
+            // the way out (decision 2).
+            <div className="room-error-surface">
+              <h2 className="room-gone-title">That room isn’t on this device</h2>
+              <p className="muted">
+                Nothing here matches <code className="mono">{shortId(roomId)}</code>. It may live on another device, or
+                you may not have joined it yet.
+              </p>
+              <div className="room-error-actions">
+                <button type="button" className="btn btn-primary" onClick={backToRooms}>
+                  Back to Rooms
+                </button>
+                <button type="button" className="btn btn-ghost" onClick={() => setJoinOpen(true)}>
+                  Join with a ticket
+                </button>
+              </div>
+            </div>
+          ) : currentRoom && (currentRoom.status === 'left' || currentRoom.status === 'removed') ? (
+            // A signed fact, so state it as one and do not open the room.
+            <div className="room-error-surface">
+              <h2 className="room-gone-title">
+                {currentRoom.status === 'left' ? 'You left this room' : 'You were removed from this room'}
+              </h2>
+              <p className="muted">
+                {currentRoom.status === 'left'
+                  ? 'Your departure is published to the room’s signed log. You’ll need a new invite to rejoin.'
+                  : 'Your removal is published to the room’s signed log. You’ll need a new invite to rejoin.'}
+              </p>
+              <div className="room-error-actions">
+                <button type="button" className="btn btn-primary" onClick={backToRooms}>
+                  Back to Rooms
+                </button>
+              </div>
+            </div>
+          ) : currentRoom ? (
             <>
               <RoomHeader
+                room={currentRoom}
                 name={currentRoom.name ?? 'Untitled room'}
-                memberCount={members.length || currentRoom.member_count}
                 members={members}
+                membersLoaded={!roomLoading && !roomError}
                 peers={peers}
+                compact={shell === 'compact'}
+                onBack={() => navigate({ kind: 'rooms' })}
                 onInvite={() => setInviteOpen(true)}
-                onShareFile={() => openPanelTab('files')}
-                onOpenPipe={() => openPanelTab('pipes')}
+                onShareFile={() => openRoomDest('files')}
+                onOpenPipe={() => openRoomDest('pipes')}
               />
+              {/* The room's nested navigation, under its header on every
+                  shell. Without it, People and Agents & Runs would have no
+                  entry point at all while the inspector is closed. */}
+              <RoomNav dest={roomDest} counts={roomNavCounts} onDest={goToDest} />
               {roomError ? (
                 // The open failed: the error owns the pane. Rendering the
                 // empty timeline ("No events yet") and a live composer under
@@ -826,7 +952,7 @@ export default function App({ client }: { client: Client }) {
                     onFetch={fetchFile}
                     onRecheckFiles={recheckFiles}
                     onRetryPendingMessage={retryPendingMessage}
-                    onShowPipes={(pipeId) => openPanelTab('pipes', pipeId)}
+                    onShowPipes={(pipeId) => openRoomDest('pipes', pipeId)}
                   />
                   <Composer
                     roomId={currentRoom.room_id}
@@ -843,16 +969,16 @@ export default function App({ client }: { client: Client }) {
           )}
         </main>
 
+        {/* The inspector is mounted only when the route opens it, and on
+            `activity` it is closed. It is a view of the route, so its tab
+            strip navigates rather than setting any state of its own. */}
+        {inspector ? (
         <RightPanel
-          tab={tab}
-          onTab={(next) => {
-            // The panel's own tab strip must keep the bottom navigation
-            // truthful on compact: switching to Files/Pipes there moves the
-            // active pane too (Members/Agents are sub-views of whichever
-            // pane is showing and have no bottom-nav destination).
-            if (next === 'files' || next === 'pipes') openPanelTab(next);
-            else setTab(next);
-          }}
+          tab={inspector}
+          onDest={goToDest}
+          counts={roomNavCounts}
+          onClose={closeInspector}
+          shell={shell}
           roomName={currentRoom?.name ?? null}
           members={members}
           timeline={timeline}
@@ -873,18 +999,10 @@ export default function App({ client }: { client: Client }) {
           onPipeExpose={pipeExpose}
           onLeaveRoom={() => setLeaveOpen(true)}
         />
+        ) : null}
 
-        {activeNav === 'agents' ? (
-          <FleetDashboard
-            client={client}
-            rooms={rooms}
-            onOpenRoom={(rid) => {
-              const room = rooms.find((r) => r.room_id === rid);
-              if (room?.status === 'left' || room?.status === 'removed') return;
-              setMobileView('chat');
-              if (rid !== roomId || roomError) void openRoom(rid);
-            }}
-          />
+        {route.kind === 'fleet' ? (
+          <FleetDashboard client={client} rooms={rooms} onOpenRoom={selectRoom} />
         ) : null}
 
         <SettingsPanel
@@ -897,7 +1015,10 @@ export default function App({ client }: { client: Client }) {
           onCreateRoom={() => setCreateOpen(true)}
         />
 
-        <MobileTabBar active={activeNav} onNav={navigate} />
+        {/* Inside a room the bar gives way to the room's own app bar — the
+            behavior mockups/mobile-triptych.png shows, and what buys the
+            timeline its height back on a 320x568 phone. Back returns to it. */}
+        {pane === 'room' || pane === 'inspector' ? null : <MobileTabBar active={activeNav} onNav={navToGlobal} />}
 
         {inviteOpen && roomId ? (
           <InviteModal
@@ -917,8 +1038,15 @@ export default function App({ client }: { client: Client }) {
             onClose={() => setCreateOpen(false)}
             onCreated={(rid) => {
               setCreateOpen(false);
-              void refreshRooms();
-              void openRoom(rid);
+              // Navigate; do not open. Opening here would write the room behind
+              // the route's back, and the route effect would then snap the
+              // session back to whichever room the URL still named.
+              //
+              // Refresh first, and await it: the route effect resolves a room
+              // against `rooms`, so naming one that room.list has not returned
+              // yet would flash "that room isn't on this device" at the user
+              // for the room they just made.
+              void refreshRooms().then(() => navigate({ kind: 'room', roomId: rid, dest: 'activity' }));
             }}
           />
         ) : null}
@@ -931,8 +1059,8 @@ export default function App({ client }: { client: Client }) {
             onClose={() => setJoinOpen(false)}
             onJoined={(rid) => {
               setJoinOpen(false);
-              void refreshRooms();
-              void openRoom(rid);
+              // See onCreated: refresh, then let the route open the room.
+              void refreshRooms().then(() => navigate({ kind: 'room', roomId: rid, dest: 'activity' }));
             }}
           />
         ) : null}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -109,6 +109,10 @@ export default function App({ client }: { client: Client }) {
 
   const [roomId, setRoomId] = useState<string | null>(null);
   const roomIdRef = useRef<string | null>(null);
+  // The room we have actually opened, distinct from the one the route selects:
+  // a route can name a room that has not synced into `rooms` yet. See the
+  // route → session effect.
+  const openedRef = useRef<string | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [timeline, setTimeline] = useState<TimelineEvent[]>([]);
   const timelineRef = useRef<TimelineEvent[]>([]);
@@ -407,19 +411,33 @@ export default function App({ client }: { client: Client }) {
 
   // The open room follows the route, and this is the only place that opens
   // one: a rail click, a fleet card, and a pasted URL all just navigate.
+  //
+  // `openedRef` tracks the room we have actually called room.open for, which
+  // is NOT the same as the room the route selects. A deep link (or a
+  // create/join whose refreshRooms was swallowed by a reconnect) can name a
+  // room that room.list has not returned yet; we select it — the render shows
+  // the recoverable "not on this device" state — but do not open it. When the
+  // room later syncs into `rooms`, this effect reruns and must retry the open.
+  // Guarding on `roomIdRef` alone would skip that retry (the id already
+  // matches) and strand the user on an unopened room.
   useEffect(() => {
     if (phase !== 'ready') return;
     const rid = routeRoomId(route);
-    if (rid === roomIdRef.current) return;
-    roomIdRef.current = rid;
-    setRoomId(rid);
-    resetRoomState();
+    if (rid !== roomIdRef.current) {
+      roomIdRef.current = rid;
+      setRoomId(rid);
+      resetRoomState();
+      openedRef.current = null;
+    }
     if (rid === null) return;
     // `phase === 'ready'` means room.list has answered, so an id that is not
-    // in it is genuinely not on this device — a recoverable state the render
-    // resolves, not a reason to call room.open and surface a daemon error.
+    // in it is genuinely not on this device (yet) — a recoverable state the
+    // render resolves, not a reason to call room.open and surface a daemon
+    // error. If it appears later, the rerun opens it.
     const room = rooms.find((r) => r.room_id === rid);
     if (!room || room.status === 'left' || room.status === 'removed') return;
+    if (openedRef.current === rid) return;
+    openedRef.current = rid;
     void openRoom(rid);
   }, [phase, route, rooms, openRoom, resetRoomState]);
 
@@ -730,6 +748,17 @@ export default function App({ client }: { client: Client }) {
   /** Which single surface the compact shell shows. Derived — so the bar, the
    *  pane, and the inspector's own tab strip cannot disagree, because there is
    *  nothing left for them to disagree *with*. */
+  // A room route to a room room.list does not have — a deep link that hasn't
+  // synced, or a room this identity left. Its recovery surface (below) lives
+  // in `.center`, so the pane must stay `room` even when the route names a
+  // tool: an `inspector` pane would hide `.center` on compact and strand the
+  // user in an empty tool with no visible way out — and let file/pipe actions
+  // fire against a room that isn't open.
+  const roomUnavailable =
+    roomId !== null && (!currentRoom || currentRoom.status === 'left' || currentRoom.status === 'removed');
+
+  const inspector: InspectorDest | null = roomUnavailable ? null : inspectorDest(route);
+
   const pane: 'rooms' | 'room' | 'inspector' | 'fleet' | 'settings' =
     route.kind === 'rooms'
       ? 'rooms'
@@ -737,11 +766,9 @@ export default function App({ client }: { client: Client }) {
         ? 'fleet'
         : route.kind === 'settings'
           ? 'settings'
-          : inspectorDest(route)
+          : inspector
             ? 'inspector'
             : 'room';
-
-  const inspector: InspectorDest | null = inspectorDest(route);
   const roomDest: RoomDest = route.kind === 'room' ? route.dest : 'activity';
 
   /** Tab counts — facts the daemon has answered with, so they are only shown
@@ -906,10 +933,17 @@ export default function App({ client }: { client: Client }) {
                 onShareFile={() => openRoomDest('files')}
                 onOpenPipe={() => openRoomDest('pipes')}
               />
-              {/* The room's nested navigation, under its header on every
-                  shell. Without it, People and Agents & Runs would have no
-                  entry point at all while the inspector is closed. */}
-              <RoomNav dest={roomDest} counts={roomNavCounts} onDest={goToDest} />
+              {/* The room's nested navigation, under its header. Exactly one
+                  strip is ever live: the workspace carries it on wide (where
+                  the inspector is a column beside it) and whenever the
+                  inspector is closed; when the inspector is open on compact or
+                  medium it carries its own, and this one stands down. Two live
+                  strips would duplicate the `room-tab-*` ids, and the roving-
+                  tabindex keyboard handler's getElementById would move focus
+                  into the hidden copy. */}
+              {shell === 'wide' || !inspector ? (
+                <RoomNav dest={roomDest} counts={roomNavCounts} onDest={goToDest} />
+              ) : null}
               {roomError ? (
                 // The open failed: the error owns the pane. Rendering the
                 // empty timeline ("No events yet") and a live composer under

--- a/ui/src/components/FleetDashboard.tsx
+++ b/ui/src/components/FleetDashboard.tsx
@@ -503,19 +503,28 @@ export function FleetDashboard({
 
   const filters: { key: FleetFilter; label: string }[] = [
     { key: 'all', label: 'All' },
-    { key: 'active', label: 'Active' },
+    // This filter is `working || online-idle` — an agent whose peer is
+    // reachable. "Live" says that; "Active" said it in a word the room rail
+    // used for a local session and the wire uses for signed membership
+    // (docs/room-workbench.md, decision 4).
+    { key: 'active', label: 'Live' },
     { key: 'needs-attention', label: 'Needs attention' },
     { key: 'working', label: 'Working' },
     { key: 'offline', label: 'Offline' },
   ];
 
   return (
-    <section className="fleet-view" aria-label="Agents fleet">
+    <section className="fleet-view" aria-label="Agent Fleet">
       <header className="fleet-head">
         <div className="fleet-head-top">
           <div className="fleet-title">
             <TreeMark size={26} />
-            <h1>Agents</h1>
+            {/* The destination is named once (docs/room-workbench.md,
+                decision 1). A rail entry reading "Agent Fleet" that opens a
+                page titled "Agents" leaves the user to guess whether this is
+                the same place as a room's "Agents & Runs" — the exact
+                collision the record exists to remove. */}
+            <h1>Agent Fleet</h1>
           </div>
           <div className="fleet-head-actions">
             <input

--- a/ui/src/components/MobileTabBar.tsx
+++ b/ui/src/components/MobileTabBar.tsx
@@ -1,13 +1,16 @@
 import type { NavKey } from './Sidebar';
 
-/** Bottom tab bar shown only on narrow (mobile) viewports — mirrors
- *  mockups/mobile-*.png (Rooms / Agents / Pipes / Files / Settings). It drives
- *  the same navigation state as the desktop left rail. */
+/** The compact bottom bar carries the global destinations and nothing else
+ *  (docs/room-workbench.md, decision 3).
+ *
+ *  It used to carry Pipes and Files as tabs, which made a room-scoped tool
+ *  look like a place you could stand without a room — and let the bar, the
+ *  visible pane, and the panel's own tab strip disagree about where you were.
+ *  Room tools are reached by entering a room; inside one, this bar gives way
+ *  to the room's app bar (the behavior mockups/mobile-triptych.png shows). */
 const TABS: { key: NavKey; label: string; glyph: string }[] = [
   { key: 'rooms', label: 'Rooms', glyph: '▦' },
-  { key: 'agents', label: 'Agents', glyph: '✦' },
-  { key: 'pipes', label: 'Pipes', glyph: '⤳' },
-  { key: 'files', label: 'Files', glyph: '▤' },
+  { key: 'fleet', label: 'Agent Fleet', glyph: '✦' },
   { key: 'settings', label: 'Settings', glyph: '⚙' },
 ];
 
@@ -15,9 +18,7 @@ export function MobileTabBar({ active, onNav }: { active: NavKey; onNav(key: Nav
   return (
     <nav className="mobile-tabbar" aria-label="Primary (mobile)">
       {TABS.map((tab) => {
-        // The chat sub-view lives under the Rooms tab, so keep Rooms highlighted
-        // while a room is open.
-        const on = active === tab.key || (tab.key === 'rooms' && (active === 'home' || active === 'calls'));
+        const on = active === tab.key;
         return (
           <button
             key={tab.key}

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { DaemonErrorShape, FileEntry, Member, PipeEntry, TimelineEvent } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
 import { extOf, fileTint, formatBytes, formatTime, labelTone, prettyLabel } from '../lib/format';
+import type { InspectorDest, RoomDest } from '../lib/routes';
+import type { Shell } from '../lib/shell';
+import { RoomNav } from './RoomNav';
 import { useNames } from './names';
 import { Avatar, ErrorNote, FetchControl, FetchDetail, ProgressBar, SenderName } from './ui';
 import type { FetchAvailability, FetchState } from './ui';
 
-export type PanelTab = 'members' | 'agents' | 'files' | 'pipes';
+/** The inspector renders one room tool, and which one is the route's job
+ *  (docs/room-workbench.md, decision 3) — so the tab strip is a view of
+ *  `InspectorDest`, never a second place navigation state can live. */
+export type PanelTab = InspectorDest;
 
 export type PipeConnState =
   | { phase: 'connecting' }
@@ -35,8 +40,25 @@ function statusTone(status: string): 'active' | 'invited' | 'left' | 'removed' |
   return 'unknown';
 }
 
+/** Signed roster status, as a label (docs/room-workbench.md, decision 4).
+ *
+ *  This used to title-case the wire value, which rendered the roster's
+ *  `active` as "Active" — the same word the room rail used for a live local
+ *  session, and the collision the record exists to remove. Display labels and
+ *  wire values are never the same constant (docs/i18n.md, rule 3). */
 function displayStatus(status: string): string {
-  return status ? status.charAt(0).toUpperCase() + status.slice(1) : 'Unknown';
+  switch (status) {
+    case 'active':
+      return 'Member';
+    case 'invited':
+      return 'Invited';
+    case 'left':
+      return 'Left';
+    case 'removed':
+      return 'Removed';
+    default:
+      return 'Unknown';
+  }
 }
 
 function displayRole(role: Member['role']): string {
@@ -80,13 +102,16 @@ function MembersTab({
       <section className="members-summary" aria-label="Room members summary">
         <div className="members-summary-copy">
           <h2>
-            {members.length} room member{members.length === 1 ? '' : 's'}
+            {members.length} in the roster
           </h2>
           <p>Roster from the signed room history. Statuses reflect membership events, not live peer reachability.</p>
         </div>
         <dl className="member-stats" aria-label="Member counts">
           <div>
-            <dt>Active</dt>
+            {/* The roster holds everyone with a membership event; only some of
+                them are currently members. Calling the whole list "members"
+                and this count "active" made the two disagree by construction. */}
+            <dt>Members</dt>
             <dd>{activeCount}</dd>
           </div>
           <div>
@@ -104,7 +129,9 @@ function MembersTab({
 
       <div className="members-section-head">
         <h3>Room roster</h3>
-        <span>{activeCount} active</span>
+        <span>
+          {activeCount} member{activeCount === 1 ? '' : 's'}
+        </span>
       </div>
 
       {sorted.map((member) => {
@@ -583,8 +610,10 @@ function PipesTab({
                 ⤳
               </span>
               <strong className="mono">{pipe.target}</strong>
+              {/* Pipe connection, and only that (decision 4): exposed with a
+                  live forwarding session, exposed with none, or closed. */}
               <span className={`chip chip-state state-${pipe.state}`}>
-                {pipe.state === 'open' ? (pipe.connected ? 'Active' : 'Open') : 'Closed'}
+                {pipe.state === 'open' ? (pipe.connected ? 'Connected' : 'Open') : 'Closed'}
               </span>
             </div>
             <div className="pipe-row-meta muted">
@@ -677,13 +706,12 @@ function PipesTab({
 
 // -- panel shell -----------------------------------------------------------------
 
-function tabCountLabel(count: number): string {
-  return count > 99 ? '99+' : String(count);
-}
-
 export function RightPanel({
   tab,
-  onTab,
+  onDest,
+  counts,
+  onClose,
+  shell,
   roomName,
   members,
   timeline,
@@ -705,7 +733,16 @@ export function RightPanel({
   onLeaveRoom,
 }: {
   tab: PanelTab;
-  onTab(tab: PanelTab): void;
+  /** Compact renders the room nav inside this panel, so it needs the same
+   *  inputs the workspace strip gets. */
+  onDest(dest: RoomDest): void;
+  counts: Partial<Record<RoomDest, number>>;
+  /** Close the inspector — which is navigating to the room's Activity
+   *  (docs/room-workbench.md, decision 3), not a local visibility toggle. */
+  onClose(): void;
+  /** Medium floats this over the workspace as a dismissible drawer; wide
+   *  places it in flow as a column; compact gives it the whole pane. */
+  shell: Shell;
   roomName?: string | null;
   members: Member[];
   timeline: TimelineEvent[];
@@ -726,60 +763,39 @@ export function RightPanel({
   onPipeExpose(target: string, peerIdentity: string): Promise<void>;
   onLeaveRoom(): void;
 }) {
-  const agentCount = members.filter((m) => m.role === 'agent').length;
-  const openPipes = pipes.filter((p) => p.state === 'open').length;
-
-  const tabs: { id: PanelTab; label: string; count: number }[] = [
-    { id: 'members', label: 'Members', count: members.length },
-    { id: 'agents', label: 'Agents', count: agentCount },
-    { id: 'files', label: 'Files', count: files.length },
-    { id: 'pipes', label: 'Pipes', count: openPipes },
-  ];
-
-  // Full ARIA tabs keyboard pattern: arrow keys move between tabs (a single tab
-  // stop via roving tabindex), Home/End jump to the ends. Without this the tab
-  // roles would announce a pattern that does not actually work.
-  const onTabsKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
-    const idx = tabs.findIndex((t) => t.id === tab);
-    let next = idx;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % tabs.length;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + tabs.length) % tabs.length;
-    else if (e.key === 'Home') next = 0;
-    else if (e.key === 'End') next = tabs.length - 1;
-    else return;
-    e.preventDefault();
-    onTab(tabs[next].id);
-    document.getElementById(`panel-tab-${tabs[next].id}`)?.focus();
-  };
-
   return (
-    <aside className="right-panel">
-      {/* Mobile-only: on the standalone Files/Pipes tab this panel is the whole
-          screen and RoomHeader (which normally carries the room name) is off in
-          the hidden `.center` pane, so without this a multi-room user has no way
-          to tell which room they're looking at. Not aria-hidden — this is the
-          only place the room name reaches the accessible tree in that view. */}
-      {roomName ? <div className="panel-room-context">{roomName}</div> : null}
-      <div className="panel-tabs" role="tablist" aria-label="Room panel" onKeyDown={onTabsKeyDown}>
-        {tabs.map((t) => (
-          <button
-            key={t.id}
-            type="button"
-            role="tab"
-            id={`panel-tab-${t.id}`}
-            aria-selected={tab === t.id}
-            aria-controls="panel-body"
-            tabIndex={tab === t.id ? 0 : -1}
-            className={tab === t.id ? 'active' : ''}
-            onClick={() => onTab(t.id)}
-          >
-            <span className="panel-tab-label">{t.label}</span>
-            {t.count > 0 ? <span className="count">{tabCountLabel(t.count)}</span> : null}
+    <aside className={`right-panel${shell === 'medium' ? ' right-panel-drawer' : ''}`}>
+      {/* The room stays named on every room-scoped surface (decision 3). On
+          compact this panel IS the screen and the room header is off in the
+          hidden `.center` pane; on medium it floats over the workspace. Not
+          aria-hidden — on compact this is the only place the room name reaches
+          the accessible tree. */}
+      <div className="panel-head">
+        {/* One navigation, three affordances. Compact needs a Back of its own:
+            this panel is the whole screen there and the bottom bar is gone, so
+            without it the only way out would be the browser's own Back — which
+            an installed PWA does not show. */}
+        {shell === 'compact' ? (
+          <button type="button" className="icon-btn panel-back" onClick={onClose} aria-label="Back to Activity">
+            <span aria-hidden="true">‹</span>
           </button>
-        ))}
+        ) : null}
+        {roomName ? <div className="panel-room-context">{roomName}</div> : <span />}
+        {shell !== 'compact' ? (
+          <button type="button" className="icon-btn panel-close" onClick={onClose} aria-label="Close inspector">
+            <span aria-hidden="true">×</span>
+          </button>
+        ) : null}
       </div>
-      <div className="panel-body" id="panel-body" role="tabpanel" aria-labelledby={`panel-tab-${tab}`}>
-        {tab === 'members' ? <MembersTab members={members} selfId={selfId} onLeaveRoom={onLeaveRoom} /> : null}
+      {/* Whenever this panel covers the workspace — the whole pane on compact,
+          a drawer on medium — it owes the room's nav, because the workspace's
+          copy is underneath it. Only on wide, where the panel opens beside the
+          workspace rather than over it, does the workspace keep the strip and
+          this render nothing: two tablists for one room would be two tablists
+          in the a11y tree. */}
+      {shell !== 'wide' ? <RoomNav dest={tab} counts={counts} onDest={onDest} /> : null}
+      <div className="panel-body" id="panel-body" role="tabpanel" aria-labelledby={`room-tab-${tab}`}>
+        {tab === 'people' ? <MembersTab members={members} selfId={selfId} onLeaveRoom={onLeaveRoom} /> : null}
         {tab === 'agents' ? <AgentsTab members={members} timeline={timeline} /> : null}
         {tab === 'files' ? (
           <FilesTab

--- a/ui/src/components/RoomHeader.tsx
+++ b/ui/src/components/RoomHeader.tsx
@@ -1,4 +1,5 @@
-import type { Member, PeerStatus } from '../lib/protocol';
+import { useState } from 'react';
+import type { Member, PeerStatus, RoomSummary } from '../lib/protocol';
 import { shortId } from '../lib/format';
 import { useNames } from './names';
 
@@ -19,49 +20,161 @@ function PeerChip({ peer }: { peer: PeerStatus }) {
   );
 }
 
+/** What the daemon's peer list actually proves (docs/room-workbench.md,
+ *  decision 4). Peer reachability is an observed transport path and nothing
+ *  more: it is not presence, and it is not who is in the room.
+ *
+ *  "Alone in this room" used to render here whenever zero connections were
+ *  observed — including in a five-member room whose peers are merely offline.
+ *  Absence of an observed connection is not evidence of solitude. */
+function peerSummary(peers: PeerStatus[]): { dot: 'dot-green' | 'dot-neutral' | null; label: string } {
+  const connected = peers.filter((p) => p.state === 'connected');
+  if (connected.some((p) => p.path === 'direct')) return { dot: 'dot-green', label: 'Direct' };
+  // Connected, just not on the path we would prefer. Amber, and never hidden.
+  if (connected.length > 0) return { dot: null, label: 'Relay' };
+  if (peers.some((p) => p.state === 'connecting')) return { dot: 'dot-neutral', label: 'Connecting…' };
+  return { dot: 'dot-neutral', label: 'No peers connected' };
+}
+
 export function RoomHeader({
+  room,
   name,
-  memberCount,
   members,
+  membersLoaded,
   peers,
+  compact,
+  onBack,
   onInvite,
   onShareFile,
   onOpenPipe,
 }: {
+  /** The room's list row — its short id disambiguates homonyms, and its
+   *  member_count is the only count available before the roster loads. */
+  room: RoomSummary;
   name: string;
-  memberCount: number;
   members: Member[];
+  /** Whether `room.members` has answered. The roster count may not be shown
+   *  before it has: the old header substituted the room's *total* count under
+   *  an "N active" label, asserting a fact it did not have. */
+  membersLoaded: boolean;
   peers: PeerStatus[];
+  /** Compact renders the app bar form (#61): Back, a single-line title, the
+   *  connectivity summary, Invite, and an overflow disclosure — under 150px
+   *  at 320x568 so the timeline keeps at least 180px above the composer. */
+  compact?: boolean;
+  onBack(): void;
   onInvite(): void;
   onShareFile(): void;
   onOpenPipe(): void;
 }) {
-  const activeCount = members.length > 0 ? members.filter((m) => m.status === 'active').length : memberCount;
+  const [infoOpen, setInfoOpen] = useState(false);
+  const memberCount = members.filter((m) => m.status === 'active').length;
   const invitedCount = members.filter((m) => m.status === 'invited').length;
   const agentCount = members.filter((m) => m.role === 'agent').length;
-  const connected = peers.filter((p) => p.state === 'connected');
-  const hasDirect = connected.some((p) => p.path === 'direct');
-  // Three honest states: nobody here, a live direct link, or relay-only
-  // (still connected, just not the path we'd prefer). A room with peers that
-  // are merely connecting/offline reads as the same "alone" state — there's
-  // no live link to call peer-to-peer yet either way.
-  const p2p =
-    peers.length === 0
-      ? { dot: 'dot-neutral', label: 'Alone in this room' }
-      : hasDirect
-        ? { dot: 'dot-green', label: 'Peer-to-Peer' }
-        : connected.length > 0
-          ? { dot: null, label: 'Relay only' } // amber: no dedicated CSS class, see inline style below
-          : { dot: 'dot-neutral', label: 'Alone in this room' };
+  const p2p = peerSummary(peers);
+
+  const p2pBadge = (
+    <span className="p2p-badge">
+      <span className={p2p.dot ? `dot ${p2p.dot}` : 'dot'} style={p2p.dot ? undefined : { color: 'var(--amber)' }} />{' '}
+      {p2p.label}
+    </span>
+  );
+
+  if (compact) {
+    return (
+      <header className="room-header room-appbar">
+        <div className="appbar-row">
+          <button type="button" className="icon-btn appbar-back" onClick={onBack} aria-label="Back to Rooms">
+            <span aria-hidden="true">‹</span>
+          </button>
+          <div className="appbar-title">
+            <h1 title={name}>{name}</h1>
+            <div className="appbar-sub">
+              {membersLoaded ? (
+                <span>
+                  {memberCount} member{memberCount === 1 ? '' : 's'}
+                </span>
+              ) : (
+                <span className="muted">Loading…</span>
+              )}
+              <span className="sep">|</span>
+              {p2pBadge}
+            </div>
+          </div>
+          <button type="button" className="btn btn-primary appbar-invite" onClick={onInvite}>
+            Invite
+          </button>
+          {/* Peer paths are diagnostic detail, not app-bar chrome: on a 320px
+              phone the chip strip is what pushed the timeline under 180px.
+              Behind a disclosure it stays reachable and stops competing. */}
+          <button
+            type="button"
+            className="icon-btn appbar-more"
+            aria-expanded={infoOpen}
+            aria-label="Room information"
+            onClick={() => setInfoOpen((open) => !open)}
+          >
+            <span aria-hidden="true">⋮</span>
+          </button>
+        </div>
+        {infoOpen ? (
+          <div className="appbar-info">
+            <dl className="room-info-facts">
+              <dt>Room</dt>
+              <dd className="mono">{shortId(room.room_id)}</dd>
+              <dt>Session</dt>
+              <dd>{room.open ? 'Open' : 'Closed'}</dd>
+              {agentCount > 0 ? (
+                <>
+                  <dt>Agents</dt>
+                  <dd>{agentCount}</dd>
+                </>
+              ) : null}
+              {invitedCount > 0 ? (
+                <>
+                  <dt>Invites</dt>
+                  <dd>{invitedCount} pending</dd>
+                </>
+              ) : null}
+            </dl>
+            {peers.length > 0 ? (
+              <div className="peer-strip" role="group" aria-label="Peer connections">
+                {peers.map((p) => (
+                  <PeerChip key={p.endpoint_id} peer={p} />
+                ))}
+              </div>
+            ) : (
+              <p className="muted room-info-empty">No peers connected.</p>
+            )}
+            <div className="appbar-info-actions">
+              <button type="button" className="btn" onClick={onShareFile}>
+                <span aria-hidden="true">⎘</span> Share File
+              </button>
+              <button type="button" className="btn" onClick={onOpenPipe}>
+                <span aria-hidden="true">⤳</span> Open Pipe
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </header>
+    );
+  }
+
   return (
     <header className="room-header">
       <div className="room-header-top">
         <div className="room-title">
           <h1>{name}</h1>
           <div className="room-subtitle">
-            <span>
-              {activeCount} active
-            </span>
+            {membersLoaded ? (
+              <span>
+                {memberCount} member{memberCount === 1 ? '' : 's'}
+              </span>
+            ) : (
+              // The roster has not answered. The room's total member_count is a
+              // different fact and cannot stand in for it under this label.
+              <span className="muted">Loading members…</span>
+            )}
             {agentCount > 0 ? (
               <>
                 <span className="sep">|</span>
@@ -79,13 +192,7 @@ export function RoomHeader({
               </>
             ) : null}
             <span className="sep">|</span>
-            <span className="p2p-badge">
-              <span
-                className={p2p.dot ? `dot ${p2p.dot}` : 'dot'}
-                style={p2p.dot ? undefined : { color: 'var(--amber)' }}
-              />{' '}
-              {p2p.label}
-            </span>
+            {p2pBadge}
           </div>
         </div>
         <div className="room-actions">

--- a/ui/src/components/RoomHeader.tsx
+++ b/ui/src/components/RoomHeader.tsx
@@ -31,7 +31,13 @@ function peerSummary(peers: PeerStatus[]): { dot: 'dot-green' | 'dot-neutral' | 
   const connected = peers.filter((p) => p.state === 'connected');
   if (connected.some((p) => p.path === 'direct')) return { dot: 'dot-green', label: 'Direct' };
   // Connected, just not on the path we would prefer. Amber, and never hidden.
-  if (connected.length > 0) return { dot: null, label: 'Relay' };
+  if (connected.some((p) => p.path === 'relay')) return { dot: null, label: 'Relay' };
+  // `path` is nullable while `state` is already `connected`: the SDK knows the
+  // peer is reachable before it knows how. Falling through to Relay here —
+  // which is what a bare `connected.length > 0` did — would invent the exact
+  // fact (direct vs relay) the honesty rules exist to protect. Green is
+  // earned, the link is real; the path is simply not claimed until it is known.
+  if (connected.length > 0) return { dot: 'dot-green', label: 'Connected' };
   if (peers.some((p) => p.state === 'connecting')) return { dot: 'dot-neutral', label: 'Connecting…' };
   return { dot: 'dot-neutral', label: 'No peers connected' };
 }

--- a/ui/src/components/RoomNav.tsx
+++ b/ui/src/components/RoomNav.tsx
@@ -1,0 +1,81 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { ROOM_DESTS } from '../lib/routes';
+import type { RoomDest } from '../lib/routes';
+
+function tabCountLabel(count: number): string {
+  return count > 99 ? '99+' : String(count);
+}
+
+/** The room's nested navigation — one model, every shell
+ *  (docs/room-workbench.md, decisions 1 and 3).
+ *
+ *  Activity is a tab like the others because it is a destination like the
+ *  others: it is the room with no tool open. That is what lets "close the
+ *  inspector" and "go to Activity" be the same navigation instead of two
+ *  mechanisms that can disagree.
+ *
+ *  Whoever the room's tool surface is, carries this strip. On wide the tool
+ *  opens *beside* the workspace, so the workspace keeps it. On medium and
+ *  compact the tool covers the workspace — as a drawer or as the whole pane —
+ *  so the tool carries it instead, and the workspace's copy is hidden rather
+ *  than left buried under the drawer where it would still be in the
+ *  accessibility tree, still report aria-selected, and still swallow clicks
+ *  into whatever floats on top of it.
+ */
+export function RoomNav({
+  dest,
+  counts,
+  onDest,
+}: {
+  dest: RoomDest;
+  counts: Partial<Record<RoomDest, number>>;
+  onDest(dest: RoomDest): void;
+}) {
+  const labels: Record<RoomDest, string> = {
+    activity: 'Activity',
+    people: 'People',
+    agents: 'Agents & Runs',
+    files: 'Files',
+    pipes: 'Pipes',
+  };
+
+  // Full ARIA tabs keyboard pattern: arrows move between tabs (one tab stop via
+  // roving tabindex), Home/End jump to the ends. Without this the tab roles
+  // would announce a pattern that does not actually work.
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    const idx = ROOM_DESTS.indexOf(dest);
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % ROOM_DESTS.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + ROOM_DESTS.length) % ROOM_DESTS.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = ROOM_DESTS.length - 1;
+    else return;
+    e.preventDefault();
+    onDest(ROOM_DESTS[next]);
+    document.getElementById(`room-tab-${ROOM_DESTS[next]}`)?.focus();
+  };
+
+  return (
+    <div className="panel-tabs room-nav" role="tablist" aria-label="Room tools" onKeyDown={onKeyDown}>
+      {ROOM_DESTS.map((d) => {
+        const count = counts[d];
+        return (
+          <button
+            key={d}
+            type="button"
+            role="tab"
+            id={`room-tab-${d}`}
+            aria-selected={dest === d}
+            aria-controls="panel-body"
+            tabIndex={dest === d ? 0 : -1}
+            className={dest === d ? 'active' : ''}
+            onClick={() => onDest(d)}
+          >
+            <span className="panel-tab-label">{labels[d]}</span>
+            {count !== undefined && count > 0 ? <span className="count">{tabCountLabel(count)}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -10,17 +10,17 @@ const CONN_LABEL: Record<ConnectionState, string> = {
   disconnected: 'Disconnected',
 };
 
-/** Primary navigation section — mirrors the left rail in desktop-room.png and
- *  the bottom tab bar in the mobile mockups. */
-export type NavKey = 'home' | 'rooms' | 'agents' | 'pipes' | 'files' | 'calls' | 'settings';
+/** The global destinations — the only three (docs/room-workbench.md,
+ *  decision 1). Files and Pipes left this rail because neither can answer a
+ *  question without a room_id: they were always secretly about one room,
+ *  chosen elsewhere, and now live in the room's own workbench. Home went
+ *  because it duplicated Rooms, and Calls because a destination that only
+ *  says "Soon" is a promise the product has not earned. */
+export type NavKey = 'rooms' | 'fleet' | 'settings';
 
-const NAV: { key: NavKey; label: string; glyph: string; soon?: boolean }[] = [
-  { key: 'home', label: 'Home', glyph: '⌂' },
+const NAV: { key: NavKey; label: string; glyph: string }[] = [
   { key: 'rooms', label: 'Rooms', glyph: '▦' },
-  { key: 'agents', label: 'Agents', glyph: '✦' },
-  { key: 'pipes', label: 'Pipes', glyph: '⤳' },
-  { key: 'files', label: 'Files', glyph: '▤' },
-  { key: 'calls', label: 'Calls', glyph: '☎', soon: true },
+  { key: 'fleet', label: 'Agent Fleet', glyph: '✦' },
   { key: 'settings', label: 'Settings', glyph: '⚙' },
 ];
 
@@ -88,14 +88,12 @@ export function Sidebar({
             type="button"
             className={`nav-item${activeNav === item.key ? ' active' : ''}`}
             aria-current={activeNav === item.key ? 'page' : undefined}
-            disabled={item.soon}
             onClick={() => onNav(item.key)}
           >
             <span className="nav-glyph" aria-hidden="true">
               {item.glyph}
             </span>
             <span className="nav-label">{item.label}</span>
-            {item.soon ? <span className="nav-soon">Soon</span> : null}
           </button>
         ))}
       </nav>
@@ -112,7 +110,17 @@ export function Sidebar({
           const tint = colorForId(room.room_id);
           const active = room.room_id === currentRoomId;
           const departed = room.status === 'left' || room.status === 'removed';
-          const stateLabel = departed ? (room.status === 'left' ? 'Left' : 'Removed') : room.open ? 'Active' : 'Idle';
+          // One label, one fact (docs/room-workbench.md, decision 4). `status`
+          // is signed membership; `open` is whether this daemon holds a live
+          // session. "Active" used to mean the latter here while meaning the
+          // former on the wire — so it is gone.
+          const stateLabel = departed
+            ? room.status === 'left'
+              ? 'Left'
+              : 'Removed'
+            : room.open
+              ? 'Open'
+              : 'Closed';
           return (
             <button
               key={room.room_id}

--- a/ui/src/lib/history.ts
+++ b/ui/src/lib/history.ts
@@ -1,0 +1,60 @@
+/** The History API binding for the canonical route (docs/room-workbench.md,
+ *  decision 2). Deliberately hand-rolled: the app's entire runtime dependency
+ *  set is react + react-dom, and adding a router library is a decision this
+ *  record explicitly declines to make for ~60 lines of pushState.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { parseRoute, routePath, searchWithoutLegacyTab } from './routes';
+import type { Route } from './routes';
+
+export type NavigateOptions = {
+  /** Replace the current entry instead of pushing one. Use for corrections the
+   *  user did not perform — canonicalizing `/` to `/rooms`, restoring the last
+   *  room at boot — so Back never walks through a state they never saw. */
+  replace?: boolean;
+};
+
+export type Navigate = (route: Route, options?: NavigateOptions) => void;
+
+/** Build the full URL for a route, preserving the query and fragment.
+ *
+ *  Preserving `search` is a contract, not a nicety: `?daemon=` selects the
+ *  daemon and `?mock…` installs the e2e fixtures. A redirect that dropped it
+ *  would point the client at a different daemon and silently unfixture the
+ *  suite — which passes, for the wrong reason. `?tab=` is the one key we
+ *  consume, and only once it has been migrated onto a route. */
+function urlFor(route: Route): string {
+  const search = searchWithoutLegacyTab(window.location.search);
+  return `${routePath(route)}${search}${window.location.hash}`;
+}
+
+/** Subscribe to the canonical route.
+ *
+ *  `popstate` covers Back/Forward; pushState/replaceState do not fire it, so
+ *  navigate() updates the subscriber itself. */
+export function useRoute(): [Route, Navigate] {
+  const [pathname, setPathname] = useState(() => window.location.pathname);
+
+  useEffect(() => {
+    const onPopState = () => setPathname(window.location.pathname);
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const route = useMemo(() => parseRoute(pathname), [pathname]);
+
+  const navigate = useCallback<Navigate>((next, options) => {
+    const url = urlFor(next);
+    const path = routePath(next);
+    // Re-navigating to the route we are already on must not push a duplicate
+    // entry — otherwise Back becomes a no-op the user has to press twice.
+    // A replace still runs: it is how a legacy `?tab=` link gets rewritten.
+    if (path === window.location.pathname && !options?.replace) return;
+    if (options?.replace) window.history.replaceState(null, '', url);
+    else window.history.pushState(null, '', url);
+    setPathname(path);
+  }, []);
+
+  return [route, navigate];
+}

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -470,6 +470,11 @@ class MockClient implements Client {
         'member',
         'Tokens v2 exploration lives here.',
       );
+      // Connected-but-unknown-path fixture: PeerStatus.path is nullable while
+      // state is already `connected` — the SDK knows a peer is reachable
+      // before it knows how. The header must say "Connected" and never guess
+      // `relay`, which is what a `connected.length > 0` fallthrough did.
+      design.peers = design.peers.map((p) => ({ ...p, state: 'connected' as const, path: null }));
       const research = buildSideRoom(
         'research-lab',
         'Research Lab',

--- a/ui/src/lib/routes.test.ts
+++ b/ui/src/lib/routes.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inspectorDest,
+  legacyTabDest,
+  parseRoute,
+  routePath,
+  routeRoomId,
+  searchWithoutLegacyTab,
+} from './routes';
+import type { Route } from './routes';
+
+const ROOM = 'blake3:1111111111111111111111111111111111111111111111111111111111111111';
+
+describe('parseRoute', () => {
+  it('resolves the bare root and unknown paths to Rooms', () => {
+    // Total by construction: an unknown URL is a navigation miss, and Rooms is
+    // the recovery — never a blank panel or a thrown error.
+    expect(parseRoute('/')).toEqual({ kind: 'rooms' });
+    expect(parseRoute('')).toEqual({ kind: 'rooms' });
+    expect(parseRoute('/rooms')).toEqual({ kind: 'rooms' });
+    expect(parseRoute('/nope')).toEqual({ kind: 'rooms' });
+    expect(parseRoute('/rooms/')).toEqual({ kind: 'rooms' });
+  });
+
+  it('parses the global destinations', () => {
+    expect(parseRoute('/fleet')).toEqual({ kind: 'fleet' });
+    expect(parseRoute('/settings')).toEqual({ kind: 'settings' });
+  });
+
+  it('parses every room destination', () => {
+    for (const dest of ['activity', 'people', 'agents', 'files', 'pipes'] as const) {
+      expect(parseRoute(`/rooms/${encodeURIComponent(ROOM)}/${dest}`)).toEqual({
+        kind: 'room',
+        roomId: ROOM,
+        dest,
+      });
+    }
+  });
+
+  it('normalizes a bare room and an unknown destination to Activity', () => {
+    expect(parseRoute(`/rooms/${encodeURIComponent(ROOM)}`)).toEqual({
+      kind: 'room',
+      roomId: ROOM,
+      dest: 'activity',
+    });
+    expect(parseRoute(`/rooms/${encodeURIComponent(ROOM)}/bogus`)).toEqual({
+      kind: 'room',
+      roomId: ROOM,
+      dest: 'activity',
+    });
+  });
+
+  it('survives a malformed percent-escape', () => {
+    // decodeURIComponent throws on '%zz'; a bad URL is a miss, not a crash.
+    expect(parseRoute('/rooms/%zz/activity')).toEqual({ kind: 'rooms' });
+  });
+
+  it('round-trips every route through routePath', () => {
+    const routes: Route[] = [
+      { kind: 'rooms' },
+      { kind: 'fleet' },
+      { kind: 'settings' },
+      { kind: 'room', roomId: ROOM, dest: 'activity' },
+      { kind: 'room', roomId: ROOM, dest: 'pipes' },
+    ];
+    for (const route of routes) {
+      expect(parseRoute(routePath(route))).toEqual(route);
+    }
+  });
+
+  it('round-trips a room id that needs escaping', () => {
+    const awkward = 'blake3:a/b c';
+    const path = routePath({ kind: 'room', roomId: awkward, dest: 'files' });
+    expect(path).not.toContain('a/b');
+    expect(parseRoute(path)).toEqual({ kind: 'room', roomId: awkward, dest: 'files' });
+  });
+});
+
+describe('routeRoomId', () => {
+  it('is the selected room, or null for a global destination', () => {
+    expect(routeRoomId({ kind: 'room', roomId: ROOM, dest: 'activity' })).toBe(ROOM);
+    expect(routeRoomId({ kind: 'rooms' })).toBeNull();
+    expect(routeRoomId({ kind: 'fleet' })).toBeNull();
+    expect(routeRoomId({ kind: 'settings' })).toBeNull();
+  });
+});
+
+describe('inspectorDest', () => {
+  it('is closed on Activity and open on every tool', () => {
+    expect(inspectorDest({ kind: 'room', roomId: ROOM, dest: 'activity' })).toBeNull();
+    expect(inspectorDest({ kind: 'room', roomId: ROOM, dest: 'people' })).toBe('people');
+    expect(inspectorDest({ kind: 'room', roomId: ROOM, dest: 'files' })).toBe('files');
+  });
+
+  it('is closed for every global destination', () => {
+    expect(inspectorDest({ kind: 'rooms' })).toBeNull();
+    expect(inspectorDest({ kind: 'fleet' })).toBeNull();
+    expect(inspectorDest({ kind: 'settings' })).toBeNull();
+  });
+});
+
+describe('legacyTabDest', () => {
+  it('migrates ?tab= onto room destinations', () => {
+    expect(legacyTabDest('?tab=members')).toBe('people');
+    expect(legacyTabDest('?tab=agents')).toBe('agents');
+    expect(legacyTabDest('?tab=files')).toBe('files');
+    expect(legacyTabDest('?tab=pipes')).toBe('pipes');
+  });
+
+  it('ignores a missing or unknown tab', () => {
+    expect(legacyTabDest('')).toBeNull();
+    expect(legacyTabDest('?daemon=7420')).toBeNull();
+    expect(legacyTabDest('?tab=nonsense')).toBeNull();
+  });
+});
+
+describe('searchWithoutLegacyTab', () => {
+  it('drops only the migrated key', () => {
+    // ?daemon= picks the daemon and ?mock… installs the e2e fixtures: losing
+    // them would re-point the client and silently unfixture the suite.
+    expect(searchWithoutLegacyTab('?tab=files&daemon=7420')).toBe('?daemon=7420');
+    expect(searchWithoutLegacyTab('?mock=1&tab=pipes&mock_fail=room.open:1')).toBe(
+      '?mock=1&mock_fail=room.open%3A1',
+    );
+  });
+
+  it('leaves a query with no legacy tab byte-identical', () => {
+    // Not merely equivalent: re-encoding '?mock_fail=room.open:1' would escape
+    // the colon and change the string for no reason.
+    expect(searchWithoutLegacyTab('?mock_fail=room.open:1')).toBe('?mock_fail=room.open:1');
+    expect(searchWithoutLegacyTab('')).toBe('');
+  });
+
+  it('empties a query that was only a legacy tab', () => {
+    expect(searchWithoutLegacyTab('?tab=members')).toBe('');
+  });
+});

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -1,0 +1,124 @@
+/** Canonical navigation state (docs/room-workbench.md, decision 2).
+ *
+ *  The route IS the navigation state — not a mirror of it. Everything the
+ *  shell needs to render (which global destination, which room, which room
+ *  tool, whether the inspector is open) is derived from this module on read.
+ *  Nothing else may hold navigation state that can disagree with it: the
+ *  three-way `tab` / `mobileView` / `roomId` split this replaced could, and
+ *  did, contradict itself.
+ *
+ *  The web keeps these as URL paths. `crates/jeliyad/src/serve.rs` serves
+ *  `index.html` for any extensionless unknown path, and Vite dev does the
+ *  same, so deep links work in production and under the e2e harness with no
+ *  daemon change.
+ */
+
+/** Room tools, in tab-strip order. `activity` is the room's workspace — a
+ *  real destination (the inspector is closed there), not a synonym for "a
+ *  room is selected". */
+export const ROOM_DESTS = ['activity', 'people', 'agents', 'files', 'pipes'] as const;
+export type RoomDest = (typeof ROOM_DESTS)[number];
+
+/** The room tools that render in the inspector; `activity` is the workspace. */
+export type InspectorDest = Exclude<RoomDest, 'activity'>;
+
+export type Route =
+  | { kind: 'rooms' }
+  | { kind: 'room'; roomId: string; dest: RoomDest }
+  | { kind: 'fleet' }
+  | { kind: 'settings' };
+
+export const ROOMS_ROUTE: Route = { kind: 'rooms' };
+
+function isRoomDest(value: string | undefined): value is RoomDest {
+  return value !== undefined && (ROOM_DESTS as readonly string[]).includes(value);
+}
+
+/** Parse a pathname into a route. Total by construction: an unknown path is
+ *  not an error state to render, it is simply Rooms (decision 2 — unknown
+ *  URLs resolve to a clear recoverable state, and Rooms is the recovery).
+ *  `/rooms/:id` and `/rooms/:id/<unknown>` normalize to that room's Activity. */
+export function parseRoute(pathname: string): Route {
+  let segments: string[];
+  try {
+    segments = pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  } catch {
+    // A malformed percent-escape ("/rooms/%zz") throws in decodeURIComponent.
+    // A bad URL is a navigation miss, not a crash.
+    return ROOMS_ROUTE;
+  }
+  if (segments.length === 0) return ROOMS_ROUTE;
+  if (segments[0] === 'fleet') return { kind: 'fleet' };
+  if (segments[0] === 'settings') return { kind: 'settings' };
+  if (segments[0] === 'rooms') {
+    const roomId = segments[1];
+    if (!roomId) return ROOMS_ROUTE;
+    return { kind: 'room', roomId, dest: isRoomDest(segments[2]) ? segments[2] : 'activity' };
+  }
+  return ROOMS_ROUTE;
+}
+
+/** The canonical pathname for a route — one destination, one spelling. */
+export function routePath(route: Route): string {
+  switch (route.kind) {
+    case 'rooms':
+      return '/rooms';
+    case 'fleet':
+      return '/fleet';
+    case 'settings':
+      return '/settings';
+    case 'room':
+      return `/rooms/${encodeURIComponent(route.roomId)}/${route.dest}`;
+  }
+}
+
+export function sameRoute(a: Route, b: Route): boolean {
+  return routePath(a) === routePath(b);
+}
+
+/** The room a route selects, or null. */
+export function routeRoomId(route: Route): string | null {
+  return route.kind === 'room' ? route.roomId : null;
+}
+
+/** The tool the inspector shows, or null when it is closed. Closed is the
+ *  `activity` destination — collapsing the inspector *is* navigating there. */
+export function inspectorDest(route: Route): InspectorDest | null {
+  return route.kind === 'room' && route.dest !== 'activity' ? route.dest : null;
+}
+
+/** Legacy `?tab=` links (App.tsx read this once at startup and never wrote it
+ *  back). It is a shipped URL surface, so it migrates onto the equivalent room
+ *  destination of whichever room is restored rather than 404ing. `members`
+ *  became `people`; the rest kept their names. Returns null when the query
+ *  carries no legacy tab. */
+export function legacyTabDest(search: string): RoomDest | null {
+  const tab = new URLSearchParams(search).get('tab');
+  switch (tab) {
+    case 'members':
+      return 'people';
+    case 'agents':
+      return 'agents';
+    case 'files':
+      return 'files';
+    case 'pipes':
+      return 'pipes';
+    default:
+      return null;
+  }
+}
+
+/** Strip the migrated `?tab=` while preserving every other param.
+ *
+ *  `?daemon=` picks the daemon and `?mock…` installs the e2e fixtures, and
+ *  both are parsed from `window.location.search` — so a canonicalizing
+ *  redirect that dropped the query would silently re-point the client at a
+ *  different daemon and unfixture the suite (decision 2, rule 6). Only the
+ *  key this module consumes is removed. */
+export function searchWithoutLegacyTab(search: string): string {
+  const params = new URLSearchParams(search);
+  if (!params.has('tab')) return search;
+  params.delete('tab');
+  const rest = params.toString();
+  return rest ? `?${rest}` : '';
+}

--- a/ui/src/lib/shell.test.ts
+++ b/ui/src/lib/shell.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { COMPACT_MAX, WIDE_MIN, shellFor } from './shell';
+
+const CSS = readFileSync(fileURLToPath(new URL('../styles.css', import.meta.url)), 'utf8');
+
+/** Every `@media` condition in the stylesheet, as `(max-width: 899.98px)`. */
+function mediaConditions(): string[] {
+  return [...CSS.matchAll(/@media\s+([^{]+)\{/g)].map((m) => m[1].trim());
+}
+
+describe('shellFor', () => {
+  it('classifies the widths the responsive contract names', () => {
+    // docs/room-workbench.md, decision 3 — and the exact matrix issue #62 asks
+    // for coverage at.
+    expect(shellFor(360)).toBe('compact');
+    expect(shellFor(899)).toBe('compact');
+    expect(shellFor(900)).toBe('medium');
+    expect(shellFor(920)).toBe('medium');
+    expect(shellFor(1279)).toBe('medium');
+    expect(shellFor(1280)).toBe('wide');
+    expect(shellFor(1440)).toBe('wide');
+  });
+
+  it('leaves no width unclassified across the boundaries', () => {
+    // The fractional band between the compact and medium queries is where a
+    // zoomed or scaled viewport lands; it must belong to exactly one shell.
+    for (const width of [899.5, 899.98, 899.99, 900, 1279.98, 1279.99]) {
+      expect(['compact', 'medium', 'wide']).toContain(shellFor(width));
+    }
+    expect(shellFor(899.98)).toBe('compact');
+    expect(shellFor(899.99)).toBe('medium');
+  });
+});
+
+describe('the stylesheet agrees with this module', () => {
+  // The breakpoints exist twice — here and in styles.css — because a media
+  // query cannot read a var(). That duplication gets no compiler help, so it
+  // gets this instead.
+
+  it('uses COMPACT_MAX as the only compact boundary', () => {
+    const maxWidths = mediaConditions()
+      .flatMap((c) => [...c.matchAll(/max-width:\s*([\d.]+)px/g)].map((m) => Number(m[1])))
+      // 480 is a component-internal reflow, not a shell boundary.
+      .filter((px) => px > 480);
+    expect(maxWidths.length).toBeGreaterThan(0);
+    for (const px of maxWidths) {
+      expect([COMPACT_MAX, WIDE_MIN - 0.02]).toContain(px);
+    }
+  });
+
+  it('uses WIDE_MIN and the compact boundary as the only min-widths', () => {
+    const minWidths = mediaConditions().flatMap((c) =>
+      [...c.matchAll(/min-width:\s*([\d.]+)px/g)].map((m) => Number(m[1])),
+    );
+    expect(minWidths.length).toBeGreaterThan(0);
+    for (const px of minWidths) {
+      // Medium starts where compact stops, and wide starts at WIDE_MIN.
+      expect([Math.ceil(COMPACT_MAX), WIDE_MIN]).toContain(px);
+    }
+  });
+
+  it('declares the compact shell and the wide inspector column', () => {
+    expect(CSS).toContain(`@media (max-width: ${COMPACT_MAX}px)`);
+    expect(CSS).toContain(`@media (min-width: ${WIDE_MIN}px)`);
+  });
+
+  it('keeps the connection banner out of the overlay stacking order', () => {
+    // Decision 3: connection status reserves layout space. A banner that is
+    // positioned and z-indexed is one that covers Back and list content.
+    const banner = /\.conn-banner\s*\{([^}]*)\}/.exec(CSS);
+    expect(banner).not.toBeNull();
+    expect(banner?.[1]).not.toMatch(/position:\s*(absolute|fixed)/);
+    expect(banner?.[1]).not.toMatch(/z-index/);
+  });
+});

--- a/ui/src/lib/shell.ts
+++ b/ui/src/lib/shell.ts
@@ -1,0 +1,54 @@
+/** The three shells (docs/room-workbench.md, decision 3).
+ *
+ *  CSS owns the layout — which panes show, and the grid that places them.
+ *  This module exists for the one fork CSS cannot make: the compact room app
+ *  bar and the desktop room header are different elements, not one element
+ *  restyled, and rendering both to hide one would put two room titles in the
+ *  accessibility tree.
+ *
+ *  The breakpoints are therefore written twice — here and in `styles.css` —
+ *  because a media query cannot read a `var()`. `shell.test.ts` parses the
+ *  stylesheet and fails if the two ever disagree, which is the compiler help
+ *  this duplication otherwise would not get.
+ */
+
+import { useEffect, useState } from 'react';
+
+/** Below this, one pane at a time. 899.98 rather than 899 so that a
+ *  fractional width (browser zoom, a scaled display) cannot fall into a gap
+ *  between the compact and medium queries and match neither. */
+export const COMPACT_MAX = 899.98;
+
+/** At and above this, the inspector is a third column rather than a drawer. */
+export const WIDE_MIN = 1280;
+
+export type Shell = 'compact' | 'medium' | 'wide';
+
+export const COMPACT_QUERY = `(max-width: ${COMPACT_MAX}px)`;
+export const WIDE_QUERY = `(min-width: ${WIDE_MIN}px)`;
+
+export function shellFor(width: number): Shell {
+  if (width <= COMPACT_MAX) return 'compact';
+  return width >= WIDE_MIN ? 'wide' : 'medium';
+}
+
+/** Track the current shell. Subscribes to `matchMedia` rather than `resize`:
+ *  it fires only on the transitions that matter, not on every pixel. */
+export function useShell(): Shell {
+  const [shell, setShell] = useState<Shell>(() => shellFor(window.innerWidth));
+
+  useEffect(() => {
+    const compact = window.matchMedia(COMPACT_QUERY);
+    const wide = window.matchMedia(WIDE_QUERY);
+    const sync = () => setShell(compact.matches ? 'compact' : wide.matches ? 'wide' : 'medium');
+    sync();
+    compact.addEventListener('change', sync);
+    wide.addEventListener('change', sync);
+    return () => {
+      compact.removeEventListener('change', sync);
+      wide.removeEventListener('change', sync);
+    };
+  }, []);
+
+  return shell;
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -30,10 +30,12 @@
   --red-dim: rgba(242, 109, 109, 0.1);
   --blue-line: rgba(106, 168, 247, 0.4);
   --blue-dim: rgba(106, 168, 247, 0.1);
-  /* stacking order: fleet page < mobile tabbar < connection banner < modal */
+  /* stacking order: fleet page < inspector drawer < mobile tabbar < modal.
+     The connection banner is no longer in this order: it reserves a grid row
+     rather than floating over the panes (docs/room-workbench.md, decision 3). */
   --z-fleet: 5;
+  --z-drawer: 20;
   --z-tabbar: 50;
-  --z-banner: 60;
   --z-modal: 100;
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, Roboto, 'Helvetica Neue', sans-serif;
   --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -113,17 +115,89 @@ select {
 
 /* ---------- app frame ---------- */
 
+/* Three shells, one information architecture (docs/room-workbench.md,
+   decision 3). The breakpoints are duplicated in ui/src/lib/shell.ts — a
+   media query cannot read a var() — and shell.test.ts parses this file and
+   fails if the two ever disagree.
+
+     compact  < 900px     one pane
+     medium   900-1279px  rail + workspace, inspector as a drawer
+     wide     >= 1280px   rail + workspace + inspector column
+
+   The banner is a grid ROW, not an overlay: connection status reserves its
+   space so it can never cover Back, a header, or list content. It collapses
+   to 0 when connected, so it costs nothing while it has nothing to say. */
+
 .app {
   position: relative;
   display: grid;
-  grid-template-columns: 272px minmax(0, 1fr) 360px;
+  grid-template-columns: 272px minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   height: var(--vh-full);
   overflow: hidden;
 }
 
-@media (max-width: 1100px) {
+.conn-region {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+/* Explicit placement, not auto-flow: at medium the grid has two columns and
+   an auto-placed inspector would invent a third, shrinking the workspace by
+   exactly the amount this band exists to give back. */
+.app > .sidebar {
+  grid-column: 1;
+  grid-row: 2;
+  min-height: 0;
+}
+
+.app > .center {
+  grid-column: 2;
+  grid-row: 2;
+  min-height: 0;
+}
+
+/* Medium: the inspector shares the workspace cell and pins to its right edge —
+   a drawer, in flow, under the reserved banner row rather than over it. */
+.app > .right-panel {
+  grid-column: 2;
+  grid-row: 2;
+  min-height: 0;
+  justify-self: end;
+  z-index: var(--z-drawer);
+  width: min(360px, 100%);
+  border-left: 1px solid var(--border-strong);
+  box-shadow: -12px 0 32px rgba(0, 0, 0, 0.45);
+}
+
+/* Wide: it stops being a drawer and takes a column of its own. */
+@media (min-width: 1280px) {
+  .app.inspector-open {
+    grid-template-columns: 272px minmax(0, 1fr) 360px;
+  }
+
+  .app > .right-panel {
+    grid-column: 3;
+    justify-self: stretch;
+    width: auto;
+    box-shadow: none;
+    border-left: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 1279.98px) and (min-width: 900px) {
   .app {
-    grid-template-columns: 232px minmax(0, 1fr) 300px;
+    grid-template-columns: 232px minmax(0, 1fr);
+  }
+
+  /* The drawer floats over the workspace, and the room nav lives under the
+     workspace's header — so an open drawer buries most of the strip. A buried
+     tab is worse than a missing one: it still reports aria-selected, still
+     takes focus, and still swallows a click into the drawer on top of it.
+     The drawer carries the strip while it is open (see RightPanel), so the
+     workspace's copy stands down rather than lying there. */
+  .app.inspector-open .center .room-nav {
+    display: none;
   }
 }
 
@@ -277,28 +351,31 @@ select {
   margin-top: 2px;
 }
 
-@media (max-width: 900px) {
+/* Compact: one pane at a time. 899.98 rather than 900 — the medium shell now
+   starts exactly at 900, and a fractional viewport width must not fall into a
+   gap between the two queries and match neither. Mirrored in
+   ui/src/lib/shell.ts; shell.test.ts fails if they drift apart. */
+@media (max-width: 899.98px) {
   .app {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
   }
 
   /* Scoped to `.app` so these win over the standalone `.sidebar/.center/
      .right-panel { display: flex }` base rules, which appear later in source
      order at equal (0,0,1) specificity and would otherwise re-show every pane —
      stacking all three columns on top of each other on a phone. `.app <pane>`
-     is (0,0,2); the mv-* show rules below are (0,0,3) and win in turn. */
+     is (0,0,2); the pane-* show rules below are (0,0,3) and win in turn. */
   .app .sidebar,
   .app .center,
   .app .right-panel {
     display: none;
     grid-column: 1;
-    grid-row: 1;
-    height: var(--vh-full);
+    grid-row: 2;
     min-height: 0;
-    /* Reserve the fixed tab bar + home-indicator inset so the last row of any
-       pane is never hidden behind the bottom chrome; reserve top/side safe
-       areas for standalone/mobile-browser landscape modes. */
+    /* Reserve top/side safe areas for standalone/mobile-browser landscape
+       modes. The bottom reservation is per-pane below: only the panes the tab
+       bar actually covers owe it space. */
     padding-top: var(--safe-top);
     padding-right: var(--safe-right);
     padding-bottom: calc(var(--tabbar-h) + var(--safe-bottom));
@@ -307,35 +384,48 @@ select {
     border-right: none;
   }
 
-  .app.mv-rooms .sidebar {
+  /* The inspector is the whole screen here — no drawer, no shadow. */
+  .app .right-panel {
+    justify-self: stretch;
+    width: auto;
+    box-shadow: none;
+    border-left: none;
+  }
+
+  .app.pane-rooms .sidebar {
     display: flex;
   }
 
-  .app.mv-chat .center {
+  .app.pane-room .center {
     display: flex;
   }
 
-  .app.mv-pipes .right-panel,
-  .app.mv-files .right-panel {
+  .app.pane-inspector .right-panel {
     display: flex;
   }
 
-  .app.mv-agents .fleet-view {
+  /* Inside a room the tab bar is gone (the room's app bar replaces it), so
+     these two panes must not reserve its height — that reservation was ~72px
+     of dead space between the composer and the bottom of a 568px phone. */
+  .app.pane-room .center,
+  .app.pane-inspector .right-panel {
+    padding-bottom: var(--safe-bottom);
+  }
+
+  .app.pane-fleet .fleet-view {
     display: flex;
     grid-column: 1;
-    grid-row: 1;
-    height: var(--vh-full);
+    grid-row: 2;
     padding-top: var(--safe-top);
     padding-right: var(--safe-right);
     padding-bottom: calc(var(--tabbar-h) + var(--safe-bottom));
     padding-left: var(--safe-left);
   }
 
-  .app.mv-settings .mobile-settings {
+  .app.pane-settings .mobile-settings {
     display: flex;
     grid-column: 1;
-    grid-row: 1;
-    height: var(--vh-full);
+    grid-row: 2;
   }
 
   .mobile-tabbar {
@@ -394,7 +484,8 @@ select {
      later in the file and would otherwise win by source order. */
   .app .panel-room-context {
     display: block;
-    padding: 10px 16px 0;
+    flex: 1 1 auto;
+    min-width: 0;
     font-size: 14px;
     font-weight: 700;
     color: var(--text);
@@ -402,21 +493,34 @@ select {
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  /* The inspector's own Back — the bottom bar is gone inside a room, so this
+     is the only in-app way to Activity on a phone. */
+  .app .panel-head {
+    padding: 4px 8px 0;
+  }
+
+  .app .panel-back {
+    min-width: 44px;
+    min-height: 44px;
+    font-size: 22px;
+    line-height: 1;
+  }
 }
 
+/* In flow, full width, and it wraps. It used to be absolutely positioned and
+   centred, which put it on top of the compact room header's Back button and
+   the first rows of every list — the one piece of chrome guaranteed to appear
+   exactly when the user most needs to leave the screen. */
 .conn-banner {
-  position: absolute;
-  top: var(--safe-top);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: var(--z-banner);
-  padding: 6px 16px;
-  border-radius: 0 0 10px 10px;
+  padding: calc(6px + var(--safe-top)) calc(16px + var(--safe-right)) 6px calc(16px + var(--safe-left));
   font-size: 12.5px;
+  line-height: 1.35;
+  text-align: center;
+  overflow-wrap: anywhere;
   background: rgba(245, 180, 83, 0.14);
   color: var(--amber);
-  border: 1px solid rgba(245, 180, 83, 0.35);
-  border-top: none;
+  border-bottom: 1px solid rgba(245, 180, 83, 0.35);
 }
 
 .conn-banner.conn-disconnected {
@@ -1128,6 +1232,119 @@ button.sender-name:not(:disabled):hover {
   background: var(--bg-raise);
 }
 
+/* ---------- compact room app bar (#61) ----------
+   The budget at 320x568 is hard: <=150px of app bar, and >=180px of timeline
+   above the composer. The old header spent it on a wrapping action row and a
+   peer-chip strip that grew with the room. Here Back, the title, the
+   connectivity summary, and Invite hold one row; everything diagnostic moves
+   behind the room-information disclosure. Nothing wraps, so the height is a
+   constant, not a function of how many peers are connected. */
+
+.room-appbar {
+  padding: 0;
+  flex: 0 0 auto;
+}
+
+.appbar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  /* No wrap: a second row is exactly the overflow this bar exists to prevent. */
+  flex-wrap: nowrap;
+}
+
+.appbar-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.appbar-title h1 {
+  font-size: 15.5px;
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.appbar-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.appbar-sub .sep {
+  color: var(--text-mute);
+}
+
+.appbar-back,
+.appbar-more {
+  flex: 0 0 auto;
+}
+
+.appbar-back {
+  font-size: 22px;
+  line-height: 1;
+}
+
+/* The one place a compact button may drop under the 44px floor is nowhere:
+   these keep it while staying inside the 150px budget because they sit on a
+   single row with the title. */
+.app .appbar-back,
+.app .appbar-more {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.appbar-invite {
+  flex: 0 0 auto;
+  padding: 0 12px;
+}
+
+.appbar-info {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-card);
+}
+
+.room-info-facts {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px 12px;
+  margin: 0;
+  font-size: 12.5px;
+}
+
+.room-info-facts dt {
+  color: var(--text-mute);
+}
+
+.room-info-facts dd {
+  margin: 0;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.room-info-empty {
+  margin: 0;
+  font-size: 12.5px;
+}
+
+.appbar-info-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .room-header-top {
   display: flex;
   align-items: center;
@@ -1738,11 +1955,27 @@ button.sender-name:not(:disabled):hover {
   min-height: 0;
 }
 
-/* Mobile-only room label for the standalone Files/Pipes tab — see the mobile
-   breakpoint below. Desktop always shows RoomHeader alongside this panel, so
-   it would be pure duplication there. */
+/* Room context stays visible on every room-scoped surface (decision 3), but
+   how it is delivered differs: on compact this panel IS the screen, so it
+   carries the room name itself; on medium and wide the room header is
+   alongside, so repeating it would be duplication — the close control is what
+   this row is for there. */
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 8px 0 14px;
+}
+
 .panel-room-context {
   display: none;
+}
+
+.panel-close {
+  flex: 0 0 auto;
+  font-size: 18px;
+  line-height: 1;
 }
 
 .panel-tabs {
@@ -2559,7 +2792,7 @@ textarea::placeholder {
    viewports every text-entry control is floored at 16px to suppress that zoom.
    This intentionally applies to all narrow viewports, not just pointer:coarse,
    so browser emulation and hybrid devices get the same safe behavior. */
-@media (max-width: 900px) {
+@media (max-width: 899.98px) {
   input,
   textarea,
   select,
@@ -2886,8 +3119,7 @@ select {
 .app-fleet .fleet-view {
   display: flex;
   grid-column: 2 / -1;
-  grid-row: 1;
-  height: var(--vh-full);
+  grid-row: 2;
   background: var(--bg);
   z-index: var(--z-fleet);
   overflow: hidden;
@@ -2896,7 +3128,7 @@ select {
 /* The fleet page paints over the center + right columns on desktop; hide the
    obscured room UI from the tab order and a11y tree. visibility (not display)
    preserves the timeline's stick-to-bottom scroll position. */
-@media (min-width: 901px) {
+@media (min-width: 900px) {
   .app-fleet .center,
   .app-fleet .right-panel {
     visibility: hidden;
@@ -2905,14 +3137,13 @@ select {
 
 /* Settings is a full-surface view like the fleet page — on desktop it paints
    over the center + right columns (the sidebar stays visible so the user can
-   navigate away). Keep this desktop-only: on mobile, `.mv-settings` must keep
+   navigate away). Keep this desktop-only: on compact, `.pane-settings` must keep
    the safe-area + bottom-tab padding defined in the mobile pane rules above. */
-@media (min-width: 901px) {
+@media (min-width: 900px) {
   .app-settings .mobile-settings {
     display: flex;
     grid-column: 2 / -1;
-    grid-row: 1;
-    height: var(--vh-full);
+    grid-row: 2;
     max-width: 640px;
     /* Reset the mobile pane's tab-bar/safe-area padding to a desktop rhythm. */
     padding: 24px 28px;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -189,16 +189,6 @@ select {
   .app {
     grid-template-columns: 232px minmax(0, 1fr);
   }
-
-  /* The drawer floats over the workspace, and the room nav lives under the
-     workspace's header — so an open drawer buries most of the strip. A buried
-     tab is worse than a missing one: it still reports aria-selected, still
-     takes focus, and still swallows a click into the drawer on top of it.
-     The drawer carries the strip while it is open (see RightPanel), so the
-     workspace's copy stands down rather than lying there. */
-  .app.inspector-open .center .room-nav {
-    display: none;
-  }
 }
 
 /* ---------- mobile shell (mockups/mobile-*.png) ----------


### PR DESCRIPTION
Closes #59. Closes #61. Implements the React half of #62. Milestone [UX 1](https://github.com/kortiene/jeliya/milestone/2).

> **Stacked on #89** (the contract it implements). Retarget to `main` before merging #89.

## The route is the navigation state

`App.tsx` kept three fields that could disagree — `tab`, `mobileView`, and a `roomId` the bootstrap re-picked on every reconnect independently of both. One route replaces them; everything else derives on read.

`/rooms` · `/rooms/:roomId/{activity,people,agents,files,pipes}` · `/fleet` · `/settings`

Reload restores, Back/Forward traverse, deep links work, `?tab=` migrates. Unknown/left/removed rooms resolve to a state that names the fact rather than a blank panel.

**Router is ~60 lines of History API** — no new dependency. `crates/jeliyad/src/serve.rs` already serves extensionless paths from `index.html`, so no daemon change.

**This closes #88 structurally**, not by patch: `/rooms` is an explicit destination and only `/` restores, so an explicit "Back to Rooms" can't be undone by the next reconnect.

## The three shells

| | width | layout |
|---|---|---|
| compact | `< 900` | one pane |
| medium | `900–1279` | rail + workspace, inspector as drawer |
| wide | `>= 1280` | rail + workspace + inspector column |

Medium is the point: **at 901px the old grid left the workspace 369px** — narrower than the phone layout it had just graduated from.

## Honesty fixes (the reason for the vocabulary work)

| Was | Meant | Now |
|---|---|---|
| rail "Active" | live local session | **Open** / **Closed** |
| roster "Active" | wire value title-cased onto the screen | **Member** / **Invited** / **Left** / **Removed** |
| header "N active" | **fell back to the room's *total* count** when the roster hadn't loaded | **Loading members…** until it knows |
| "Alone in this room" | zero peers *observed* — incl. a 5-member room whose peers are offline | **No peers connected** |
| pipe "Active" | live forwarding session | **Connected** |
| fleet "Active" | reachable agents | **Live** |

Plus: the rail said "Agent Fleet" and opened a page titled "Agents", leaving the user to guess whether that was the room's "Agents & Runs".

## Three bugs found by the review agents, not by me

Worth calling out since they're the substance of the diff:

1. **`onCreated`/`onJoined` still called `openRoom()` imperatively** — writing `roomId` behind the route's back, exactly the second state machine the contract forbids. The route effect then snapped back to the previously-open room, so create/join silently didn't land, and leaked an abandoned `room.open` session against a real daemon.
2. **At medium, the inspector drawer buried 3 of the 5 room tabs.** Measured at 920px: `Agents & Runs`, `Files`, and `Pipes` hit-tested to the drawer. They stayed `aria-selected`, focusable, and in the a11y tree while clicks fed the drawer on top — the issue #54 lie from the other side. `RoomNav`'s own comment claimed the tool "opens beside" the strip; code disagreeing with itself. Fixed by having whichever surface *covers* the workspace carry the strip.
3. **`room.open` refreshed `room.list` only after a navigated-away guard**, so leaving a room quickly left the rail calling a live session "Closed".

## Verification

- `npm run build` (tsc + vite) — clean
- `npx vitest run` — **36/36**, including a test that parses `styles.css` and fails if its breakpoints drift from `ui/src/lib/shell.ts` (a media query can't read a `var()`, so the duplication gets a test instead of a compiler)
- `npm run test:e2e` — **203 passed / 0 failed** across all four viewport projects, stable across repeated runs

New specs: `responsive.spec.ts` walks 360/899/900/920/1280 + safe-area insets; `compact-room.spec.ts` pins the 320×568 budget (app bar ≤150px, timeline ≥180px).

## Notes for review

- **`desktop-920x800` is now medium** — deliberate, and why the AC names 899/900/920 separately. The inspector is a drawer there, not a column.
- **Boot lands inside the restored room on compact too.** The old split (room open, rooms list showing) is unrepresentable now. `/` is replaced with `/rooms`, then the room is *pushed* — so Back reaches the list rather than exiting the app.
- **On text scaling:** the design sizes text in px, so browser-faithful "200% text" is page zoom, which is mathematically a narrower viewport; WCAG 1.4.10 fixes reflow at 320 CSS px (= 1280 @ 400%), which the 320 cases cover. Real `textScale: 2.0` coverage belongs to the Flutter suite, where the platform exposes it faithfully — it lands with #60.
- Deleted `mobile: the panel tab strip keeps the bottom navigation truthful`: its invariant is now structurally unviolable (the bar has no Files/Pipes to hang over the wrong content). Replaced with a test that the route, the strip, and the visible pane agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)