### PR TITLE
feat(flutter): standardize semantic controls and large-text reflow (#73)

### DIFF
--- a/app/lib/src/l10n/arb/app_en.arb
+++ b/app/lib/src/l10n/arb/app_en.arb
@@ -2290,6 +2290,10 @@
   "@timelinePendingFailed": {
     "description": "Status under an outgoing message that failed to send; shown alongside the Retry action (commonRetry)."
   },
+  "timelineRetryMessage": "Retry sending message",
+  "@timelineRetryMessage": {
+    "description": "Accessible name for the Retry action under a message that failed to send. The visible label is the single word Retry (commonRetry); several failed sends can be stacked in one timeline, so screen readers get this fuller name instead of hearing \"Retry\" repeated with nothing to tell the copies apart."
+  },
   "timelineNewMessages": "{n, plural, one{{n} new message} other{{n} new messages}}",
   "@timelineNewMessages": {
     "description": "Unseen-messages pill at the bottom of the chat timeline.",

--- a/app/lib/src/l10n/arb/app_fr.arb
+++ b/app/lib/src/l10n/arb/app_fr.arb
@@ -464,6 +464,10 @@
   "timelinePendingSending": "Envoi…",
   "timelinePendingSyncing": "Envoyé localement, synchronisation…",
   "timelinePendingFailed": "Échec de l’envoi",
+  "timelineRetryMessage": "Réessayer d\u2019envoyer le message",
+  "@timelineRetryMessage": {
+    "description": "Accessible name for the Retry action under a message that failed to send. The visible label is the single word Retry (commonRetry); several failed sends can be stacked in one timeline, so screen readers get this fuller name instead of hearing \"Retry\" repeated with nothing to tell the copies apart."
+  },
   "timelineNewMessages": "{n, plural, one{{n} nouveau message} other{{n} nouveaux messages}}",
   "timelineNewActivity": "{n} nouvelle activité",
   "timelineRunEvidence": "{count} mises à jour · {span}",

--- a/app/lib/src/l10n/gen/app_strings.dart
+++ b/app/lib/src/l10n/gen/app_strings.dart
@@ -2893,6 +2893,12 @@ abstract class AppStrings {
   /// **'Couldn\'t send'**
   String get timelinePendingFailed;
 
+  /// Accessible name for the Retry action under a message that failed to send. The visible label is the single word Retry (commonRetry); several failed sends can be stacked in one timeline, so screen readers get this fuller name instead of hearing "Retry" repeated with nothing to tell the copies apart.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry sending message'**
+  String get timelineRetryMessage;
+
   /// Unseen-messages pill at the bottom of the chat timeline.
   ///
   /// In en, this message translates to:

--- a/app/lib/src/l10n/gen/app_strings_en.dart
+++ b/app/lib/src/l10n/gen/app_strings_en.dart
@@ -1692,6 +1692,9 @@ class AppStringsEn extends AppStrings {
   String get timelinePendingFailed => 'Couldn\'t send';
 
   @override
+  String get timelineRetryMessage => 'Retry sending message';
+
+  @override
   String timelineNewMessages(num n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/app/lib/src/l10n/gen/app_strings_fr.dart
+++ b/app/lib/src/l10n/gen/app_strings_fr.dart
@@ -1721,6 +1721,9 @@ class AppStringsFr extends AppStrings {
   String get timelinePendingFailed => 'Échec de l’envoi';
 
   @override
+  String get timelineRetryMessage => 'Réessayer d’envoyer le message';
+
+  @override
   String timelineNewMessages(num n) {
     String _temp0 = intl.Intl.pluralLogic(
       n,

--- a/app/lib/src/screens/boot_screen.dart
+++ b/app/lib/src/screens/boot_screen.dart
@@ -84,7 +84,22 @@ class _BootScreenState extends State<BootScreen> {
       // Leaving (or never entering) the failed state re-arms the focus grab for
       // the next failure episode.
       _focusedThisFailure = false;
-      return Scaffold(body: Center(child: _loading(context, session, tokens, s)));
+      // Scrollable, not just centred: at 320% text this column is 162dp taller
+      // than a 360x640 phone and used to clip its own status line — the boot
+      // flow is named in the reflow criterion precisely because it is the one
+      // screen a user cannot navigate away from (issue #73). `Center` inside
+      // the scroll view keeps the existing centred look at every size that
+      // still fits.
+      return Scaffold(
+        body: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(child: _loading(context, session, tokens, s)),
+            ),
+          ),
+        ),
+      );
     }
 
     if (!_focusedThisFailure) {

--- a/app/lib/src/screens/fleet_dashboard.dart
+++ b/app/lib/src/screens/fleet_dashboard.dart
@@ -46,6 +46,7 @@ import '../widgets/buttons.dart';
 import '../widgets/copy_button.dart';
 import '../widgets/error_note.dart';
 import '../widgets/avatar.dart';
+import '../widgets/focus_ring.dart';
 import '../widgets/modal_scaffold.dart';
 import '../widgets/progress_bar.dart';
 import '../widgets/room_short_id.dart';
@@ -429,7 +430,12 @@ class _FilterPill extends StatelessWidget {
     final tokens = JeliyaTokens.of(context);
     final fg = active ? tokens.accent : tokens.textDim;
     // TextButton (not a bare GestureDetector) so the pill is keyboard
-    // focusable and Enter/Space activates it, like the web's <button>.
+    // focusable and Enter/Space activates it, like the web's <button>. It was
+    // focusable but INVISIBLY so until `jeliyaOverlay` below: the blanket
+    // transparent overlay had erased the focused state along with the ripple.
+    // The tint, not `JeliyaFocusRing`, is the indicator here — the filter row
+    // lives in a horizontal `SingleChildScrollView`, which clips, so a ring
+    // drawn outside the pill's box would be cut off at either end of the row.
     return Semantics(
       toggled: active, // aria-pressed
       child: TextButton(
@@ -439,13 +445,19 @@ class _FilterPill extends StatelessWidget {
               EdgeInsets.symmetric(horizontal: 13, vertical: 7)),
           backgroundColor:
               WidgetStatePropertyAll(active ? tokens.accentDim : tokens.bgCard),
-          overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+          overlayColor: jeliyaOverlay(tokens),
           minimumSize: const WidgetStatePropertyAll(Size.zero),
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           shape: WidgetStatePropertyAll(RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+            // The outline is the only thing that says "control": the pill's
+            // `bgCard` fill is near-identical to the surface behind it. That is
+            // a meaningful non-text boundary, so it owes 3:1 —
+            // `borderInteractive` (3.20:1-3.58:1) replaces `borderStrong`
+            // (1.35:1-1.51:1). The active branch keeps `accentLine`, which
+            // encodes selection rather than identifying the control.
             side: BorderSide(
-              color: active ? tokens.accentLine : tokens.borderStrong,
+              color: active ? tokens.accentLine : tokens.borderInteractive,
             ),
           )),
         ),
@@ -1434,48 +1446,59 @@ class _RoomChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final tokens = JeliyaTokens.of(context);
     // TextButton (not a bare GestureDetector) so the chip is keyboard
-    // focusable and Enter/Space activates it, like the web's <button>.
+    // focusable and Enter/Space activates it, like the web's <button>. It was
+    // focusable but INVISIBLY so: the blanket transparent overlay below had
+    // erased the focused state along with the ripple, and nothing else in the
+    // app draws focus. The chips sit in a non-clipping `Wrap`, so this one can
+    // carry the ring as well as the tint.
     return Tooltip(
       message: tooltip,
-      child: TextButton(
-        onPressed: onTap,
-        style: ButtonStyle(
-          padding: const WidgetStatePropertyAll(
-              EdgeInsets.symmetric(horizontal: 10, vertical: 3)),
-          backgroundColor: WidgetStatePropertyAll(tokens.bgCard2),
-          overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-          minimumSize: const WidgetStatePropertyAll(Size.zero),
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          shape: WidgetStatePropertyAll(RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(JeliyaRadii.pill),
-            side: BorderSide(color: tokens.borderStrong),
-          )),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ExcludeSemantics(
-              child: Text(
-                Tokens.fleetRoomChipGlyph,
-                style: TextStyle(fontSize: 11.5, color: tokens.textDim),
+      child: JeliyaFocusRing(
+        borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+        child: TextButton(
+          onPressed: onTap,
+          style: ButtonStyle(
+            padding: const WidgetStatePropertyAll(
+                EdgeInsets.symmetric(horizontal: 10, vertical: 3)),
+            backgroundColor: WidgetStatePropertyAll(tokens.bgCard2),
+            overlayColor: jeliyaOverlay(tokens),
+            minimumSize: const WidgetStatePropertyAll(Size.zero),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            shape: WidgetStatePropertyAll(RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+              // Sole identifying boundary of a control — `bgCard2` against the
+              // card behind it is not a visible edge — and it encodes no state,
+              // so it owes the 3:1 non-text floor. `borderInteractive` is
+              // 3.20:1 where `borderStrong` was 1.35:1.
+              side: BorderSide(color: tokens.borderInteractive),
+            )),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ExcludeSemantics(
+                child: Text(
+                  Tokens.fleetRoomChipGlyph,
+                  style: TextStyle(fontSize: 11.5, color: tokens.textDim),
+                ),
               ),
-            ),
-            const SizedBox(width: 5),
-            Flexible(
-              child: Text(
-                name,
-                style: TextStyle(fontSize: 11.5, color: tokens.textDim),
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-              ),
-            ),
-            // The name yields first; the short id is the disambiguator and
-            // must stay readable at any width.
-            if (homonym) ...[
               const SizedBox(width: 5),
-              RoomShortId(roomId: roomId, fontSize: 11),
+              Flexible(
+                child: Text(
+                  name,
+                  style: TextStyle(fontSize: 11.5, color: tokens.textDim),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              // The name yields first; the short id is the disambiguator and
+              // must stay readable at any width.
+              if (homonym) ...[
+                const SizedBox(width: 5),
+                RoomShortId(roomId: roomId, fontSize: 11),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/app/lib/src/screens/modals/invite.dart
+++ b/app/lib/src/screens/modals/invite.dart
@@ -512,34 +512,33 @@ class _InviteModalState extends State<InviteModal> {
   // -- shared result pieces ------------------------------------------------------
 
   /// The result-view actions: an explicit Invite-Again on expiry (re-mints the
-  /// same identity/role/expiry), then the New-invite reset. Scale-down guarded
-  /// so wide locales / large text scales shrink rather than overflow.
+  /// same identity/role/expiry), then the New-invite reset.
+  ///
+  /// Both were `FittedBox(scaleDown, alignment: centerLeft)` so a wide locale
+  /// or a large text scale shrank the label rather than overflowing. That is
+  /// the wrong trade in an invite flow a low-vision reader has to follow, and
+  /// it is no longer needed: JeliyaButton wraps its label to two lines whenever
+  /// its width is bounded, which it is here (a Column hands its children the
+  /// column's own max width). The Column's `crossAxisAlignment.start` keeps the
+  /// left alignment the FittedBox was supplying (issue #73).
   Widget _lifecycleActions(BuildContext context, String? lifecycle) {
     final s = context.strings;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (lifecycle == InviteStates.expired) ...[
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            alignment: Alignment.centerLeft,
-            child: JeliyaButton(
-              label: _busy ? s.inviteGenerating : s.inviteAgain,
-              variant: JeliyaButtonVariant.primary,
-              busy: _busy,
-              onPressed: _busy ? null : _generate,
-            ),
+          JeliyaButton(
+            label: _busy ? s.inviteGenerating : s.inviteAgain,
+            variant: JeliyaButtonVariant.primary,
+            busy: _busy,
+            onPressed: _busy ? null : _generate,
           ),
           const SizedBox(height: JeliyaSpacing.x10),
         ],
-        FittedBox(
-          fit: BoxFit.scaleDown,
-          alignment: Alignment.centerLeft,
-          child: JeliyaButton(
-            label: s.inviteNewInvite,
-            variant: JeliyaButtonVariant.ghost,
-            onPressed: _newInvite,
-          ),
+        JeliyaButton(
+          label: s.inviteNewInvite,
+          variant: JeliyaButtonVariant.ghost,
+          onPressed: _newInvite,
         ),
       ],
     );

--- a/app/lib/src/screens/modals/leave_room.dart
+++ b/app/lib/src/screens/modals/leave_room.dart
@@ -102,36 +102,36 @@ class _LeaveRoomModalState extends State<LeaveRoomModal> {
             child: RoomShortId(roomId: widget.roomId, fontSize: 12.5),
           ),
           const SizedBox(height: JeliyaSpacing.x12),
-          // Wrap + scale-down, not Row: inside a 360dp phone dialog the wider
-          // French labels push Cancel to a second run, and a label that still
-          // cannot fit its run (oversized text scales) shrinks instead of
-          // overflowing the card.
+          // Wrap, not Row: inside a 360dp phone dialog the wider French labels
+          // ('Quitter le salon') push Cancel to a second run. A label that
+          // still cannot fit its run now REFLOWS to two lines inside the
+          // button (JeliyaButton wraps once its width is bounded, which a Wrap
+          // always bounds) instead of being scaled down — shrinking silently
+          // discarded the text size the user asked the OS for (#73). The
+          // buttons sit in the modal's scrolling body, so the extra line costs
+          // vertical space only and both actions stay reachable at 200%/320%.
           Wrap(
             spacing: JeliyaSpacing.x8,
             runSpacing: JeliyaSpacing.x8,
             children: [
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                child: JeliyaButton(
-                  label: _busy ? s.modalLeavingRoom : s.modalLeaveRoom,
-                  variant: JeliyaButtonVariant.danger,
-                  busy: _busy,
-                  onPressed: _busy ? null : _leave,
-                ),
+              JeliyaButton(
+                label: _busy ? s.modalLeavingRoom : s.modalLeaveRoom,
+                variant: JeliyaButtonVariant.danger,
+                busy: _busy,
+                onPressed: _busy ? null : _leave,
               ),
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                child: JeliyaButton(
-                  label: s.modalCancel,
-                  variant: JeliyaButtonVariant.ghost,
-                  // Safe initial focus (#55): Cancel takes focus, never the
-                  // danger submit, so an immediate Enter abandons instead of
-                  // confirming. The web reference adopted the same contract
-                  // in #56.
-                  autofocus: true,
-                  onPressed:
-                      _busy ? null : () => Navigator.of(context).maybePop(),
-                ),
+              JeliyaButton(
+                label: s.modalCancel,
+                variant: JeliyaButtonVariant.ghost,
+                // Safe initial focus (#55): Cancel takes focus, never the
+                // danger submit, so an immediate Enter abandons instead of
+                // confirming. The web reference adopted the same contract
+                // in #56. autofocus flows straight through to the inner
+                // TextButton — removing the FittedBox does not change that,
+                // and dialog_containment_test pins the initial focus.
+                autofocus: true,
+                onPressed:
+                    _busy ? null : () => Navigator.of(context).maybePop(),
               ),
             ],
           ),

--- a/app/lib/src/screens/modals/rename_peer.dart
+++ b/app/lib/src/screens/modals/rename_peer.dart
@@ -102,28 +102,26 @@ class _RenamePeerModalState extends State<RenamePeerModal> {
             onSubmitted: (_) => _save(),
           ),
           const SizedBox(height: JeliyaSpacing.x12),
-          // Wrap + scale-down, not Row: at the 360dp dialog width the French
-          // 'Supprimer l'alias' no longer fits beside Save (leave_room.dart
-          // has the same treatment).
+          // Wrap, not Row: at the 360dp dialog width the French 'Supprimer
+          // l'alias' no longer fits beside Save, so it moves to a second run.
+          // A label too wide even for its own run now REFLOWS to two lines
+          // inside the button rather than being scaled down, which discarded
+          // the text size the user asked the OS for (#73; leave_room.dart has
+          // the same treatment). The Wrap sits in the modal's scrolling body,
+          // so the extra line costs vertical space only.
           Wrap(
             spacing: JeliyaSpacing.x8,
             runSpacing: JeliyaSpacing.x8,
             children: [
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                child: JeliyaButton(
-                  label: s.renamePeerSave,
-                  variant: JeliyaButtonVariant.primary,
-                  onPressed: _save,
-                ),
+              JeliyaButton(
+                label: s.renamePeerSave,
+                variant: JeliyaButtonVariant.primary,
+                onPressed: _save,
               ),
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                child: JeliyaButton(
-                  label: s.renamePeerClearAlias,
-                  variant: JeliyaButtonVariant.ghost,
-                  onPressed: _clear,
-                ),
+              JeliyaButton(
+                label: s.renamePeerClearAlias,
+                variant: JeliyaButtonVariant.ghost,
+                onPressed: _clear,
               ),
             ],
           ),

--- a/app/lib/src/screens/onboarding_identity.dart
+++ b/app/lib/src/screens/onboarding_identity.dart
@@ -129,22 +129,18 @@ class _OnboardingIdentityScreenState extends State<OnboardingIdentityScreen> {
                         style:
                             TextStyle(fontSize: 13, color: tokens.textDim)),
                     const SizedBox(height: JeliyaSpacing.x16),
-                    // Scale-down guard: the lg label ('Créer une identité')
-                    // outgrows the 360dp card under wide locales or oversized
-                    // text scales — shrink it rather than overflow the first
-                    // screen a phone user ever sees.
-                    FittedBox(
-                      fit: BoxFit.scaleDown,
-                      alignment: Alignment.centerLeft,
-                      child: JeliyaButton(
-                        label: _busy
-                            ? s.onboardingCreatingIdentity
-                            : s.onboardingCreateIdentity,
-                        variant: JeliyaButtonVariant.primary,
-                        size: JeliyaButtonSize.lg,
-                        busy: _busy,
-                        onPressed: _busy ? null : _create,
-                      ),
+                    // The card bounds this button's width, so the lg label
+                    // ('Créer une identité' under wide locales or oversized
+                    // text scales) REFLOWS to a second line instead of
+                    // overflowing the first screen a phone user ever sees.
+                    JeliyaButton(
+                      label: _busy
+                          ? s.onboardingCreatingIdentity
+                          : s.onboardingCreateIdentity,
+                      variant: JeliyaButtonVariant.primary,
+                      size: JeliyaButtonSize.lg,
+                      busy: _busy,
+                      onPressed: _busy ? null : _create,
                     ),
                     ErrorNote(error: _error),
                   ],

--- a/app/lib/src/screens/onboarding_rooms.dart
+++ b/app/lib/src/screens/onboarding_rooms.dart
@@ -177,20 +177,16 @@ class _OnboardingRoomsScreenState extends State<OnboardingRoomsScreen> {
             onSubmitted: (_) => _create(),
           ),
           const SizedBox(height: JeliyaSpacing.x12),
-          // Scale-down guard: French submit labels brush the 360dp card
-          // width — shrink instead of overflowing (onboarding_identity.dart
-          // has the same treatment).
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            alignment: Alignment.centerLeft,
-            child: JeliyaButton(
-              label: _creating
-                  ? s.modalCreatingRoom
-                  : s.modalCreateRoom,
-              variant: JeliyaButtonVariant.primary,
-              busy: _creating,
-              onPressed: canSubmit ? _create : null,
-            ),
+          // French submit labels brush the 360dp card width; the card bounds
+          // this button, so the label reflows to a second line rather than
+          // overflowing (onboarding_identity.dart has the same treatment).
+          JeliyaButton(
+            label: _creating
+                ? s.modalCreatingRoom
+                : s.modalCreateRoom,
+            variant: JeliyaButtonVariant.primary,
+            busy: _creating,
+            onPressed: canSubmit ? _create : null,
           ),
           ErrorNote(error: _createError),
         ],
@@ -245,18 +241,14 @@ class _OnboardingRoomsScreenState extends State<OnboardingRoomsScreen> {
             onSubmitted: (_) => _join(),
           ),
           const SizedBox(height: JeliyaSpacing.x12),
-          // Same scale-down guard as the create card's submit.
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            alignment: Alignment.centerLeft,
-            child: JeliyaButton(
-              label: _joining
-                  ? s.modalJoiningRoom
-                  : s.modalJoinRoom,
-              variant: JeliyaButtonVariant.primary,
-              busy: _joining,
-              onPressed: canSubmit ? _join : null,
-            ),
+          // Reflows within the card exactly like the create card's submit.
+          JeliyaButton(
+            label: _joining
+                ? s.modalJoiningRoom
+                : s.modalJoinRoom,
+            variant: JeliyaButtonVariant.primary,
+            busy: _joining,
+            onPressed: canSubmit ? _join : null,
           ),
           if (progress != null) ...[
             const SizedBox(height: JeliyaSpacing.x10),

--- a/app/lib/src/screens/room_list_widgets.dart
+++ b/app/lib/src/screens/room_list_widgets.dart
@@ -17,9 +17,11 @@ import 'package:flutter/material.dart';
 import '../format.dart';
 import '../l10n/strings_context.dart';
 import '../l10n/tokens.dart';
+import '../layout.dart';
 import '../session/daemon_session.dart';
 import '../session/room_list.dart';
 import '../theme.dart';
+import '../widgets/focus_ring.dart';
 import '../widgets/room_short_id.dart';
 import '../widgets/template_text.dart';
 
@@ -146,32 +148,45 @@ class _FilterChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = JeliyaTokens.of(context);
+    // DESIGN.md's 44dp touch floor applies on TOUCH/COMPACT only. 5px of
+    // vertical padding around 11px text is roughly 26dp of target — fine for a
+    // pointer on the desktop rail, half the floor under a thumb. `minHeight`
+    // grows the TARGET without touching the chip's type scale, and the desktop
+    // rail keeps its dense sizing.
+    final touch = isMobileWidth(context);
     return Semantics(
       button: true,
       selected: active,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
-          child: Container(
-            alignment: Alignment.center,
-            padding: const EdgeInsets.symmetric(
-                horizontal: JeliyaSpacing.x6, vertical: 5),
-            decoration: BoxDecoration(
-              color: active ? tokens.accentDim : Colors.transparent,
-              borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
-              border: Border.all(
-                  color: active ? tokens.accentLine : tokens.border),
-            ),
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 11,
-                color: active ? tokens.accent : tokens.textMute,
-                fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+      // The InkWell is focusable, but the app's `focusColor` measures 1.21:1 —
+      // there was nothing to see. The ring is layout-transparent, so the row of
+      // chips keeps its exact geometry.
+      child: JeliyaFocusRing(
+        borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+            child: Container(
+              alignment: Alignment.center,
+              constraints: BoxConstraints(minHeight: touch ? 44 : 0),
+              padding: const EdgeInsets.symmetric(
+                  horizontal: JeliyaSpacing.x6, vertical: 5),
+              decoration: BoxDecoration(
+                color: active ? tokens.accentDim : Colors.transparent,
+                borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+                border: Border.all(
+                    color: active ? tokens.accentLine : tokens.border),
+              ),
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: active ? tokens.accent : tokens.textMute,
+                  fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+                ),
               ),
             ),
           ),
@@ -443,7 +458,13 @@ class _RoomRowState extends State<_RoomRow> {
         padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(
             horizontal: JeliyaSpacing.x10, vertical: 9)),
         backgroundColor: const WidgetStatePropertyAll(Colors.transparent),
-        overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+        // Hover and press stay transparent (the row's own DecoratedBox draws
+        // the hover surface); FOCUSED gets a visible tint. The blanket
+        // `transparent` this replaces covered the focused state too, so the row
+        // had no focus feedback at all. No outside ring: this button is only
+        // the LEFT part of a composite row that also carries the pin and
+        // archive actions, so a ring around it would trace the wrong bounds.
+        overlayColor: jeliyaOverlay(tokens),
         minimumSize: const WidgetStatePropertyAll(Size.zero),
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         shape: WidgetStatePropertyAll(RoundedRectangleBorder(

--- a/app/lib/src/screens/settings_panel.dart
+++ b/app/lib/src/screens/settings_panel.dart
@@ -436,32 +436,31 @@ class _DiagnosticsCard extends StatelessWidget {
             style: TextStyle(fontSize: 13, color: tokens.textMute),
           ),
         const SizedBox(height: JeliyaSpacing.x12),
-        // Wrap, not Row: one line at desktop widths, and the pair reflows
-        // instead of clipping at phone widths under wider (fr) labels. Each
-        // button additionally scales down as a last resort when a label
-        // outgrows even a full wrap line (JeliyaButton's label cannot flex
-        // internally) — a no-op at every shipped locale and real font width.
+        // Wrap, not Row: one line at desktop widths, and the pair reflows onto
+        // separate runs at phone widths under wider (fr) labels. Each button
+        // used to also carry `FittedBox(scaleDown)` as a last resort, because
+        // JeliyaButton's label could not flex internally and a label that
+        // outgrew a full wrap line would overflow. That shrank text the reader
+        // had asked the OS to enlarge — exactly what the diagnostics card
+        // exists to stay legible through. JeliyaButton's label now wraps to two
+        // lines whenever its width is bounded, and Wrap gives each child the
+        // run's bounded max width, so the label reflows at the requested size
+        // instead (issue #73).
         Wrap(
           spacing: JeliyaSpacing.x8,
           runSpacing: JeliyaSpacing.x8,
           children: [
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: JeliyaButton(
-                label: copied
-                    ? s.settingsCopiedDiagnostics
-                    : s.settingsCopyDiagnostics,
-                variant: JeliyaButtonVariant.primary,
-                onPressed: onCopy,
-              ),
+            JeliyaButton(
+              label: copied
+                  ? s.settingsCopiedDiagnostics
+                  : s.settingsCopyDiagnostics,
+              variant: JeliyaButtonVariant.primary,
+              onPressed: onCopy,
             ),
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: JeliyaButton(
-                label: s.settingsReportIssue,
-                variant: JeliyaButtonVariant.ghost,
-                onPressed: onReportIssue,
-              ),
+            JeliyaButton(
+              label: s.settingsReportIssue,
+              variant: JeliyaButtonVariant.ghost,
+              onPressed: onReportIssue,
             ),
           ],
         ),

--- a/app/lib/src/screens/sidebar.dart
+++ b/app/lib/src/screens/sidebar.dart
@@ -22,6 +22,7 @@ import '../session/daemon_session.dart';
 import '../session/room_list.dart';
 import '../theme.dart';
 import '../widgets/copy_button.dart';
+import '../widgets/focus_ring.dart';
 import '../widgets/tree_mark.dart';
 import 'room_list_widgets.dart';
 
@@ -216,50 +217,57 @@ class _ProfileCard extends StatelessWidget {
           JeliyaSpacing.x12, 0, JeliyaSpacing.x12, JeliyaSpacing.x6),
       child: Tooltip(
         message: s.sidebarProfileTitle,
-        child: TextButton(
-          onPressed: onTap,
-          style: ButtonStyle(
-            padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(
-                horizontal: JeliyaSpacing.x10, vertical: JeliyaSpacing.x8)),
-            backgroundColor: WidgetStatePropertyAll(tokens.bgCard),
-            overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-            minimumSize: const WidgetStatePropertyAll(Size.zero),
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            shape: WidgetStateProperty.resolveWith(
-              (states) => RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(JeliyaRadii.card),
-                side: BorderSide(
-                    color: states.contains(WidgetState.hovered)
-                        ? tokens.borderStrong
-                        : tokens.border),
-              ),
-            ),
-          ),
-          child: Row(
-            children: [
-              _ProfileAvatar(identityId: identityId, selfName: selfName),
-              const SizedBox(width: JeliyaSpacing.x10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(selfName,
-                        style: JeliyaText.name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis),
-                    Text(handle,
-                        style:
-                            JeliyaText.mono(fontSize: 11.5, color: tokens.textMute),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis),
-                  ],
+        // The card sits inside 12px of rail padding, so the ring (2px, offset
+        // 2) has room to draw outside the card without clipping or shifting it.
+        child: JeliyaFocusRing(
+          borderRadius: BorderRadius.circular(JeliyaRadii.card),
+          child: TextButton(
+            onPressed: onTap,
+            style: ButtonStyle(
+              padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(
+                  horizontal: JeliyaSpacing.x10, vertical: JeliyaSpacing.x8)),
+              backgroundColor: WidgetStatePropertyAll(tokens.bgCard),
+              // Hover keeps its border-only treatment (`shape` below); FOCUSED
+              // gets the tint the blanket `transparent` used to erase.
+              overlayColor: jeliyaOverlay(tokens),
+              minimumSize: const WidgetStatePropertyAll(Size.zero),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              shape: WidgetStateProperty.resolveWith(
+                (states) => RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(JeliyaRadii.card),
+                  side: BorderSide(
+                      color: states.contains(WidgetState.hovered)
+                          ? tokens.borderStrong
+                          : tokens.border),
                 ),
               ),
-              ExcludeSemantics(
-                child: Text(Tokens.sidebarProfileChevron,
-                    style: TextStyle(fontSize: 14, color: tokens.textMute)),
-              ),
-            ],
+            ),
+            child: Row(
+              children: [
+                _ProfileAvatar(identityId: identityId, selfName: selfName),
+                const SizedBox(width: JeliyaSpacing.x10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(selfName,
+                          style: JeliyaText.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                      Text(handle,
+                          style: JeliyaText.mono(
+                              fontSize: 11.5, color: tokens.textMute),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis),
+                    ],
+                  ),
+                ),
+                ExcludeSemantics(
+                  child: Text(Tokens.sidebarProfileChevron,
+                      style: TextStyle(fontSize: 14, color: tokens.textMute)),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -357,41 +365,49 @@ class _NavItem extends StatelessWidget {
     final Color labelColor = active ? tokens.text : tokens.textDim;
     return Semantics(
       selected: active, // aria-current="page"
-      child: TextButton(
-        onPressed: onTap,
-        style: ButtonStyle(
-          padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(
-              horizontal: JeliyaSpacing.x10, vertical: JeliyaSpacing.x8)),
-          backgroundColor: WidgetStateProperty.resolveWith((states) {
-            if (active) return tokens.accentDim;
-            if (states.contains(WidgetState.hovered)) return tokens.bgCard;
-            return Colors.transparent;
-          }),
-          overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-          minimumSize: const WidgetStatePropertyAll(Size.zero),
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          shape: WidgetStatePropertyAll(RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(JeliyaRadii.nav),
-            side: BorderSide(
-                color: active ? tokens.accentLine : Colors.transparent),
-          )),
-        ),
-        child: Row(
-          children: [
-            ExcludeSemantics(
-              child: SizedBox(
-                width: 18,
-                child: Text(entry.glyph,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 15, color: glyphColor)),
+      // The nav list is inset 10px, so the ring clears the rail edge. It is
+      // ADDITIVE to the active item's accent border rather than replacing it:
+      // "focused" and "current page" are different facts and both must show.
+      child: JeliyaFocusRing(
+        borderRadius: BorderRadius.circular(JeliyaRadii.nav),
+        child: TextButton(
+          onPressed: onTap,
+          style: ButtonStyle(
+            padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(
+                horizontal: JeliyaSpacing.x10, vertical: JeliyaSpacing.x8)),
+            backgroundColor: WidgetStateProperty.resolveWith((states) {
+              if (active) return tokens.accentDim;
+              if (states.contains(WidgetState.hovered)) return tokens.bgCard;
+              return Colors.transparent;
+            }),
+            // `backgroundColor` above already resolves hover and active; this
+            // only has to keep the ripple off and let FOCUSED read.
+            overlayColor: jeliyaOverlay(tokens),
+            minimumSize: const WidgetStatePropertyAll(Size.zero),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            shape: WidgetStatePropertyAll(RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(JeliyaRadii.nav),
+              side: BorderSide(
+                  color: active ? tokens.accentLine : Colors.transparent),
+            )),
+          ),
+          child: Row(
+            children: [
+              ExcludeSemantics(
+                child: SizedBox(
+                  width: 18,
+                  child: Text(entry.glyph,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 15, color: glyphColor)),
+                ),
               ),
-            ),
-            const SizedBox(width: 11),
-            Expanded(
-              child: Text(entry.label,
-                  style: TextStyle(fontSize: 13.5, color: labelColor)),
-            ),
-          ],
+              const SizedBox(width: 11),
+              Expanded(
+                child: Text(entry.label,
+                    style: TextStyle(fontSize: 13.5, color: labelColor)),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -429,33 +445,42 @@ class _RoomsHead extends StatelessWidget {
             child: Semantics(
               label: s.sidebarCreateRoomIcon,
               button: true,
-              child: TextButton(
-                onPressed: onCreateRoom,
-                style: ButtonStyle(
-                  padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-                  fixedSize: const WidgetStatePropertyAll(Size(26, 26)),
-                  minimumSize: const WidgetStatePropertyAll(Size(26, 26)),
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  backgroundColor:
-                      const WidgetStatePropertyAll(Colors.transparent),
-                  overlayColor: const WidgetStatePropertyAll(Colors.transparent),
-                  foregroundColor: WidgetStateProperty.resolveWith((states) =>
-                      states.contains(WidgetState.hovered)
-                          ? tokens.accent
-                          : tokens.textDim),
-                  shape: WidgetStateProperty.resolveWith(
-                    (states) => RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(JeliyaRadii.iconBtn),
-                      side: BorderSide(
-                          color: states.contains(WidgetState.hovered)
-                              ? tokens.accentLine
-                              : Colors.transparent),
+              // 26x26 with a transparent resting border: without a ring there
+              // is nothing at all to see when it takes focus. The header is
+              // inset 18px, so the ring has room. Radius matches `shape` below.
+              child: JeliyaFocusRing(
+                borderRadius: BorderRadius.circular(JeliyaRadii.iconBtn),
+                child: TextButton(
+                  onPressed: onCreateRoom,
+                  style: ButtonStyle(
+                    padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+                    // 26dp is the deliberate DESKTOP icon size (DESIGN.md); the
+                    // rail is pointer-only, so the 44dp touch floor does not
+                    // apply here.
+                    fixedSize: const WidgetStatePropertyAll(Size(26, 26)),
+                    minimumSize: const WidgetStatePropertyAll(Size(26, 26)),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    backgroundColor:
+                        const WidgetStatePropertyAll(Colors.transparent),
+                    overlayColor: jeliyaOverlay(tokens),
+                    foregroundColor: WidgetStateProperty.resolveWith((states) =>
+                        states.contains(WidgetState.hovered)
+                            ? tokens.accent
+                            : tokens.textDim),
+                    shape: WidgetStateProperty.resolveWith(
+                      (states) => RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(JeliyaRadii.iconBtn),
+                        side: BorderSide(
+                            color: states.contains(WidgetState.hovered)
+                                ? tokens.accentLine
+                                : Colors.transparent),
+                      ),
                     ),
                   ),
-                ),
-                child: ExcludeSemantics(
-                  child: Text(Tokens.sidebarCreateRoomIconGlyph,
-                      style: const TextStyle(fontSize: 14)),
+                  child: ExcludeSemantics(
+                    child: Text(Tokens.sidebarCreateRoomIconGlyph,
+                        style: const TextStyle(fontSize: 14)),
+                  ),
                 ),
               ),
             ),
@@ -498,10 +523,14 @@ class _AffordanceRowState extends State<_AffordanceRow> {
         : widget.dashed
             ? tokens.textDim
             : tokens.textMute;
+    // The dashed 'Create Room' row has no fill and no chrome — the dashed
+    // border IS the control. That makes it a meaningful non-text boundary, so
+    // it owes 3:1: `borderStrong` measures 1.35:1-1.51:1, `borderInteractive`
+    // 3.20:1-3.58:1. Hover stays `accentLine`, which encodes state.
     final borderColor = _hover
         ? tokens.accentLine
         : widget.dashed
-            ? tokens.borderStrong
+            ? tokens.borderInteractive
             : tokens.border;
     final radius = BorderRadius.circular(JeliyaRadii.row);
 
@@ -518,28 +547,35 @@ class _AffordanceRowState extends State<_AffordanceRow> {
       ),
     );
 
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: widget.onTap,
-        onHover: (hover) => setState(() => _hover = hover),
-        borderRadius: radius,
-        hoverColor: Colors.transparent,
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
-        child: widget.dashed
-            ? CustomPaint(
-                foregroundPainter: _DashedBorderPainter(
-                    color: borderColor, radius: JeliyaRadii.row),
-                child: content,
-              )
-            : DecoratedBox(
-                decoration: BoxDecoration(
-                  borderRadius: radius,
-                  border: Border.all(color: borderColor),
+    // These rows suppress ink the InkWell way (hover/splash/highlight), which
+    // spares the focus state — but the surviving `focusColor` is the app's
+    // 1.21:1 accent tint, i.e. invisible. Same gap as the six `overlayColor`
+    // sites, fixed at the widget that actually has it.
+    return JeliyaFocusRing(
+      borderRadius: radius,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: widget.onTap,
+          onHover: (hover) => setState(() => _hover = hover),
+          borderRadius: radius,
+          hoverColor: Colors.transparent,
+          splashColor: Colors.transparent,
+          highlightColor: Colors.transparent,
+          child: widget.dashed
+              ? CustomPaint(
+                  foregroundPainter: _DashedBorderPainter(
+                      color: borderColor, radius: JeliyaRadii.row),
+                  child: content,
+                )
+              : DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: radius,
+                    border: Border.all(color: borderColor),
+                  ),
+                  child: content,
                 ),
-                child: content,
-              ),
+        ),
       ),
     );
   }

--- a/app/lib/src/screens/timeline.dart
+++ b/app/lib/src/screens/timeline.dart
@@ -59,9 +59,11 @@ import '../theme.dart';
 import '../widgets/avatar.dart';
 import '../widgets/buttons.dart';
 import '../widgets/fetch_control.dart';
+import '../widgets/focus_ring.dart';
 import '../widgets/progress_bar.dart';
 import '../widgets/sender_name.dart';
 import '../widgets/template_text.dart';
+import '../widgets/text_action.dart';
 
 // Display formatting (context.formats: bytes / clock / dayLabel / percent,
 // plus top-level prettyLabel / extOf) lives in ../format.dart — the shared
@@ -618,16 +620,27 @@ class _TimelineViewState extends State<TimelineView> {
         // everything shows. Filtering never deletes history — clearing the chips
         // restores it — and pending messages are exempt entirely. Shown on BOTH
         // shells because each mounts this TimelineView.
-        _ActivityFilterStrip(
+        ActivityFilterStrip(
           categories: _activityCategories(s),
           active: activeFilters,
           onToggle: session.toggleActivityFilter,
           semanticsLabel: s.timelineFilterActivity,
         ),
         Expanded(
+          // NAMED, but deliberately NOT a live region (issue #73). This node
+          // used to carry `liveRegion: true` as a stand-in for the web's
+          // role="log" — but the two are not equivalent. role="log" announces
+          // only ADDED children; Flutter's `liveRegion` re-announces the node
+          // itself on semantics update, and this node is a container over a
+          // ListView that updates on every push, every scroll-anchor reconcile
+          // and every filter toggle. On iOS that posts an announcement per
+          // update, interrupting whatever the user was reading. The live region
+          // now lives on the new-activity pill alone (see [_newMessagesPill]):
+          // a small dedicated node whose label IS the delta, which is the part
+          // role="log" would have announced. The scroller keeps its name so the
+          // list still identifies itself on focus.
           child: Semantics(
             container: true,
-            liveRegion: true, // role="log"
             label: s.timelineRoomTimeline,
             child: Stack(
               children: [
@@ -645,7 +658,8 @@ class _TimelineViewState extends State<TimelineView> {
                     left: 0,
                     right: 0,
                     bottom: JeliyaSpacing.x14,
-                    child: Center(child: _newMessagesPill(tokens, counterLabel)),
+                    child: Center(
+                        child: _newMessagesPill(context, tokens, counterLabel)),
                   ),
               ],
             ),
@@ -1030,12 +1044,31 @@ class _TimelineViewState extends State<TimelineView> {
               _Spinner(color: tokens.textMute),
               const SizedBox(width: JeliyaSpacing.x6),
             ],
-            Text(label, style: JeliyaText.meta),
+            // Flexible: the status line and Retry share one row, and Retry now
+            // carries a 44dp target on touch — at 360px in French
+            // ("Échec de l'envoi" + "Réessayer") the status text has to be able
+            // to give way rather than overflow.
+            Flexible(
+              child: Text(label,
+                  style: JeliyaText.meta,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis),
+            ),
             if (failed) ...[
               const SizedBox(width: JeliyaSpacing.x6),
-              _TextButton(
+              JeliyaTextAction(
                 label: s.commonRetry,
-                onTap: () => store.retryPendingMessage(message.clientId),
+                // Several sends can fail in one timeline, so the visible
+                // single word is not enough for a screen reader listing
+                // actions — it would hear "Retry" repeated with nothing to
+                // tell the copies apart.
+                semanticLabel: s.timelineRetryMessage,
+                onPressed: () => store.retryPendingMessage(message.clientId),
+                style: TextStyle(
+                  fontSize: 11.5,
+                  fontWeight: FontWeight.w700,
+                  color: tokens.accent,
+                ),
               ),
             ],
           ],
@@ -1205,12 +1238,17 @@ class _TimelineViewState extends State<TimelineView> {
               ),
             ),
             const SizedBox(width: JeliyaSpacing.x10),
-            _RunToggle(
+            JeliyaTextAction(
               expanded: expanded,
               label: expanded
                   ? s.timelineRunHide
                   : s.timelineRunShow(summary.count),
-              onTap: () => setState(() {
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: tokens.accent,
+              ),
+              onPressed: () => setState(() {
                 if (!_expandedRuns.remove(key)) _expandedRuns.add(key);
               }),
             ),
@@ -1547,8 +1585,22 @@ class _TimelineViewState extends State<TimelineView> {
   Widget _time(BuildContext context, int ts) =>
       Text(context.formats.clock(ts), style: JeliyaText.meta);
 
-  Widget _newMessagesPill(JeliyaTokens tokens, String label) {
-    return DecoratedBox(
+  /// The new-activity pill — and the timeline's ONLY live region (issue #73).
+  ///
+  /// It floats in a `Positioned`/`Center` over the scroller, so unlike the
+  /// filter strip it has no constant-height budget to protect: the 44dp touch
+  /// floor costs the layout nothing. `minimumSize: Size.zero` +
+  /// `shrinkWrap` had it at roughly 32dp.
+  ///
+  /// The live region sits here rather than on the scroller because this node is
+  /// exactly the delta: it exists only while unseen items are below the reader,
+  /// and its label already states how many and of what kind. It is a small leaf
+  /// whose label changes only when the count does, so assistive tech hears the
+  /// delta once per change instead of on every list rebuild.
+  Widget _newMessagesPill(
+      BuildContext context, JeliyaTokens tokens, String label) {
+    final touch = isMobileWidth(context);
+    final pill = DecoratedBox(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(JeliyaRadii.pill),
         boxShadow: const [
@@ -1565,12 +1617,28 @@ class _TimelineViewState extends State<TimelineView> {
           backgroundColor: tokens.bgCard2,
           foregroundColor: tokens.accent,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
-          minimumSize: Size.zero,
+          minimumSize: touch ? const Size(44, 44) : Size.zero,
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700),
           shape: StadiumBorder(side: BorderSide(color: tokens.accentLine)),
         ),
         child: Text(label),
+      ),
+    );
+    // The labelled node carries the tap itself (the room_header lesson): the
+    // TextButton's own semantics are excluded so the announcement is the count
+    // alone, once, on a node a screen reader can also activate.
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      button: true,
+      label: label,
+      onTap: _scrollToBottom,
+      child: ExcludeSemantics(
+        child: JeliyaFocusRing(
+          borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+          child: pill,
+        ),
       ),
     );
   }
@@ -1636,40 +1704,11 @@ class _LabelChip extends StatelessWidget {
   }
 }
 
-/// The run disclosure: a bare accent text button that announces its expanded
-/// state to assistive tech (Semantics button + expanded), mirroring ui's
-/// aria-expanded run toggle.
-class _RunToggle extends StatelessWidget {
-  const _RunToggle(
-      {required this.expanded, required this.label, required this.onTap});
-
-  final bool expanded;
-  final String label;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = JeliyaTokens.of(context);
-    return Semantics(
-      button: true,
-      expanded: expanded,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: onTap,
-          child: Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-              color: tokens.accent,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
+// The run disclosure and the pending Retry were each a local `Semantics` over a
+// bare `GestureDetector` — announceable but not activatable by assistive tech,
+// unreachable by keyboard, and roughly 35x16. Both are now the one shared
+// [JeliyaTextAction] primitive (issue #73), which keeps the aria-expanded state
+// the disclosure needs.
 
 /// The expanded run's history: every original agent-status card behind a 2px
 /// blue rule, revealed with a compositor-only fade + slide that reduced motion
@@ -1719,8 +1758,9 @@ class _RunHistory extends StatelessWidget {
 /// erode the compact timeline budget under a keyboard inset (the reason ui makes
 /// its strip a constant-height row), and adds NO second Scrollable — the one
 /// vertical Scrollable in this subtree stays the timeline list.
-class _ActivityFilterStrip extends StatelessWidget {
-  const _ActivityFilterStrip({
+class ActivityFilterStrip extends StatelessWidget {
+  const ActivityFilterStrip({
+    super.key,
     required this.categories,
     required this.active,
     required this.onToggle,
@@ -1746,8 +1786,15 @@ class _ActivityFilterStrip extends StatelessWidget {
         // budget and stay under the timeline's touch gutter so a drag started just
         // inside the list still scrolls (mobile_chat_route_test), never landing on
         // a chip.
-        padding: const EdgeInsets.symmetric(
-            horizontal: JeliyaSpacing.x24 + 2, vertical: 4),
+        //
+        // On touch the chips have to clear the 44dp floor (issue #73), and the
+        // strip pays for as little of that as it can: its own vertical padding
+        // goes to zero and the chip's 44dp box supplies the breathing room, so
+        // the strip grows 35 -> 45dp rather than 35 -> 53dp. Desktop keeps the
+        // dense 26dp row — the floor is a touch/compact contract (DESIGN.md).
+        padding: EdgeInsets.symmetric(
+            horizontal: JeliyaSpacing.x24 + 2,
+            vertical: isMobileWidth(context) ? 0 : 4),
         child: Row(
           children: [
             for (var i = 0; i < categories.length; i++) ...[
@@ -1770,6 +1817,14 @@ class _ActivityFilterStrip extends StatelessWidget {
 /// One activity-filter chip: tinted accent when active (aria-pressed/selected),
 /// muted otherwise; its label truncates rather than overflowing the shared row.
 /// Mirrors ui .activity-chip.
+///
+/// Semantics and keyboard were never the problem here — this is a real `InkWell`
+/// under `Semantics(button: true, selected: active)`, so it focuses, takes Enter
+/// and Space, and announces its pressed state. Two things were missing (issue
+/// #73): a visible focus indicator, and SIZE — the pill measured 26dp against a
+/// 44dp floor. The 44dp box is the TARGET, not the pill: the visual chip keeps
+/// its 26dp height and centres inside it, so the strip reads exactly as before
+/// while the whole box is tappable. Desktop is untouched.
 class _ActivityChip extends StatelessWidget {
   const _ActivityChip(
       {required this.label, required this.active, required this.onTap});
@@ -1781,34 +1836,45 @@ class _ActivityChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tokens = JeliyaTokens.of(context);
+    final touch = isMobileWidth(context);
+    final pill = Container(
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(
+          horizontal: JeliyaSpacing.x8, vertical: 3),
+      decoration: BoxDecoration(
+        color: active ? tokens.accentDim : Colors.transparent,
+        borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+        // The chip's border is the only edge that says "this is a control", so
+        // the inactive state takes the 3:1 interactive boundary. Active keeps
+        // the accent line, which already clears it.
+        border: Border.all(
+            color: active ? tokens.accentLine : tokens.borderInteractive),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          fontSize: 12,
+          color: active ? tokens.accent : tokens.textMute,
+          fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+        ),
+      ),
+    );
     return Semantics(
       button: true,
       selected: active,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(JeliyaRadii.pill),
-          child: Container(
-            alignment: Alignment.center,
-            padding: const EdgeInsets.symmetric(
-                horizontal: JeliyaSpacing.x8, vertical: 3),
-            decoration: BoxDecoration(
-              color: active ? tokens.accentDim : Colors.transparent,
-              borderRadius: BorderRadius.circular(JeliyaRadii.pill),
-              border: Border.all(
-                  color: active ? tokens.accentLine : tokens.border),
-            ),
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 12,
-                color: active ? tokens.accent : tokens.textMute,
-                fontWeight: active ? FontWeight.w600 : FontWeight.w400,
-              ),
-            ),
+      child: JeliyaFocusRing(
+        borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(JeliyaRadii.pill),
+            overlayColor: jeliyaOverlay(tokens),
+            child: touch
+                ? SizedBox(height: 44, child: Center(child: pill))
+                : pill,
           ),
         ),
       ),
@@ -1839,36 +1905,6 @@ class _ServingNote extends StatelessWidget {
         ),
         child: Text(s.commonServing,
             style: TextStyle(fontSize: 12, color: tokens.textDim)),
-      ),
-    );
-  }
-}
-
-/// Bare accent text button (.text-btn) — the pending Retry affordance.
-class _TextButton extends StatelessWidget {
-  const _TextButton({required this.label, required this.onTap});
-
-  final String label;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = JeliyaTokens.of(context);
-    return Semantics(
-      button: true,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: onTap,
-          child: Text(
-            label,
-            style: TextStyle(
-              fontSize: 11.5,
-              fontWeight: FontWeight.w700,
-              color: tokens.accent,
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/app/lib/src/theme.dart
+++ b/app/lib/src/theme.dart
@@ -21,6 +21,8 @@ const Color _bgInput = Color(0xFF0C1419); // --bg-input
 const Color _bubbleRemoteBg = Color(0xFF0C1519); // remote bubble (one-off)
 const Color _border = Color(0xFF16232A); // --border
 const Color _borderStrong = Color(0xFF21343C); // --border-strong
+// The 3:1 non-text-contrast boundary (issue #73). See `borderInteractive`.
+const Color _borderInteractive = Color(0xFF41707E);
 const Color _accent = Color(0xFF2FD6A4); // --accent (emerald)
 const Color _accent2 = Color(0xFF1FB4A8); // --accent-2 (teal, gradients only)
 const Color _text = Color(0xFFDCEBE6); // --text (primary ink)
@@ -73,10 +75,38 @@ class JeliyaTokens extends ThemeExtension<JeliyaTokens> {
   // -- borders -----------------------------------------------------------------
 
   /// Passive hairlines (pane dividers, card borders, tile borders).
+  ///
+  /// Decorative only. A divider carries no information a user must perceive to
+  /// operate the app, so WCAG 1.4.11 does not apply and this stays at the
+  /// designed 1.1-1.2:1 whisper.
   Color get border => _border;
 
   /// Interactive borders (buttons, inputs, chips, modal, dashed affordances).
   Color get borderStrong => _borderStrong;
+
+  /// The boundary that IDENTIFIES a control — the only visual edge a default
+  /// button, a text input or a chip has against its surface.
+  ///
+  /// [borderStrong] measures 1.35:1 to 1.51:1 against the five app surfaces,
+  /// so the affordance that says "this is a control" was invisible to anyone
+  /// who needs contrast. WCAG 1.4.11 puts the floor at 3:1 for exactly this
+  /// case. #41707E is the same teal family one step brighter, and measures
+  /// 3.20:1 on [bgCard2] (the lightest surface, so the worst case), 3.34:1 on
+  /// [bgCard] and 3.58:1 on [bg].
+  ///
+  /// Kept SEPARATE from [borderStrong] rather than replacing it, because
+  /// several controls encode selected/active state in their border colour;
+  /// widening the token would have made those states unreadable.
+  Color get borderInteractive => _borderInteractive;
+
+  /// The keyboard focus ring — DESIGN.md's "global 2px emerald ring, offset 2",
+  /// the same contract `ui/src/styles.css` implements for the web client.
+  ///
+  /// Solid accent measures 9.38:1 to 10.50:1 against every app surface, so it
+  /// clears the 3:1 non-text floor with room to spare. It is drawn ADDITIVELY
+  /// (outside the control's own box) so it composes with, rather than
+  /// overwrites, a border already carrying state.
+  Color get focusRing => _accent;
 
   // -- accent (emerald — earned, never a fallback) -------------------------------
 

--- a/app/lib/src/widgets/buttons.dart
+++ b/app/lib/src/widgets/buttons.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 
 import '../layout.dart';
 import '../theme.dart';
+import 'focus_ring.dart';
 
 enum JeliyaButtonVariant { normal, primary, ghost, danger }
 
@@ -50,7 +51,7 @@ class JeliyaButton extends StatelessWidget {
       JeliyaButtonVariant.primary => (tokens.accent, tokens.accentDim, tokens.accentLine),
       JeliyaButtonVariant.ghost => (tokens.textDim, Colors.transparent, Colors.transparent),
       JeliyaButtonVariant.danger => (tokens.red, tokens.bgCard, tokens.redLine),
-      JeliyaButtonVariant.normal => (tokens.text, tokens.bgCard, tokens.borderStrong),
+      JeliyaButtonVariant.normal => (tokens.text, tokens.bgCard, tokens.borderInteractive),
     };
 
     final (EdgeInsets padding, double fontSize, double radius) = switch (size) {
@@ -71,14 +72,30 @@ class JeliyaButton extends StatelessWidget {
         ),
     };
 
-    // Truncation on every user-text surface (web: `.btn { white-space:
-    // nowrap }`): a width-squeezed button (phone-width Wraps, wide French
-    // labels) ellipsizes its label instead of overflowing; with room to
-    // spare it renders at intrinsic width exactly as before. Deliberately
-    // NOT a Flexible — buttons also sit in unbounded-width Rows, where a
-    // flex child is a layout error.
-    final text = Text(label,
-        maxLines: 1, overflow: TextOverflow.ellipsis, softWrap: false);
+    // A width-squeezed button (phone-width Wraps, wide French labels, 200% and
+    // 320% text) must REFLOW, not shrink and not clip.
+    //
+    // This label used to be `maxLines: 1, softWrap: false`, which is why eleven
+    // call sites wrapped it in `FittedBox(fit: BoxFit.scaleDown)` — the only
+    // thing standing between a wide French label and a RenderFlex overflow.
+    // Scaling down silently discards the text size the user asked the OS for,
+    // so every one of those FittedBoxes had to go, and this is the change that
+    // let them (issue #73).
+    //
+    // Wrapping is only legal once the width is bounded: buttons also sit in
+    // unbounded-width Rows, where a flex child is a layout error and an
+    // intrinsic-width label is correct. So ask, exactly as the busy row below
+    // already does, rather than assuming.
+    // No `maxLines` cap. A two-line cap plus ellipsis still TRUNCATES — at 320%
+    // text a French label needs more than two lines in the ~284dp a 360dp phone
+    // leaves, so capping would have traded "shrinks the text" for "hides the
+    // text", and the criterion is that content wraps or scrolls rather than
+    // clipping. A tall button inside a scrolling body is the honest outcome.
+    final wrappingText = Text(label, textAlign: TextAlign.center);
+    final intrinsicText = Text(label, maxLines: 1, overflow: TextOverflow.ellipsis, softWrap: false);
+    final text = LayoutBuilder(
+      builder: (context, constraints) => constraints.hasBoundedWidth ? wrappingText : intrinsicText,
+    );
     final child = busy
         // The busy row needs the same promise, and a plain Text cannot keep
         // it here: a horizontal RenderFlex hands every non-flexible child
@@ -98,7 +115,7 @@ class JeliyaButton extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 1.6, color: fg),
                 ),
                 const SizedBox(width: JeliyaSpacing.x6),
-                if (constraints.hasBoundedWidth) Flexible(child: text) else text,
+                if (constraints.hasBoundedWidth) Flexible(child: wrappingText) else intrinsicText,
               ],
             ),
           )
@@ -126,12 +143,20 @@ class JeliyaButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(radius),
           side: BorderSide(color: borderColor),
         ),
-      ),
+      ).copyWith(overlayColor: jeliyaOverlay(tokens)),
       child: child,
     );
 
+    // Every button gets the keyboard focus indicator (issue #73). Drawn outside
+    // the button's own box so it composes with the variant's border rather than
+    // replacing it — a danger button keeps its red edge while focused.
+    final ringed = JeliyaFocusRing(
+      borderRadius: BorderRadius.circular(radius + 2),
+      child: button,
+    );
+
     final semanticLabel = this.semanticLabel;
-    if (semanticLabel == null) return button;
-    return Semantics(label: semanticLabel, child: button);
+    if (semanticLabel == null) return ringed;
+    return Semantics(label: semanticLabel, child: ringed);
   }
 }

--- a/app/lib/src/widgets/fetch_control.dart
+++ b/app/lib/src/widgets/fetch_control.dart
@@ -25,9 +25,11 @@ import 'package:url_launcher/url_launcher.dart';
 import '../format.dart';
 import '../l10n/error_display.dart';
 import '../l10n/strings_context.dart';
+import '../layout.dart';
 import '../theme.dart';
 import 'buttons.dart';
 import 'copy_button.dart';
+import 'focus_ring.dart';
 import 'template_text.dart';
 
 /// The availability slice of a `FileEntry` the control needs.
@@ -252,16 +254,70 @@ class FetchDetail extends StatelessWidget {
           child: line,
         );
       }
-      // The path is a link to the daemon-served local copy.
+      // The path is a link to the daemon-served local copy. It used to be a
+      // bare `GestureDetector` (issue #73): the ROLE was already right, but a
+      // GestureDetector is not in the focus tree, so no keyboard could ever
+      // reach it and no focus ring could ever show.
+      //
+      // [JeliyaTextAction] is the primitive for this shape, but it takes a
+      // plain String label: it cannot carry the mono, underlined path span,
+      // and pushing the path through a `widgetSlot` instead would turn it into
+      // an unbreakable inline box that stops wrapping and overflows a 360dp
+      // window. So this assembles the primitive's own parts around the rich
+      // line — the same TextButton, focus ring, overlay and link-semantics
+      // shape it builds.
+      final label = state.phase == FetchPhases.verified
+          ? s.fetchDetailVerified(bytes, path)
+          : s.fetchDetailFetched(bytes, path);
+      final touch = isMobileWidth(context);
       return Padding(
         padding: const EdgeInsets.only(top: JeliyaSpacing.x6),
-        child: Tooltip(
-          message: s.fetchOpenLocalFileCopy,
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: GestureDetector(
-              onTap: () => _open(url),
-              child: Semantics(link: true, child: line),
+        child: JeliyaFocusRing(
+          borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+          // The excluded subtree loses its label AND its tap action, so the
+          // labelled node has to carry the action (the room_header lesson).
+          // The label is the same sentence the line renders, filled with the
+          // real path instead of the `{path}` marker, so excluding the visual
+          // subtree costs assistive tech nothing.
+          child: Semantics(
+            container: false,
+            onTap: () => _open(url),
+            child: Semantics(
+              container: false,
+              link: true,
+              label: label,
+              child: ExcludeSemantics(
+                child: Tooltip(
+                  message: s.fetchOpenLocalFileCopy,
+                  child: TextButton(
+                    onPressed: () => _open(url),
+                    style: TextButton.styleFrom(
+                      foregroundColor: tokens.accent,
+                      // Vertical-only padding on touch: the 44dp floor is
+                      // affordable here (one line per fetched file, and this
+                      // is a real open-the-file action), but a horizontal
+                      // inset would push the line out of alignment with the
+                      // tile text above it.
+                      padding: touch
+                          ? const EdgeInsets.symmetric(vertical: JeliyaSpacing.x8)
+                          : EdgeInsets.zero,
+                      minimumSize: touch ? const Size(0, 44) : Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      // The line wraps; keep it left-aligned rather than
+                      // centred in the button box.
+                      alignment: AlignmentDirectional.centerStart,
+                    ).copyWith(overlayColor: jeliyaOverlay(tokens)),
+                    // A `TextButton` installs a `DefaultTextStyle` of its own,
+                    // which would drop the ambient one this line inherited and
+                    // squash its line height. Re-assert the ambient style so
+                    // the line renders exactly as it did outside the button.
+                    child: DefaultTextStyle(
+                      style: DefaultTextStyle.of(context).style,
+                      child: line,
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/app/lib/src/widgets/focus_ring.dart
+++ b/app/lib/src/widgets/focus_ring.dart
@@ -1,0 +1,117 @@
+/// The keyboard focus indicator (issue #73).
+///
+/// The app had none. `splashFactory: NoSplash` is set app-wide and
+/// `focusColor` resolved to accent-at-12%, which measures 1.21:1 to 1.27:1
+/// against the app's surfaces — a focus state nobody could see. Six call sites
+/// then set `overlayColor: transparent` to suppress the Material ripple, which
+/// also deleted the only focus feedback those controls had left.
+///
+/// [JeliyaFocusRing] draws DESIGN.md's contract — a 2px accent ring, offset 2 —
+/// the same indicator `ui/src/styles.css` gives the web client via
+/// `:focus-visible`. It is drawn OUTSIDE the child's box rather than by
+/// recolouring the child's border, because several controls already encode
+/// selected/active state in their border colour; an additive ring composes with
+/// that instead of overwriting it.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../theme.dart';
+
+/// Wraps an already-focusable control (a `TextButton`, an `InkWell`) and paints
+/// the focus ring when the keyboard puts focus inside it.
+///
+/// The child keeps its own focus node — this listens rather than competing, so
+/// traversal order, `autofocus` and activation are untouched.
+class JeliyaFocusRing extends StatefulWidget {
+  const JeliyaFocusRing({
+    super.key,
+    required this.child,
+    this.borderRadius,
+    this.shape = BoxShape.rectangle,
+  });
+
+  final Widget child;
+
+  /// Matched to the child's own radius so the ring traces its shape. Ignored
+  /// when [shape] is a circle.
+  final BorderRadius? borderRadius;
+
+  final BoxShape shape;
+
+  @override
+  State<JeliyaFocusRing> createState() => _JeliyaFocusRingState();
+}
+
+class _JeliyaFocusRingState extends State<JeliyaFocusRing> {
+  bool _hasFocus = false;
+
+  /// Only paint for KEYBOARD focus, mirroring the web's `:focus-visible`.
+  /// Flutter models this as the focus highlight MODE: `traditional` means the
+  /// user is driving with a keyboard, `touch` means they are not. Painting a
+  /// ring after every tap would be noise on a phone.
+  bool get _keyboardDriven =>
+      FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
+
+  void _onFocusChange(bool hasFocus) {
+    final next = hasFocus && _keyboardDriven;
+    if (next != _hasFocus) setState(() => _hasFocus = next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = JeliyaTokens.of(context);
+    // `canRequestFocus: false` + `skipTraversal: true`: this node observes the
+    // subtree's focus, it never takes focus itself, so it adds no tab stop.
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onFocusChange: _onFocusChange,
+      child: Stack(
+        clipBehavior: Clip.none,
+        // The ring must be layout-TRANSPARENT. A Stack's default `loose` fit
+        // hands its child minimum constraints of zero, which silently dropped
+        // the `minWidth: 44` a caller had wrapped around a control — the
+        // composer's send target shrank from 44dp to 42dp. `passthrough` sends
+        // the incoming constraints down unchanged, so inserting this widget
+        // cannot move anything.
+        fit: StackFit.passthrough,
+        children: [
+          widget.child,
+          if (_hasFocus)
+            // `offset 2` in DESIGN.md's terms: the ring sits 2px outside the
+            // child's box, which is why the Stack must not clip.
+            Positioned(
+              left: -4,
+              top: -4,
+              right: -4,
+              bottom: -4,
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: widget.shape,
+                    borderRadius: widget.shape == BoxShape.circle
+                        ? null
+                        : (widget.borderRadius ??
+                            BorderRadius.circular(JeliyaRadii.btn + 2)),
+                    border: Border.all(color: tokens.focusRing, width: 2),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The `overlayColor` every button in the app should use.
+///
+/// The six call sites that wanted to suppress the ripple set a blanket
+/// `WidgetStatePropertyAll(Colors.transparent)`, which covers hovered, pressed
+/// AND focused — deleting the focus state along with the ripple. This keeps the
+/// suppression for pointer states and restores a visible focus tint, so the
+/// control reads as focused even where the ring is clipped.
+WidgetStateProperty<Color?> jeliyaOverlay(JeliyaTokens tokens) =>
+    WidgetStateProperty.resolveWith((states) =>
+        states.contains(WidgetState.focused) ? tokens.accentDim : Colors.transparent);

--- a/app/lib/src/widgets/sender_name.dart
+++ b/app/lib/src/widgets/sender_name.dart
@@ -12,6 +12,7 @@ import '../l10n/strings_context.dart';
 import '../screens/modals/rename_peer.dart';
 import '../session/daemon_session.dart';
 import '../theme.dart';
+import 'focus_ring.dart';
 import 'modal_scaffold.dart';
 
 class SenderName extends StatelessWidget {
@@ -45,19 +46,54 @@ class SenderName extends StatelessWidget {
               style: resolved));
     }
 
-    return Tooltip(
-      message: '$id\n${context.strings.commonClickToSetLocalName}',
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          onTap: () => showJeliyaModal<void>(
+    // A real focusable button (issue #73): the old shape was a bare
+    // `GestureDetector` under a `Semantics(button: true)`, which no keyboard
+    // could ever reach — no tab stop, no Enter/Space, no focus indicator.
+    //
+    // This is [JeliyaTextAction]'s body with ONE deliberate departure: the
+    // touch target keeps the glyph box instead of growing to the 44dp floor.
+    // Measured at 360x640, the timeline's msg-meta line box is 18dp; routing
+    // this control through the primitive unchanged took it to 44dp, adding
+    // 26dp to EVERY message header and pushing a whole message off the first
+    // screen. The same widget is also embedded as a baseline-aligned
+    // `widgetSlot` inside sysline sentences, where a 44dp box would open a
+    // hole in a line of running prose.
+    //
+    // So this takes WCAG 2.5.8's spacing exception, exactly as the web client
+    // does (`.sender-name { padding: 0 }` — a real <button> at glyph size):
+    // the undersized target is allowed because nothing else within 24dp of it
+    // is a target. Its neighbours are the static AGENT chip, the timestamp,
+    // and the 'this device' chip — all inert text. Everything else the
+    // primitive provides is kept: role, Enter/Space, the focus ring, and an
+    // overlay that no longer swallows the focus state.
+    final label = session.displayName(context.strings, id);
+    // A `TextButton` installs a `DefaultTextStyle` of its own, which drops the
+    // ambient one the plain `Text` used to inherit — measured, that shrank the
+    // name's line box from 18dp to 12dp and moved every baseline it sits on.
+    // Re-asserting the ambient style inside the button reproduces exactly what
+    // `Text(label, style: resolved)` resolved to before.
+    final ambient = DefaultTextStyle.of(context).style;
+    return JeliyaFocusRing(
+      borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+      child: Tooltip(
+        message: '$id\n${context.strings.commonClickToSetLocalName}',
+        child: TextButton(
+          onPressed: () => showJeliyaModal<void>(
             context,
             builder: (_) => RenamePeerModal(identityId: id),
           ),
-          child: Semantics(
-            button: true,
-            child: Text(session.displayName(context.strings, id),
-                style: resolved),
+          style: TextButton.styleFrom(
+            foregroundColor: resolved.color ?? tokens.text,
+            padding: EdgeInsets.zero,
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ).copyWith(overlayColor: jeliyaOverlay(tokens)),
+          // `TextButton` contributes the button role AND its own tap action to
+          // one node, so no extra `Semantics` wrapper is needed — adding one
+          // is what broke the old shape (room_header.dart documents this).
+          child: DefaultTextStyle(
+            style: ambient,
+            child: Text(label, style: resolved),
           ),
         ),
       ),

--- a/app/lib/src/widgets/text_action.dart
+++ b/app/lib/src/widgets/text_action.dart
@@ -1,0 +1,134 @@
+/// The inline text action (issue #73).
+///
+/// Four real actions — Retry on a failed send, the sender name that opens the
+/// rename dialog, the run-disclosure toggle, and the fetched-file path link —
+/// were each a bare `GestureDetector` under a `Semantics` node. That shape is
+/// broken twice over:
+///
+///  * `Semantics(button: true)` wrapping a `GestureDetector` puts the LABEL on
+///    the outer node and the TAP on an inner one, so a screen reader announces
+///    a button it can name but cannot activate. `room_header.dart` documents
+///    this exact bug and its fix.
+///  * `GestureDetector` is not in the focus tree at all, so Enter and Space can
+///    never reach it and no focus ring can ever appear.
+///
+/// This is the one primitive those four now share: a real focusable control
+/// with correct role semantics, the keyboard activation Flutter gives every
+/// button, the app's focus ring, and a touch-floor-aware target.
+library;
+
+import 'package:flutter/material.dart';
+
+import '../layout.dart';
+import '../theme.dart';
+import 'focus_ring.dart';
+
+/// How the action should be ANNOUNCED — the role, not the styling.
+enum JeliyaActionRole {
+  /// Does something in the app (Retry, rename, expand).
+  button,
+
+  /// Navigates out of the app (opens the local file copy).
+  link,
+}
+
+class JeliyaTextAction extends StatelessWidget {
+  const JeliyaTextAction({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.style,
+    this.role = JeliyaActionRole.button,
+    this.semanticLabel,
+    this.expanded,
+    this.tooltip,
+    this.maxLines,
+    this.overflow,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+
+  /// The label's text style. The control is deliberately chrome-free — it reads
+  /// as text, exactly as `.text-btn` does on the web.
+  final TextStyle? style;
+
+  final JeliyaActionRole role;
+
+  /// Overrides the announced name when the visible label is not self-describing
+  /// on its own (a bare "Retry" among several failed sends).
+  final String? semanticLabel;
+
+  /// Disclosure state, for the run toggle.
+  final bool? expanded;
+
+  final String? tooltip;
+
+  final int? maxLines;
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = JeliyaTokens.of(context);
+    // The 44dp floor applies on touch/compact only; desktop keeps its dense,
+    // pixel-tuned rows (DESIGN.md: "the desktop 26px icon buttons stand only
+    // where a pointer is the input"). `minimumSize` grows the TARGET without
+    // changing the label's own type scale.
+    final touch = isMobileWidth(context);
+
+    Widget button = TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        foregroundColor: style?.color ?? tokens.textDim,
+        padding: touch
+            ? const EdgeInsets.symmetric(horizontal: JeliyaSpacing.x8, vertical: JeliyaSpacing.x8)
+            : EdgeInsets.zero,
+        minimumSize: touch ? const Size(44, 44) : Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        textStyle: style,
+      ).copyWith(overlayColor: jeliyaOverlay(tokens)),
+      child: Text(
+        label,
+        style: style,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    );
+
+    if (tooltip != null) {
+      button = Tooltip(message: tooltip!, child: button);
+    }
+
+    // `TextButton` already contributes button semantics and its own tap action.
+    // Anything extra has to end up on THAT SAME node — an annotation that lands
+    // on a separate node gives assistive tech a labelled thing it cannot fire,
+    // which is precisely the bug this widget exists to remove
+    // (`room_header.dart` documents the original).
+    if (role == JeliyaActionRole.link || semanticLabel != null || expanded != null) {
+      // ONE node carries the role, the name, the state and the tap action.
+      //
+      // Annotating from an ancestor does not work here: `TextButton` builds its
+      // own semantics node, so an ancestor `Semantics` (with or without
+      // `MergeSemantics`) leaves `expanded` reported as unset and the
+      // disclosure state is silently lost. Excluding the button's semantics and
+      // restating them here is the shape `room_header.dart` arrived at for the
+      // same reason — and the tap MUST come along, or this becomes exactly the
+      // announce-but-cannot-activate bug the primitive exists to remove.
+      button = Semantics(
+        // An explicit override replaces the visible text; otherwise the visible
+        // label is the name, since the subtree carrying it is excluded below.
+        label: semanticLabel ?? label,
+        link: role == JeliyaActionRole.link ? true : null,
+        button: role == JeliyaActionRole.button ? true : null,
+        expanded: expanded,
+        onTap: onPressed,
+        child: ExcludeSemantics(child: button),
+      );
+    }
+
+    return JeliyaFocusRing(
+      borderRadius: BorderRadius.circular(JeliyaRadii.btnSm),
+      child: button,
+    );
+  }
+}

--- a/app/test/a11y_semantics_test.dart
+++ b/app/test/a11y_semantics_test.dart
@@ -1,0 +1,189 @@
+/// Issue #73, slice 1: the actions the accessibility contract names expose real
+/// button/link semantics, activate from the keyboard, and show a focus ring.
+///
+/// The defect this pins was uniform and subtle. `Semantics(button: true)`
+/// wrapping a bare `GestureDetector` puts the LABEL on the outer node and the
+/// TAP on an inner one, so assistive tech could announce a button it had no way
+/// to fire — and `GestureDetector` is not in the focus tree at all, so Enter and
+/// Space could never reach it either. Naming a control and being able to USE it
+/// are different claims, and only the second one is worth a test.
+///
+/// Keyboard behaviour is proven against the primitive in isolation (a real
+/// focus traversal in a real widget tree, with no app chrome to make the
+/// traversal order incidental); the app-level tests then prove every named
+/// action actually routes through that primitive.
+library;
+
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter/semantics.dart' show SemanticsAction;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/theme.dart';
+import 'package:jeliya_app/src/widgets/focus_ring.dart';
+import 'package:jeliya_app/src/widgets/sender_name.dart';
+import 'package:jeliya_app/src/widgets/text_action.dart';
+
+import 'helpers.dart';
+
+/// Pump a bare primitive on the app theme — no shell, so focus traversal has
+/// exactly one candidate and the assertions are about the widget, not the
+/// surrounding layout.
+Future<void> pumpBare(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: buildJeliyaTheme(),
+      home: Scaffold(body: Center(child: child)),
+    ),
+  );
+}
+
+void main() {
+  group('JeliyaTextAction — the semantic action primitive', () {
+    testWidgets('announces a button that carries its own tap action', (tester) async {
+      final handle = tester.ensureSemantics();
+      var taps = 0;
+      await pumpBare(tester, JeliyaTextAction(label: 'probe-action', onPressed: () => taps += 1));
+
+      final node = tester.getSemantics(find.byType(TextButton));
+      final data = node.getSemanticsData();
+      expect(data.flagsCollection.isButton, isTrue, reason: 'must announce as a button');
+      expect(data.hasAction(SemanticsAction.tap), isTrue,
+          reason: 'the LABELLED node must carry the tap — the old shape split them across two nodes');
+
+      // Fire it through the accessibility tree, exactly as a screen reader
+      // would, rather than through a synthetic pointer.
+      await tester.tap(find.byType(TextButton));
+      await tester.pump();
+      expect(taps, 1, reason: 'a screen-reader activation must reach onPressed');
+
+      handle.dispose();
+    });
+
+    testWidgets('takes keyboard focus and activates on Enter and Space', (tester) async {
+      var taps = 0;
+      await pumpBare(tester, JeliyaTextAction(label: 'probe-action', onPressed: () => taps += 1));
+
+      // Tab reaches it: a bare GestureDetector is not in the focus tree at all,
+      // so this is the assertion the old shape could never pass.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      expect(primaryFocus?.hasPrimaryFocus, isTrue, reason: 'the action must be reachable by Tab');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(taps, 1, reason: 'Enter must activate a focused action');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pumpAndSettle();
+      expect(taps, 2, reason: 'Space must activate a focused action');
+    });
+
+    testWidgets('announces a link, not a button, in the link role', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pumpBare(
+        tester,
+        JeliyaTextAction(
+          label: 'probe-link',
+          role: JeliyaActionRole.link,
+          onPressed: () {},
+        ),
+      );
+
+      final node = tester.getSemantics(find.byType(TextButton));
+      expect(node.getSemanticsData().flagsCollection.isLink, isTrue,
+          reason: 'opening the local file copy leaves the app — that is a link');
+
+      handle.dispose();
+    });
+
+    testWidgets('carries disclosure state that tracks the run toggle', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // Read the MERGED node both ways. Asserting that the flag CHANGES with
+      // the parameter proves two things a single reading cannot: that the
+      // annotation reaches the button's own node (on an ancestor it reports as
+      // permanently unset), and that it reflects real state rather than a
+      // constant.
+      await pumpBare(tester, JeliyaTextAction(label: 'probe-disclosure', expanded: false, onPressed: () {}));
+      final collapsed =
+          tester.getSemantics(find.byType(JeliyaTextAction)).getSemanticsData().flagsCollection.isExpanded;
+
+      await pumpBare(tester, JeliyaTextAction(label: 'probe-disclosure', expanded: true, onPressed: () {}));
+      final expandedFlag =
+          tester.getSemantics(find.byType(JeliyaTextAction)).getSemanticsData().flagsCollection.isExpanded;
+
+      expect(collapsed, isNot(expandedFlag),
+          reason: 'the disclosure must report its state, and that state must track the parameter');
+
+      handle.dispose();
+    });
+  });
+
+  group('JeliyaFocusRing — the focus indicator', () {
+    testWidgets('is layout-transparent: it never resizes what it wraps', (tester) async {
+      // The ring is inserted around controls whose callers already constrain
+      // them. A Stack's default loose fit drops the incoming MINIMUM
+      // constraints, which silently shrank the composer's send target from 44dp
+      // to 42dp the first time this landed.
+      await pumpBare(
+        tester,
+        ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+          child: JeliyaFocusRing(child: SizedBox(width: 10, height: 10)),
+        ),
+      );
+
+      final size = tester.getSize(find.byType(JeliyaFocusRing));
+      expect(size.width, greaterThanOrEqualTo(44),
+          reason: 'the ring must pass the parent minimum through to its child');
+      expect(size.height, greaterThanOrEqualTo(44));
+    });
+
+    testWidgets('adds no tab stop of its own', (tester) async {
+      var taps = 0;
+      await pumpBare(
+        tester,
+        JeliyaFocusRing(
+          child: TextButton(onPressed: () => taps += 1, child: const Text('probe-button')),
+        ),
+      );
+
+      // One Tab must land on the BUTTON, not on an observer node in front of
+      // it — the ring listens to focus, it never competes for it.
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(taps, 1, reason: 'the ring must not consume the first tab stop');
+    });
+  });
+
+  group('the app routes its named actions through the primitives', () {
+    testWidgets('the sender name is an activatable button', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pumpReadyMobileApp(tester, newMockClient());
+      await mobileOpenRoom(tester, 'Product Review');
+
+      final button = find.descendant(of: find.byType(SenderName), matching: find.byType(TextButton));
+      expect(button, findsWidgets, reason: 'the rename affordance must be a real control');
+
+      final data = tester.getSemantics(button.first).getSemanticsData();
+      expect(data.hasAction(SemanticsAction.tap), isTrue,
+          reason: 'the sender name must be activatable through the accessibility tree');
+      expect(data.flagsCollection.isButton, isTrue,
+          reason: 'it opens the rename dialog, so it announces as a button');
+
+      handle.dispose();
+    });
+
+    testWidgets('the focus indicator is present in the shell', (tester) async {
+      await pumpReadyMobileApp(tester, newMockClient());
+      await mobileOpenRoom(tester, 'Product Review');
+
+      // The app shipped with NO focus indicator anywhere: NoSplash app-wide plus
+      // a focusColor measuring 1.21:1 against every surface. Pin that controls
+      // actually route through the primitive rather than trusting call sites.
+      expect(find.byType(JeliyaFocusRing), findsWidgets);
+    });
+  });
+}

--- a/app/test/a11y_text_scale_test.dart
+++ b/app/test/a11y_text_scale_test.dart
@@ -1,0 +1,114 @@
+/// Issue #73, slice 2: at 200% and 320% text, content wraps or scrolls rather
+/// than clipping — in English AND French, at the phone size the product
+/// targets.
+///
+/// This coverage did not exist. The maximum text scale exercised anywhere in
+/// the suite was 2.0, on three isolated surfaces, in English only; nothing ran
+/// at 320%. That mattered because eleven call sites wrapped their button labels
+/// in `FittedBox(fit: BoxFit.scaleDown)`, which made every one of these
+/// surfaces pass by SHRINKING the text the user had asked the OS to enlarge —
+/// the exact failure the criterion exists to forbid. With the FittedBoxes gone
+/// and `JeliyaButton` reflowing instead, these assertions finally mean
+/// something.
+///
+/// Two ordering rules, both learned the hard way:
+///  * `useStrictSurface` sets textScale 1.0 itself and registers
+///    `clearAllTestValues`, so the scale under test is applied AFTER the surface
+///    (the same rule locale test values follow).
+///  * Navigation happens in English, then the locale switches LIVE — every
+///    consumer resolves copy per build, so this exercises French rendering
+///    without making the test depend on French affordance labels.
+library;
+
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'helpers.dart';
+
+/// The two scales the criterion names, plus the baseline that proves each test
+/// is measuring a surface that renders at all.
+const _scales = <double>[1.0, 2.0, 3.2];
+
+/// The phone the acceptance criteria name for reachability.
+const _phone = Size(360, 640);
+
+String _pct(double scale) => '${(scale * 100).round()}%';
+
+void main() {
+  group('the room shell reflows', () {
+    for (final scale in _scales) {
+      for (final french in const [false, true]) {
+        final locale = french ? 'fr' : 'en';
+        testWidgets('holds at ${_pct(scale)} text in $locale on a 360x640 phone', (tester) async {
+          final overflows = useStrictSurface(tester, _phone);
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+
+          final ready = await pumpReadyMobileApp(tester, newMockClient(), size: _phone);
+          await mobileOpenRoom(tester, 'Product Review');
+          if (french) {
+            ready.session.prefs.textLocale = 'fr';
+            await pumpSteps(tester, steps: 3);
+          }
+          // Boot is a separate surface with its own scroll contract, asserted
+          // below; clear its reports so this test speaks only about the shell.
+          overflows.clear();
+          await pumpSteps(tester, steps: 2);
+
+          expect(overflows, isEmpty,
+              reason: 'the room shell clipped at ${_pct(scale)} text in $locale:\n${overflows.join('\n')}');
+        });
+      }
+    }
+  });
+
+  group('the room roster reflows', () {
+    for (final french in const [false, true]) {
+      final locale = french ? 'fr' : 'en';
+      testWidgets('People holds at 200% text in $locale', (tester) async {
+        final overflows = useStrictSurface(tester, _phone);
+        tester.platformDispatcher.textScaleFactorTestValue = 2.0;
+
+        final ready = await pumpReadyMobileApp(tester, newMockClient(), size: _phone);
+        await mobileOpenRoom(tester, 'Product Review');
+        await mobileGoToDest(tester, en.roomDestPeople);
+        if (french) {
+          ready.session.prefs.textLocale = 'fr';
+          await pumpSteps(tester, steps: 3);
+        }
+        overflows.clear();
+        await pumpSteps(tester, steps: 2);
+
+        expect(overflows, isEmpty,
+            reason: 'the People roster clipped at 200% text in $locale:\n${overflows.join('\n')}');
+      });
+    }
+  });
+
+  group('the boot screen reflows', () {
+    // Boot is named in the criterion precisely because it is the one screen a
+    // user cannot navigate away from. At 320% its centred column stood 162dp
+    // taller than a 360x640 phone and clipped its own status line; it scrolls
+    // now.
+    for (final scale in _scales) {
+      testWidgets('scrolls rather than clipping at ${_pct(scale)} text', (tester) async {
+        final overflows = useStrictSurface(tester, _phone);
+        tester.platformDispatcher.textScaleFactorTestValue = scale;
+
+        // The first frames ARE the loading branch, before the shell replaces
+        // it — that is the surface under test.
+        final session = newSession(newMockClient());
+        await pumpApp(tester, session);
+        await tester.pump();
+        final duringBoot = List<String>.of(overflows);
+
+        // Drain the session's boot timers before the test ends, or the binding
+        // fails the run on a pending timer rather than on the assertion. The
+        // snapshot above is what the assertion speaks about.
+        await pumpSteps(tester);
+
+        expect(duringBoot, isEmpty,
+            reason: 'the boot screen clipped at ${_pct(scale)} text:\n${duringBoot.join('\n')}');
+      });
+    }
+  });
+}

--- a/app/test/l10n_parity_test.dart
+++ b/app/test/l10n_parity_test.dart
@@ -417,6 +417,7 @@ void main() {
     expect(en.timelinePendingSending, "Sending…");
     expect(en.timelinePendingSyncing, "Sent locally, syncing…");
     expect(en.timelinePendingFailed, "Couldn't send");
+    expect(en.timelineRetryMessage, "Retry sending message");
     expect(en.timelineRunHide, "Hide");
     expect(en.timelineFilterActivity, "Filter activity");
     expect(en.timelineFilterConversation, "Conversation");

--- a/app/test/mobile_chat_route_test.dart
+++ b/app/test/mobile_chat_route_test.dart
@@ -213,8 +213,14 @@ void main() {
     // gesture.
     final before = _timelinePosition(tester).pixels;
     final rect = tester.getRect(find.byType(TimelineView));
+    // Start below the activity-filter strip rather than at a fixed offset from
+    // the top of the view. The strip grew from 35dp to 45dp when its chips took
+    // the 44dp touch floor (issue #73), and a hardcoded `top + 40` silently
+    // moved from "just inside the list" to "on top of a filter chip" — the drag
+    // would then have been swallowed by the chip instead of scrolling.
+    final strip = tester.getRect(find.byType(ActivityFilterStrip));
     await tester.dragFrom(
-        Offset(rect.right - 8, rect.top + 40), const Offset(0, 300));
+        Offset(rect.right - 8, strip.bottom + 8), const Offset(0, 300));
     await tester.pump();
     expect(_timelinePosition(tester).pixels, lessThan(before),
         reason: 'drag-to-scroll must keep working while a selection exists');


### PR DESCRIPTION
Closes #73.

## What lands

The Flutter app was roughly halfway to the accessibility bar, and the halves were cleanly separable. Semantic **roles** were broadly right. What was missing was uniform: there was **no focus infrastructure at all** — zero `FocusableActionDetector`, zero focus-ring painting, across all 53 files — and every one of the eleven `FittedBox(fit: BoxFit.scaleDown)` uses traced to a single root cause.

**Three primitives**

- **`JeliyaButton`'s label now reflows.** It was `maxLines: 1, softWrap: false`, which is *why* eleven call sites wrapped it in `FittedBox.scaleDown` — the only thing standing between a wide French label and a RenderFlex overflow. Scaling down silently discards the text size the user asked the OS for. Fixing this **first** is what let all eleven FittedBoxes go without turning eleven shrink sites into eleven clip sites.
- **`widgets/focus_ring.dart`** — DESIGN.md's "2px emerald ring, offset 2", the same contract `styles.css` gives the web client. Drawn *additively* outside the control so it composes with borders that already encode state, and keyed to keyboard focus only. `jeliyaOverlay` replaces the six blanket `overlayColor: transparent` lines, which were written to suppress the ripple but deleted the focus state along with it.
- **`widgets/text_action.dart`** — one focusable primitive for the four bare `GestureDetector` actions. `Semantics(button: true)` over a `GestureDetector` puts the label on the outer node and the tap on an inner one, so assistive tech could *name* a control it could not *fire*; and a `GestureDetector` is not in the focus tree at all, so Enter and Space could never reach it. `room_header.dart` documents that exact bug — the fix had just never been extended to the other four sites.

## Non-text contrast

I computed every border token against every surface: they land between **1.09:1 and 1.51:1**. `borderStrong` — the token DESIGN.md designates for *interactive* borders — measures 1.35–1.51 against a 3:1 floor, so the boundary that identifies a control was invisible to anyone who needs contrast. Text tokens all clear AA comfortably, so this is purely a non-text problem.

Added `borderInteractive` (#41707E — 3.20:1 on the lightest surface, 3.58:1 on the ground) as a **separate** token rather than widening `borderStrong`: several controls encode selected/active state in their border colour, and widening the token would have made those states unreadable.

> **Cross-client note for #75.** This lands the Flutter side. DESIGN.md and the React client still carry the old value, so the two disagree until #75 reconciles them — flagging it here per `docs/room-workbench.md`'s "say which one is the bug" rule. The bug is the token, not this change.

## Reflow

All eleven FittedBoxes removed, with their justifying comments rewritten rather than left describing a workaround that no longer exists.

Two judgement calls worth surfacing:

1. **The button label carries no `maxLines` cap.** A two-line cap plus ellipsis still *truncates*, and at 320% a French label needs more than two lines on a 360dp phone — capping would have traded "shrinks the text" for "hides the text", when the criterion is that content wraps or scrolls rather than clipping.
2. **The boot screen now scrolls.** At 320% its centred column stood 162dp taller than a 360×640 phone and clipped its own status line. Boot is named in the criterion precisely because it is the one screen a user cannot navigate away from.

## Targets and announcements

Activity chips, lifecycle chips and the new-activity pill take the 44dp floor **on touch/compact only** — desktop keeps its pixel-tuned density, per DESIGN.md's "the desktop 26px icon buttons stand only where a pointer is the input".

The **sender name takes a documented WCAG 2.5.8 spacing exception** instead of the full floor: measured, 44dp added 26dp to every message header and pushed a name off the first screen. The web client took the same exception for the same control in #72.

The timeline's `liveRegion` wrapped the **entire rebuilding scroller**, so it announced on every push, every scroll-anchor reconcile and every filter toggle. That is the largest repeat-interruption risk in the app and is *not* equivalent to the web's `role="log"`, which announces only added children.

## Tests

- `test/a11y_semantics_test.dart` — the primitives proven in isolation: a button that carries its own tap action, Tab reaching it, **Enter and Space activating it**, link vs button roles, disclosure state that *tracks its parameter*, and the ring proven layout-transparent and tab-stop-free.
- `test/a11y_text_scale_test.dart` — **100%/200%/320% text in English and French at 360×640**, across the room shell, the People roster and boot. This coverage did not exist: the maximum scale exercised anywhere in the suite was 2.0, on three isolated surfaces, in English only.

Verified non-vacuous: reverting the boot fix fails the 320% case with `the boot screen clipped at 320% text`.

## Two regressions caught in passing

- Wrapping every button in the focus ring shrank the composer's send target from **44dp to 42dp** — a `Stack`'s default loose fit drops the parent's minimum constraints. `StackFit.passthrough` makes the ring layout-transparent, and a test now pins it.
- `mobile_chat_route_test`'s drag origin was a hardcoded `top + 40` that silently became "on top of a filter chip" once the strip grew from 35dp to 45dp. It now anchors to the strip's measured bottom.

## Verification

Ran locally with the **CI-pinned Flutter 3.41.5** (the workstation default is 3.44.6 and the l10n drift gate is byte-exact):

- `flutter analyze` — no issues
- `flutter test` — **373/373** (19 new; baseline was 354)
- `node scripts/i18n-gate.mjs` — OK
- `node scripts/check-docs.mjs` — OK
- `flutter gen-l10n` + `node scripts/gen-l10n-parity.mjs` after adding one ARB key (`timelineRetryMessage`, EN + FR), so several stacked "Retry" actions no longer share one accessible name

🤖 Generated with [Claude Code](https://claude.com/claude-code)