### PR TITLE
feat: disambiguate homonymous rooms with the short id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 /dist/
-node_modules/
+node_modules
 ui/dist/
 ui/test-results/
 ui/playwright-report/

--- a/app/lib/src/l10n/arb/app_en.arb
+++ b/app/lib/src/l10n/arb/app_en.arb
@@ -635,6 +635,20 @@
   "@modalCreatingRoom": {
     "description": "Create Room modal confirm button label while creation is in progress (temporarily replaces 'Create room'). Keep the trailing ellipsis character (…)."
   },
+  "modalCreateRoomHomonymWarning": "A room with that name already exists on this device — this one will get its own ID.",
+  "@modalCreateRoomHomonymWarning": {
+    "description": "Non-blocking inline warning under the room-name field in the Create Room modal, shown when the typed name (trimmed and case-folded) matches an existing local room's display name. Creation is NOT blocked and the Create button stays enabled — the name is a non-unique label and the new room gets its own room_id (docs/room-workbench.md, decision 6). Factual, not alarming."
+  },
+  "roomShortIdLabel": "Room ID {shortId}",
+  "@roomShortIdLabel": {
+    "description": "Accessible label announcing a room's short id — the homonym disambiguator shown as a mono/code element next to a room name wherever homonymous rooms are listed (the rooms list rows and the fleet room chips) and always on the Leave Room confirmation. {shortId} is the truncated room_id from the shared shortId helper (e.g. 4f2a…9c1b) and must NOT be translated; only the word 'Room' translates (salon).",
+    "placeholders": {
+      "shortId": {
+        "type": "String",
+        "example": "4f2a…9c1b"
+      }
+    }
+  },
   "modalJoinRoomTitle": "Join with a ticket",
   "@modalJoinRoomTitle": {
     "description": "Reused on three surfaces: the Join Room modal title, the onboarding join-card heading, and a compact sidebar entry-point row. Keep it short enough for a one-line sidebar row."

--- a/app/lib/src/l10n/arb/app_fr.arb
+++ b/app/lib/src/l10n/arb/app_fr.arb
@@ -134,6 +134,8 @@
   "modalRoomNamePlaceholder": "Construire le MVP Iroh Rooms",
   "modalCreateRoom": "Créer un salon",
   "modalCreatingRoom": "Création…",
+  "modalCreateRoomHomonymWarning": "Un salon portant ce nom existe déjà sur cet appareil — celui-ci aura son propre identifiant.",
+  "roomShortIdLabel": "Identifiant du salon {shortId}",
   "modalJoinRoomTitle": "Rejoindre avec un ticket",
   "modalJoinCopy": "Collez l’invitation que vous avez reçue. Une invitation combinée ({combined}) renseigne automatiquement l’adresse du pair.",
   "modalTicketLabel": "Ticket",

--- a/app/lib/src/l10n/gen/app_strings.dart
+++ b/app/lib/src/l10n/gen/app_strings.dart
@@ -908,6 +908,18 @@ abstract class AppStrings {
   /// **'Creating…'**
   String get modalCreatingRoom;
 
+  /// Non-blocking inline warning under the room-name field in the Create Room modal, shown when the typed name (trimmed and case-folded) matches an existing local room's display name. Creation is NOT blocked and the Create button stays enabled — the name is a non-unique label and the new room gets its own room_id (docs/room-workbench.md, decision 6). Factual, not alarming.
+  ///
+  /// In en, this message translates to:
+  /// **'A room with that name already exists on this device — this one will get its own ID.'**
+  String get modalCreateRoomHomonymWarning;
+
+  /// Accessible label announcing a room's short id — the homonym disambiguator shown as a mono/code element next to a room name wherever homonymous rooms are listed (the rooms list rows and the fleet room chips) and always on the Leave Room confirmation. {shortId} is the truncated room_id from the shared shortId helper (e.g. 4f2a…9c1b) and must NOT be translated; only the word 'Room' translates (salon).
+  ///
+  /// In en, this message translates to:
+  /// **'Room ID {shortId}'**
+  String roomShortIdLabel(String shortId);
+
   /// Reused on three surfaces: the Join Room modal title, the onboarding join-card heading, and a compact sidebar entry-point row. Keep it short enough for a one-line sidebar row.
   ///
   /// In en, this message translates to:

--- a/app/lib/src/l10n/gen/app_strings_en.dart
+++ b/app/lib/src/l10n/gen/app_strings_en.dart
@@ -503,6 +503,15 @@ class AppStringsEn extends AppStrings {
   String get modalCreatingRoom => 'Creating…';
 
   @override
+  String get modalCreateRoomHomonymWarning =>
+      'A room with that name already exists on this device — this one will get its own ID.';
+
+  @override
+  String roomShortIdLabel(String shortId) {
+    return 'Room ID $shortId';
+  }
+
+  @override
   String get modalJoinRoomTitle => 'Join with a ticket';
 
   @override

--- a/app/lib/src/l10n/gen/app_strings_fr.dart
+++ b/app/lib/src/l10n/gen/app_strings_fr.dart
@@ -507,6 +507,15 @@ class AppStringsFr extends AppStrings {
   String get modalCreatingRoom => 'Création…';
 
   @override
+  String get modalCreateRoomHomonymWarning =>
+      'Un salon portant ce nom existe déjà sur cet appareil — celui-ci aura son propre identifiant.';
+
+  @override
+  String roomShortIdLabel(String shortId) {
+    return 'Identifiant du salon $shortId';
+  }
+
+  @override
   String get modalJoinRoomTitle => 'Rejoindre avec un ticket';
 
   @override

--- a/app/lib/src/screens/fleet_dashboard.dart
+++ b/app/lib/src/screens/fleet_dashboard.dart
@@ -300,17 +300,19 @@ class _FleetDashboardState extends State<FleetDashboard> {
           a.identityId.toLowerCase().contains(q);
     }).toList();
 
-    // Homonyms across every room the fleet references (not just the visible
-    // agents — stable as filters change). A fleet chip DISPLAYS `name ??
-    // shortId(room_id)`, so that resolved string is what we group on: two
-    // rooms named the same collide and get the disambiguator, while untitled
-    // rooms already show their own short id and never do (docs/room-workbench.md,
-    // decision 6). Same grouping rule as the rooms list, its own display name.
+    // Homonyms across EVERY local room, not just the ones the fleet
+    // references. A name is ambiguous when two of the user's rooms share it —
+    // whether or not both have agents — so a fleet chip whose twin has no
+    // agents yet must still be disambiguated (it would otherwise read as
+    // unique here while the rooms rail shows it is not). A fleet chip DISPLAYS
+    // `name ?? shortId(room_id)`, so that resolved string is what we group on:
+    // two rooms named the same collide and get the disambiguator, while
+    // untitled rooms already show their own short id and never do
+    // (docs/room-workbench.md, decision 6).
     final roomHomonyms = homonymousRoomIds(
       [
-        for (final a in (fleet?.agents ?? const <FleetAgent>[]))
-          for (final r in a.rooms)
-            (roomId: r.roomId, name: r.name ?? shortId(r.roomId)),
+        for (final r in session.rooms)
+          (roomId: r.roomId, name: r.name ?? shortId(r.roomId)),
       ],
       untitledLabel: '',
     );

--- a/app/lib/src/screens/fleet_dashboard.dart
+++ b/app/lib/src/screens/fleet_dashboard.dart
@@ -34,6 +34,7 @@ import '../l10n/tokens.dart';
 import '../layout.dart';
 import '../session/daemon_session.dart';
 import '../session/fleet_store.dart';
+import '../session/room_homonyms.dart';
 import '../theme.dart';
 import '../widgets/buttons.dart';
 import '../widgets/copy_button.dart';
@@ -41,6 +42,7 @@ import '../widgets/error_note.dart';
 import '../widgets/avatar.dart';
 import '../widgets/modal_scaffold.dart';
 import '../widgets/progress_bar.dart';
+import '../widgets/room_short_id.dart';
 import '../widgets/sender_name.dart';
 import '../widgets/tree_mark.dart';
 import 'modals/add_agent.dart';
@@ -298,6 +300,21 @@ class _FleetDashboardState extends State<FleetDashboard> {
           a.identityId.toLowerCase().contains(q);
     }).toList();
 
+    // Homonyms across every room the fleet references (not just the visible
+    // agents — stable as filters change). A fleet chip DISPLAYS `name ??
+    // shortId(room_id)`, so that resolved string is what we group on: two
+    // rooms named the same collide and get the disambiguator, while untitled
+    // rooms already show their own short id and never do (docs/room-workbench.md,
+    // decision 6). Same grouping rule as the rooms list, its own display name.
+    final roomHomonyms = homonymousRoomIds(
+      [
+        for (final a in (fleet?.agents ?? const <FleetAgent>[]))
+          for (final r in a.rooms)
+            (roomId: r.roomId, name: r.name ?? shortId(r.roomId)),
+      ],
+      untitledLabel: '',
+    );
+
     return ListView(
       padding: const EdgeInsets.fromLTRB(
         JeliyaSpacing.page,
@@ -328,6 +345,7 @@ class _FleetDashboardState extends State<FleetDashboard> {
           _AgentGrid(
             agents: visible,
             store: store,
+            roomHomonyms: roomHomonyms,
             onOpenRoom: widget.onOpenRoom,
           ),
       ],
@@ -707,11 +725,16 @@ class _AgentGrid extends StatelessWidget {
   const _AgentGrid({
     required this.agents,
     required this.store,
+    required this.roomHomonyms,
     required this.onOpenRoom,
   });
 
   final List<FleetAgent> agents;
   final FleetStore store;
+
+  /// room_ids that share a displayed name with another fleet room (decision 6).
+  final Set<String> roomHomonyms;
+
   final ValueChanged<String> onOpenRoom;
 
   @override
@@ -736,6 +759,7 @@ class _AgentGrid extends StatelessWidget {
                 child: _AgentCard(
                   agent: agent,
                   points: store.historyFor(agent.identityId),
+                  roomHomonyms: roomHomonyms,
                   onOpenRoom: onOpenRoom,
                 ),
               ),
@@ -752,6 +776,7 @@ class _AgentCard extends StatelessWidget {
   const _AgentCard({
     required this.agent,
     required this.points,
+    required this.roomHomonyms,
     required this.onOpenRoom,
   });
 
@@ -759,6 +784,9 @@ class _AgentCard extends StatelessWidget {
 
   /// Sparkline history: null while loading, empty when none.
   final List<HistoryPoint>? points;
+
+  /// room_ids that share a displayed name with another fleet room (decision 6).
+  final Set<String> roomHomonyms;
 
   final ValueChanged<String> onOpenRoom;
 
@@ -909,7 +937,11 @@ class _AgentCard extends StatelessWidget {
               children: [
                 for (final r in agent.rooms)
                   _RoomChip(
+                    roomId: r.roomId,
                     name: r.name ?? shortId(r.roomId),
+                    // A named room shared with another fleet room repeats its
+                    // short id; an untitled room already shows one as its name.
+                    homonym: roomHomonyms.contains(r.roomId) && r.name != null,
                     tooltip: r.name ?? r.roomId,
                     onTap: () => onOpenRoom(r.roomId),
                   ),
@@ -1050,12 +1082,22 @@ class _LabelChip extends StatelessWidget {
 
 class _RoomChip extends StatelessWidget {
   const _RoomChip({
+    required this.roomId,
     required this.name,
+    required this.homonym,
     required this.tooltip,
     required this.onTap,
   });
 
+  final String roomId;
   final String name;
+
+  /// True when this room shares its DISPLAYED name with another fleet room —
+  /// then the chip repeats the short id so the two can be told apart (decision
+  /// 6). An untitled room already shows its short id as [name] and is never a
+  /// homonym here.
+  final bool homonym;
+
   final String tooltip;
   final VoidCallback onTap;
 
@@ -1098,6 +1140,12 @@ class _RoomChip extends StatelessWidget {
                 maxLines: 1,
               ),
             ),
+            // The name yields first; the short id is the disambiguator and
+            // must stay readable at any width.
+            if (homonym) ...[
+              const SizedBox(width: 5),
+              RoomShortId(roomId: roomId, fontSize: 11),
+            ],
           ],
         ),
       ),

--- a/app/lib/src/screens/mobile_rooms.dart
+++ b/app/lib/src/screens/mobile_rooms.dart
@@ -14,7 +14,9 @@ import 'package:jeliya_protocol/jeliya_protocol.dart' show RoomSummary;
 import '../l10n/strings_context.dart';
 import '../l10n/tokens.dart';
 import '../session/daemon_session.dart';
+import '../session/room_homonyms.dart';
 import '../theme.dart';
+import '../widgets/room_short_id.dart';
 import '../widgets/template_text.dart';
 import '../widgets/tree_mark.dart';
 import 'sidebar.dart' show IdentityFooter;
@@ -83,23 +85,38 @@ class MobileRoomsScreen extends StatelessWidget {
                               TextStyle(fontSize: 13, color: tokens.textDim)),
                     ),
                   )
-                : Semantics(
-                    container: true,
-                    label: s.sidebarRoomsListLabel,
-                    child: ListView.separated(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: JeliyaSpacing.x10),
-                      itemCount: session.rooms.length,
-                      separatorBuilder: (_, _) =>
-                          const SizedBox(height: JeliyaSpacing.x4),
-                      itemBuilder: (context, index) => _MobileRoomRow(
-                        room: session.rooms[index],
-                        selected:
-                            session.rooms[index].roomId == currentRoomId,
-                        onSelectRoom: onSelectRoom,
+                : Builder(builder: (context) {
+                    // Computed once for the whole list: the short id
+                    // disambiguates rooms that DISPLAY the same name, including
+                    // two untitled rooms (docs/room-workbench.md, decision 6).
+                    // TODO(#49): a future room-search surface accepting name and
+                    // short id lives here (the rooms list).
+                    final homonyms = homonymousRoomIds(
+                      [
+                        for (final r in session.rooms) (roomId: r.roomId, name: r.name)
+                      ],
+                      untitledLabel: s.shellUntitledRoom,
+                    );
+                    return Semantics(
+                      container: true,
+                      label: s.sidebarRoomsListLabel,
+                      child: ListView.separated(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: JeliyaSpacing.x10),
+                        itemCount: session.rooms.length,
+                        separatorBuilder: (_, _) =>
+                            const SizedBox(height: JeliyaSpacing.x4),
+                        itemBuilder: (context, index) => _MobileRoomRow(
+                          room: session.rooms[index],
+                          selected:
+                              session.rooms[index].roomId == currentRoomId,
+                          homonym:
+                              homonyms.contains(session.rooms[index].roomId),
+                          onSelectRoom: onSelectRoom,
+                        ),
                       ),
-                    ),
-                  ),
+                    );
+                  }),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(
@@ -138,11 +155,17 @@ class _MobileRoomRow extends StatelessWidget {
   const _MobileRoomRow({
     required this.room,
     required this.selected,
+    required this.homonym,
     required this.onSelectRoom,
   });
 
   final RoomSummary room;
   final bool selected;
+
+  /// True when another room in the list DISPLAYS the same name — then the row
+  /// carries the short id (decision 6). Unique names get no disambiguator.
+  final bool homonym;
+
   final ValueChanged<String> onSelectRoom;
 
   @override
@@ -197,10 +220,22 @@ class _MobileRoomRow extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(room.name ?? s.shellUntitledRoom,
-                    style: JeliyaText.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis),
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(room.name ?? s.shellUntitledRoom,
+                          style: JeliyaText.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                    ),
+                    // The name yields first; the short id is the disambiguator
+                    // and must stay readable at any width.
+                    if (homonym) ...[
+                      const SizedBox(width: JeliyaSpacing.x6),
+                      RoomShortId(roomId: room.roomId),
+                    ],
+                  ],
+                ),
                 _metaLine(s, tokens, stateLabel, departed),
               ],
             ),

--- a/app/lib/src/screens/modals/create_room.dart
+++ b/app/lib/src/screens/modals/create_room.dart
@@ -79,7 +79,17 @@ class _CreateRoomModalState extends State<CreateRoomModal> {
   Widget build(BuildContext context) {
     final s = context.strings;
     final tokens = JeliyaTokens.of(context);
+    final session = SessionScope.of(context);
     final canSubmit = !_busy && _name.text.trim().isNotEmpty;
+    // A local homonym WARNS but never blocks (decision 6): the name is a label
+    // the product does not own, and the new room gets its own room_id. Folds
+    // on the same DISPLAYED name the rooms list shows (name ?? Untitled room),
+    // trimmed and case-folded, so it clears the instant the name stops
+    // colliding (the field listener re-renders this).
+    final typed = _name.text.trim().toLowerCase();
+    final homonym = typed.isNotEmpty &&
+        session.rooms.any((r) =>
+            (r.name ?? s.shellUntitledRoom).trim().toLowerCase() == typed);
     return ModalScaffold(
       title: s.modalCreateRoomTitle,
       busy: _busy,
@@ -98,6 +108,18 @@ class _CreateRoomModalState extends State<CreateRoomModal> {
                 hintText: s.modalRoomNamePlaceholder),
             onSubmitted: (_) => _create(),
           ),
+          if (homonym) ...[
+            const SizedBox(height: JeliyaSpacing.x8),
+            // liveRegion: the warning appears/clears as the user types, so a
+            // screen reader hears it without the field losing focus.
+            Semantics(
+              liveRegion: true,
+              child: Text(
+                s.modalCreateRoomHomonymWarning,
+                style: TextStyle(fontSize: 12.5, color: tokens.amber),
+              ),
+            ),
+          ],
           const SizedBox(height: JeliyaSpacing.x12),
           JeliyaButton(
             label: _busy ? s.modalCreatingRoom : s.modalCreateRoom,

--- a/app/lib/src/screens/modals/leave_room.dart
+++ b/app/lib/src/screens/modals/leave_room.dart
@@ -20,6 +20,7 @@ import '../../theme.dart';
 import '../../widgets/buttons.dart';
 import '../../widgets/error_note.dart';
 import '../../widgets/modal_scaffold.dart';
+import '../../widgets/room_short_id.dart';
 import '../../widgets/template_text.dart';
 
 class LeaveRoomModal extends StatefulWidget {
@@ -91,6 +92,14 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
                       fontWeight: FontWeight.w700,
                       color: tokens.text)),
             },
+          ),
+          // The short id is repeated ALWAYS, homonym or not (decision 6):
+          // leaving publishes a signed departure that cannot be undone, and
+          // the name alone cannot identify which room that is. One mono line.
+          const SizedBox(height: JeliyaSpacing.x8),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: RoomShortId(roomId: widget.roomId, fontSize: 12.5),
           ),
           const SizedBox(height: JeliyaSpacing.x12),
           // Wrap + scale-down, not Row: inside a 360dp phone dialog the wider

--- a/app/lib/src/screens/sidebar.dart
+++ b/app/lib/src/screens/sidebar.dart
@@ -19,8 +19,10 @@ import '../l10n/strings_context.dart';
 import '../l10n/tokens.dart';
 import '../routes.dart';
 import '../session/daemon_session.dart';
+import '../session/room_homonyms.dart';
 import '../theme.dart';
 import '../widgets/copy_button.dart';
+import '../widgets/room_short_id.dart';
 import '../widgets/tree_mark.dart';
 
 /// One primary-nav entry (Sidebar.tsx `NAV`).
@@ -475,6 +477,14 @@ class _RoomsList extends StatelessWidget {
         ),
       );
     }
+    // Computed once for the whole list (not per row): the short id disambiguates
+    // rooms that DISPLAY the same name, including two untitled rooms
+    // (docs/room-workbench.md, decision 6). TODO(#49): a future room-search
+    // surface accepting name and short id lives here (the rooms list).
+    final homonyms = homonymousRoomIds(
+      [for (final r in rooms) (roomId: r.roomId, name: r.name)],
+      untitledLabel: s.shellUntitledRoom,
+    );
     return SliverSemantics(
       container: true,
       label: s.sidebarRoomsListLabel,
@@ -486,6 +496,7 @@ class _RoomsList extends StatelessWidget {
           itemBuilder: (context, index) => _RoomItem(
             room: rooms[index],
             selected: rooms[index].roomId == currentRoomId,
+            homonym: homonyms.contains(rooms[index].roomId),
             onSelectRoom: onSelectRoom,
           ),
         ),
@@ -498,11 +509,18 @@ class _RoomItem extends StatelessWidget {
   const _RoomItem({
     required this.room,
     required this.selected,
+    required this.homonym,
     required this.onSelectRoom,
   });
 
   final RoomSummary room;
   final bool selected;
+
+  /// True when another room in the list DISPLAYS the same name — then the row
+  /// carries the short id (decision 6). Unique names get no disambiguator:
+  /// it is noise when the name already identifies the room.
+  final bool homonym;
+
   final ValueChanged<String> onSelectRoom;
 
   @override
@@ -562,10 +580,22 @@ class _RoomItem extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(room.name ?? s.shellUntitledRoom,
-                    style: JeliyaText.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis),
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(room.name ?? s.shellUntitledRoom,
+                          style: JeliyaText.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                    ),
+                    // The name yields first; the short id is the disambiguator
+                    // and must stay readable at any width.
+                    if (homonym) ...[
+                      const SizedBox(width: JeliyaSpacing.x6),
+                      RoomShortId(roomId: room.roomId),
+                    ],
+                  ],
+                ),
                 Text(s.sidebarRoomMeta(room.memberCount, stateLabel),
                     style: JeliyaText.meta,
                     maxLines: 1,

--- a/app/lib/src/session/room_homonyms.dart
+++ b/app/lib/src/session/room_homonyms.dart
@@ -1,0 +1,43 @@
+/// Homonymous-room detection (docs/room-workbench.md, decision 6).
+///
+/// `room_id` is identity; `name` is a non-unique, daemon-local label that is
+/// `null` until the genesis event syncs. Two rooms are HOMONYMS when the names
+/// the UI actually displays are equal after trimming and case-folding —
+/// INCLUDING the untitled placeholder, so two unsynced (null-named) rooms are
+/// homonyms of each other, which is the most likely case for a new user.
+///
+/// Any surface where acting on the wrong room matters shows the short room id
+/// for a room in this set (the disambiguator), via the shared `shortId` helper.
+/// This is the SAME rule and the SAME facts the React client uses
+/// (`ui/src/lib/rooms.ts`) — the milestone AC.
+library;
+
+/// The set of `room_id`s that share a displayed name with at least one OTHER
+/// room in [rooms].
+///
+/// Display-driven on purpose: it folds over the SAME name the row shows
+/// (`name ?? untitledLabel`), trimmed and lower-cased, so a homonym is exactly
+/// what the eye sees as a duplicate. [untitledLabel] is the localized
+/// placeholder a null name renders as (`AppStrings.shellUntitledRoom`), folded
+/// in so untitled rooms count as homonyms of one another.
+///
+/// Pure — no widget, no localization lookup, no I/O — so it unit-tests without
+/// a tester. Callers map their own row type (`RoomSummary`, `FleetAgentRoom`,
+/// …) onto the `(roomId, name)` record. Repeated `room_id`s under one display
+/// name collapse (a room the fleet references from several agents is not a
+/// homonym of itself).
+Set<String> homonymousRoomIds(
+  Iterable<({String roomId, String? name})> rooms, {
+  required String untitledLabel,
+}) {
+  final idsByDisplayName = <String, Set<String>>{};
+  for (final room in rooms) {
+    final display = (room.name ?? untitledLabel).trim().toLowerCase();
+    (idsByDisplayName[display] ??= <String>{}).add(room.roomId);
+  }
+  final homonyms = <String>{};
+  for (final ids in idsByDisplayName.values) {
+    if (ids.length > 1) homonyms.addAll(ids);
+  }
+  return homonyms;
+}

--- a/app/lib/src/widgets/room_short_id.dart
+++ b/app/lib/src/widgets/room_short_id.dart
@@ -1,0 +1,45 @@
+/// The homonym disambiguator (docs/room-workbench.md, decision 6).
+///
+/// `room_id` is identity; `name` is a non-unique label. Wherever acting on the
+/// wrong room matters, the short room id is shown next to the name so two rooms
+/// that display the same name can be told apart. This renders it as a mono/code
+/// element via the shared [shortId] helper — not a second id-shortening rule —
+/// with an accessible label so a screen reader announces "Room ID {shortId}"
+/// rather than a bare hash floating in the row's name.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:jeliya_protocol/jeliya_protocol.dart' show shortId;
+
+import '../l10n/strings_context.dart';
+import '../theme.dart';
+
+class RoomShortId extends StatelessWidget {
+  const RoomShortId({super.key, required this.roomId, this.fontSize = 11.5});
+
+  final String roomId;
+
+  /// Matches the meta line it sits beside (11.5 in the room rows); the fleet
+  /// chip passes its own smaller size.
+  final double fontSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final s = context.strings;
+    final tokens = JeliyaTokens.of(context);
+    final short = shortId(roomId);
+    // One clean semantics node: the visible mono span is excluded so the row's
+    // accessible name reads "Room ID 4f2a…9c1b", not the raw truncation twice.
+    return Semantics(
+      label: s.roomShortIdLabel(short),
+      child: ExcludeSemantics(
+        child: Text(
+          short,
+          style: JeliyaText.mono(fontSize: fontSize, color: tokens.textMute),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/l10n_parity_test.dart
+++ b/app/test/l10n_parity_test.dart
@@ -132,6 +132,7 @@ void main() {
     expect(en.modalRoomNamePlaceholder, "Build Iroh Rooms MVP");
     expect(en.modalCreateRoom, "Create room");
     expect(en.modalCreatingRoom, "Creating…");
+    expect(en.modalCreateRoomHomonymWarning, "A room with that name already exists on this device — this one will get its own ID.");
     expect(en.modalJoinRoomTitle, "Join with a ticket");
     expect(en.modalTicketLabel, "Ticket");
     expect(en.modalTicketPlaceholder, "roomtkt1… or roomtkt1…#<endpoint_id>@host:port");
@@ -421,6 +422,7 @@ void main() {
     expect(en.fleetRelDaysAgo(7), "7d ago");
     expect(en.addAgentIntro('XemphasisX'), "Mint an agent-role ticket for a room you own. This XemphasisX — running the command below on the agent’s machine is a deliberate, human step (the security boundary).");
     expect(en.addAgentGuidance('XnpmX', 'XjeliyadX', 'XprefixX', 'XguideX'), "The runner lives in the repo — clone it and run this from the checkout (no XnpmX needed; Node 22+ required). Installed XjeliyadX via brew/script instead of building? Prefix the command with XprefixX so the runner finds it. Full guide: XguideX.");
+    expect(en.roomShortIdLabel('XshortIdX'), "Room ID XshortIdX");
     expect(en.modalJoinCopy('XcombinedX'), "Paste the invite you received. A combined invite (XcombinedX) fills in the peer address automatically.");
     expect(en.modalLeaveCopy('XroomX'), "Leaving XroomX publishes a signed membership departure. This is different from closing the local session; you’ll need a new invite to join again.");
     expect(en.onboardingJoinAttempt(7, 13), "Attempt 7/13");

--- a/app/test/room_disambiguation_test.dart
+++ b/app/test/room_disambiguation_test.dart
@@ -1,0 +1,263 @@
+/// Homonymous-room disambiguation (issue #49; docs/room-workbench.md,
+/// decision 6). `room_id` is identity and `name` is a non-unique local label,
+/// so any surface where acting on the wrong room matters shows the short id.
+///
+/// Covered here:
+///  - the pure [homonymousRoomIds] fold: named collisions, the untitled
+///    placeholder (two unsynced rooms are homonyms), case/trim folding, and
+///    the fleet's repeated-id dedup;
+///  - the rooms list shows the short id for BOTH same-named rooms — in the
+///    desktop rail AND the compact list, in the row's accessible name — at a
+///    strict phone surface in English AND French with zero overflow;
+///  - the Leave Room confirmation ALWAYS repeats the short id (homonym or not);
+///  - the Create Room dialog WARNS on a local homonym without disabling Create,
+///    and clears the warning when the name no longer collides.
+///
+/// Copy is asserted through the shared `en`/`fr` catalog instances
+/// (test/helpers.dart, docs/i18n.md rule 6). Room names are fixture data.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/screens/mobile_rooms.dart';
+import 'package:jeliya_app/src/screens/modals/create_room.dart';
+import 'package:jeliya_app/src/screens/modals/leave_room.dart';
+import 'package:jeliya_app/src/l10n/strings_context.dart';
+import 'package:jeliya_app/src/screens/sidebar.dart';
+import 'package:jeliya_app/src/session/daemon_session.dart';
+import 'package:jeliya_app/src/session/room_homonyms.dart';
+import 'package:jeliya_app/src/widgets/buttons.dart';
+import 'package:jeliya_app/src/widgets/modal_scaffold.dart';
+import 'package:jeliya_app/src/widgets/room_short_id.dart';
+import 'package:jeliya_protocol/jeliya_protocol.dart' show JeliyaMethods, shortId;
+
+import 'helpers.dart';
+
+// i18n-exempt: fixture room name reused across the file, not catalog copy.
+const _review = 'Product Review';
+
+/// Create a second room whose name collides with an existing one, then refresh
+/// the session so both appear in the room list (room.create allows duplicate
+/// names — decision 6). The mock delays every call (~60ms), so the create and
+/// the follow-up room.list are kicked off UNAWAITED and the fake clock is
+/// advanced by pumping — awaiting them directly would deadlock (no pump runs
+/// during the await).
+Future<void> _seedHomonym(
+    WidgetTester tester, DaemonSession session, String name) async {
+  unawaited(
+      session.client!.roomCreate(name).then((_) => session.refreshRooms()));
+  await pumpSteps(tester, steps: 8);
+}
+
+/// The TextButton inside the Create dialog's primary [JeliyaButton], for the
+/// enabled/disabled assertion.
+TextButton _createSubmit(WidgetTester tester) =>
+    tester.widget<TextButton>(find.descendant(
+      of: find.descendant(
+          of: find.byType(CreateRoomModal),
+          matching: find.widgetWithText(JeliyaButton, en.modalCreateRoom)),
+      matching: find.byType(TextButton),
+    ));
+
+/// A homonymous row's short id must be in the row's ACCESSIBLE name, not only a
+/// visual mono span. The row is a button that merges its descendants, so the
+/// disambiguator label is a substring of the merged node label.
+Finder _accessibleShortId(AppStrings s, String roomId) =>
+    find.bySemanticsLabel(RegExp(RegExp.escape(s.roomShortIdLabel(shortId(roomId)))));
+
+void main() {
+  group('homonymousRoomIds', () {
+    ({String roomId, String? name}) room(String id, String? name) =>
+        (roomId: id, name: name);
+    final untitled = en.shellUntitledRoom;
+
+    test('same displayed name → homonyms; a unique name is not', () {
+      final set = homonymousRoomIds(
+        [
+          room('a', _review),
+          room('b', _review),
+          room('c', 'Design System'), // i18n-exempt: fixture room name
+        ],
+        untitledLabel: untitled,
+      );
+      expect(set, {'a', 'b'});
+    });
+
+    test('two null-named rooms are homonyms via the untitled placeholder', () {
+      final set = homonymousRoomIds(
+        [
+          room('a', null),
+          room('b', null),
+          room('c', 'Named'), // i18n-exempt: fixture room name
+        ],
+        untitledLabel: untitled,
+      );
+      expect(set, {'a', 'b'},
+          reason: 'two unsynced rooms both render the placeholder');
+    });
+
+    test('a room literally named the placeholder is a homonym of a null room',
+        () {
+      final set = homonymousRoomIds(
+        [
+          room('a', null),
+          room('b', en.shellUntitledRoom),
+        ],
+        untitledLabel: untitled,
+      );
+      expect(set, {'a', 'b'});
+    });
+
+    test('folds case and trims surrounding whitespace', () {
+      final set = homonymousRoomIds(
+        [
+          room('a', 'Ops'), // i18n-exempt: fixture room name
+          room('b', '  ops  '), // i18n-exempt: fixture room name
+          room('c', 'OPS'), // i18n-exempt: fixture room name
+        ],
+        untitledLabel: untitled,
+      );
+      expect(set, {'a', 'b', 'c'});
+    });
+
+    test('a single room, and an empty list, yield no homonyms', () {
+      expect(
+          homonymousRoomIds([room('a', 'Solo')], untitledLabel: untitled), // i18n-exempt: fixture room name
+          isEmpty);
+      expect(homonymousRoomIds(const [], untitledLabel: untitled), isEmpty);
+    });
+
+    test('a repeated room id under one name collapses (fleet dedup)', () {
+      final set = homonymousRoomIds(
+        [
+          room('a', 'Shared'), // i18n-exempt: fixture room name
+          room('a', 'Shared'), // i18n-exempt: fixture room name
+        ],
+        untitledLabel: untitled,
+      );
+      expect(set, isEmpty,
+          reason: 'the same room referenced twice is not its own homonym');
+    });
+  });
+
+  testWidgets(
+      'desktop rail: both same-named rooms show the short id, in the row '
+      'accessible name', (tester) async {
+    final session = await pumpReadyApp(tester, newMockClient());
+    await _seedHomonym(tester, session, _review);
+
+    final inRail = find.descendant(
+        of: find.byType(Sidebar), matching: find.byType(RoomShortId));
+    expect(inRail, findsNWidgets(2),
+        reason: 'both Product Review rooms carry the disambiguator; '
+            'the unique-named rooms do not');
+
+    final reviews = session.rooms.where((r) => r.name == _review).toList();
+    expect(reviews, hasLength(2));
+    for (final r in reviews) {
+      expect(_accessibleShortId(en, r.roomId), findsOneWidget,
+          reason: 'the short id belongs in the row accessible name');
+    }
+  });
+
+  for (final french in const [false, true]) {
+    final lang = french ? 'fr' : 'en';
+    testWidgets(
+        'compact list ($lang): both same-named rooms show the short id, '
+        'accessible, zero overflow', (tester) async {
+      final ready = await pumpReadyMobileApp(tester, newMockClient());
+      final session = ready.session;
+      await _seedHomonym(tester, session, _review);
+      // Reach the rooms list the way a user does (EN back label) BEFORE the
+      // French flip, mirroring the rooms-screen regression test.
+      await mobileShowRoomsList(tester);
+      if (french) {
+        session.prefs.textLocale = 'fr';
+        await pumpSteps(tester, steps: 3);
+      }
+      final s = french ? fr : en;
+
+      final screen = find.byType(MobileRoomsScreen);
+      expect(screen, findsOneWidget);
+      expect(
+          find.descendant(of: screen, matching: find.byType(RoomShortId)),
+          findsNWidgets(2),
+          reason: 'both Product Review rows show the short id');
+
+      final reviews = session.rooms.where((r) => r.name == _review).toList();
+      expect(reviews, hasLength(2));
+      for (final r in reviews) {
+        expect(_accessibleShortId(s, r.roomId), findsOneWidget,
+            reason: 'the short id belongs in the row accessible name ($lang)');
+      }
+
+      expect(ready.overflows, isEmpty,
+          reason: 'zero overflows expected ($lang):\n'
+              '${ready.overflows.join('\n')}');
+    });
+  }
+
+  testWidgets('leave modal always repeats the room short id (mono, accessible)',
+      (tester) async {
+    final session = await pumpReadyApp(tester, newMockClient());
+    // Any room — the short id is shown ALWAYS, homonym or not, because leaving
+    // the wrong room publishes an irreversible signed departure.
+    final target = session.rooms.first;
+    final ctx = tester.element(find.byType(Sidebar));
+    unawaited(showJeliyaModal<bool>(ctx,
+        builder: (_) =>
+            LeaveRoomModal(roomId: target.roomId, roomName: target.name)));
+    await pumpSteps(tester, steps: 3);
+
+    final modal = find.byType(LeaveRoomModal);
+    expect(modal, findsOneWidget);
+    expect(find.descendant(of: modal, matching: find.byType(RoomShortId)),
+        findsOneWidget);
+    expect(
+        find.descendant(of: modal, matching: find.text(shortId(target.roomId))),
+        findsOneWidget,
+        reason: 'the truncated room id renders as a mono span');
+    expect(_accessibleShortId(en, target.roomId), findsOneWidget,
+        reason: 'the short id is announced to assistive tech');
+  });
+
+  testWidgets('create dialog warns on a local homonym without disabling Create',
+      (tester) async {
+    await pumpReadyApp(tester, newMockClient());
+    final ctx = tester.element(find.byType(Sidebar));
+    unawaited(showJeliyaModal<String>(ctx,
+        builder: (_) => const CreateRoomModal()));
+    await pumpSteps(tester, steps: 3);
+    expect(find.byType(CreateRoomModal), findsOneWidget);
+
+    final field = find.widgetWithText(TextField, en.modalRoomNamePlaceholder);
+
+    // A name that collides with an existing local room: warn, stay enabled.
+    await tester.enterText(field, _review);
+    await tester.pump();
+    expect(find.text(en.modalCreateRoomHomonymWarning), findsOneWidget);
+    expect(_createSubmit(tester).onPressed, isNotNull,
+        reason: 'a homonym never blocks creation');
+
+    // Case-folded / whitespace-padded collisions still warn.
+    await tester.enterText(field, '  product review  '); // i18n-exempt: fixture room name, folded
+    await tester.pump();
+    expect(find.text(en.modalCreateRoomHomonymWarning), findsOneWidget);
+
+    // A unique name clears the warning; Create stays enabled throughout.
+    await tester.enterText(field, 'A room with no twin'); // i18n-exempt: fixture room name
+    await tester.pump();
+    expect(find.text(en.modalCreateRoomHomonymWarning), findsNothing);
+    expect(_createSubmit(tester).onPressed, isNotNull);
+
+    // French: the warning renders from the fr catalog.
+    await tester.enterText(field, _review);
+    await tester.pump();
+    final session = SessionScope.of(ctx);
+    session.prefs.textLocale = 'fr';
+    await pumpSteps(tester, steps: 3);
+    expect(find.text(fr.modalCreateRoomHomonymWarning), findsOneWidget);
+  });
+}

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -20,7 +20,10 @@ export type GlobalDest = 'Rooms' | 'Agent Fleet' | 'Settings';
 /** The room destinations, as they are labelled. */
 export type RoomDestLabel = 'Activity' | 'People' | 'Agents & Runs' | 'Files' | 'Pipes';
 
-/** Room names from the populated mock fixture (ui/src/lib/mock.ts). */
+/** Room names from the populated mock fixture (ui/src/lib/mock.ts). Each is
+ *  UNIQUE, so `roomItem(name)` matches exactly one row — the homonym pair below
+ *  is deliberately kept out of this map so callers that iterate it stay
+ *  single-match. */
 export const MOCK_ROOMS = {
   main: 'Build Iroh Rooms MVP',
   workspace: 'Agent Workspace',
@@ -28,6 +31,11 @@ export const MOCK_ROOMS = {
   design: 'Design System',
   research: 'Research Lab',
 } as const;
+
+/** The name shared by the two homonymous fixture rooms (docs/room-workbench.md,
+ *  decision 6). `roomItem(HOMONYM_ROOM)` matches BOTH rows, which is the point:
+ *  only the short id shown on each row tells them apart. */
+export const HOMONYM_ROOM = 'Bug Triage';
 
 interface AppFixtures {
   /** True when this project's viewport is in the compact (phone) layout. */
@@ -104,10 +112,15 @@ export class AppDriver {
     ).toHaveAttribute('data-jeliya-transport', /mock fixtures \(VITE_MOCK=1\)/);
   }
 
-  roomItem(name: string) {
-    return this.page
+  /** A room row in the rail. Homonymous rooms share a name (decision 6), so
+   *  `disambig` — the short id the row shows next to that name — narrows to a
+   *  single one. Unique-named rooms need only the name, so existing callers
+   *  pass it alone and still get their one row. */
+  roomItem(name: string, disambig?: string) {
+    const byName = this.page
       .getByRole('navigation', { name: 'Rooms' })
       .getByRole('button', { name, exact: false });
+    return disambig ? byName.filter({ hasText: disambig }) : byName;
   }
 
   /** The single-pane containers (visibility differs per breakpoint). */

--- a/ui/e2e/room-disambiguation.spec.ts
+++ b/ui/e2e/room-disambiguation.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, MOCK_ROOMS, HOMONYM_ROOM } from './fixtures';
+import type { Page } from '@playwright/test';
+
+// Issue #49 / docs/room-workbench.md decision 6: `room_id` is identity, `name`
+// is a non-unique label. Any surface where acting on the wrong room matters
+// shows the short room id. The fixture seeds two rooms both named "Bug Triage"
+// (ui/src/lib/mock.ts) so the disambiguation has something to disambiguate.
+
+/** shortId(id) renders the tail of a `blake3:<hex>` id as `abcd…wxyz`. */
+const SHORT_ID = /^[0-9a-f]{4}…[0-9a-f]{4}$/;
+
+function dialog(page: Page) {
+  return page.getByRole('dialog');
+}
+
+test('homonymous rooms each show a distinct short id in the rail', async ({ app, page }) => {
+  await app.gotoRoomsList();
+
+  const rows = app.roomItem(HOMONYM_ROOM);
+  await expect(rows).toHaveCount(2);
+
+  // Every homonym row carries its own short-id token…
+  const disambigs = rows.locator('.room-disambig');
+  await expect(disambigs).toHaveCount(2);
+  const ids = (await disambigs.allInnerTexts()).map((t) => t.trim());
+  expect(ids[0]).toMatch(SHORT_ID);
+  expect(ids[1]).toMatch(SHORT_ID);
+  // …and the two differ — that difference is the whole point.
+  expect(ids[0]).not.toBe(ids[1]);
+
+  // The short id is real text in the row, so it lands in the accessible name:
+  // narrowing the same locator by it resolves to exactly one row.
+  await expect(app.roomItem(HOMONYM_ROOM, ids[0])).toHaveCount(1);
+
+  // A uniquely-named room gets no disambiguator — it would be noise there.
+  await expect(app.roomItem(MOCK_ROOMS.main).locator('.room-disambig')).toHaveCount(0);
+  // And nothing about this reintroduces the retired "Active" label.
+  await expect(page.getByRole('navigation', { name: 'Rooms' })).not.toContainText('Active');
+});
+
+test('the leave dialog always shows the room short id, even for a unique name', async ({
+  app,
+  page,
+}) => {
+  // Product Review has a unique name, so its rail row shows no disambiguator —
+  // but leaving is destructive and irreversible, so the dialog shows the short
+  // id anyway (decision 6: destructive actions repeat it, homonym or not).
+  await app.gotoPopulated();
+  await app.openRoom(MOCK_ROOMS.review);
+  await app.goToRoomDest('People');
+  await app.rightPanel.getByRole('button', { name: 'Leave', exact: true }).click();
+
+  const leave = dialog(page);
+  await expect(leave).toBeVisible();
+  await expect(leave.locator('.room-disambig')).toHaveCount(1);
+  await expect(leave.locator('.room-disambig')).toHaveText(SHORT_ID);
+});
+
+test('leaving one homonym shows that exact room’s short id', async ({ app, page }) => {
+  await app.gotoRoomsList();
+
+  // The first "Bug Triage" row is the one this identity is a plain member of
+  // (mock insertion order), so its roster offers Leave. Read its short id off
+  // the row before opening it.
+  const memberRow = app.roomItem(HOMONYM_ROOM).first();
+  const rowId = (await memberRow.locator('.room-disambig').innerText()).trim();
+  expect(rowId).toMatch(SHORT_ID);
+
+  await memberRow.click();
+  await expect(page.getByRole('heading', { level: 1, name: HOMONYM_ROOM })).toBeVisible();
+  await expect(app.timeline).toBeVisible();
+
+  await app.goToRoomDest('People');
+  await app.rightPanel.getByRole('button', { name: 'Leave', exact: true }).click();
+
+  // The dialog's short id is the one from the row we opened — not the other
+  // same-named room's. That is exactly what stops a departure landing on the
+  // wrong room.
+  await expect(dialog(page).locator('.room-disambig')).toHaveText(rowId);
+});
+
+test('the fleet shows short ids only on homonymous room chips', async ({ app, page }) => {
+  await app.gotoPopulated();
+  await app.navigate('Agent Fleet');
+
+  const fleet = page.getByRole('region', { name: 'Agent Fleet' });
+  const qaCard = fleet.locator('.fleet-card', { hasText: 'QA Agent' });
+  await expect(qaCard).toHaveCount(1);
+
+  // QA is a member of both "Bug Triage" rooms — two identically-labelled chips
+  // that only the short id separates.
+  const triageChips = qaCard.locator('.room-chip', { hasText: HOMONYM_ROOM });
+  await expect(triageChips).toHaveCount(2);
+  await expect(triageChips.locator('.room-disambig')).toHaveCount(2);
+
+  // Its uniquely-named room chip carries none.
+  const mvpChip = qaCard.locator('.room-chip', { hasText: MOCK_ROOMS.main });
+  await expect(mvpChip).toHaveCount(1);
+  await expect(mvpChip.locator('.room-disambig')).toHaveCount(0);
+});
+
+test('creating a room warns on a local name collision without blocking', async ({ app, page }) => {
+  await app.gotoRoomsList();
+  await page.getByRole('button', { name: 'Create Room', exact: true }).click();
+
+  const create = dialog(page);
+  const input = create.getByLabel('Room name');
+  const submit = create.getByRole('button', { name: 'Create room' });
+  const warning = create.getByText('already exists on this device', { exact: false });
+
+  // No warning for a fresh name.
+  await input.fill('A Brand New Room');
+  await expect(warning).toHaveCount(0);
+  await expect(submit).toBeEnabled();
+
+  // A collision — folded the same way homonym detection folds (trim + case) —
+  // warns but never disables Create.
+  await input.fill(`  ${MOCK_ROOMS.design.toUpperCase()}  `);
+  await expect(warning).toBeVisible();
+  await expect(submit).toBeEnabled();
+
+  // Clearing the collision clears the warning.
+  await input.fill('Something Else Entirely');
+  await expect(warning).toHaveCount(0);
+});

--- a/ui/node_modules
+++ b/ui/node_modules
@@ -1,1 +1,0 @@
-/home/sekou/AGI/jeliya/ui/node_modules

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,7 @@ import { buildDiagnostics } from './lib/diagnostics';
 import type { DiagnosticEvent } from './lib/diagnostics';
 import { loadAliases, saveAliases, suggestedNames } from './lib/names';
 import { shortId } from './lib/format';
+import { roomDisplayName } from './lib/rooms';
 import { splitInvite } from './lib/invite';
 import { joinRoomWithRetry } from './lib/join';
 import type { JoinProgress } from './lib/join';
@@ -1068,6 +1069,7 @@ export default function App({ client }: { client: Client }) {
           <CreateRoomModal
             client={client}
             connected={conn === 'connected'}
+            rooms={rooms}
             onDiagnosticError={rememberError}
             onClose={() => setCreateOpen(false)}
             onCreated={(rid) => {
@@ -1226,6 +1228,7 @@ function JoinRoomModal({
 function CreateRoomModal({
   client,
   connected,
+  rooms,
   onDiagnosticError,
   onClose,
   onCreated,
@@ -1233,6 +1236,9 @@ function CreateRoomModal({
   client: Client;
   /** See JoinRoomModal.connected. */
   connected: boolean;
+  /** The local room list, to warn — never block — on a name that already
+   *  exists on this device (docs/room-workbench.md, decision 6). */
+  rooms: RoomSummary[];
   onDiagnosticError: DiagnosticErrorRecorder;
   onClose(): void;
   onCreated(roomId: string): void;
@@ -1240,6 +1246,13 @@ function CreateRoomModal({
   const [name, setName] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<DaemonErrorShape | null>(null);
+
+  // A name is a label, not an identity: the product does not own the user's
+  // vocabulary, so a local collision warns and proceeds. Folded the same way
+  // homonym detection folds (trim + case), so the warning and the resulting
+  // short-id disambiguator agree on what "already exists" means.
+  const typed = name.trim().toLowerCase();
+  const collides = typed.length > 0 && rooms.some((r) => roomDisplayName(r).trim().toLowerCase() === typed);
 
   const create = async () => {
     if (!name.trim() || busy || !connected) return;
@@ -1266,6 +1279,13 @@ function CreateRoomModal({
           <span>Room name</span>
           <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Build Iroh Rooms MVP" autoFocus />
         </label>
+        {/* Non-blocking: role="status" (not "alert"), and the button stays
+            enabled. A duplicate name is allowed — the new room gets its own id. */}
+        {collides ? (
+          <p className="inline-warning" role="status">
+            A room named that already exists on this device — this one will get its own ID.
+          </p>
+        ) : null}
         <button type="submit" className="btn btn-primary" disabled={busy || !name.trim() || !connected}>
           {busy ? 'Creating…' : connected ? 'Create room' : 'Reconnecting…'}
         </button>
@@ -1318,8 +1338,12 @@ function LeaveRoomModal({
         }}
       >
         <p className="muted">
-          Leaving <strong>{roomName}</strong> publishes a signed membership departure. This is different from closing
-          the local session; you’ll need a new invite to join again.
+          Leaving <strong>{roomName}</strong>{' '}
+          {/* Always shown, homonym or not: leaving publishes a signed departure
+              that can't be undone, and the name alone cannot prove which room
+              this is (docs/room-workbench.md, decision 6). */}
+          <code className="room-disambig mono">{shortId(roomId)}</code> publishes a signed membership departure. This
+          is different from closing the local session; you’ll need a new invite to join again.
         </p>
         <div className="field-row">
           <button type="submit" className="btn btn-danger" disabled={busy || !connected}>

--- a/ui/src/components/FleetDashboard.tsx
+++ b/ui/src/components/FleetDashboard.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../lib/protocol';
 import { errorShape } from '../lib/protocol';
 import { colorForId, labelTone, prettyLabel, relTime, shortId } from '../lib/format';
+import { homonymousRoomIds, roomDisplayName } from '../lib/rooms';
 import { useNames } from './names';
 import { Avatar, CopyButton, ErrorNote, Modal, ProgressBar, SenderName, TreeMark } from './ui';
 
@@ -128,10 +129,14 @@ function Sparkline({ points, color, muted }: { points: HistoryPoint[] | null; co
 function AgentCard({
   agent,
   client,
+  homonyms,
   onOpenRoom,
 }: {
   agent: FleetAgent;
   client: Client;
+  /** Room_ids that share a display name with another room in the fleet's room
+   *  list — those chips carry a short id (docs/room-workbench.md, decision 6). */
+  homonyms: Set<string>;
   onOpenRoom(roomId: string): void;
 }) {
   const [points, setPoints] = useState<HistoryPoint[] | null>(null);
@@ -205,18 +210,26 @@ function AgentCard({
       ) : null}
 
       <div className="fleet-rooms">
-        {agent.rooms.map((r) => (
-          <button
-            key={r.room_id}
-            type="button"
-            className="room-chip"
-            onClick={() => onOpenRoom(r.room_id)}
-            title={r.name ?? r.room_id}
-          >
-            <span aria-hidden="true">⬡</span>
-            <span className="room-chip-name">{r.name ?? shortId(r.room_id)}</span>
-          </button>
-        ))}
+        {agent.rooms.map((r) => {
+          const name = roomDisplayName(r);
+          const isHomonym = homonyms.has(r.room_id);
+          return (
+            <button
+              key={r.room_id}
+              type="button"
+              className="room-chip"
+              onClick={() => onOpenRoom(r.room_id)}
+              title={r.name ?? r.room_id}
+              // A homonym chip's name alone can't say which room it opens, so
+              // the short id joins its accessible name, not just its visuals.
+              aria-label={isHomonym ? `${name} (${shortId(r.room_id)})` : undefined}
+            >
+              <span aria-hidden="true">⬡</span>
+              <span className="room-chip-name">{name}</span>
+              {isHomonym ? <code className="room-disambig mono">{shortId(r.room_id)}</code> : null}
+            </button>
+          );
+        })}
       </div>
 
       <div className="fleet-card-foot">
@@ -447,6 +460,9 @@ export function FleetDashboard({
   onOpenRoom(roomId: string): void;
 }) {
   const names = useNames();
+  // Homonyms are keyed off this identity's room list (the same rule the rail
+  // uses), so a chip is disambiguated the moment two of its rooms share a name.
+  const homonyms = homonymousRoomIds(rooms);
   const [fleet, setFleet] = useState<FleetResult | null>(null);
   const [error, setError] = useState<DaemonErrorShape | null>(null);
   const [loaded, setLoaded] = useState(false);
@@ -610,7 +626,7 @@ export function FleetDashboard({
         ) : (
           <div className="fleet-grid">
             {visible.map((a) => (
-              <AgentCard key={a.identity_id} agent={a} client={client} onOpenRoom={onOpenRoom} />
+              <AgentCard key={a.identity_id} agent={a} client={client} homonyms={homonyms} onOpenRoom={onOpenRoom} />
             ))}
           </div>
         )}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import type { ConnectionState, DaemonStatus, RoomSummary } from '../lib/protocol';
 import { colorForId, shortId } from '../lib/format';
+import { homonymousRoomIds, roomDisplayName } from '../lib/rooms';
 import { CopyButton, TreeMark, Wordmark } from './ui';
 import { useNames } from './names';
 
@@ -46,6 +47,10 @@ export function Sidebar({
   onJoinRoom(): void;
 }) {
   const names = useNames();
+  // Room_ids that share a display name with at least one other listed room
+  // (docs/room-workbench.md, decision 6). Computed once per render off the same
+  // list the rows are drawn from.
+  const homonyms = homonymousRoomIds(rooms);
   const identityId = status?.identity?.identity_id ?? null;
   const endpointId = status?.endpoint?.endpoint_id ?? null;
   const selfName = identityId ? names.display(identityId) : 'You';
@@ -105,11 +110,20 @@ export function Sidebar({
         </button>
       </div>
 
+      {/* TODO(#49): a room search (accepting the name AND the short id) belongs
+          here when it lands — a separate surface, deliberately deferred. Until
+          then the short-id disambiguator below is how a user tells homonyms
+          apart (docs/room-workbench.md, decision 6). */}
       <nav className="rooms-list" aria-label="Rooms">
         {rooms.map((room) => {
           const tint = colorForId(room.room_id);
           const active = room.room_id === currentRoomId;
           const departed = room.status === 'left' || room.status === 'removed';
+          const name = roomDisplayName(room);
+          // Only rooms sharing a display name with another get the short id:
+          // it is noise when the name already identifies the room, and the
+          // signal that prevents acting on the wrong room when it doesn't.
+          const isHomonym = homonyms.has(room.room_id);
           // One label, one fact (docs/room-workbench.md, decision 4). `status`
           // is signed membership; `open` is whether this daemon holds a live
           // session. "Active" used to mean the latter here while meaning the
@@ -134,9 +148,18 @@ export function Sidebar({
                 ⬡
               </span>
               <span className="room-info">
-                <span className="room-name">{room.name}</span>
+                <span className="room-name">{name}</span>
                 <span className="room-meta">
                   {room.member_count} member{room.member_count === 1 ? '' : 's'} · {stateLabel}
+                  {isHomonym ? (
+                    // Real text, not aria-hidden, so it lands in the row's
+                    // accessible name and a screen-reader user can tell the
+                    // homonyms apart too.
+                    <>
+                      {' · '}
+                      <code className="room-disambig mono">{shortId(room.room_id)}</code>
+                    </>
+                  ) : null}
                 </span>
               </span>
               {room.open ? <span className="dot dot-green" title="Session open" /> : null}

--- a/ui/src/lib/mock.ts
+++ b/ui/src/lib/mock.ts
@@ -504,7 +504,29 @@ class MockClient implements Client {
           progress: 60,
         }),
       );
-      for (const room of [workspace, review, design, research]) this.rooms.set(room.room_id, room);
+      // Homonym fixture (docs/room-workbench.md, decision 6): two rooms that
+      // render the SAME display name. `name` is a non-unique label, so the rail
+      // rows, the fleet chips, and any destructive action must show the short
+      // room id to keep them apart. Appended AFTER the rooms above so the first
+      // active room (the boot-restored default) stays the MVP room. `triageA`
+      // has this identity as a plain member (so its roster offers Leave);
+      // `triageB` is owned here. QA is in both, so the fleet shows one agent
+      // card with two identically-named chips that only the short id separates.
+      const triageA = buildSideRoom(
+        'bug-triage-a',
+        'Bug Triage',
+        [MAYA, ALEX, SAM, QA],
+        'member',
+        'Triage inbound bug reports here.',
+      );
+      const triageB = buildSideRoom(
+        'bug-triage-b',
+        'Bug Triage',
+        [ALEX, SAM, QA],
+        'owner',
+        'Second triage room — same name, different room.',
+      );
+      for (const room of [workspace, review, design, research, triageA, triageB]) this.rooms.set(room.room_id, room);
       // Regression-suite hook (`?mock_ticket=<suffix>`): a pre-minted,
       // redeemable ticket into a room this identity has NOT joined yet (see
       // INVITED_ID), so a join success path exercises a real membership and

--- a/ui/src/lib/rooms.test.ts
+++ b/ui/src/lib/rooms.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { homonymousRoomIds, roomDisplayName, UNTITLED_ROOM } from './rooms';
+
+const room = (room_id: string, name: string | null) => ({ room_id, name });
+
+describe('roomDisplayName', () => {
+  it('shows the label when present', () => {
+    expect(roomDisplayName(room('r1', 'Design System'))).toBe('Design System');
+  });
+
+  it('falls back to the untitled placeholder for a null (unsynced) name', () => {
+    expect(roomDisplayName(room('r1', null))).toBe(UNTITLED_ROOM);
+  });
+});
+
+describe('homonymousRoomIds', () => {
+  it('returns no ids when every display name is unique', () => {
+    const set = homonymousRoomIds([
+      room('a', 'Design System'),
+      room('b', 'Product Review'),
+      room('c', 'Research Lab'),
+    ]);
+    expect(set.size).toBe(0);
+  });
+
+  it('flags every member of a homonym group, and only those', () => {
+    const set = homonymousRoomIds([
+      room('a', 'Bug Triage'),
+      room('b', 'Bug Triage'),
+      room('c', 'Design System'),
+    ]);
+    expect([...set].sort()).toEqual(['a', 'b']);
+    expect(set.has('c')).toBe(false);
+  });
+
+  it('treats two unsynced (null-named) rooms as homonyms of each other', () => {
+    // The most likely case for a new user: neither genesis event has synced, so
+    // both render the untitled placeholder and must both disambiguate.
+    const set = homonymousRoomIds([room('a', null), room('b', null)]);
+    expect([...set].sort()).toEqual(['a', 'b']);
+  });
+
+  it('a single untitled room is not a homonym of anything', () => {
+    const set = homonymousRoomIds([room('a', null), room('b', 'Named Room')]);
+    expect(set.size).toBe(0);
+  });
+
+  it('folds case and surrounding whitespace before comparing', () => {
+    // The same display name the UI shows, trimmed and case-folded — a user
+    // cannot act on the difference between "Design" and " design ".
+    const set = homonymousRoomIds([
+      room('a', 'Design'),
+      room('b', '  design  '),
+      room('c', 'DESIGN'),
+    ]);
+    expect([...set].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('an unsynced room is a homonym of a room literally named "Untitled room"', () => {
+    // The placeholder is compared like any other display name, so a null name
+    // and an explicit "untitled room" label collide.
+    const set = homonymousRoomIds([room('a', null), room('b', 'untitled room')]);
+    expect([...set].sort()).toEqual(['a', 'b']);
+  });
+});

--- a/ui/src/lib/rooms.ts
+++ b/ui/src/lib/rooms.ts
@@ -1,0 +1,53 @@
+// Room identity vs. label (docs/room-workbench.md, decision 6). `room_id` is
+// identity; `name` is a non-unique, daemon-local label that is null until the
+// genesis event syncs. Homonym detection and the untitled placeholder both live
+// here so every surface shows — and disambiguates by short id — the SAME
+// display name the user reads.
+
+/** What a room with no synced name renders as. A null name means the genesis
+ *  event has not arrived yet, so two such rooms render the same string and are
+ *  homonyms of each other — the most likely case for a brand-new user. Must
+ *  match the placeholder App.tsx renders for a null name. */
+export const UNTITLED_ROOM = 'Untitled room';
+
+/** The minimum a room needs to be named and compared — satisfied by both
+ *  `RoomSummary` and a fleet room reference (`FleetAgentRoom`). */
+export interface NamedRoom {
+  room_id: string;
+  name: string | null;
+}
+
+/** The name the UI shows for a room: its label, or the untitled placeholder
+ *  when the name has not synced. Every surface must display this so homonym
+ *  detection stays based on the exact string the user reads. */
+export function roomDisplayName(room: NamedRoom): string {
+  return room.name ?? UNTITLED_ROOM;
+}
+
+/** The key two rooms collide on: the displayed name, trimmed and case-folded.
+ *  Case and surrounding whitespace are not a distinction a human scanning a
+ *  list can act on, so " Design " and "design" fold together. */
+function homonymKey(room: NamedRoom): string {
+  return roomDisplayName(room).trim().toLowerCase();
+}
+
+/** The set of `room_id`s that share a display name (trimmed, case-folded) with
+ *  at least one OTHER room in the list. A room whose display name is unique is
+ *  NOT in the set: the short-id disambiguator is noise when the name already
+ *  identifies the room. The untitled placeholder participates like any other
+ *  name, so two unsynced rooms are homonyms of each other. Pure — every surface
+ *  disambiguates off this one rule. */
+export function homonymousRoomIds(rooms: NamedRoom[]): Set<string> {
+  const idsByKey = new Map<string, string[]>();
+  for (const room of rooms) {
+    const key = homonymKey(room);
+    const ids = idsByKey.get(key);
+    if (ids) ids.push(room.room_id);
+    else idsByKey.set(key, [room.room_id]);
+  }
+  const homonyms = new Set<string>();
+  for (const ids of idsByKey.values()) {
+    if (ids.length > 1) for (const id of ids) homonyms.add(id);
+  }
+  return homonyms;
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -763,6 +763,18 @@ button.sender-name:not(:disabled):hover {
   gap: 4px;
 }
 
+/* A non-blocking advisory (e.g. a locally-colliding room name): amber, not the
+   red of a failure, and it never disables the action it sits above. */
+.inline-warning {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: 9px;
+  background: var(--amber-dim);
+  border: 1px solid var(--amber-line);
+  color: var(--text);
+  font-size: 13px;
+}
+
 .error-title {
   color: var(--text);
   font-size: 13.5px;
@@ -1083,6 +1095,16 @@ button.sender-name:not(:disabled):hover {
 .room-meta {
   font-size: 11.5px;
   color: var(--text-mute);
+}
+
+/* The short-id disambiguator (docs/room-workbench.md, decision 6): a subtle
+   mono token shown next to a room's name wherever two rooms share one — in a
+   rail row's meta line, a fleet room chip, and always in the Leave dialog.
+   Dim and letterspaced so it reads as an id, never competing with the name. */
+.room-disambig {
+  color: var(--text-mute);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .rooms-empty {


### PR DESCRIPTION
Closes #49. The last issue in milestone [UX 1 — Room Workbench foundation](https://github.com/kortiene/jeliya/milestone/2). Cross-client; base is `main` (the shell stack #89/#90/#93 is merged).

A room's `name` is a non-unique local label — two rooms can share one, and two rooms whose genesis event hasn't synced both render "Untitled room" (the case a new user hits first). `room_id` is the identity (`docs/room-workbench.md`, decision 6). Where acting on the wrong room matters, the short room id disambiguates.

## The rule (identical on both clients)

- **`homonymousRoomIds(rooms)`** — a pure helper on each client (`ui/src/lib/rooms.ts`, `app/lib/src/session/room_homonyms.dart`) returning the ids that share a **display** name (trimmed, case-folded, **untitled placeholder included**) with another room. Only ambiguous rooms get the marker — a short id on a uniquely-named room is noise.
- **The short id renders** on homonymous rooms in the rooms rail/list rows and the fleet chips, **in the accessible name** (not just a visual mono span).
- **The Leave modal shows it always**, homonym or not — a signed departure can't be undone, and one mono line is cheap insurance against leaving the wrong room.
- **Create warns, without blocking**, when the typed name collides with an existing local room (trim/case-folded). The Create button stays enabled; the warning clears when the name stops colliding.

## Scope note: room search deferred

The final AC ("search accepts name and short id") has **no surface to attach to** — neither client has a room search today. Rather than invent one in this change, a `// TODO(#49)` marks where it would live; the visible disambiguator makes homonyms distinguishable in the meantime. Happy to file a follow-up if you'd like the search built.

## ⚠️ Also fixes a regression I introduced in #90

`ui/node_modules` was accidentally committed in #90 as a **self-referential symlink** (mode 120000 → itself) and is now on `main`. A fresh checkout of main gets a broken symlink where node_modules should be (`Too many levels of symbolic links` breaks tsc/vite/playwright); CI survives only because `npm ci` clobbers it first. Root cause: the ignore pattern was `node_modules/` (trailing slash → matches directories but not a symlink of that name), so a worktree convenience symlink got staged by `git add -A`. This PR removes the tracked entry and changes the pattern to `node_modules`. **This is worth cherry-picking to main promptly** if you'd rather not wait for this PR — it's the first commit (`4c48bb7`), isolated.

## Verification

**React:** tsc clean · vitest 44/44 · build clean · playwright **255/255** across all four viewport projects (20 new in `room-disambiguation.spec.ts`).
**Flutter (pinned 3.41.5):** analyze clean · l10n + parity byte-exact · `flutter test` **202/202** · i18n-gate OK (2 new ARB keys, EN+FR, regenerated).

New coverage on both: two same-named rooms show distinct short ids (EN+FR, strict surface, no overflow); the leave modal shows the id; create warns on a folded collision without disabling Create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)