### PR TITLE
fix(flutter): anchor the timeline across reconnect and backlog replay (#68)

### DIFF
--- a/app/lib/src/screens/timeline.dart
+++ b/app/lib/src/screens/timeline.dart
@@ -8,6 +8,14 @@
 /// pending status lines (Sending... / Sent locally, syncing... / Couldn't
 /// send + Retry).
 ///
+/// Reconnect anchoring (#68): a reconnect re-opens the room into a fresh store,
+/// so the timeline collapses to empty and refills with the resynced backlog. A
+/// reader at the bottom stays pinned to the newest event; a reader in history
+/// keeps their exact position (numeric offset for the wholesale reload; a
+/// captured getOffsetToReveal anchor for a live splice above the viewport, as
+/// Flutter has no native scroll anchoring), and the pill counts only genuinely
+/// new events past a reload baseline — never the whole reloaded backlog.
+///
 /// Data comes from `SessionScope.of(context).room`; the shell keys this
 /// widget by roomId and wraps it in a ListenableBuilder on the RoomStore, so
 /// scroll/live-region state resets on room switch and rebuilds ride the
@@ -17,6 +25,7 @@ library;
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:jeliya_protocol/jeliya_protocol.dart'
     show
         FetchState,
@@ -151,11 +160,57 @@ class TimelineView extends StatefulWidget {
 
 class _TimelineViewState extends State<TimelineView> {
   final ScrollController _controller = ScrollController();
+
+  /// True while the reader is within [_stickThresholdPx] of the bottom — new
+  /// content then jumps into view; scrolled up, it feeds the pill instead.
   bool _stick = true;
-  int _lastCount = 0;
-  String? _lastTailId;
+
+  /// Item count and tail identity from the last processed build, so the next
+  /// change is classified as an append (new tail) vs a splice above the
+  /// viewport (out-of-order / backlog insert).
+  int _prevCount = 0;
+  String? _prevTailId;
+  bool _pendingAppended = false;
+  int _pendingGrew = 0;
+
+  /// The reader's last deliberate scroll offset (from [_onScroll]); the anchor
+  /// restored after a wholesale reload collapses and refills the list.
+  double _lastOffset = 0;
+
   int _newItemCount = 0;
   double _viewportDim = 0;
+
+  // -- reload / anchor bookkeeping ----------------------------------------------
+  //
+  // A reconnect re-opens the room into a fresh RoomStore, so the timeline
+  // collapses to empty (skeleton) and then refills with the resynced backlog.
+  // Across that churn the reader's position and an honest "new" count must
+  // survive — the fix for the position shifting under a reader (#68).
+
+  /// Set when a reader-in-history reload is in flight: restore [_restoreOffset]
+  /// once the backlog lands (not before — the empty frames would restore to 0).
+  bool _restorePending = false;
+  double _restoreOffset = 0;
+
+  /// Seen-item baseline captured when the timeline empties, so the refilled
+  /// backlog announces only genuinely-new events, never the whole reload.
+  int? _reloadBaseline;
+
+  /// Stable per-row [GlobalKey]s so the reader's anchor row can be located and
+  /// measured (getOffsetToReveal) before and after a splice inserts events
+  /// above it — Flutter has no native scroll anchoring, so we recreate it.
+  final Map<String, GlobalKey> _rowKeys = {};
+
+  /// The reader's anchor across a splice: the stable id of the row nearest the
+  /// viewport top and its signed offset from that top, captured pre-layout.
+  String? _anchorId;
+  double _anchorDelta = 0;
+
+  /// The current store, captured each build so the post-frame reconcile can
+  /// read [RoomStore.loading] without another context lookup.
+  RoomStore? _store;
+
+  bool _reconcileScheduled = false;
 
   @override
   void initState() {
@@ -171,21 +226,102 @@ class _TimelineViewState extends State<TimelineView> {
 
   void _onScroll() {
     if (!_controller.hasClients) return;
+    // Ignore the churn while a reload empties then refills the list: the
+    // transient 0-extent frames must not flip stick or corrupt the anchor.
+    if (_restorePending) return;
     final pos = _controller.position;
+    _lastOffset = pos.pixels;
     _stick = pos.maxScrollExtent - pos.pixels < _stickThresholdPx;
     // Scrolling back within the threshold clears the pill.
     if (_stick && _newItemCount != 0) setState(() => _newItemCount = 0);
   }
 
-  /// On item-count change: stick → jump to bottom and reset the counter;
-  /// scrolled up → accumulate the delta into the pill.
-  void _afterItemsChanged(int delta) {
-    if (!mounted) return;
+  /// Post-frame scroll reconciliation after the item set changed. Ported from
+  /// Timeline.tsx's `syncScroll` + items effect: restore the reader's anchor
+  /// across a reconnect reload, stick to the bottom, grow the pill on appends,
+  /// or absorb a splice above the viewport so the first visible event holds its
+  /// pixel offset. Reads the intent captured in build ([_restorePending],
+  /// [_reloadBaseline], [_pendingAppended]/[_pendingGrew]) and the pre-layout
+  /// anchor ([_captureAnchor]).
+  void _applyScroll() {
+    if (!mounted || !_controller.hasClients) return;
+    final loading = _store?.loading ?? false;
+
+    if (_restorePending) {
+      // Wait for the resynced backlog: restoring against the empty/skeleton
+      // frames would land at the top and drop the reader's anchor.
+      if (loading || _prevCount == 0) return;
+      final max = math.max(0.0, _controller.position.maxScrollExtent);
+      _controller.jumpTo(math.min(_restoreOffset, max));
+      _lastOffset = _controller.position.pixels;
+      // Everything past what the reader had actually seen is "new" — announcing
+      // the whole reloaded backlog would be a lie.
+      final seen = _reloadBaseline ?? 0;
+      final next = math.max(0, _prevCount - seen);
+      _restorePending = false;
+      _reloadBaseline = null;
+      if (next != _newItemCount) setState(() => _newItemCount = next);
+      return;
+    }
+
     if (_stick) {
+      _reloadBaseline = null;
       _jumpToBottom(3);
       if (_newItemCount != 0) setState(() => _newItemCount = 0);
-    } else if (delta > 0) {
-      setState(() => _newItemCount += delta);
+      return;
+    }
+
+    // Reading history, a live change with no reload in flight.
+    _reloadBaseline = null;
+    if (_pendingAppended) {
+      // New tail content the reader has not seen — count it, do not move.
+      if (_pendingGrew > 0) setState(() => _newItemCount += _pendingGrew);
+    } else {
+      // A splice above the viewport (out-of-order / backlog insert): re-pin the
+      // anchor captured pre-layout so the first visible event holds its pixel
+      // offset. Nothing counts as new-at-bottom.
+      _restoreAnchor();
+    }
+  }
+
+  /// Record the reader's anchor: the built row nearest the viewport top and its
+  /// signed offset from that top. Reads the CURRENT (pre-layout) geometry, so a
+  /// splice landing this frame can be undone in [_restoreAnchor] post-layout.
+  void _captureAnchor() {
+    _anchorId = null;
+    if (!_controller.hasClients) return;
+    final pixels = _controller.position.pixels;
+    var best = double.infinity;
+    for (final entry in _rowKeys.entries) {
+      final renderObject = entry.value.currentContext?.findRenderObject();
+      if (renderObject == null || !renderObject.attached) continue;
+      final reveal =
+          RenderAbstractViewport.of(renderObject).getOffsetToReveal(renderObject, 0).offset;
+      final delta = reveal - pixels;
+      if (delta.abs() < best) {
+        best = delta.abs();
+        _anchorId = entry.key;
+        _anchorDelta = delta;
+      }
+    }
+  }
+
+  /// Restore the [_captureAnchor] anchor: jump so that row sits [_anchorDelta]
+  /// below the viewport top again, absorbing whatever height a splice inserted
+  /// above it.
+  void _restoreAnchor() {
+    final id = _anchorId;
+    if (id == null || !_controller.hasClients) return;
+    final renderObject = _rowKeys[id]?.currentContext?.findRenderObject();
+    if (renderObject == null || !renderObject.attached) return;
+    final reveal =
+        RenderAbstractViewport.of(renderObject).getOffsetToReveal(renderObject, 0).offset;
+    final target = (reveal - _anchorDelta)
+        .clamp(0.0, _controller.position.maxScrollExtent)
+        .toDouble();
+    if ((target - _controller.position.pixels).abs() > 0.5) {
+      _controller.jumpTo(target);
+      _lastOffset = _controller.position.pixels;
     }
   }
 
@@ -255,26 +391,53 @@ class _TimelineViewState extends State<TimelineView> {
       });
     final items = [for (final i in indexed) merged[i]];
 
-    if (items.length != _lastCount) {
-      final delta = items.length - _lastCount;
-      // A late-backlog SPLICE (reconnected peer's older events insert above)
-      // leaves the tail item unchanged — it must not inflate the 'new
-      // messages' pill, which promises new content at the BOTTOM. Known
-      // deviation from the web: the browser's native scroll anchoring also
-      // preserves the reading position across such splices; Flutter has no
-      // equivalent without a custom RenderSliver, so a splice above the
-      // viewport still shifts the scroll position here.
-      final tailId = items.isEmpty
-          ? null
-          : (items.last.event?.eventId ?? items.last.pendingMsg!.clientId);
-      final appended = tailId != _lastTailId;
-      _lastCount = items.length;
-      _lastTailId = tailId;
-      WidgetsBinding.instance
-          .addPostFrameCallback((_) => _afterItemsChanged(appended ? delta : 0));
+    _store = store;
+
+    // While reading history, snapshot the reader's anchor from the CURRENT
+    // (pre-layout) frame, so a splice this build can restore it post-layout.
+    if (!_restorePending && !_stick) _captureAnchor();
+
+    final count = items.length;
+    final tailId = items.isEmpty
+        ? null
+        : (items.last.event?.eventId ?? items.last.pendingMsg!.clientId);
+
+    if (count != _prevCount) {
+      final previous = _prevCount;
+      // A splice above the viewport (out-of-order / backlog insert) leaves the
+      // tail unchanged; only a new tail is an append that feeds the pill.
+      _pendingAppended = tailId != _prevTailId;
+      _pendingGrew = count - previous;
+      _prevCount = count;
+      _prevTailId = tailId;
+
+      // A wholesale reload (reconnect re-open into a fresh store) empties the
+      // timeline before it refills. The instant it empties, remember how much
+      // the reader had truly seen and — if they were reading history — the spot
+      // to restore, so neither the pill nor the position lies on refill.
+      if (count == 0 && previous > 0) {
+        _reloadBaseline = previous - _newItemCount;
+        if (!_stick) {
+          _restorePending = true;
+          _restoreOffset = _lastOffset;
+        }
+      }
+
+      if (!_reconcileScheduled) {
+        _reconcileScheduled = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _reconcileScheduled = false;
+          _applyScroll();
+        });
+      }
     }
 
     final rows = _buildRows(fmt, items, selfId);
+    // Each row carries a stable GlobalKey (below) so [_captureAnchor] can locate
+    // and measure the reader's anchor row; prune keys for rows that left so the
+    // map tracks only what is currently on screen.
+    final rowIds = {for (final row in rows) _rowKey(row)};
+    _rowKeys.removeWhere((id, _) => !rowIds.contains(id));
 
     Widget scroller;
     if (!loading && items.isEmpty) {
@@ -306,7 +469,9 @@ class _TimelineViewState extends State<TimelineView> {
               itemBuilder: (context, index) {
                 if (loading && index == 0) return const _SkeletonRows();
                 final row = rows[index - extra];
+                final id = _rowKey(row);
                 return Padding(
+                  key: _rowKeys.putIfAbsent(id, GlobalKey.new),
                   padding: EdgeInsets.only(top: row.topSpacing),
                   child: _buildRow(context, row, store, selfId, rowCap),
                 );
@@ -342,6 +507,15 @@ class _TimelineViewState extends State<TimelineView> {
         ],
       ),
     );
+  }
+
+  /// A stable identity for a render row: a divider keys on its (unique-per-day)
+  /// label, an item on its signed `event_id` or optimistic `clientId`. Feeds the
+  /// ListView row keys + [ListView.builder]'s `findChildIndexCallback`.
+  String _rowKey(_Row row) {
+    final item = row.item;
+    if (item == null) return 'div:${row.dividerLabel}';
+    return 'it:${item.event?.eventId ?? item.pendingMsg!.clientId}';
   }
 
   List<_Row> _buildRows(JeliyaFormats fmt, List<_Item> items, String? selfId) {

--- a/app/test/helpers.dart
+++ b/app/test/helpers.dart
@@ -324,6 +324,97 @@ class FlakySendClient extends DelegatingClient {
   }
 }
 
+/// Drives disconnect→reconnect by hand and lets a test grow the `room.open`
+/// backlog (the reconnect re-sync) or push a single event (a live splice), so
+/// the timeline scroll-anchor behaviour (#68) can be exercised deterministically.
+///
+/// Everything in [backlog] is appended to every `room.open` for
+/// [MockClient.mainRoomId], so setting it BEFORE boot seeds a tall history and
+/// growing it before [reconnect] models newly-synced events. A [reconnect] drops
+/// then restores the connection, which re-runs the session bootstrap (the real
+/// reconnect re-sync path — pushes are lossy) and re-opens the current room into
+/// a fresh store, collapsing then refilling its timeline.
+class ReplayClient extends DelegatingClient {
+  ReplayClient(super.inner) {
+    inner.states.listen(_emitState);
+    inner.pushes.listen(_pushes.add);
+  }
+
+  final StreamController<ConnectionState> _states =
+      StreamController<ConnectionState>.broadcast();
+  final StreamController<Push> _pushes = StreamController<Push>.broadcast();
+  ConnectionState _state = ConnectionState.disconnected;
+
+  /// Events appended to every mainRoom `room.open` timeline (the resynced
+  /// backlog); mutate before [reconnect] to model events arriving in the gap.
+  final List<TimelineEvent> backlog = [];
+
+  @override
+  ConnectionState get state => _state;
+
+  @override
+  Stream<ConnectionState> get states => _states.stream;
+
+  @override
+  Stream<Push> get pushes => _pushes.stream;
+
+  void _emitState(ConnectionState next) {
+    _state = next;
+    _states.add(next);
+  }
+
+  /// One reconnect cycle: drop then restore the connection. The session re-runs
+  /// bootstrap on the transition back to connected and re-opens the room.
+  void reconnect() {
+    _emitState(ConnectionState.disconnected);
+    _emitState(ConnectionState.connected);
+  }
+
+  /// Deliver a live `room.event` push (an out-of-order or tail splice).
+  void pushEvent(TimelineEvent event) => _pushes.add(
+      Push('room.event', {'room_id': event.roomId, 'event': event.toJson()}));
+
+  @override
+  Future<dynamic> call(String method, [Map<String, dynamic>? params]) async {
+    final result = await inner.call(method, params);
+    if (method == 'room.open' &&
+        backlog.isNotEmpty &&
+        params?['room_id'] == MockClient.mainRoomId &&
+        result is Map) {
+      final map = Map<String, dynamic>.from(result);
+      final timeline = List<dynamic>.from(map['timeline'] as List);
+      timeline.addAll(backlog.map((e) => e.toJson()));
+      map['timeline'] = timeline;
+      return map;
+    }
+    return result;
+  }
+}
+
+/// A minimal `message` event for injecting history/backlog/splices. [eventId]
+/// defaults to a stable id derived from [ts]+[body], so replaying the same
+/// event id exercises the fold's dedup (no duplicate row).
+TimelineEvent syntheticMessage({
+  required int ts,
+  required String body,
+  String? roomId,
+  MockPerson? from,
+  String? eventId,
+}) {
+  final person = from ?? MockPeople.maya;
+  return TimelineEvent(
+    eventId: eventId ?? 'test-$ts-$body',
+    roomId: roomId ?? MockClient.mainRoomId,
+    ts: ts,
+    sender: Sender(
+        identityId: person.identityId,
+        deviceId: person.deviceId,
+        role: person.role),
+    kind: TimelineKinds.message,
+    body: body,
+  );
+}
+
 /// Masks the identity off the FIRST `daemon.status` so the identity
 /// onboarding step renders against a daemon that already has one — the race
 /// where `identity.create` fails with `identity_exists` and the client must

--- a/app/test/timeline_reconnect_anchor_test.dart
+++ b/app/test/timeline_reconnect_anchor_test.dart
@@ -1,0 +1,220 @@
+/// Timeline scroll-anchor behaviour across reconnect backlog replay and live
+/// splices (#68): a reader in history keeps the first visible event and its
+/// pixel offset while the resynced backlog lands; a reader at the bottom stays
+/// pinned to the newest event; the "new activity" pill counts only genuinely
+/// new events, never the whole reloaded backlog; and duplicate / out-of-order
+/// replay neither duplicates a row nor jumps the viewport. Covered on both the
+/// desktop and the compact (mobile) shells.
+library;
+
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/screens/timeline.dart';
+import 'package:jeliya_protocol/jeliya_protocol.dart' show TimelineEvent;
+import 'package:jeliya_protocol/testing.dart';
+
+import 'helpers.dart';
+
+Finder _timelineScrollable() => find.descendant(
+    of: find.byType(TimelineView), matching: find.byType(Scrollable));
+
+ScrollPosition _position(WidgetTester tester) =>
+    tester.state<ScrollableState>(_timelineScrollable()).position;
+
+/// Jump the timeline to [offset] (0 = oldest at the top) and let stick/anchor
+/// state settle. Returns the resulting scroll position.
+Future<ScrollPosition> _scrollTo(WidgetTester tester, double offset) async {
+  final pos = _position(tester);
+  pos.jumpTo(offset.clamp(0.0, pos.maxScrollExtent));
+  await tester.pump();
+  await tester.pump();
+  return _position(tester);
+}
+
+/// [count] short `message` events starting at [startTs], one per minute, bodied
+/// `prefix i` (e.g. `history 0`) for stable finders.
+List<TimelineEvent> _messages(int count,
+    {required int startTs, required String prefix, MockPerson? from}) {
+  return [
+    for (var i = 0; i < count; i++)
+      syntheticMessage(
+          ts: startTs + i * 60000, body: '$prefix $i', from: from),
+  ];
+}
+
+void main() {
+  // A day well before the fixtures so seeded history sorts to the very top; a
+  // day after so fresh backlog sorts to the tail. Absolute (not fixture-derived)
+  // so it can be set before the room id is known.
+  final now = DateTime.now().millisecondsSinceEpoch;
+  final historyStart = now - 7 * 86400000;
+  final freshStart = now + 3600000;
+
+  testWidgets(
+      'reading history: a reconnect backlog holds the position and counts only new',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    // Seed a tall history (top anchors) so the room actually scrolls.
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    await pumpReadyApp(tester, client);
+
+    // Read history: jump to the very top, where the seeded lines live.
+    await _scrollTo(tester, 0);
+    expect(find.text('history 1'), findsOneWidget);
+    final anchorDy = tester.getTopLeft(find.text('history 1')).dy;
+
+    // Three genuinely-new events sync in during the gap, at the tail.
+    client.backlog
+        .addAll(_messages(3, startTs: freshStart, prefix: 'fresh', from: MockPeople.sam));
+    client.reconnect();
+    await pumpSteps(tester);
+
+    // The reader's spot is preserved: the anchor holds its exact pixel offset
+    // and the viewport did not jump to the freshly-synced tail.
+    expect(find.text('history 1'), findsOneWidget);
+    expect(tester.getTopLeft(find.text('history 1')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, closeTo(0, 1.0));
+    expect(find.text('fresh 2'), findsNothing);
+
+    // The pill announces only the three new events, never the whole reload.
+    expect(find.text(en.timelineNewMessages(3)), findsOneWidget);
+  });
+
+  testWidgets('reading history: a large reconnect backlog does not jump to the bottom',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    await pumpReadyApp(tester, client);
+
+    await _scrollTo(tester, 0);
+    final anchorDy = tester.getTopLeft(find.text('history 2')).dy;
+
+    // A big backlog (40) lands — the reader must not be yanked down.
+    client.backlog
+        .addAll(_messages(40, startTs: freshStart, prefix: 'bulk', from: MockPeople.sam));
+    client.reconnect();
+    await pumpSteps(tester);
+
+    expect(tester.getTopLeft(find.text('history 2')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, closeTo(0, 1.0));
+    expect(find.text('bulk 39'), findsNothing);
+    expect(find.text(en.timelineNewMessages(40)), findsOneWidget);
+  });
+
+  testWidgets('at the bottom: a reconnect stays pinned to the newest event',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    await pumpReadyApp(tester, client);
+    // Do not scroll — the reader is stuck at the bottom.
+
+    client.backlog
+        .addAll(_messages(3, startTs: freshStart, prefix: 'fresh', from: MockPeople.sam));
+    client.reconnect();
+    await pumpSteps(tester);
+
+    // Pinned to the tail: the newest synced event is visible and no pill shows.
+    expect(find.text('fresh 2'), findsOneWidget);
+    expect(_position(tester).pixels,
+        closeTo(_position(tester).maxScrollExtent, 1.0));
+    expect(find.textContaining('new message'), findsNothing);
+  });
+
+  testWidgets('duplicate replay adds no row and does not move the viewport',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    final session = await pumpReadyApp(tester, client);
+
+    await _scrollTo(tester, 0);
+    final anchorDy = tester.getTopLeft(find.text('history 1')).dy;
+    final before = session.room!.timeline.length;
+    final offsetBefore = _position(tester).pixels;
+
+    // Replay an event already in the fold (same event_id) — dedup drops it.
+    client.pushEvent(session.room!.timeline[8]);
+    await tester.pump();
+    await tester.pump();
+
+    expect(session.room!.timeline.length, before);
+    expect(tester.getTopLeft(find.text('history 1')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, closeTo(offsetBefore, 1.0));
+    expect(find.textContaining('new message'), findsNothing);
+  });
+
+  testWidgets(
+      'an out-of-order older event keeps the first visible event pinned, no pill',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    final session = await pumpReadyApp(tester, client);
+
+    // Read mid-history: scroll down into the seeded history block so several
+    // early lines sit off-screen above the viewport, then anchor on a line the
+    // reader can see.
+    await _scrollTo(tester, 0);
+    await _scrollTo(tester, 300);
+    final anchorDy = tester.getTopLeft(find.text('history 6')).dy;
+    final offsetBefore = _position(tester).pixels;
+    final before = session.room!.timeline.length;
+
+    // A late, older-than-everything event splices in above the viewport.
+    client.pushEvent(syntheticMessage(
+        ts: historyStart - 60000, body: 'stale straggler', from: MockPeople.alex));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    // It landed (one more row) above the viewport; the first visible event kept
+    // its exact pixel offset (the sliver absorbed the height added above by
+    // growing the scroll offset), and nothing was announced as new-at-bottom.
+    expect(session.room!.timeline.length, before + 1);
+    expect(tester.getTopLeft(find.text('history 6')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, greaterThan(offsetBefore));
+    expect(find.textContaining('new message'), findsNothing);
+  });
+
+  testWidgets('a live tail event during history reading counts without moving',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    await pumpReadyApp(tester, client);
+
+    await _scrollTo(tester, 0);
+    final anchorDy = tester.getTopLeft(find.text('history 1')).dy;
+
+    // A new live event arrives at the tail while the reader is up in history.
+    client.pushEvent(syntheticMessage(
+        ts: freshStart, body: 'live one', from: MockPeople.sam));
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text(en.timelineNewMessages(1)), findsOneWidget);
+    expect(tester.getTopLeft(find.text('history 1')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, closeTo(0, 1.0));
+    expect(find.text('live one'), findsNothing);
+  });
+
+  testWidgets(
+      'compact: a reconnect backlog holds the position and counts only new',
+      (tester) async {
+    final client = ReplayClient(newMockClient());
+    client.backlog.addAll(_messages(16, startTs: historyStart, prefix: 'history'));
+    await pumpReadyMobileApp(tester, client);
+
+    await _scrollTo(tester, 0);
+    expect(find.text('history 1'), findsOneWidget);
+    final anchorDy = tester.getTopLeft(find.text('history 1')).dy;
+
+    client.backlog
+        .addAll(_messages(3, startTs: freshStart, prefix: 'fresh', from: MockPeople.sam));
+    client.reconnect();
+    await pumpSteps(tester);
+
+    expect(tester.getTopLeft(find.text('history 1')).dy, closeTo(anchorDy, 1.0));
+    expect(_position(tester).pixels, closeTo(0, 1.0));
+    expect(find.text('fresh 2'), findsNothing);
+    expect(find.text(en.timelineNewMessages(3)), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #68.

## Problem
A reconnect re-opens the room into a fresh `RoomStore`, so the timeline collapses to empty (skeleton) and refills with the resynced backlog. That dropped a history reader to the top and announced the **whole** reloaded backlog as new activity; a live event splicing in **above** the viewport silently shifted the reading position (the "known deviation" the old comment acknowledged).

## Fix
Timeline scroll reconciliation is reworked to preserve the reader's place across both paths, mirroring the web `syncScroll` state machine:

- **At the bottom** → stays pinned to the newest event.
- **In history** → keeps the exact position: the wholesale reload restores the saved numeric offset (content above is unchanged), and a live splice above the viewport re-pins a `getOffsetToReveal` anchor captured pre-layout. Flutter has no native scroll anchoring, so rows now carry stable `GlobalKey`s to measure the anchor row.
- **The pill** counts only genuinely-new events past a reload baseline (`seen = prev − unseen`), never the whole reloaded backlog.
- **Duplicate replay** is dropped by the fold (no row, no jump); the empty reload frames no longer flip stick or corrupt the anchor.

Acceptance criteria — first-visible event + pixel offset preserved; near-bottom stays pinned; unseen replayed events update the affordance without moving the viewport; duplicate/out-of-order replay produces no dup rows or jumps; covered on compact and desktop.

## Tests
New `timeline_reconnect_anchor_test.dart` covers small/large backlog, duplicate replay, out-of-order splice, and a live tail event during history reading, on **both** the desktop and compact shells, driven by a `ReplayClient` reconnect/backlog/push injector added to `helpers.dart`.

- `flutter analyze` clean · full `flutter test` suite green (252, +7 new)
- Flutter-only: no ARB/l10n, Rust, TS, or docs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)