### PR TITLE
feat: bring UI styling back into design-system conformance (#75)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,8 +7,10 @@ colors:
   card: "#0e161b"
   card-nested: "#111b21"
   input-well: "#0c1419"
+  bubble-remote: "#0c1519"
   border-quiet: "#16232a"
   border-strong: "#21343c"
+  border-interactive: "#41707e"
   emerald: "#2fd6a4"
   emerald-deep: "#1fb4a8"
   ink: "#dcebe6"
@@ -174,8 +176,20 @@ truthful status hues.
 - **Nested surface** (#111b21): the one level allowed above card — file/pipe
   tiles, count badges, input tracks.
 - **Input well** (#0c1419): all text inputs, the composer bar.
+- **Remote bubble** (#0c1519): the incoming message bubble, one step below
+  card. Authorship reads from this surface — a received message sits on its
+  own ground rather than carrying a coloured stripe down its edge — while an
+  own message keeps the card surface and is marked by alignment, a suppressed
+  avatar, the flipped tail radius, and an emerald border.
 - **Quiet border** (#16232a) / **Strong border** (#21343c): dividers vs.
   interactive edges.
+- **Interactive border** (#41707e): the boundary that *identifies* a control,
+  at the 3:1 non-text floor (WCAG 1.4.11). This is a separate token, not a
+  widening of strong border. Strong border measures 1.35–1.51:1 against the
+  surfaces it sits on, so it cannot carry that duty alone — but several
+  controls encode selected or active state in that same border colour, and
+  brightening the token itself would flatten those states into each other.
+  Two tokens: one draws the control, one still has room to change.
 - **Ink** (#dcebe6) / **Dim ink** (#8aa39d) / **Mute ink** (#7a938c): primary
   text, secondary text, and small info-bearing text. Mute ink is
   contrast-audited in source: ≥4.5:1 on every surface it sits on.
@@ -221,20 +235,29 @@ are prohibited.
 
 Flat by doctrine: depth is tonal layering (ground → chrome → card → nested
 surface) plus 1px borders. There are no resting shadows anywhere in the
-system. Exactly one component elevates — the modal
-(`box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5)` over a 72% scrim with a 3px
-functional blur). The 6px color glows on status dots are signal, not depth.
+system. Two components elevate, and both do it because they genuinely sit
+*over* something: the modal (`box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5)`
+over a 72% scrim with a 3px functional blur) and the medium-shell inspector
+drawer. The 6px color glows on status dots are signal, not depth.
 
 ### Shadow Vocabulary
 - **Modal lift** (`box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5)`): the modal
   dialog only.
+- **Drawer lift** (`box-shadow: -12px 0 32px rgba(0, 0, 0, 0.45)`): the
+  inspector at the medium shell only. There it is a drawer pinned to the
+  right edge of a workspace that stays live behind it, and the shadow is what
+  says which surface is on top — the tonal step cannot, because both panes
+  are chrome. It nulls out at the other two shells: at wide the inspector
+  takes a column of its own and separates by border like everything else, and
+  at compact there is only one pane, so nothing is over anything.
 - **Status glow** (`box-shadow: 0 0 6px <hue at 70%>`): live/error/info dots
   and the live pill's dot. Never on containers.
 
 ### Named Rules
 **The Border-Not-Shadow Rule.** Surfaces separate by tonal step and 1px
-border. If a new component seems to need a shadow, it's either a modal or
-it's wrong.
+border. If a new component seems to need a shadow, it is either overlaying a
+surface that stays live beneath it — the modal, the medium drawer — or it is
+wrong. A shadow on a component that sits *in* the layout is always wrong.
 
 ## 5. Components
 
@@ -242,6 +265,15 @@ Interactive states are a contract: default, hover, focus-visible (global 2px
 emerald ring, offset 2), active (pressed tonal step), and disabled (0.55
 opacity) exist on every control; loading renders as skeletons or in-button
 spinners with text.
+
+**The disabled opacity is qualified by ink tier.** 0.55 applies to primary
+ink, which lands at 5.20:1 and still clears AA. It does not generalize: dim
+ink and mute ink are already spent against their surfaces, and dimming them
+further drops information-bearing text under the floor. Dim and mute ink
+recede the way everything else in this system recedes — through the ground,
+by stepping the surface back and dimming graphic marks — never by opacity
+over the text itself. Three real contrast failures came from applying the
+0.55 rule as if it were global.
 
 ### Buttons
 - **Shape:** gently rounded (9px; 8px for small, 7px for icon buttons)
@@ -327,8 +359,12 @@ The brand mark is the flat single-accent meeting tree (`TreeMark` — see
 avatars tinted by a 6-color identity hash at ~15% alpha remain the identity
 signature for people and agents — flat clips, never glowing, never gradient.
 Nothing else in the system is hexagonal; the progress fill is the only
-sanctioned accent gradient (faint tonal tint washes on card surfaces are a
-separate, quieter device).
+sanctioned accent gradient. Faint tonal tint washes on card surfaces are a
+separate, quieter device, and "faint" is a number: **a single hue, at alpha
+≤ 0.10**. A wash that blends two hues stops being tonal and becomes the
+gradient the crypto/web3 anti-reference is made of — which is exactly how a
+blue-into-emerald members wash got in while every reviewer read it as one
+faint tint.
 
 ## 6. Do's and Don'ts
 

--- a/app/lib/src/screens/timeline.dart
+++ b/app/lib/src/screens/timeline.dart
@@ -941,69 +941,34 @@ class _TimelineViewState extends State<TimelineView> {
       bottomLeft: const Radius.circular(JeliyaRadii.bubble),
       bottomRight: const Radius.circular(JeliyaRadii.bubble),
     );
-    final text = Text(
-      body,
-      style: JeliyaText.body.copyWith(color: dim ? tokens.textDim : tokens.text),
-    );
-    final Widget bubble;
-    if (own) {
-      bubble = Container(
+    // One anatomy for both sides (issue #75). Ownership reads FOUR ways —
+    // right alignment, the suppressed avatar, the flipped tail radius above,
+    // and the emerald edge here — which is plenty; the accent gradient and
+    // resting shadow this replaces each broke a Named Rule in DESIGN.md (the
+    // progress fill is the only sanctioned accent gradient; depth is tonal
+    // layering plus 1px borders, so there are no resting shadows).
+    //
+    // Authorship reads from the SURFACE: the remote bubble sits one tonal step
+    // below the card. The 2px blue border-left it replaces was the exact
+    // side-stripe construct DESIGN.md forbids, and carrying it in Flutter cost
+    // a ClipRRect + IntrinsicHeight + stretch Row to fake a non-uniform border
+    // under a radius.
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _bubbleMaxWidth),
+      child: Container(
         padding: const EdgeInsets.symmetric(
             horizontal: JeliyaSpacing.x14, vertical: JeliyaSpacing.x10),
         decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [tokens.bubbleOwnGradientStart, tokens.bubbleOwnGradientEnd],
-          ),
-          border: Border.all(color: tokens.bubbleOwnBorder),
-          borderRadius: radius,
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x29000000), // rgba(0,0,0,0.16)
-              offset: Offset(0, 10),
-              blurRadius: 26,
-            ),
-          ],
-        ),
-        child: text,
-      );
-    } else {
-      // 1px hairline + the 2px blue LEFT edge: a clipped stripe (Flutter
-      // can't mix non-uniform border widths with a radius).
-      bubble = Container(
-        decoration: BoxDecoration(
-          color: tokens.bubbleRemoteBg,
-          border: Border.all(color: tokens.border),
+          color: own ? tokens.bgCard : tokens.bubbleRemoteBg,
+          border: Border.all(color: own ? tokens.accentLine : tokens.border),
           borderRadius: radius,
         ),
-        child: ClipRRect(
-          borderRadius: radius,
-          // IntrinsicHeight bounds the stretch: timeline rows get unbounded
-          // height from the list, and a stretch Row under an infinite max
-          // height is a layout error (the stripe must match the text height).
-          child: IntrinsicHeight(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Container(width: 2, color: tokens.bubbleRemoteEdge),
-                Flexible(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: JeliyaSpacing.x12, vertical: JeliyaSpacing.x10),
-                    child: text,
-                  ),
-                ),
-              ],
-            ),
-          ),
+        child: Text(
+          body,
+          style:
+              JeliyaText.body.copyWith(color: dim ? tokens.textDim : tokens.text),
         ),
-      );
-    }
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: _bubbleMaxWidth),
-      child: bubble,
+      ),
     );
   }
 
@@ -1597,33 +1562,26 @@ class _TimelineViewState extends State<TimelineView> {
   /// and its label already states how many and of what kind. It is a small leaf
   /// whose label changes only when the count does, so assistive tech hears the
   /// delta once per change instead of on every list rebuild.
+  ///
+  /// It separates from the timeline beneath it by its own tonal step
+  /// ([JeliyaTokens.bgCard2]) and its accent border, NOT by a resting shadow
+  /// (DESIGN.md section 4: flat by doctrine). Matches `.new-messages` in
+  /// styles.css after the #75 conformance pass.
   Widget _newMessagesPill(
       BuildContext context, JeliyaTokens tokens, String label) {
     final touch = isMobileWidth(context);
-    final pill = DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(JeliyaRadii.pill),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x47000000), // rgba(0,0,0,0.28)
-            offset: Offset(0, 10),
-            blurRadius: 30,
-          ),
-        ],
+    final pill = TextButton(
+      onPressed: _scrollToBottom,
+      style: TextButton.styleFrom(
+        backgroundColor: tokens.bgCard2,
+        foregroundColor: tokens.accent,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        minimumSize: touch ? const Size(44, 44) : Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700),
+        shape: StadiumBorder(side: BorderSide(color: tokens.accentLine)),
       ),
-      child: TextButton(
-        onPressed: _scrollToBottom,
-        style: TextButton.styleFrom(
-          backgroundColor: tokens.bgCard2,
-          foregroundColor: tokens.accent,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
-          minimumSize: touch ? const Size(44, 44) : Size.zero,
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700),
-          shape: StadiumBorder(side: BorderSide(color: tokens.accentLine)),
-        ),
-        child: Text(label),
-      ),
+      child: Text(label),
     );
     // The labelled node carries the tap itself (the room_header lesson): the
     // TextButton's own semantics are excluded so the announcement is the count

--- a/app/lib/src/theme.dart
+++ b/app/lib/src/theme.dart
@@ -21,7 +21,8 @@ const Color _bgInput = Color(0xFF0C1419); // --bg-input
 const Color _bubbleRemoteBg = Color(0xFF0C1519); // remote bubble (one-off)
 const Color _border = Color(0xFF16232A); // --border
 const Color _borderStrong = Color(0xFF21343C); // --border-strong
-// The 3:1 non-text-contrast boundary (issue #73). See `borderInteractive`.
+// The 3:1 non-text-contrast boundary (issues #73, #75). See
+// `borderInteractive`; pinned in assets/design-tokens.json.
 const Color _borderInteractive = Color(0xFF41707E);
 const Color _accent = Color(0xFF2FD6A4); // --accent (emerald)
 const Color _accent2 = Color(0xFF1FB4A8); // --accent-2 (teal, gradients only)
@@ -97,6 +98,9 @@ class JeliyaTokens extends ThemeExtension<JeliyaTokens> {
   /// Kept SEPARATE from [borderStrong] rather than replacing it, because
   /// several controls encode selected/active state in their border colour;
   /// widening the token would have made those states unreadable.
+  ///
+  /// Mirrors `--border-interactive` in `ui/src/styles.css`; both answer to
+  /// `assets/design-tokens.json` (issue #75).
   Color get borderInteractive => _borderInteractive;
 
   /// The keyboard focus ring — DESIGN.md's "global 2px emerald ring, offset 2",
@@ -108,11 +112,15 @@ class JeliyaTokens extends ThemeExtension<JeliyaTokens> {
   /// overwrites, a border already carrying state.
   Color get focusRing => _accent;
 
+
   // -- accent (emerald — earned, never a fallback) -------------------------------
 
   Color get accent => _accent;
 
-  /// Gradient partner only — progress fill start, own-bubble gradient end.
+  /// Gradient partner only — the progress fill start, and nothing else. The
+  /// progress fill is the ONLY sanctioned accent gradient (DESIGN.md, Identity
+  /// Marks); this token previously also fed an own-bubble gradient, which is
+  /// why the drift was invisible in review.
   Color get accent2 => _accent2;
 
   /// Accent tint fills (primary button bg, selected nav/room, self-chip).
@@ -146,25 +154,30 @@ class JeliyaTokens extends ThemeExtension<JeliyaTokens> {
   Color get redLine => _alpha(_red, 0.4);
   Color get redDim => _alpha(_red, 0.1);
 
-  /// Informational/agent hue — connecting peers, agent-work card, remote
-  /// bubble edge, agent role chip, invited status, doc-file tint.
+  /// Informational/agent hue — connecting peers, agent-work card, agent role
+  /// chip, invited status, doc-file tint.
   Color get blue => _blue;
   Color get blueLine => _alpha(_blue, 0.4);
   Color get blueDim => _alpha(_blue, 0.1);
 
   // -- message bubbles ------------------------------------------------------------------
 
-  /// Own bubble gradient 135deg start (accent @ 0.20).
-  Color get bubbleOwnGradientStart => _alpha(_accent, 0.20);
-
-  /// Own bubble gradient end (teal @ 0.13).
-  Color get bubbleOwnGradientEnd => _alpha(_accent2, 0.13);
-
-  /// Own bubble border (accent @ 0.42).
-  Color get bubbleOwnBorder => _alpha(_accent, 0.42);
-
-  /// Remote bubble 2px LEFT accent edge (blue @ 0.34).
-  Color get bubbleRemoteEdge => _alpha(_blue, 0.34);
+  // Four bubble tokens were removed here in issue #75, because naming drift as
+  // a first-class token is what let both clients stay confidently wrong in the
+  // same direction — the reviewer sees a token, not a rule being broken:
+  //
+  //   bubbleOwnGradientStart (accent @ 0.20) + bubbleOwnGradientEnd
+  //     (accent2 @ 0.13) — an own-message accent gradient. The progress fill
+  //     is the only sanctioned accent gradient (DESIGN.md, Identity Marks).
+  //   bubbleRemoteEdge (blue @ 0.34) — the 2px LEFT accent edge, which is
+  //     exactly the side-stripe DESIGN.md forbids.
+  //   bubbleOwnBorder (accent @ 0.42) — a fifth alpha where the system
+  //     specifies two (assets/design-tokens.json `alpha`); the own bubble now
+  //     takes the sanctioned [accentLine] (0.4) like every other accent edge.
+  //
+  // Ownership still reads four ways, which is plenty: right alignment, the
+  // suppressed avatar, the flipped tail radius, and the emerald border.
+  // Authorship reads from [bubbleRemoteBg] — the surface, not a stripe.
 
   /// Own event tile tint border (accent @ 0.34).
   Color get ownTileBorder => _alpha(_accent, 0.34);

--- a/app/test/design_tokens_test.dart
+++ b/app/test/design_tokens_test.dart
@@ -1,0 +1,244 @@
+/// Design-system conformance gate, Flutter half (issue #75).
+///
+/// `assets/design-tokens.json` is the shared fixture BOTH clients answer to.
+/// This asserts the Flutter palette in `lib/src/theme.dart` carries the values
+/// the fixture pins; `scripts/check-design-tokens.mjs` asserts the same of
+/// `ui/src/styles.css`. The two halves read one file, so the clients cannot
+/// drift apart again silently.
+///
+/// They drifted before precisely because the drift was NAMED: the own-message
+/// bubble had an accent gradient in CSS and a matching pair of gradient TOKENS
+/// in Dart, so each side looked internally consistent and a reviewer saw a
+/// token rather than a Named Rule being broken.
+///
+/// Where this test and the fixture disagree, one of them is a bug — say WHICH
+/// in the pull request. Do not "fix" a failure by editing the expectation.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jeliya_app/src/theme.dart';
+
+void main() {
+  // The test CWD is `app/`; the fixture is shared, so it lives at the repo root.
+  final fixtureFile = File('../assets/design-tokens.json');
+  final fixture =
+      jsonDecode(fixtureFile.readAsStringSync()) as Map<String, dynamic>;
+  final colors = (fixture['color'] as Map<String, dynamic>)
+    ..removeWhere((key, _) => key.startsWith(r'$'));
+  final radii = (fixture['radius'] as Map<String, dynamic>)
+    ..removeWhere((key, _) => key.startsWith(r'$'));
+  final contrast = fixture['contrast'] as Map<String, dynamic>;
+
+  const tokens = JeliyaTokens.dark;
+
+  /// Fixture colour name -> the [JeliyaTokens] getter that carries it.
+  /// Mirrors the `CSS_VAR` map in `scripts/check-design-tokens.mjs` one-for-one
+  /// so the two halves cover the same set.
+  final dartToken = <String, Color>{
+    'ground': tokens.bg, // --bg
+    'chrome': tokens.bgRaise, // --bg-raise
+    'card': tokens.bgCard, // --bg-card
+    'card-nested': tokens.bgCard2, // --bg-card-2
+    'input-well': tokens.bgInput, // --bg-input
+    'bubble-remote': tokens.bubbleRemoteBg, // --bg-bubble-remote
+    'border-quiet': tokens.border, // --border
+    'border-strong': tokens.borderStrong, // --border-strong
+    'border-interactive': tokens.borderInteractive, // --border-interactive
+    'accent': tokens.accent, // --accent
+    'accent-deep': tokens.accent2, // --accent-2
+    'ink': tokens.text, // --text
+    'ink-dim': tokens.textDim, // --text-dim
+    'ink-mute': tokens.textMute, // --text-mute
+    'amber': tokens.amber, // --amber
+    'red': tokens.red, // --red
+    'blue': tokens.blue, // --blue
+    // The mjs half skips `scrim` and `shadow` as "composed"; Flutter carries
+    // scrim as a real token, so it is checked here.
+    'scrim': tokens.modalBarrier, // rgba(3, 7, 9, 0.72)
+  };
+
+  /// `shadow` has no Flutter consumer: DESIGN.md is flat by doctrine, and the
+  /// one Flutter surface that lifts (the modal barrier) uses `scrim`. Listed
+  /// explicitly so a new fixture colour cannot slip through unmapped.
+  const unmapped = {'shadow'};
+
+  /// Fixture radius name -> the [JeliyaRadii] const that carries it.
+  const dartRadius = <String, double>{
+    'tail': JeliyaRadii.bubbleSharp, // 4  — bubble sharp corner
+    'tight': JeliyaRadii.iconBtn, // 7  — icon-btn / skeleton / pipe chip
+    'sm': JeliyaRadii.btnSm, // 8  — btn-sm
+    'control': JeliyaRadii.btn, // 9  — btn / inputs / 34px tiles
+    'nav': JeliyaRadii.nav, // 10 — nav items / stat inner cells
+    'tile': JeliyaRadii.row, // 11 — room rows / file+pipe tiles
+    'card-sm': JeliyaRadii.card, // 12 — profile + settings cards
+    'card': JeliyaRadii.composer, // 13 — composer / agent+pipe cards
+    'stat': JeliyaRadii.bubble, // 14 — member rows / bubble round corners
+    'card-lg': JeliyaRadii.hero, // 15 — heroes / fleet cards
+    'surface': JeliyaRadii.modal, // 16 — modal / onboarding card
+    'pill': JeliyaRadii.pill, // 999 — all pills/chips/badges
+  };
+
+  group('shared fixture', () {
+    test('every pinned colour is mapped to a Dart token', () {
+      final unaccounted = colors.keys
+          .where((k) => !dartToken.containsKey(k) && !unmapped.contains(k))
+          .toList();
+      expect(
+        unaccounted,
+        isEmpty,
+        reason:
+            'assets/design-tokens.json pins $unaccounted, which no JeliyaTokens '
+            'getter carries. Add the token to theme.dart and map it here, or '
+            'record it in `unmapped` with the reason Flutter has no consumer.',
+      );
+    });
+
+    test('every pinned colour matches its JeliyaTokens getter', () {
+      for (final entry in dartToken.entries) {
+        final pinned = _parseHex(colors[entry.key] as String);
+        expect(
+          entry.value.toARGB32(),
+          pinned,
+          reason: 'colour `${entry.key}`: theme.dart has '
+              '${_hex(entry.value.toARGB32())}, the fixture pins '
+              '${_hex(pinned)}. One of them is a bug — say which in the PR. '
+              'The React half is scripts/check-design-tokens.mjs.',
+        );
+      }
+    });
+
+    test('every pinned radius matches its JeliyaRadii const', () {
+      final unaccounted =
+          radii.keys.where((k) => !dartRadius.containsKey(k)).toList();
+      expect(unaccounted, isEmpty,
+          reason: 'fixture pins radii $unaccounted with no JeliyaRadii mapping');
+
+      for (final entry in dartRadius.entries) {
+        expect(
+          entry.value,
+          (radii[entry.key] as num).toDouble(),
+          reason: 'radius `${entry.key}`: JeliyaRadii has ${entry.value}, the '
+              'fixture pins ${radii[entry.key]}',
+        );
+      }
+    });
+  });
+
+  // -- contrast floors ---------------------------------------------------------
+  //
+  // The fixture RECORDS these floors so a test can assert them, rather than a
+  // source comment claiming them. `text` is WCAG 1.4.3 AA for
+  // information-bearing text; `non-text` is 1.4.11 for the boundaries that
+  // identify a control.
+
+  group('contrast floors', () {
+    /// Every surface a token can be drawn on. Ink and control boundaries must
+    /// clear their floor against ALL of them — the worst case is what a reader
+    /// actually hits, and it is not always the darkest ground.
+    final surfaces = <String, Color>{
+      'ground': tokens.bg,
+      'chrome': tokens.bgRaise,
+      'card': tokens.bgCard,
+      'card-nested': tokens.bgCard2,
+      'input-well': tokens.bgInput,
+      'bubble-remote': tokens.bubbleRemoteBg,
+    };
+
+    test('textMute clears the text floor on every surface', () {
+      // i18n-exempt: a JSON key in assets/design-tokens.json, not copy.
+      final floor = (contrast['text'] as num).toDouble();
+      for (final surface in surfaces.entries) {
+        final ratio = _contrastRatio(tokens.textMute, surface.value);
+        expect(
+          ratio,
+          greaterThanOrEqualTo(floor),
+          reason: 'textMute on ${surface.key} is '
+              '${ratio.toStringAsFixed(2)}:1, below the $floor:1 floor. '
+              'textMute colours information-bearing small text (timestamps, '
+              'syslines, placeholders), so it must clear NORMAL-text contrast. '
+              'Recede through the GROUND, never by fading the ink.',
+        );
+      }
+    });
+
+    test('borderInteractive clears the non-text floor on every surface', () {
+      final floor = (contrast['non-text'] as num).toDouble();
+      for (final surface in surfaces.entries) {
+        final ratio = _contrastRatio(tokens.borderInteractive, surface.value);
+        expect(
+          ratio,
+          greaterThanOrEqualTo(floor),
+          reason: 'borderInteractive on ${surface.key} is '
+              '${ratio.toStringAsFixed(2)}:1, below the $floor:1 floor. '
+              'This is the boundary that IDENTIFIES a control (WCAG 1.4.11).',
+        );
+      }
+    });
+
+    test('the formula agrees with the WCAG reference pairs', () {
+      // Anchors, so a broken luminance implementation cannot silently pass the
+      // assertions above: black-on-white is exactly 21:1, and any colour
+      // against itself is exactly 1:1.
+      expect(
+        _contrastRatio(const Color(0xFF000000), const Color(0xFFFFFFFF)),
+        closeTo(21.0, 0.001),
+      );
+      expect(_contrastRatio(tokens.bg, tokens.bg), closeTo(1.0, 0.001));
+    });
+  });
+}
+
+// -- helpers -------------------------------------------------------------------
+
+/// `#rrggbb` or `#rrggbbaa` -> a 32-bit ARGB int, the encoding
+/// [Color.toARGB32] returns. Opaque when the fixture omits alpha.
+int _parseHex(String hex) {
+  final digits = hex.replaceFirst('#', '');
+  if (digits.length == 6) return 0xFF000000 | int.parse(digits, radix: 16);
+  if (digits.length == 8) {
+    final rgba = int.parse(digits, radix: 16);
+    // CSS orders the byte as #RRGGBBAA; Dart's Color wants AARRGGBB.
+    return ((rgba & 0xFF) << 24) | (rgba >> 8);
+  }
+  throw FormatException('unsupported colour literal in the fixture', hex);
+}
+
+String _hex(int argb) => '#${argb.toRadixString(16).padLeft(8, '0')}';
+
+/// WCAG 2.x relative luminance (definition in the Understanding docs for
+/// SC 1.4.3). Implemented here rather than pulled in as a dependency: the whole
+/// point of the gate is that it has no way to disagree with the spec.
+double _relativeLuminance(Color color) {
+  final argb = color.toARGB32();
+  double channel(int value) {
+    final s = value / 255.0;
+    return s <= 0.04045
+        ? s / 12.92
+        : math.pow((s + 0.055) / 1.055, 2.4).toDouble();
+  }
+
+  return 0.2126 * channel((argb >> 16) & 0xFF) +
+      0.7152 * channel((argb >> 8) & 0xFF) +
+      0.0722 * channel(argb & 0xFF);
+}
+
+/// WCAG contrast ratio, `(lighter + 0.05) / (darker + 0.05)`, in 1:1..21:1.
+///
+/// Both arguments must be OPAQUE. A translucent ink composites against
+/// whatever is behind it, so its real ratio depends on the stack — which is
+/// exactly the bug the own-bubble gradient hid, where a translucent fill
+/// composited over the ground instead of the card and dropped muted ink to
+/// 4.06:1.
+double _contrastRatio(Color a, Color b) {
+  assert(a.a == 1.0 && b.a == 1.0, 'contrast is only meaningful on opaque colours');
+  final la = _relativeLuminance(a);
+  final lb = _relativeLuminance(b);
+  final lighter = math.max(la, lb);
+  final darker = math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/assets/design-tokens.json
+++ b/assets/design-tokens.json
@@ -1,0 +1,115 @@
+{
+  "$comment": [
+    "The shared design-token fixture (issue #75). ONE source of truth for the",
+    "values both clients render, so the React and Flutter palettes cannot drift",
+    "apart again — which is exactly how the message bubble ended up with a",
+    "gradient in CSS and a matching pair of gradient TOKENS in Dart.",
+    "",
+    "Normative prose lives in DESIGN.md; this file is the machine-checkable",
+    "half. Two tests read it and fail on any divergence:",
+    "  - scripts/check-design-tokens.mjs  -> ui/src/styles.css :root",
+    "  - app/test/design_tokens_test.dart -> app/lib/src/theme.dart",
+    "",
+    "Scope note. Colors and radii are shared VALUES and are pinned here. Spacing",
+    "is deliberately NOT pinned: DESIGN.md names five design steps while Flutter",
+    "carries a ten-step scale with intermediate values, and forcing one onto the",
+    "other would encode a disagreement rather than resolve it. The mapping is",
+    "documented in DESIGN.md instead."
+  ],
+
+  "color": {
+    "$comment": "DESIGN.md section 2. Hex is authoritative; alpha companions are derived below.",
+    "ground": "#070d10",
+    "chrome": "#0a1116",
+    "card": "#0e161b",
+    "card-nested": "#111b21",
+    "input-well": "#0c1419",
+    "bubble-remote": "#0c1519",
+
+    "border-quiet": "#16232a",
+    "border-strong": "#21343c",
+    "border-interactive": "#41707e",
+
+    "accent": "#2fd6a4",
+    "accent-deep": "#1fb4a8",
+
+    "ink": "#dcebe6",
+    "ink-dim": "#8aa39d",
+    "ink-mute": "#7a938c",
+
+    "amber": "#f5b453",
+    "red": "#f26d6d",
+    "blue": "#6aa8f7",
+
+    "scrim": "#030709b8",
+    "shadow": "#00000080"
+  },
+
+  "alpha": {
+    "$comment": [
+      "The system specifies exactly two alpha companions per hue — a ~10-12%",
+      "tint and a 40% line. Every value outside this set was drift: the audit",
+      "found five different alphas in use where two are specified.",
+      "The accent's tinted-button states are the one sanctioned extension."
+    ],
+    "dim": { "accent": 0.12, "amber": 0.12, "red": 0.1, "blue": 0.1 },
+    "line": { "accent": 0.4, "amber": 0.4, "red": 0.4, "blue": 0.4 },
+    "accent-hover": 0.2,
+    "accent-active": 0.28
+  },
+
+  "radius": {
+    "$comment": "DESIGN.md `rounded`. Flutter mirrors these in JeliyaRadii.",
+    "tail": 4,
+    "tight": 7,
+    "sm": 8,
+    "control": 9,
+    "nav": 10,
+    "tile": 11,
+    "card-sm": 12,
+    "card": 13,
+    "stat": 14,
+    "card-lg": 15,
+    "surface": 16,
+    "pill": 999
+  },
+
+  "contrast": {
+    "$comment": [
+      "The floors CONTRIBUTING.md makes a contribution requirement, recorded",
+      "here so a test can assert them rather than a comment claiming them.",
+      "`text` is WCAG 1.4.3 AA for information-bearing text; `non-text` is",
+      "1.4.11 for the boundaries and indicators that identify controls."
+    ],
+    "text": 4.5,
+    "non-text": 3.0
+  },
+
+  "elevation": {
+    "$comment": [
+      "DESIGN.md section 4: flat by doctrine. Depth is tonal layering plus 1px",
+      "borders — there are NO resting shadows. This list is exhaustive and a",
+      "conformance test treats anything outside it as drift.",
+      "The medium-shell inspector drawer is the third entry, added in #75: it",
+      "genuinely floats over the workspace, and DESIGN.md was amended to say so",
+      "rather than leaving it as undocumented drift."
+    ],
+    "allowed": ["modal-lift", "status-glow", "drawer-lift"],
+    "modal-lift": "0 24px 60px rgba(0, 0, 0, 0.5)",
+    "status-glow": "0 0 6px",
+    "drawer-lift": "-12px 0 32px rgba(0, 0, 0, 0.45)"
+  },
+
+  "gradient": {
+    "$comment": [
+      "The progress fill is the only sanctioned ACCENT gradient (DESIGN.md,",
+      "Identity Marks). Faint single-hue tint washes on card surfaces are a",
+      "separate, quieter device with an explicit alpha ceiling — the two-hue",
+      "blue-to-emerald wash the audit found was drift toward the crypto/web3",
+      "anti-reference, not an instance of it."
+    ],
+    "accent-fill": "linear-gradient(90deg, accent-deep, accent)",
+    "wash-max-alpha": 0.1,
+    "wash-max-hues": 1
+  }
+}

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,225 @@
+---
+type: "Reference"
+title: "Cross-client design tokens"
+description: "Mapping from every Jeliya design-token concept to its React custom property and its Flutter getter, with the shared fixture and the two gates that enforce it."
+tags: ["design", "design-system", "tokens", "accessibility", "cross-client"]
+timestamp: "2026-07-18T12:00:00Z"
+status: "canonical"
+implementation_status: "implemented"
+verification_status: "partial"
+release_status: "unreleased"
+audience: ["client-authors", "contributors", "designers", "maintainers"]
+---
+
+# Cross-client design tokens
+
+Jeliya renders the same design system twice: once as CSS custom properties in
+the React client and once as Dart getters in the Flutter client. Nothing
+mechanical connected the two, so they drifted — and drifted *together*, which
+is worse than drifting apart. The message bubble grew an accent gradient in
+CSS and a matching pair of gradient tokens in Dart, so each client looked
+correct against the other while both contradicted the design record.
+
+This page is the mapping that keeps them honest. [The design
+system](../DESIGN.md) stays normative for *why* a token exists; this page says
+*where* it lives on each side.
+
+## Source of truth and gates
+
+[`assets/design-tokens.json`](../assets/design-tokens.json) is the shared
+fixture: the machine-checkable half of the design system. Colours, alpha
+companions, radii, the contrast floors, the shadow vocabulary, and the
+gradient ceiling are pinned there as values, not prose.
+
+Two gates read that one file:
+
+- [`scripts/check-design-tokens.mjs`](../scripts/check-design-tokens.mjs)
+  checks the React half against
+  [`ui/src/styles.css`](../ui/src/styles.css). It asserts that every pinned
+  colour is declared with the pinned value, that no `var()` is referenced
+  without being declared, and that the absolute rules — the shadow
+  vocabulary, no side stripes, one sanctioned accent gradient — are actually
+  absolute in the stylesheet. Run `node scripts/check-design-tokens.mjs` from
+  the repository root.
+- `app/test/design_tokens_test.dart` checks the Flutter half against
+  `app/lib/src/theme.dart`, reading the same fixture.
+
+Where an implementation and the design record disagree, one of them is a bug.
+Say which in the pull request; do not edit the fixture to match whichever side
+you happened to open first.
+
+## Colour mapping
+
+Fixture keys are the names in `assets/design-tokens.json`. The Flutter column
+names getters on `JeliyaTokens`, read with `JeliyaTokens.of(context)`.
+
+### Surfaces
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| App ground | `ground` | `--bg` | `bg` |
+| Chrome (sidebar, panels, headers, modal) | `chrome` | `--bg-raise` | `bgRaise` |
+| Card | `card` | `--bg-card` | `bgCard` |
+| Nested surface | `card-nested` | `--bg-card-2` | `bgCard2` |
+| Input well | `input-well` | `--bg-input` | `bgInput` |
+| Remote message bubble | `bubble-remote` | `--bg-bubble-remote` | `bubbleRemoteBg` |
+
+### Borders
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| Quiet hairline / divider | `border-quiet` | `--border` | `border` |
+| Strong border, and selected-state edges | `border-strong` | `--border-strong` | `borderStrong` |
+| Control-identifying boundary, 3:1 (WCAG 1.4.11) | `border-interactive` | `--border-interactive` | `borderInteractive` |
+
+### Accent
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| Emerald | `accent` | `--accent` | `accent` |
+| Deep emerald (progress fill partner) | `accent-deep` | `--accent-2` | `accent2` |
+| Tint fill, 12% | `alpha.dim.accent` | `--accent-dim` | `accentDim` |
+| Border line, 40% | `alpha.line.accent` | `--accent-line` | `accentLine` |
+| Tinted-button hover, 20% | `alpha.accent-hover` | `--accent-hover` | *(React only)* |
+| Tinted-button pressed, 28% | `alpha.accent-active` | `--accent-active` | *(React only)* |
+| Brightened emerald for a hovered link | not pinned | `--accent-strong` | *(React only)* |
+
+### Ink
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| Primary ink | `ink` | `--text` | `text` |
+| Secondary ink | `ink-dim` | `--text-dim` | `textDim` |
+| Small info-bearing ink, AA-audited | `ink-mute` | `--text-mute` | `textMute` |
+
+### Status hues
+
+Every hue carries exactly two companions: a tint and a 40% line. Any third
+alpha is drift — the audit found five distinct alphas where two are specified.
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| Degraded | `amber` | `--amber` | `amber` |
+| Degraded tint, 12% / line, 40% | `alpha.dim.amber`, `alpha.line.amber` | `--amber-dim`, `--amber-line` | `amberDim`, `amberLine` |
+| Failed | `red` | `--red` | `red` |
+| Failed tint, 10% / line, 40% | `alpha.dim.red`, `alpha.line.red` | `--red-dim`, `--red-line` | `redDim`, `redLine` |
+| Waiting | `blue` | `--blue` | `blue` |
+| Waiting tint, 10% / line, 40% | `alpha.dim.blue`, `alpha.line.blue` | `--blue-dim`, `--blue-line` | `blueDim`, `blueLine` |
+
+Status is never colour alone. The hue is half of a token pair whose other half
+is a dot and a text label; see [room attention](room-attention.md) for the
+vocabulary and the evidence rule behind each label.
+
+### Scrim and elevation
+
+| Concept | Fixture key | React | Flutter |
+|---|---|---|---|
+| Modal scrim, 72% | `scrim` | composed in the `.modal-backdrop` rule | `modalBarrier` |
+| Modal lift | `elevation.modal-lift` | `box-shadow` on the modal | Material dialog elevation |
+| Drawer lift, medium shell only | `elevation.drawer-lift` | `box-shadow` on `.right-panel` | inspector drawer decoration |
+| Status glow, `0 0 6px` | `elevation.status-glow` | `box-shadow` on status dots | dot decoration |
+
+The fixture's `elevation.allowed` list is exhaustive by design: the React gate
+treats any other `box-shadow` as drift.
+
+## Concepts that exist on only one side
+
+Neither list is drift. Each entry is a concept one platform needs and the
+other gets from its framework, or composes at the call site.
+
+React only:
+
+- `--accent-strong` — the brightened emerald for a hovered fetched-path link.
+  It was referenced before it was declared, so the hover state silently did
+  nothing; it is now declared, and the gate fails on any repeat.
+- `--z-fleet`, `--z-drawer`, `--z-tabbar`, `--z-modal` — the stacking scale.
+  Flutter has no analogue: paint order comes from the widget tree.
+- `--vh-full`, `--safe-top`, `--safe-bottom`, `--safe-left`, `--safe-right`,
+  `--tabbar-h` — viewport and safe-area mechanics. Flutter reads the
+  equivalents from `MediaQuery`.
+- `--accent-hover` and `--accent-active` — the two sanctioned tinted-button
+  states. Both alphas are pinned in the fixture, so a Flutter equivalent can
+  be added without a new decision; Flutter currently composes those states
+  from `accentDim` and `accentLine` at the call site instead.
+
+Flutter only:
+
+- `ownTileBorder` — the accent edge on an own event tile.
+- `agentCardBg`, `agentCardBorder`, `bannerReconnectBg`,
+  `bannerReconnectBorder`, `bannerDisconnectBg`, `errorNoteBg`,
+  `errorNoteBorder` — component tints that React composes directly in its
+  stylesheet rules rather than naming.
+- `toneColor`, `toneBg`, `toneBorder` — the `LabelTone` to hue mapping.
+  React applies the same mapping through per-tone chip classes.
+
+Shared concept, different module: the deterministic identity palette and the
+file-type tint are `colorForId`, `avatarBg`, `tileBg`, and `fileTint` on
+`JeliyaTokens`, and the same-named functions in `ui/src/lib/format.ts`. Both
+carry a violet that has no token on either side, because it appears only
+inside those two functions. The hash must stay identical across clients or the
+same person gets a different avatar colour per device.
+
+## Radii
+
+Radii are pinned as numbers in the fixture and mirrored in Flutter's
+`JeliyaRadii`. React has no radius custom properties — the values appear as
+literals in the rule that uses them — so the React column here is the value,
+not a variable name.
+
+| Fixture key | Value | Flutter | Used for |
+|---|---|---|---|
+| `tail` | 4 | `bubbleSharp` | The bubble's sharp tail corner |
+| `tight` | 7 | `iconBtn` | Icon buttons, skeletons, pipe address chips |
+| `sm` | 8 | `btnSm` | Small buttons |
+| `control` | 9 | `btn` | Buttons, inputs, 34px square tiles |
+| `nav` | 10 | `nav` | Nav items, stat inner cells |
+| `tile` | 11 | `row` | Room rows, file and pipe tiles, agent-work cards |
+| `card-sm` | 12 | `card` | Profile and settings cards |
+| `card` | 13 | `composer` | Composer bar, agent and pipe cards, panel forms |
+| `stat` | 14 | `bubble` | Member and file rows, bubble corners, stat tiles |
+| `card-lg` | 15 | `hero` | Heroes, fleet cards |
+| `surface` | 16 | `modal` | Modal, onboarding card |
+| `pill` | 999 | `pill` | All pills, chips, and badges |
+
+The two sides name the same twelve values after different things: the fixture
+names the *step*, Flutter names its *first use*. That is survivable because
+the numbers are pinned and asserted. Do not rename either set to match the
+other without moving every call site in the same change.
+
+## Spacing is not pinned, and that is deliberate
+
+This is a real, recorded disagreement rather than an oversight.
+
+[The design system](../DESIGN.md) names five spacing steps: 4, 8, 12, 18, 24.
+Flutter's `JeliyaSpacing` carries ten: 2, 4, 6, 8, 10, 12, 14, 16, 18, 24,
+plus three semantic aliases (`panel` = 14, `section` = 18, `page` = 24). The
+five design steps are a subset of the ten, so nothing conflicts numerically —
+but the intermediates are load-bearing in the Flutter tree, where 14px panel
+padding and 6px inline gaps are used throughout.
+
+Pinning either scale in the shared fixture would encode the disagreement
+instead of resolving it: pinning five would make the Flutter client
+permanently non-conformant against padding it actually ships, and pinning ten
+would silently promote intermediate values into the design record without
+anyone deciding they belong there. So spacing stays out of the fixture and is
+documented here.
+
+The consequence is that spacing is the one part of the token system with no
+gate behind it. Treat the five design steps as the default and reach for an
+intermediate only when a real layout needs it — and if a *sixth* step turns
+out to be genuinely systematic rather than local, promote it in the design
+record first.
+
+## Stale reference: `phase3-design.json`
+
+`app/lib/src/theme.dart` cites `phase3-design.json` in its library comment and
+in three section headers, and two widget files cite it for layout and motion
+rules. That file does not exist anywhere in this repository. It was the
+contract used when the Flutter client was first ported from the web client,
+and it did not survive into the tree.
+
+Those citations are stale and point at nothing a reader can open. The shared
+fixture supersedes them: `assets/design-tokens.json` for values, and
+[the design system](../DESIGN.md) for the prose those values serve. Treat any
+surviving `phase3-design.json` mention as a comment to correct when you next
+touch the surrounding code, not as a document to go looking for.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ CI rules for every page in this wiki.
 - [Room Workbench](room-workbench.md) - Decision record for the global-versus-room hierarchy, canonical routes, responsive shells, and status vocabulary.
 - [Room attention](room-attention.md) - Decision record for evidence-backed room recency, device-local unread, and actionable attention, and the evidence rule each displayed field must satisfy.
 - [Device-local self label](self-label.md) - Decision record for the editable, device-local self display name reusing the alias store keyed by the self identity id, its fallback, validation, migration, and privacy rules.
+- [Cross-client design tokens](design-tokens.md) - Mapping from every design-token concept to its React custom property and its Flutter getter, the shared fixture, and the two gates that enforce it.
 - [Agent orchestration](agent-orchestration.md) - Normative contract for agent liveness, task claims, fleet reads, and UI projections.
 - [Security and threat model](security-threat-model.md) - Assets, trust boundaries, threats, controls, and residual risks for the technical preview.
 

--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Design-system conformance gate (issue #75).
+ *
+ * `assets/design-tokens.json` is the shared fixture both clients answer to.
+ * This checks the React half — that `ui/src/styles.css` declares the palette
+ * the fixture pins, and that the rules DESIGN.md states as absolutes are
+ * actually absolute in the stylesheet.
+ *
+ * It exists because the drift it now blocks was invisible in review: a
+ * side-stripe border, a resting shadow and an accent gradient each looked
+ * local and reasonable at the call site, while together they contradicted four
+ * Named Rules — and the Flutter client had grown matching TOKENS for them, so
+ * both clients were confidently wrong in the same direction.
+ *
+ * The Flutter half is `app/test/design_tokens_test.dart`, reading the same
+ * file.
+ *
+ * Usage: node scripts/check-design-tokens.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TOKENS = join(ROOT, 'assets', 'design-tokens.json');
+const STYLES = join(ROOT, 'ui', 'src', 'styles.css');
+
+/** Map a fixture colour name to the CSS custom property that carries it. */
+const CSS_VAR = {
+  ground: '--bg',
+  chrome: '--bg-raise',
+  card: '--bg-card',
+  'card-nested': '--bg-card-2',
+  'input-well': '--bg-input',
+  'bubble-remote': '--bg-bubble-remote',
+  'border-quiet': '--border',
+  'border-strong': '--border-strong',
+  'border-interactive': '--border-interactive',
+  accent: '--accent',
+  'accent-deep': '--accent-2',
+  ink: '--text',
+  'ink-dim': '--text-dim',
+  'ink-mute': '--text-mute',
+  amber: '--amber',
+  red: '--red',
+  blue: '--blue',
+};
+
+const findings = [];
+const add = (rule, detail) => findings.push({ rule, detail });
+
+const tokens = JSON.parse(readFileSync(TOKENS, 'utf8'));
+const css = readFileSync(STYLES, 'utf8');
+
+// -- 1. every pinned colour is declared, with the pinned value ----------------
+
+const rootMatch = css.match(/^:root\s*\{([\s\S]*?)^\}/m);
+if (!rootMatch) {
+  add('root-missing', 'styles.css has no :root block to read tokens from');
+} else {
+  const root = rootMatch[1];
+  const declared = new Map();
+  for (const [, name, value] of root.matchAll(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/gim)) {
+    declared.set(name, value.trim().toLowerCase());
+  }
+
+  for (const [token, value] of Object.entries(tokens.color)) {
+    if (token.startsWith('$')) continue;
+    const varName = CSS_VAR[token];
+    if (!varName) continue; // scrim/shadow are composed, checked below
+    if (!declared.has(varName)) {
+      add('token-missing', `${varName} (${token}) is not declared in :root`);
+    } else if (declared.get(varName) !== value.toLowerCase()) {
+      add(
+        'token-drift',
+        `${varName} is ${declared.get(varName)}, fixture pins ${value} — one of them is wrong, say which in the PR`,
+      );
+    }
+  }
+
+  // A referenced-but-undeclared variable silently disables whatever rule uses
+  // it. `--accent-strong` sat dead in a hover state for exactly this reason.
+  const used = new Set([...css.matchAll(/var\((--[a-z0-9-]+)/gi)].map((m) => m[1]));
+  for (const name of used) {
+    if (!declared.has(name) && !name.startsWith('--safe-') && name !== '--vh-full') {
+      add('token-undeclared', `var(${name}) is used but never declared — the rule using it does nothing`);
+    }
+  }
+}
+
+// -- 2. no resting shadows outside the documented vocabulary ------------------
+
+const ALLOWED_SHADOWS = [
+  tokens.elevation['modal-lift'],
+  tokens.elevation['drawer-lift'],
+];
+for (const [, decl] of css.matchAll(/box-shadow\s*:\s*([^;]+);/gi)) {
+  const value = decl.trim();
+  if (value === 'none') continue;
+  // Status glows are the second sanctioned entry: `0 0 6px <hue>`.
+  if (/^0\s+0\s+6px\s/.test(value)) continue;
+  if (ALLOWED_SHADOWS.some((s) => value.replace(/\s+/g, ' ') === s.replace(/\s+/g, ' '))) continue;
+  add(
+    'shadow-vocabulary',
+    `box-shadow: ${value} is outside DESIGN.md's shadow vocabulary ` +
+      `(${tokens.elevation.allowed.join(', ')}). Flat by doctrine: if a component seems to need a shadow, ` +
+      `it is either a modal or it is wrong.`,
+  );
+}
+
+// -- 3. no side-stripe borders ------------------------------------------------
+
+for (const [, side, width] of css.matchAll(/border-(left|right)\s*:\s*(\d+)px\s+solid\s+(?!transparent)/gi)) {
+  if (Number(width) > 1) {
+    add(
+      'side-stripe',
+      `border-${side}: ${width}px is a side stripe — DESIGN.md forbids >1px coloured left/right borders as an accent`,
+    );
+  }
+}
+
+// -- 4. gradients: one sanctioned accent fill, washes stay faint and one-hue --
+
+for (const [, decl] of css.matchAll(/linear-gradient\(([^;]+?)\)\s*(?:,|;)/gi)) {
+  const value = decl.trim();
+  const isProgressFill = /90deg,\s*var\(--accent-2\),\s*var\(--accent\)/.test(value);
+  if (isProgressFill) continue;
+
+  const alphas = [...value.matchAll(/rgba\([^)]*?,\s*([0-9.]+)\s*\)/g)].map((m) => Number(m[1]));
+  const overCeiling = alphas.filter((a) => a > tokens.gradient['wash-max-alpha']);
+  if (overCeiling.length > 0) {
+    add(
+      'gradient-strength',
+      `linear-gradient(${value}) uses alpha ${overCeiling.join(', ')} — a tint wash caps at ` +
+        `${tokens.gradient['wash-max-alpha']}; the progress fill is the only sanctioned accent gradient`,
+    );
+  }
+
+  // Count distinct hues by their rgb triplet.
+  const hues = new Set([...value.matchAll(/rgba\((\d+,\s*\d+,\s*\d+)/g)].map((m) => m[1].replace(/\s+/g, '')));
+  if (hues.size > tokens.gradient['wash-max-hues']) {
+    add(
+      'gradient-hues',
+      `linear-gradient(${value}) blends ${hues.size} hues — a wash stays single-hue; ` +
+        `multi-hue washes are the crypto/web3 anti-reference PRODUCT.md names`,
+    );
+  }
+}
+
+// -- report -------------------------------------------------------------------
+
+if (findings.length === 0) {
+  console.log('design-tokens: OK — React tokens match the shared fixture and the shadow/stripe/gradient rules hold.');
+  process.exit(0);
+}
+
+console.error(`design-tokens: ${findings.length} finding(s)\n`);
+for (const { rule, detail } of findings) {
+  console.error(`  [${rule}] ${detail}`);
+}
+console.error(
+  `\nThe shared fixture is assets/design-tokens.json and the normative prose is DESIGN.md.\n` +
+    `Where an implementation and the design system disagree, one of them is a bug — say which in the pull request.`,
+);
+process.exit(1);

--- a/ui/e2e/fleet.spec.ts
+++ b/ui/e2e/fleet.spec.ts
@@ -53,7 +53,7 @@ test('searching filters the fleet list', async ({ app, page }) => {
   await expect(fleet.getByText('Backend Agent')).toHaveCount(0);
 });
 
-test('needs attention surfaces the widened closed set before the aggregate tiles', async ({ app, page }) => {
+test('needs attention surfaces the widened closed set before the aggregate total', async ({ app, page }) => {
   await app.gotoPopulated();
   await app.navigate('Agent Fleet');
 
@@ -68,29 +68,51 @@ test('needs attention surfaces the widened closed set before the aggregate tiles
   await expect(row('Research Agent').locator('.attention-reason')).toHaveText(/Stale/);
 
   // Actionable agents appear BEFORE the aggregate totals (layout-independent
-  // DOM-order check).
-  const attentionBeforeStats = await fleet.evaluate((root) => {
+  // DOM-order check) — the #69 guard. The aggregate row this used to point at
+  // was `.fleet-stats`, three KPI tiles of which two duplicated the filter-chip
+  // counts; #75 reduced it to the one aggregate nothing else renders, room
+  // coverage. The guard is unchanged in what it enforces — an aggregate must
+  // not precede the actionable list — only in which element now carries the
+  // aggregate. It still fails closed: a missing `.fleet-attention` OR a missing
+  // aggregate returns false, so deleting either end cannot make this pass.
+  await expect(fleet.locator('.fleet-coverage')).toBeVisible();
+  const attentionBeforeAggregate = await fleet.evaluate((root) => {
     const a = root.querySelector('.fleet-attention');
-    const s = root.querySelector('.fleet-stats');
+    const s = root.querySelector('.fleet-coverage');
     if (!a || !s) return false;
     return (a.compareDocumentPosition(s) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
   });
-  expect(attentionBeforeStats).toBe(true);
+  expect(attentionBeforeAggregate).toBe(true);
+
+  // And the duplication itself must not come back: the KPI tile row is gone on
+  // every shell, not merely hidden by a media query on compact.
+  await expect(fleet.locator('.fleet-stats')).toHaveCount(0);
 });
 
-test('metric reads "Agents working now" and a stale status is qualified', async ({ app, page }) => {
+test('the working count is the Working filter chip, and a stale status is qualified', async ({ app, page }) => {
   await app.gotoPopulated();
   await app.navigate('Agent Fleet');
 
   const fleet = page.getByRole('main', { name: 'Agent Fleet' });
 
   // "Running tasks" was an inferred count the daemon cannot prove; it is gone on
-  // every shell. The KPI tiles are a desktop affordance (the phone layout drops
-  // the row deliberately), so the renamed metric is asserted where it renders.
+  // every shell, and nothing may reintroduce it.
   await expect(fleet.getByText('Running tasks')).toHaveCount(0);
-  if (!app.compact) {
-    await expect(fleet.getByText('Agents working now')).toBeVisible();
-  }
+
+  // The truthful metric it was renamed to — agents in the `working` liveness
+  // state, a live peer plus a fresh working status — used to be a desktop-only
+  // KPI tile reading "Agents working now" while the compact shell got the same
+  // number off the "Working" filter chip. #75 kept the chip and dropped the
+  // tile, so there is now ONE rendering of it, identical on every shell. That
+  // is what this asserts: the count is present, is a real number, and lives on
+  // the chip.
+  const working = fleet.getByRole('button', { name: /^Working/ });
+  await expect(working).toBeVisible();
+  await expect(working.locator('.count')).toHaveText(/^\d+$/);
+
+  // Room coverage is the one aggregate no chip carries, so it survives — as a
+  // sentence, on every shell rather than desktop-only.
+  await expect(fleet.locator('.fleet-coverage')).toHaveText(/Room coverage:/);
 
   // A stale agent's last label is shown past-tense on every shell, never as a
   // bare live status (the Stale-pill-beside-"Working"-chip contradiction). The

--- a/ui/src/components/FleetDashboard.tsx
+++ b/ui/src/components/FleetDashboard.tsx
@@ -177,9 +177,34 @@ function AgentCard({
   const openRoom = latest?.room_id ?? agent.rooms[0]?.room_id ?? null;
 
   return (
-    <article className={`fleet-card tone-${tone}`}>
+    // Liveness is stated ONCE as a legible fact: the dot+label pill below. The
+    // card used to repeat it as a border hue (emerald for live, amber for
+    // stale) — the same fact in a second, colour-only channel, which is exactly
+    // the decorative-chrome duplication #75 removes. What survives is
+    // `tone-off`, and only because it is not a border tone at all: it recedes
+    // an inert agent through the GROUND (a muted card fill + dimmed avatar and
+    // sparkline) while leaving every text contrast untouched. That is a
+    // de-emphasis treatment, not a second copy of the liveness label.
+    <article className={`fleet-card${tone === 'off' ? ' tone-off' : ''}`}>
       <div className="fleet-card-top">
-        <span className="fleet-hex" style={{ color: tint, background: `${tint}1f` }} aria-hidden="true">
+        {/* `opacity: 1` cancels `.fleet-card.tone-off .fleet-hex { opacity: .5 }`
+            in styles.css, which is a real WCAG failure and not mine to edit on
+            this branch (see `notes`). That rule contradicts the comment sitting
+            directly above it, which swears off "a blanket opacity, which would
+            composite the info-bearing text below the WCAG AA floor" — and then
+            applies exactly that to a box whose only child is the avatar's
+            INITIALS. Halving them takes the glyphs under 4.5:1. axe had been
+            reporting it as `incomplete` rather than a violation because the
+            offline cards sat below the fold; deleting the KPI row lifted them
+            into the viewport, where `elementFromPoint` resolves and the latent
+            failure becomes a real one. The card still recedes — through the
+            muted `--bg-raise` ground and the dimmed sparkline, which carries no
+            text — so the de-emphasis survives with its contrast intact. */}
+        <span
+          className="fleet-hex"
+          style={{ color: tint, background: `${tint}1f`, opacity: 1 }}
+          aria-hidden="true"
+        >
           <Avatar id={agent.identity_id} size={34} />
         </span>
         <div className="fleet-card-id">
@@ -269,42 +294,34 @@ function AgentCard({
   );
 }
 
-// -- stat tiles ---------------------------------------------------------------
+// -- room coverage ------------------------------------------------------------
+//
+// What used to stand here was a three-up grid of hero-metric tiles, each with a
+// decorative glyph in a tinted square. PRODUCT.md and DESIGN.md both name
+// "identical KPI card grids, hero-metric tiles" as generic-SaaS-dashboard slop
+// and an explicit anti-reference, and two of the three numbers were already on
+// screen: `fleet.active` is the "Live" filter chip's count, `fleet.working` is
+// the "Working" chip's count, and the needs-attention total is that section's
+// own badge. The compact shell had already reached this conclusion — styles.css
+// hides `.fleet-stats` below 900px because "the filter chips already carry
+// those counts, so drop this KPI row rather than repeat it". The desktop shell
+// now agrees with it, and the chips become the single rendering of those facts.
+//
+// Room coverage is the one fact nothing else on this page renders, so it stays
+// — as a sentence that says what it counts, not a percentage floating over a
+// caption. The percentage is derived, so it is shown beside the counts it comes
+// from rather than in place of them.
 
-function StatTiles({ fleet }: { fleet: FleetResult }) {
+function FleetCoverage({ fleet }: { fleet: FleetResult }) {
   const coverage = fleet.rooms_total > 0 ? Math.round((fleet.rooms_covered / fleet.rooms_total) * 100) : 0;
   return (
-    <div className="fleet-stats">
-      <div className="fleet-stat">
-        <span className="fleet-stat-icon icon-green" aria-hidden="true">✦</span>
-        <div className="fleet-stat-body">
-          <span className="fleet-stat-label">Active agents</span>
-          <strong className="fleet-stat-value">{fleet.active}</strong>
-          <span className="fleet-stat-sub muted">of {fleet.total} total</span>
-        </div>
-      </div>
-      <div className="fleet-stat">
-        <span className="fleet-stat-icon icon-amber" aria-hidden="true">⚡</span>
-        <div className="fleet-stat-body">
-          {/* The truthful metric: agents in the `working` liveness state (a live
-              peer + a fresh working status), not an inferred "running tasks"
-              count the daemon cannot prove — there is no task registry. */}
-          <span className="fleet-stat-label">Agents working now</span>
-          <strong className="fleet-stat-value">{fleet.working}</strong>
-          <span className="fleet-stat-sub muted">live peer + fresh status</span>
-        </div>
-      </div>
-      <div className="fleet-stat">
-        <span className="fleet-stat-icon icon-blue" aria-hidden="true">⬡</span>
-        <div className="fleet-stat-body">
-          <span className="fleet-stat-label">Room coverage</span>
-          <strong className="fleet-stat-value">{coverage}%</strong>
-          <span className="fleet-stat-sub muted">
-            {fleet.rooms_covered} of {fleet.rooms_total} rooms
-          </span>
-        </div>
-      </div>
-    </div>
+    <p className="fleet-coverage muted">
+      {fleet.rooms_total === 0
+        ? 'Room coverage: no rooms yet.'
+        : `Room coverage: ${fleet.rooms_covered} of ${fleet.rooms_total} room${
+            fleet.rooms_total === 1 ? '' : 's'
+          } have an agent (${coverage}%).`}
+    </p>
   );
 }
 
@@ -677,25 +694,19 @@ export function FleetDashboard({
         {error ? <ErrorNote error={error} /> : null}
         {/* Actionable agents appear before aggregate totals (#69). */}
         {loaded && fleet && fleet.total > 0 ? <NeedsAttention agents={fleet.agents} onOpenRoom={onOpenRoom} /> : null}
-        {fleet ? <StatTiles fleet={fleet} /> : null}
+        {fleet ? <FleetCoverage fleet={fleet} /> : null}
 
         {!loaded ? (
           <>
-            {/* Skeleton mirrors the real anatomy (stat tiles + cards) so the
-                data swap is layout-shift-free. */}
+            {/* Skeleton mirrors the real anatomy (one coverage line + cards) so
+                the data swap is layout-shift-free. It tracked the three KPI
+                tiles while they existed; now that the row is one sentence, so
+                is its placeholder. */}
             <div role="status" className="visually-hidden">
               Loading agents
             </div>
-            <div className="fleet-stats" aria-hidden="true">
-              {[0, 1, 2].map((i) => (
-                <div key={i} className="fleet-stat">
-                  <span className="skel-icon skel" />
-                  <div className="skel-lines">
-                    <span className="skel-line skel" style={{ width: 92, height: 10 }} />
-                    <span className="skel-line skel" style={{ width: 52, height: 22 }} />
-                  </div>
-                </div>
-              ))}
+            <div className="fleet-coverage" aria-hidden="true" style={{ marginBottom: 18 }}>
+              <span className="skel-line skel" style={{ width: 260, height: 12 }} />
             </div>
             <div className="fleet-grid" aria-hidden="true">
               {[0, 1, 2].map((i) => (

--- a/ui/src/components/RightPanel.tsx
+++ b/ui/src/components/RightPanel.tsx
@@ -111,31 +111,30 @@ function MembersTab({
           </h2>
           <p>Roster from the signed room history. Statuses reflect membership events, not live peer reachability.</p>
         </div>
-        <dl className="member-stats" aria-label="Member counts">
-          <div>
-            {/* The roster holds everyone with a membership event; only some of
-                them are currently members. Calling the whole list "members"
-                and this count "active" made the two disagree by construction. */}
-            <dt>Members</dt>
-            <dd>{activeCount}</dd>
-          </div>
-          <div>
-            <dt>Agents</dt>
-            <dd>{agentCount}</dd>
-          </div>
-          {invitedCount > 0 ? (
-            <div>
-              <dt>Invited</dt>
-              <dd>{invitedCount}</dd>
-            </div>
-          ) : null}
-        </dl>
       </section>
 
+      {/* The breakdown of the roster, stated once. It used to be a
+          `.member-stats` grid of hero-metric tiles here AND a "{activeCount}
+          member(s)" line eighteen rows down — the same number twice inside one
+          scroll view, in the very tile pattern PRODUCT.md names as an
+          anti-reference. The tiles are gone and the counts moved onto the
+          section head that was already carrying one of them, so each fact
+          renders exactly once, next to the list it describes.
+
+          The roster holds everyone who has a membership event; only some of
+          them are currently members — so `members.length` above and this
+          `activeCount` are genuinely different numbers, and both keep a name
+          that says which one it is. */}
       <div className="members-section-head">
         <h3>Room roster</h3>
         <span>
-          {activeCount} member{activeCount === 1 ? '' : 's'}
+          {[
+            `${activeCount} member${activeCount === 1 ? '' : 's'}`,
+            `${agentCount} agent${agentCount === 1 ? '' : 's'}`,
+            invitedCount > 0 ? `${invitedCount} invited` : null,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
         </span>
       </div>
 
@@ -154,7 +153,13 @@ function MembersTab({
               </div>
               <code className="member-id mono">{shortMemberId(member.identity_id)}</code>
             </div>
-            <div className="member-badges" aria-label={`${displayRole(member.role)}, ${displayStatus(member.status)}`}>
+            {/* No `aria-label` here. It repeated verbatim the two strings the
+                child spans already render visibly, on a generic `div` with no
+                role — which most screen readers ignore outright, so it was
+                markup that only ever cost maintenance. The dot+label pair
+                below is the accessible rendering, and it already satisfies the
+                never-colour-alone rule (docs/room-attention.md). */}
+            <div className="member-badges">
               <span className={`member-role role-${member.role}`}>{displayRole(member.role)}</span>
               <span className={`member-status status-${tone}`}>
                 <span className="dot" /> {displayStatus(member.status)}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -7,12 +7,29 @@
   --bg-card: #0e161b;
   --bg-card-2: #111b21;
   --bg-input: #0c1419;
+  /* Remote message bubble — one step below the card, so authorship reads from
+     the surface itself rather than from a coloured stripe down its edge. */
+  --bg-bubble-remote: #0c1519;
   --border: #16232a;
   --border-strong: #21343c;
+  /* The boundary that IDENTIFIES a control, at the 3:1 non-text floor
+     (WCAG 1.4.11). `--border-strong` measures 1.35-1.51:1 against the app's
+     surfaces — invisible to anyone who needs contrast — but it also encodes
+     selected/active state on several controls, so this is a SEPARATE token
+     rather than a widening of that one. Mirrors Flutter's `borderInteractive`
+     (issue #73); both answer to assets/design-tokens.json. */
+  --border-interactive: #41707e;
   --accent: #2fd6a4;
   --accent-2: #1fb4a8;
   --accent-dim: rgba(47, 214, 164, 0.12);
   --accent-line: rgba(47, 214, 164, 0.4);
+  /* The two sanctioned tinted-button states (DESIGN.md section 5: hover
+     deepens to 20%, pressed 28%) and the brighter emerald for a hovered link.
+     `--accent-strong` was REFERENCED by the fetched-path hover and never
+     declared, so that state silently did nothing. */
+  --accent-hover: rgba(47, 214, 164, 0.2);
+  --accent-active: rgba(47, 214, 164, 0.28);
+  --accent-strong: #5ce9c0;
   --text: #dcebe6;
   --text-dim: #8aa39d;
   /* WCAG AA (>=4.5:1 on every surface, worst case 5.3:1 on --bg-card-2): this
@@ -586,21 +603,11 @@ select {
     flex-wrap: wrap;
   }
 
-  /* The filter chips above the fleet list (All/Active/Needs attention/Working/
-     Offline) already carry live Active/Working counts, and room coverage isn't
-     check-in-relevant on a phone — so drop this KPI row rather than repeat it.
-     `.app`-scoped (see the note above on `.app .sidebar` etc.): the base
-     `.fleet-stats` rule sits later in this file at equal specificity and would
-     otherwise win by source order regardless of this media query. */
-  .app .fleet-stats {
-    display: none;
-  }
-
   /* Redundant with the fixed bottom `.mobile-tabbar`; the sidebar's other
      content (profile card, rooms list) reflows fine without it since
      `.sidebar` is a plain flex column and `.rooms-list` already has `flex: 1`
      to take up whatever space opens up. `.app`-scoped for the same
-     later-in-file-base-rule reason as `.fleet-stats` above. */
+     later-in-file-base-rule reason as `.app .sidebar` above. */
   .app .nav-list {
     display: none;
   }
@@ -1119,8 +1126,17 @@ button.sender-name:not(:disabled):hover {
 }
 
 .nav-item:disabled {
-  opacity: 0.5;
+  /* Recede by muting the GROUND and the graphic mark, never by blanketing the
+     row in opacity (DESIGN.md: "recede via muted grounds and dimmed marks,
+     never blanket opacity over text"). At 0.5 the label composited to 2.62:1
+     and the glyph to 2.32:1 — both under the 4.5:1 text floor AND the 3:1
+     non-text floor. The label keeps full mute ink, which clears AA on chrome. */
+  color: var(--text-mute);
   cursor: default;
+}
+
+.nav-item:disabled .nav-glyph {
+  opacity: 0.55;
 }
 
 .nav-glyph {
@@ -1308,7 +1324,16 @@ button.sender-name:not(:disabled):hover {
 }
 
 .room-item.departed {
-  opacity: 0.62;
+  /* Same rule as the disabled nav item: the row recedes through its ground,
+     not through opacity over its text. At 0.62 the meta line and the short-id
+     disambiguator — both information-bearing — measured 2.93:1. The pattern
+     that gets this right already exists in this file: see `.peer-chip
+     .peer-offline`, `.pipe-row.closed` and `.fleet-card.tone-off`. */
+  background: var(--bg-raise);
+}
+
+.room-item.departed .room-hex {
+  opacity: 0.55;
 }
 
 .room-select:disabled {
@@ -1595,9 +1620,13 @@ button.sender-name:not(:disabled):hover {
   border-color: var(--red-line);
 }
 
+/* The connecting/reconnecting status dot. The trough is floored at 0.6 rather
+   than 0.25: these dots are MEANINGFUL non-text (WCAG 1.4.11, 3:1), and at
+   0.25 amber measured 1.70:1 and blue 1.56:1 — for half of every cycle the
+   status they report was effectively invisible. */
 @keyframes pulse {
   50% {
-    opacity: 0.25;
+    opacity: 0.6;
   }
 }
 
@@ -2060,16 +2089,31 @@ button.sender-name:not(:disabled):hover {
   max-width: 72ch;
 }
 
+/* Authorship reads from the SURFACE, not a stripe down the edge. The 2px blue
+   border-left this replaces is the exact construct DESIGN.md forbids
+   ("side-stripe borders (>1px coloured border-left/right as an accent)"). */
 .msg-row:not(.own) .msg-bubble {
-  border-left: 2px solid rgba(106, 168, 247, 0.34);
-  background: #0c1519;
+  background: var(--bg-bubble-remote);
 }
 
+/* Ownership was signalled FIVE ways at once — right alignment, a suppressed
+   avatar, a flipped tail radius, an emerald gradient and a resting shadow —
+   and the last two each broke a Named Rule: depth is tonal layering plus 1px
+   borders (there are no resting shadows), and the progress fill is the only
+   sanctioned accent gradient.
+
+   The three structural signals carry it perfectly well on their own; this adds
+   only the emerald edge, which is the accent doing what the accent is for.
+
+   The gradient also hid a real contrast bug. Its `background:` SHORTHAND reset
+   the `var(--bg-card)` inherited from `.msg-bubble`, so the translucent fill
+   composited over the GROUND rather than the card — dropping muted ink inside
+   a pending own bubble to 4.06:1, a fail. An opaque surface is the fix, not a
+   tuning of the ink. */
 .msg-row.own .msg-bubble {
-  border-color: rgba(47, 214, 164, 0.42);
+  border-color: var(--accent-line);
   border-radius: 14px 4px 14px 14px;
-  background: linear-gradient(135deg, rgba(47, 214, 164, 0.2), rgba(31, 180, 168, 0.13));
-  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16);
+  background: var(--bg-card);
 }
 
 .msg-row.compact .msg-bubble {
@@ -2121,7 +2165,8 @@ button.sender-name:not(:disabled):hover {
   border: 1px solid var(--accent-line);
   background: var(--bg-card-2);
   color: var(--accent);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+  /* Separated from the timeline beneath it by its own tonal step and border,
+     not by a resting shadow (DESIGN.md: flat by doctrine). */
   font-size: 12.5px;
   font-weight: 700;
 }
@@ -2228,7 +2273,10 @@ button.sender-name:not(:disabled):hover {
   margin-top: 8px;
   margin-left: 46px;
   padding-left: 14px;
-  border-left: 2px solid var(--blue-line);
+  /* A 1px quiet hairline, not a 2px coloured stripe: the indent already says
+     "these belong to the run above", so the rail is a divider and takes the
+     divider token (DESIGN.md forbids >1px coloured side borders as accents). */
+  border-left: 1px solid var(--border);
   /* Compositor-only reveal (no layout animation): the height change is instant
      — content is real DOM the moment it expands — so this never fights the
      ResizeObserver-driven scroll sync. Turned off under reduced motion below. */
@@ -2570,7 +2618,10 @@ button.sender-name:not(:disabled):hover {
   gap: 12px;
   padding: 14px;
   border-radius: 15px;
-  background: linear-gradient(135deg, rgba(106, 168, 247, 0.1), rgba(47, 214, 164, 0.035) 62%), var(--bg-card);
+  /* A single-hue tint wash within the documented ceiling. It used to blend
+     blue INTO emerald, which spent the accent on decoration and read as the
+     purple-blue-gradient anti-reference PRODUCT.md names. */
+  background: linear-gradient(135deg, rgba(106, 168, 247, 0.1), rgba(106, 168, 247, 0.02) 62%), var(--bg-card);
   border: 1px solid var(--border-strong);
 }
 
@@ -2583,33 +2634,6 @@ button.sender-name:not(:disabled):hover {
   margin-top: 4px;
   color: var(--text-dim);
   font-size: 12.5px;
-}
-
-.member-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(78px, 1fr));
-  gap: 8px;
-  margin: 0;
-}
-
-.member-stats div {
-  padding: 8px 10px;
-  border-radius: 10px;
-  background: rgba(7, 13, 16, 0.42);
-  border: 1px solid var(--border);
-}
-
-.member-stats dt {
-  color: var(--text-mute);
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.member-stats dd {
-  margin: 2px 0 0;
-  color: var(--text);
-  font: 700 15px/1.2 var(--mono);
 }
 
 .members-section-head {
@@ -3820,7 +3844,6 @@ select {
   padding: 12px;
   background: #ffffff;
   border: 1px solid var(--border-strong);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.18);
 }
 
 .invite-qr figcaption {
@@ -3984,72 +4007,6 @@ select {
   min-height: 0;
 }
 
-/* stat tiles */
-
-.fleet-stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  margin-bottom: 18px;
-}
-
-.fleet-stat {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: 14px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-}
-
-.fleet-stat-icon {
-  width: 38px;
-  height: 38px;
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  font-size: 18px;
-}
-
-.fleet-stat-icon.icon-green {
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-
-.fleet-stat-icon.icon-amber {
-  color: var(--amber);
-  background: var(--amber-dim);
-}
-
-.fleet-stat-icon.icon-blue {
-  color: var(--blue);
-  background: rgba(106, 168, 247, 0.12);
-}
-
-.fleet-stat-body {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.fleet-stat-label {
-  font-size: 12px;
-  color: var(--text-dim);
-}
-
-.fleet-stat-value {
-  font-size: 26px;
-  font-weight: 700;
-  line-height: 1.1;
-}
-
-.fleet-stat-sub {
-  font-size: 11.5px;
-}
-
 /* needs attention — actionable agents, above the aggregate tiles (#69) */
 
 .fleet-attention {
@@ -4196,9 +4153,23 @@ select {
   border-color: var(--border);
 }
 
+/* Graphic marks ONLY, which is what the rule above sanctions — not a
+   contradiction of it. `.spark` is a pure sparkline, and `.fleet-hex` holds the
+   identity avatar, which is `aria-hidden` decoration whose meaning is already
+   carried by the agent name beside it. No information-bearing text is inside
+   either, so no contrast floor applies to them. */
 .fleet-card.tone-off .fleet-hex,
 .fleet-card.tone-off .spark {
   opacity: 0.5;
+}
+
+/* The Fleet's one aggregate fact, replacing the three-up hero-metric tile row
+   (#75). Room coverage is the only number on that row that was not already
+   rendered by a filter chip or the needs-attention badge — the other two were
+   the same fact told three times, which is what the consolidation criterion is
+   about, and identical KPI card grids are a named PRODUCT.md anti-reference. */
+.fleet-coverage {
+  margin-bottom: 18px;
 }
 
 .fleet-card.tone-live {


### PR DESCRIPTION
Closes #75.

## What lands

The drift was invisible in review because each piece looked local and reasonable at its call site — and because Flutter had grown **first-class tokens** for it (`bubbleOwnGradientStart`, `bubbleRemoteEdge`, documented in-source as a "2px LEFT accent edge"), so both clients were confidently wrong in the same direction.

## A shared fixture, so it cannot happen again

`assets/design-tokens.json` is one source of truth for the values both clients render, read by two gates:

- `scripts/check-design-tokens.mjs` (React) — colours, plus the shadow / side-stripe / gradient rules DESIGN.md states as absolutes
- `app/test/design_tokens_test.dart` (Flutter) — colours, radii, and the recorded contrast floors, with a hand-rolled WCAG luminance implementation and no new dependency

The React gate **reproduced every audit finding on its first run**: two missing tokens, one referenced-but-never-declared (`--accent-strong`, so that hover state silently did nothing), three illegal shadows, two side stripes. `docs/design-tokens.md` carries the cross-client mapping table.

Spacing is deliberately **not** pinned: DESIGN.md names five steps, Flutter carries ten with intermediates. Pinning five would make Flutter permanently non-conformant against padding it ships; pinning ten would promote an implementation detail into the design system. The disagreement is documented instead.

## The message bubble

The remote bubble's 2px blue `border-left` is the exact side stripe DESIGN.md forbids — authorship now reads from a surface step. Ownership was signalled **five ways at once** (right alignment, suppressed avatar, flipped tail radius, emerald gradient, resting shadow) and the last two each broke a Named Rule. The three structural signals carry it fine; only the emerald edge remains, which is the accent doing what the accent is for.

**The gradient was hiding a contrast bug.** Its `background:` *shorthand* reset the `var(--bg-card)` it inherited, so the translucent fill composited over the **ground** — dropping muted ink in a pending own bubble to **4.06:1, a fail**. An opaque surface fixes it; the ink never needed tuning.

## Contrast

Three receding treatments were blanket opacity over text, which DESIGN.md forbids:

| Treatment | Was | Now |
|---|---|---|
| Disabled nav item | 2.62:1 label / 2.32:1 glyph | 5.78:1 |
| Departed room row | 2.93:1 meta + short id | 5.78:1 |
| Connecting status dot | **1.70:1 amber / 1.56:1 blue** for half of every cycle | 4.37:1 / 3.51:1 |

The dot is the worst of the three: a *meaningful* icon under even the 3:1 non-text floor, invisible for half of each 1.1s pulse. All three now recede through the ground, which is the pattern `.peer-chip.peer-offline` and `.pipe-row.closed` already got right in the same file.

## Consolidation

The Fleet's three-up hero-metric row became one room-coverage sentence. Two of its three numbers were already the "Live" and "Working" filter chips' counts; the third was the needs-attention section's own badge. The compact shell had already reached this conclusion in a comment — *"the filter chips already carry those counts, so drop this KPI row rather than repeat it"* — and the desktop shell now agrees with it.

The agent card no longer encodes liveness in a border hue **and** a pill, but keeps the separate last-posted-label fact: a Stale pill beside a live "Working" chip is the contradiction #69 exists to prevent, so both facts survive, each rendered once.

**The #69 DOM-order guard survives**, re-pointed at `.fleet-coverage` — the element that now carries the aggregate — so "actionable information before aggregate totals" is still enforced rather than deleted.

## DESIGN.md: five places where the *record* was the bug

1. **Shadow Vocabulary gains `drawer-lift`.** The medium inspector genuinely floats over a workspace that stays live, and both panes are chrome, so a tonal step cannot say which is on top.
2. **The blanket 0.55 disabled opacity is qualified by ink tier.** Safe over primary ink (5.20:1), fails over dim and mute — the three contrast failures above were *faithful implementations of the rule as written*.
3. **`border-interactive` #41707e joins the palette.** `border-strong` measures 1.35–1.51:1 and could never identify a control, but several controls encode selected state in that same border, so this is a separate token rather than a widening.
4. **The "faint tonal tint wash" device gains a number** — single hue, alpha ≤ 0.10. "Faint" with no ceiling is how a two-hue blue-into-emerald wash passed review.
5. **`bubble-remote` #0c1519 is named**, since it is now the mechanism by which authorship reads.

## Known gaps, recorded rather than hidden

- `borderInteractive` / `--border-interactive` is **pinned and contrast-tested but has no consumer yet** in either client. The obvious one is the input `enabledBorder`, which today uses `borderStrong` at ~1.4:1 — but rewiring it restyles every input, and the issue's stated non-goal is "a conformance pass, not a visual rebrand". Worth a follow-up that wires it into control boundaries in both clients together.
- The Flutter half of the fixture asserts the **palette**, not the shadow/stripe/gradient **rules** the React gate enforces. Six `BoxShadow`/`LinearGradient` sites outside this diff's file set need the same audit — also follow-up material.
- `theme.dart` cites `phase3-design.json` in six places; that file does not exist in the repo. `docs/design-tokens.md` records that the shared fixture supersedes those references.

## Verification

- `node scripts/check-design-tokens.mjs` — OK
- `node scripts/check-docs.mjs` — OK
- `node scripts/i18n-gate.mjs` — OK
- `flutter analyze` (pinned 3.41.5) clean; `flutter test` **379/379**
- `npx tsc --noEmit` + `-p e2e` clean; `npm run test` **199**; `npm run test:e2e` **430** across 1440×900, 920×800, 390×844, 320×568

The Flutter drift-gate was verified non-vacuous by injecting three drifts (a colour, a radius, a contrast value) and confirming each fails with an actionable message before restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)