### PR TITLE
feat(ui): localization infrastructure and EN/FR shell catalogs (#74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
       - name: Verify design-system conformance
         run: node scripts/check-design-tokens.mjs
 
+      # Catalog completeness, French typography, and the never-translate
+      # boundary for the web client (issue #74). The Flutter half is
+      # `scripts/i18n-gate.mjs`, which runs in the flutter job and scans only
+      # app/ — nothing had ever checked ui/.
+      - name: Verify web localization catalogs
+        run: |
+          set -euo pipefail
+          node --test scripts/check-ui-i18n.test.mjs
+          node scripts/check-ui-i18n.mjs
+
       # The whole vitest suite EXCEPT the live-daemon oracle. Only the
       # mock-conformance file used to run here, so twelve other test files —
       # routing, the room list, attention, QR, landmarks, motion — had never

--- a/scripts/check-ui-i18n.mjs
+++ b/scripts/check-ui-i18n.mjs
@@ -1,0 +1,888 @@
+#!/usr/bin/env node
+// React localization completeness gate (issue #74).
+//
+// `scripts/i18n-gate.mjs` guards the Flutter catalog. This is its React
+// counterpart, and it exists for the failure modes TYPES CANNOT SEE. Both
+// `ui/src/l10n/en.ts` and `ui/src/l10n/fr.ts` are typed `Catalog`, so `tsc`
+// already rejects a missing key. It cannot reject a key whose value is an
+// empty string, and it cannot reject a French value that is still the English
+// sentence — which is exactly what a translator hand-off produces when a key
+// is added late, or when a merge takes the wrong side.
+//
+// Rules:
+//  1. Key parity. Every `Catalog` interface member appears in every locale
+//     catalog, and no locale carries a key the interface does not declare.
+//     (Defence in depth behind `tsc`, and it also catches a catalog file that
+//     stopped parsing as a catalog at all.)
+//  2. No empty or whitespace-only value in any locale.
+//  3. No French value byte-identical to its English counterpart, unless it is
+//     legitimately identical. Two exemption paths, both stale-checked:
+//       - AUTOMATIC, for values that carry no translatable words: a value with
+//         no word in it (punctuation, a bare slot) and a value built only from
+//         the Tier 2/Tier 3 never-translate lexicon (`docs/glossary-fr.md`) —
+//         brand, ticket, agent, pipe, daemon, path badges, error codes.
+//       - EXPLICIT, `IDENTICAL_ALLOWLIST` below: key -> reason. An entry whose
+//         key is gone, or whose values are no longer identical, is reported.
+//         A stale exemption hides the next real one.
+//  4. French typography (`docs/glossary-fr.md`, decision 7). U+202F before
+//     `; ! ? %` and inside guillemets, U+00A0 before `:`, U+2019 for the
+//     apostrophe, U+2026 for the ellipsis, guillemets rather than double
+//     quotes. This is the rule most likely to rot: every one of these is
+//     invisible in review, and every one of them is wrong in a way a French
+//     reader notices immediately.
+//  5. User-visible string literals in `ui/src/App.tsx` and
+//     `ui/src/components/**` that never reach the catalog — the React
+//     equivalent of i18n-gate rule 1, using the same heuristics (comments
+//     stripped string-aware, `i18n-exempt: <reason>` honored on the line or
+//     the line above). `EXEMPT_FILES` records the modules that stay English
+//     BY DECISION, with the reason, and reports an entry that no longer
+//     exists.
+//
+// Parsing. This reads the catalogs as TEXT with a restricted TypeScript
+// scanner rather than importing them, for the reason `scripts/check-docs.mjs`
+// parses its own YAML subset: a gate that evaluates the thing it is gating is
+// a gate that can be talked out of its own findings, and `scripts/` has no
+// build step and no access to `ui/node_modules`. The scanner understands
+// exactly what a catalog module may contain — comments, string literals,
+// template literals with `${}` slots, and arrow functions.
+//
+// Run: node scripts/check-ui-i18n.mjs   (exit 1 on findings, 0 when clean)
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const DEFAULT_REPO_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+/** Where the catalogs live, relative to the repository root. */
+export const CATALOG_INTERFACE = 'ui/src/l10n/catalog.ts';
+export const LOCALE_FILES = Object.freeze({
+  en: 'ui/src/l10n/en.ts',
+  fr: 'ui/src/l10n/fr.ts',
+});
+
+/** Files rule 5 scans. Everything else in `ui/src` is either not copy or is
+ *  the l10n layer itself. */
+const LITERAL_SCAN_ROOTS = Object.freeze(['ui/src/App.tsx', 'ui/src/components']);
+
+/** Modules that hold English strings BY DECISION, with the decision. Rule 5
+ *  never reports these, and reports an entry whose file has been deleted or
+ *  moved — an exemption pointing at nothing is a note, not a rule.
+ *
+ *  These are listed even where they sit outside `LITERAL_SCAN_ROOTS` today:
+ *  the reason is the durable part, and widening the scan must not silently
+ *  sweep them in. */
+export const EXEMPT_FILES = Object.freeze({
+  'ui/src/lib/mock.ts':
+    'fixture DATA, not copy — a demo room name is content, and translating it ' +
+    'would make the fixtures assert their own translation.',
+  'ui/src/lib/diagnostics.ts':
+    'the support artifact stays English in its entirety (docs/glossary-fr.md, ' +
+    'decision 1) — it is pasted into an issue read by maintainers, so a ' +
+    'localized diagnostic is a bug report nobody can act on.',
+  'ui/src/l10n/tokens.ts':
+    'the never-translate module (docs/i18n.md rule 1) — glyphs, shell ' +
+    'commands, wire-format examples, the brand, language endonyms.',
+  'ui/src/lib/format.ts':
+    'labelTone/prettyLabel are an English-token contract: they map wire ' +
+    'values to tone classes and back, and the tokens are protocol, not copy. ' +
+    'Display text for those values goes through the catalog display map ' +
+    '(docs/i18n.md rule 3).',
+});
+
+/** Tier 2 and Tier 3 of `docs/glossary-fr.md`: words that are the SAME word in
+ *  French, so a value built only from them is identical on purpose. Lowercased
+ *  and accent-stripped before lookup. */
+const NEVER_TRANSLATE = new Set([
+  // Tier 3 — the brand.
+  'jeliya',
+  // Tier 2 — the daemon's own vocabulary and machine identifiers.
+  'daemon',
+  'jeliyad',
+  'direct',
+  'relay',
+  'endpoint',
+  'endpoints',
+  'pipe',
+  'pipes',
+  'ticket',
+  'tickets',
+  'agent',
+  'agents',
+  'id',
+  'ids',
+  // Tier 2 — error codes, quoted verbatim so a user can search for them.
+  'unavailable',
+  'unauthorized',
+  'hash',
+  'mismatch',
+  'hash_mismatch',
+  // Acronyms and units that are not words in either language.
+  'p2p',
+  'qr',
+  'url',
+  'http',
+  'https',
+  'ok',
+  'ui',
+  'io',
+  'ms',
+  'kb',
+  'mb',
+  'gb',
+]);
+
+/** Keys whose French value is legitimately byte-identical to English for a
+ *  reason the automatic lexicon above cannot express. Key -> reason.
+ *
+ *  A reason says why the FRENCH is right, never "not translated yet" — that is
+ *  the finding, not the exemption. And an entry here is checked BOTH ways: if
+ *  the key leaves the catalogs, or the two values stop being identical, the
+ *  gate reports the exemption itself. A stale exemption is a claim nobody has
+ *  re-read, and it hides the next real one. */
+export const IDENTICAL_ALLOWLIST = Object.freeze({
+  identityEndpointShort:
+    '"ep" abbreviates the endpoint id, which docs/glossary-fr.md Tier 2 keeps ' +
+    'verbatim — the prefix labels a machine identifier a user may need to ' +
+    'match against daemon output, so a French "pt" would break the match.',
+  modalRenameAliasLabel:
+    '"Alias" is the French word too (Larousse), and the room roster shows it ' +
+    'beside the identity id where a synonym would read as a second concept.',
+  wireModeLoopback:
+    '"loopback" is the daemon mode as the daemon reports it — ' +
+    'docs/glossary-fr.md Tier 2 keeps wire words verbatim, because the badge ' +
+    'is claiming a network fact and a translated one would no longer match ' +
+    'what the operator sees in daemon output.',
+});
+
+/** Rule 5 is a wide net, and it is only quiet once the components actually
+ *  read the catalog. Measured on the branch that introduced this gate, with
+ *  the l10n layer in place but the components not yet migrated: 292 findings
+ *  across 13 files (App.tsx 36, RightPanel 47, FleetDashboard 41, InviteModal
+ *  37, ui.tsx 26, Sidebar 25, RoomHeader 22, Timeline 18, Onboarding 17,
+ *  SettingsPanel 16, MobileTabBar 4, Composer 2, RoomNav 1).
+ *
+ *  It ships DISABLED, and this is the staged case the paragraph above
+ *  anticipated. The l10n layer landed with the shell surfaces migrated; the
+ *  remaining eight component surfaces are follow-on work, and a gate that
+ *  fails on 292 known findings on the day it lands teaches everyone to ignore
+ *  it. Rules 1-4 run and BLOCK — those are the ones that keep the catalogs
+ *  honest, and they are green.
+ *
+ *  Turn this back on in the pull request that migrates the last component.
+ *  Until then `npm run i18n:report` prints the remaining findings, so the
+ *  number stays visible rather than forgotten, and the companion test keeps
+ *  exercising rule 5's logic so it cannot rot while switched off. */
+const LITERAL_SCAN_ENABLED = false;
+
+/** `--report` runs the staged rule anyway and exits 0 regardless. It is how the
+ *  migration's remaining surface stays countable while the rule is off — a
+ *  number nobody can print is a number nobody tracks. */
+const REPORT_ONLY = process.argv.includes('--report');
+
+// ---------------------------------------------------------------------------
+// A restricted TypeScript scanner
+// ---------------------------------------------------------------------------
+
+function unescapeJs(raw) {
+  return raw.replace(
+    /\\(u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])/g,
+    (_, escape) => {
+      if (escape.startsWith('u{')) {
+        return String.fromCodePoint(parseInt(escape.slice(2, -1), 16));
+      }
+      if (/^u[0-9a-fA-F]{4}$/.test(escape) || /^x[0-9a-fA-F]{2}$/.test(escape)) {
+        return String.fromCodePoint(parseInt(escape.slice(1), 16));
+      }
+      return { n: '\n', t: '\t', r: '\r', b: '\b', f: '\f', v: '\v', '0': '\0' }[escape] ?? escape;
+    },
+  );
+}
+
+function scanQuoted(source, start, quote) {
+  let index = start + 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
+    if (char === quote || char === '\n') break;
+    index += 1;
+  }
+  return {
+    start,
+    end: Math.min(index + 1, source.length),
+    contentStart: start + 1,
+    contentEnd: index,
+    value: unescapeJs(source.slice(start + 1, index)),
+  };
+}
+
+function scanTemplate(source, start, literals) {
+  let index = start + 1;
+  let chunkStart = index;
+  const pushChunk = (end) => {
+    literals.push({
+      start: chunkStart,
+      end,
+      contentStart: chunkStart,
+      contentEnd: end,
+      value: unescapeJs(source.slice(chunkStart, end)),
+      template: true,
+    });
+  };
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
+    if (char === '`') {
+      pushChunk(index);
+      return index + 1;
+    }
+    if (char === '$' && source[index + 1] === '{') {
+      pushChunk(index);
+      index = scanExpression(source, index + 2, literals);
+      chunkStart = index;
+      continue;
+    }
+    index += 1;
+  }
+  pushChunk(source.length);
+  return source.length;
+}
+
+function scanExpression(source, start, literals) {
+  let index = start;
+  let depth = 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "'" || char === '"') {
+      const literal = scanQuoted(source, index, char);
+      literals.push(literal);
+      index = literal.end;
+      continue;
+    }
+    if (char === '`') {
+      index = scanTemplate(source, index, literals);
+      continue;
+    }
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+  return index;
+}
+
+/** Blank comments and literal CONTENTS (newlines preserved, so line numbers
+ *  survive and so structural scanning cannot trip over a brace inside copy),
+ *  and return every literal with its source position.
+ *
+ *  A template literal yields one entry per static chunk; the `${}` expressions
+ *  between them are scanned as code, so a literal nested inside a slot is
+ *  reported on its own rather than swallowed.
+ *
+ *  Known limit, and it fails SAFE: a straight apostrophe in JSX text
+ *  (`<p>Don't</p>`) opens what looks like a string literal. The scan ends at
+ *  the newline, so the blast radius is that one line, and the effect is a
+ *  missed finding rather than a false one. The codebase writes `’` in copy
+ *  anyway — which is the house style the French rules below also enforce. */
+export function scanSource(source) {
+  const masked = Array.from(source);
+  const literals = [];
+  const blank = (from, to) => {
+    for (let index = from; index < to; index += 1) {
+      if (masked[index] !== '\n') masked[index] = ' ';
+    }
+  };
+
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '/' && source[index + 1] === '/') {
+      const end = source.indexOf('\n', index);
+      const stop = end === -1 ? source.length : end;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+    if (char === '/' && source[index + 1] === '*') {
+      const end = source.indexOf('*/', index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      const literal = scanQuoted(source, index, char);
+      literals.push(literal);
+      index = literal.end;
+      continue;
+    }
+    if (char === '`') {
+      index = scanTemplate(source, index, literals);
+      continue;
+    }
+    index += 1;
+  }
+
+  const code = masked.join('');
+  const skeleton = Array.from(code);
+  for (const literal of literals) {
+    for (let at = literal.contentStart; at < literal.contentEnd; at += 1) {
+      if (skeleton[at] !== '\n') skeleton[at] = ' ';
+    }
+  }
+  return { code, skeleton: skeleton.join(''), literals };
+}
+
+/** Stands in for a `${}` slot when a message is compared or typography-checked
+ *  as one sentence. Not a space: an adjacent slot must not look like the space
+ *  the French contract is about, and it can never occur in copy. */
+const SLOT = '\u0000';
+
+function lineOf(source, index) {
+  let line = 1;
+  for (let at = 0; at < index && at < source.length; at += 1) {
+    if (source.charCodeAt(at) === 10) line += 1;
+  }
+  return line;
+}
+
+function finding(file, line, code, message) {
+  return { file, line, code, message };
+}
+
+// ---------------------------------------------------------------------------
+// Catalog parsing
+// ---------------------------------------------------------------------------
+
+function matchingBrace(skeleton, open) {
+  let depth = 0;
+  for (let index = open; index < skeleton.length; index += 1) {
+    const char = skeleton[index];
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+/** The member names of `export interface Catalog { ... }`, in source order. */
+export function parseCatalogInterface(source, file = CATALOG_INTERFACE) {
+  const { skeleton } = scanSource(source);
+  const header = /export\s+interface\s+Catalog\s*\{/.exec(skeleton);
+  if (!header) {
+    return {
+      keys: [],
+      errors: [
+        finding(file, 1, 'catalog-unparsed', 'no `export interface Catalog {` declaration found'),
+      ],
+    };
+  }
+  const open = header.index + header[0].length - 1;
+  const close = matchingBrace(skeleton, open);
+  if (close === -1) {
+    return {
+      keys: [],
+      errors: [finding(file, lineOf(source, open), 'catalog-unparsed', 'interface body is unterminated')],
+    };
+  }
+  const body = skeleton.slice(open + 1, close);
+  const keys = [];
+  // Members are `;`-terminated at depth 0. A `name:` inside a type argument
+  // (`MessageFn<[room: string]>`) sits at depth > 0 and never terminates, so
+  // the parameter labels a translator would otherwise see as keys are skipped.
+  let depth = 0;
+  let memberStart = 0;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === '<' || char === '[' || char === '(' || char === '{') depth += 1;
+    else if (char === '>' || char === ']' || char === ')' || char === '}') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === ';' && depth === 0) {
+      const member = body.slice(memberStart, index);
+      const name = /^(?:readonly\s+)?([A-Za-z_$][\w$]*)\s*\??\s*:/.exec(member.trimStart());
+      if (name) keys.push({ key: name[1], line: lineOf(source, open + 1 + memberStart) });
+      memberStart = index + 1;
+    }
+  }
+  return { keys, errors: [] };
+}
+
+/** Parse `export const <name>: Catalog = { ... }` into key -> entry.
+ *
+ *  An entry records every static string the value contributes, joined with a
+ *  U+0000 slot marker so a `MessageFn` is compared and typography-checked as
+ *  the one sentence it renders, not as loose fragments. */
+export function parseLocaleCatalog(source, file) {
+  const { skeleton, literals } = scanSource(source);
+  const header =
+    /export\s+const\s+[A-Za-z_$][\w$]*\s*:\s*(?:Catalog|LocaleCatalog)\s*=\s*\{/.exec(skeleton) ??
+    (/\}\s*satisfies\s+(?:Catalog|LocaleCatalog)/.test(skeleton)
+      ? /export\s+const\s+[A-Za-z_$][\w$]*\s*=\s*\{/.exec(skeleton)
+      : null);
+  if (!header) {
+    return {
+      entries: new Map(),
+      errors: [
+        finding(
+          file,
+          1,
+          'catalog-unparsed',
+          'no `export const <name>: Catalog = {` declaration found — the gate ' +
+            'reads the catalog as text and cannot follow another shape',
+        ),
+      ],
+    };
+  }
+  const open = header.index + header[0].length - 1;
+  const close = matchingBrace(skeleton, open);
+  if (close === -1) {
+    return {
+      entries: new Map(),
+      errors: [finding(file, lineOf(source, open), 'catalog-unparsed', 'catalog literal is unterminated')],
+    };
+  }
+
+  const entries = new Map();
+  const errors = [];
+  let index = open + 1;
+  let depth = 0;
+  while (index < close) {
+    const rest = skeleton.slice(index, close);
+    const key = /^[\s,]*([A-Za-z_$][\w$]*)\s*:/.exec(rest);
+    if (!key) {
+      // Whitespace to the closing brace is the normal end. Anything else is a
+      // shape the scanner does not model (a spread, a computed key) — say so
+      // rather than silently treating the rest of the catalog as absent.
+      if (rest.trim() !== '') {
+        errors.push(
+          finding(
+            file,
+            lineOf(source, index + (rest.length - rest.trimStart().length)),
+            'catalog-unparsed',
+            'expected `key: value` — a catalog is a flat object literal of ' +
+              'messages, with no spread and no computed keys',
+          ),
+        );
+      }
+      break;
+    }
+    const valueStart = index + key[0].length;
+    let cursor = valueStart;
+    depth = 0;
+    while (cursor < close) {
+      const char = skeleton[cursor];
+      if ('{[('.includes(char)) depth += 1;
+      else if ('}])'.includes(char)) depth -= 1;
+      else if (char === ',' && depth === 0) break;
+      cursor += 1;
+    }
+    const valueEnd = cursor;
+    const parts = literals.filter((literal) => literal.start >= valueStart && literal.end <= valueEnd);
+    const raw = skeleton.slice(valueStart, valueEnd).trim();
+    const name = key[1];
+    if (entries.has(name)) {
+      errors.push(
+        finding(file, lineOf(source, valueStart), 'catalog-duplicate-key', `duplicate key: ${name}`),
+      );
+    }
+    entries.set(name, {
+      key: name,
+      line: lineOf(source, index + key[0].indexOf(name)),
+      // A value that is exactly one quoted literal is a plain `Message`.
+      plain: /^['"`]/.test(raw) && parts.length === 1 && !raw.includes('${'),
+      parts,
+      text: parts.map((part) => part.value).join(SLOT),
+    });
+    index = valueEnd + 1;
+  }
+  return { entries, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Rules 1-4
+// ---------------------------------------------------------------------------
+
+function words(text) {
+  return (
+    text
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .match(/[a-z]{2,}/g) ?? []
+  );
+}
+
+/** Why an identical French value may be identical, or null if it may not.
+ *
+ *  `allowlist` is a parameter rather than a direct read of the module constant
+ *  so the companion test can exercise the RULE without depending on today's
+ *  exemptions — a test that has to be edited whenever a translator adds a word
+ *  stops being run. */
+export function identityExemption(key, text, allowlist = IDENTICAL_ALLOWLIST) {
+  const explicit = Object.hasOwn(allowlist, key) ? allowlist[key] : null;
+  if (explicit) return { source: 'allowlist', reason: explicit };
+  const found = words(text);
+  if (found.length === 0) {
+    return { source: 'automatic', reason: 'no translatable word — punctuation, digits or slots only' };
+  }
+  if (found.every((word) => NEVER_TRANSLATE.has(word))) {
+    return { source: 'automatic', reason: 'never-translate lexicon (docs/glossary-fr.md Tier 2/3)' };
+  }
+  return null;
+}
+
+/** The French typography contract, written with explicit escapes.
+ *
+ *  Every character this enforces is INVISIBLE in a diff, which is the whole
+ *  reason the rule exists — and it is also the reason the patterns below spell
+ *  their spaces \u202f and \u00a0 rather than pasting them: a reviewer can see
+ *  which space a rule means. The patterns run against the rendered sentence
+ *  with slots collapsed to U+0000, so a break that straddles a `${}` boundary
+ *  is still caught and an adjacent slot never looks like a space.
+ *
+ *  `docs/glossary-fr.md`, decision 7. */
+const TYPOGRAPHY = Object.freeze([
+  {
+    code: 'fr-narrow-space',
+    pattern: /([ \u00a0])([;!?%\u00bb])/,
+    message: (match) =>
+      `space before "${match[2]}" must be U+202F (narrow no-break space), not ` +
+      (match[1] === ' ' ? 'a plain space' : 'U+00A0'),
+  },
+  {
+    code: 'fr-no-break-space',
+    pattern: /[ \u202f]:/,
+    message: () => 'space before ":" must be U+00A0 (no-break space), not a plain or narrow space',
+  },
+  {
+    code: 'fr-apostrophe',
+    pattern: /'/,
+    message: () => 'straight apostrophe \u2014 French copy uses U+2019 (l\u2019identit\u00e9)',
+  },
+  {
+    code: 'fr-quotes',
+    pattern: /["\u201c\u201d]/,
+    message: () => 'double quotes \u2014 French copy uses guillemets \u00ab \u00bb with U+202F inside',
+  },
+  {
+    code: 'fr-guillemet-space',
+    pattern: /\u00ab(?!\u202f)|(?<!\u202f)\u00bb/,
+    message: () => 'guillemets take a U+202F narrow no-break space on the inside',
+  },
+  {
+    code: 'fr-ellipsis',
+    pattern: /\.\.\./,
+    message: () => 'three dots \u2014 use U+2026 (\u2026)',
+  },
+]);
+
+/** Rules 1-4 over an already-parsed pair of catalogs. */
+export function checkCatalogs({
+  interfaceKeys,
+  locales,
+  exempt = () => false,
+  allowlist = IDENTICAL_ALLOWLIST,
+}) {
+  const findings = [];
+  const declared = new Set(interfaceKeys.map((member) => member.key));
+
+  for (const [tag, { file, entries }] of Object.entries(locales)) {
+    // Rule 1 — key parity against the interface, in both directions.
+    for (const member of interfaceKeys) {
+      if (!entries.has(member.key)) {
+        findings.push(
+          finding(file, 1, 'key-missing', `missing key declared by Catalog: ${member.key}`),
+        );
+      }
+    }
+    for (const entry of entries.values()) {
+      if (!declared.has(entry.key)) {
+        findings.push(
+          finding(file, entry.line, 'key-undeclared', `key is not declared by Catalog: ${entry.key}`),
+        );
+      }
+      // Rule 2 — an empty value is a blank on screen that types accept.
+      const empty = entry.parts.length === 0 || entry.parts.every((part) => part.value.trim() === '');
+      if (empty && entry.plain && !exempt(file, entry.line)) {
+        findings.push(
+          finding(file, entry.line, 'value-empty', `${tag}: value is empty or whitespace-only`),
+        );
+      } else if (empty && !entry.plain && !exempt(file, entry.line)) {
+        findings.push(
+          finding(
+            file,
+            entry.line,
+            'value-empty',
+            `${tag}: message contributes no text of its own — if it renders a bare ` +
+              'value that is correct, mark the line `i18n-exempt: <reason>`',
+          ),
+        );
+      }
+    }
+  }
+
+  const en = locales.en;
+  const fr = locales.fr;
+  if (!en || !fr) return findings.sort(compareFindings);
+
+  // Rule 3 — a French value left in English.
+  for (const [key, frEntry] of fr.entries) {
+    const enEntry = en.entries.get(key);
+    if (!enEntry) continue;
+    if (enEntry.text !== frEntry.text) continue;
+    const exemption = identityExemption(key, frEntry.text, allowlist);
+    if (exemption) continue;
+    findings.push(
+      finding(
+        fr.file,
+        frEntry.line,
+        'fr-untranslated',
+        `${key}: French value is byte-identical to English — translate it, or ` +
+          'add it to IDENTICAL_ALLOWLIST with the reason it is right',
+      ),
+    );
+  }
+  // Rule 3, stale side — an exemption that no longer exempts anything.
+  for (const key of Object.keys(allowlist)) {
+    const frEntry = fr.entries.get(key);
+    const enEntry = en.entries.get(key);
+    if (!frEntry || !enEntry) {
+      findings.push(
+        finding(
+          fr.file,
+          1,
+          'allowlist-stale',
+          `IDENTICAL_ALLOWLIST names ${key}, which is not in both catalogs`,
+        ),
+      );
+      continue;
+    }
+    if (enEntry.text !== frEntry.text) {
+      findings.push(
+        finding(
+          fr.file,
+          frEntry.line,
+          'allowlist-stale',
+          `IDENTICAL_ALLOWLIST exempts ${key}, but the values now differ — drop the exemption`,
+        ),
+      );
+    }
+  }
+
+  // Rule 4 — French typography, checked on the rendered sentence (slots stand
+  // in as U+0000) so a break across a `${}` boundary is still seen.
+  for (const entry of fr.entries.values()) {
+    if (entry.key === 'localeTag') continue;
+    if (exempt(fr.file, entry.line)) continue;
+    for (const rule of TYPOGRAPHY) {
+      const match = rule.pattern.exec(entry.text);
+      if (!match) continue;
+      findings.push(finding(fr.file, entry.line, rule.code, `${entry.key}: ${rule.message(match)}`));
+    }
+  }
+
+  return findings.sort(compareFindings);
+}
+
+// ---------------------------------------------------------------------------
+// Rule 5 — literals outside the catalog
+// ---------------------------------------------------------------------------
+
+/** Letters that survive `${}` interpolation are real copy — the same test
+ *  `scripts/i18n-gate.mjs` applies to Dart, so the two clients agree on what
+ *  counts as a user-visible literal. Where that is not enough on its own, the
+ *  callers below also constrain WHERE the literal is allowed to sit. */
+function bareLetters(text) {
+  return /[A-Za-z]{2,}/.test(text.replace(/\$\{[^}]*\}/g, ' '));
+}
+
+const ATTRIBUTE_NAMES =
+  'title|aria-label|aria-description|aria-placeholder|aria-roledescription|aria-valuetext|' +
+  'placeholder|alt|label|summary|message|text';
+
+/** Report user-visible literals in one component source. */
+export function scanComponentLiterals(file, source) {
+  const { code, skeleton } = scanSource(source);
+  const lines = source.split('\n');
+  const exempt = (line) =>
+    (lines[line - 1] ?? '').includes('i18n-exempt') || (lines[line - 2] ?? '').includes('i18n-exempt');
+  const findings = [];
+  const report = (index, code_, message) => {
+    const line = lineOf(source, index);
+    if (exempt(line)) return;
+    findings.push(finding(file, line, code_, message));
+  };
+
+  // JSX text between two tags. Excluding (){}<>=` keeps arrow-function bodies
+  // and expression containers out: real copy rarely carries them, and a case
+  // that does is caught by the attribute or property rules instead.
+  for (const match of skeleton.matchAll(/>([^<>{}()=`]*[A-Za-z]{2}[^<>{}()=`]*)</g)) {
+    const text = code.slice(match.index + 1, match.index + match[0].length - 1);
+    if (!bareLetters(text) || text.trim() === '') continue;
+    report(match.index + 1, 'jsx-text', `JSX text is not in the catalog: ${text.trim().slice(0, 60)}`);
+  }
+  // Copy-bearing JSX attributes and object properties, either quote style and
+  // either `=` or `:` — `{ key: 'rooms', label: 'Rooms' }` is a table of copy.
+  const attribute = new RegExp(
+    String.raw`\b(${ATTRIBUTE_NAMES})\s*[:=]\s*\{?\s*(['"])((?:\\.|(?!\2).)*)\2`,
+    'g',
+  );
+  for (const match of code.matchAll(attribute)) {
+    if (!bareLetters(match[3])) continue;
+    report(match.index, 'copy-attribute', `${match[1]} takes a literal, not a catalog message: ${match[3].slice(0, 60)}`);
+  }
+  return findings;
+}
+
+function componentFiles(repoRoot) {
+  const files = [];
+  const walk = (absolute) => {
+    for (const entry of readdirSync(absolute, { withFileTypes: true }).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    )) {
+      const path = resolve(absolute, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) files.push(path);
+    }
+  };
+  for (const root of LITERAL_SCAN_ROOTS) {
+    const absolute = resolve(repoRoot, root);
+    if (!existsSync(absolute)) continue;
+    if (/\.tsx?$/.test(root)) files.push(absolute);
+    else walk(absolute);
+  }
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+function compareFindings(a, b) {
+  const text = (x, y) => (x < y ? -1 : x > y ? 1 : 0);
+  return (
+    text(a.file, b.file) || a.line - b.line || text(a.code, b.code) || text(a.message, b.message)
+  );
+}
+
+function toRepoPath(repoRoot, path) {
+  return relative(repoRoot, path).split(sep).join('/');
+}
+
+/** Run every rule against a repository tree and return sorted findings.
+ *
+ *  The two exemption maps are parameters, defaulting to this module's, so the
+ *  companion test can build a fixture tree and exercise a rule without the
+ *  fixture having to reproduce the real repository's exemptions. */
+export function checkUiI18n({
+  repoRoot = DEFAULT_REPO_ROOT,
+  scanLiterals = LITERAL_SCAN_ENABLED,
+  allowlist = IDENTICAL_ALLOWLIST,
+  exemptFiles = EXEMPT_FILES,
+} = {}) {
+  const root = resolve(repoRoot);
+  const findings = [];
+  const read = (relativePath) => {
+    const absolute = resolve(root, relativePath);
+    return existsSync(absolute) ? readFileSync(absolute, 'utf8') : null;
+  };
+
+  const interfaceSource = read(CATALOG_INTERFACE);
+  let interfaceKeys = [];
+  if (interfaceSource === null) {
+    findings.push(finding(CATALOG_INTERFACE, 1, 'catalog-missing', 'the Catalog interface is missing'));
+  } else {
+    const parsed = parseCatalogInterface(interfaceSource, CATALOG_INTERFACE);
+    interfaceKeys = parsed.keys;
+    findings.push(...parsed.errors);
+  }
+
+  const locales = {};
+  const sources = {};
+  for (const [tag, path] of Object.entries(LOCALE_FILES)) {
+    const source = read(path);
+    if (source === null) {
+      findings.push(
+        finding(path, 1, 'catalog-missing', `the ${tag} catalog is missing — every locale ships complete`),
+      );
+      continue;
+    }
+    sources[path] = source.split('\n');
+    const parsed = parseLocaleCatalog(source, path);
+    findings.push(...parsed.errors);
+    locales[tag] = { file: path, entries: parsed.entries };
+  }
+
+  const exempt = (file, line) => {
+    const lines = sources[file] ?? [];
+    return (lines[line - 1] ?? '').includes('i18n-exempt') || (lines[line - 2] ?? '').includes('i18n-exempt');
+  };
+  findings.push(...checkCatalogs({ interfaceKeys, locales, exempt, allowlist }));
+
+  // Rule 5, stale side — an exemption whose file is gone.
+  for (const [path, reason] of Object.entries(exemptFiles)) {
+    if (existsSync(resolve(root, path))) continue;
+    findings.push(
+      finding(path, 1, 'exempt-stale', `EXEMPT_FILES names a file that does not exist (${reason.slice(0, 40)}…)`),
+    );
+  }
+
+  if (scanLiterals) {
+    for (const absolute of componentFiles(root)) {
+      const file = toRepoPath(root, absolute);
+      if (Object.hasOwn(exemptFiles, file)) continue;
+      findings.push(...scanComponentLiterals(file, readFileSync(absolute, 'utf8')));
+    }
+  }
+
+  return findings.sort(compareFindings);
+}
+
+function main() {
+  const findings = checkUiI18n(REPORT_ONLY ? { scanLiterals: true } : {});
+  if (REPORT_ONLY) {
+    // Reporting mode never fails: it exists so the staged rule's remaining
+    // surface stays countable, not so it can block a merge by the back door.
+    const staged = findings.filter((f) => f.code === 'jsx-text' || f.code === 'copy-attribute');
+    console.log(`check-ui-i18n --report: ${staged.length} literal(s) still outside the catalog`);
+    const byFile = new Map();
+    for (const entry of staged) byFile.set(entry.file, (byFile.get(entry.file) ?? 0) + 1);
+    for (const [file, count] of [...byFile].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${String(count).padStart(4)}  ${file}`);
+    }
+    process.exit(0);
+  }
+  if (findings.length > 0) {
+    console.error(`check-ui-i18n: ${findings.length} finding(s)\n`);
+    for (const entry of findings) {
+      console.error(`  ${entry.file}:${entry.line}  [${entry.code}] ${entry.message}`);
+    }
+    console.error('\nCopy belongs in ui/src/l10n/catalog.ts (the shape) and in EVERY');
+    console.error('locale catalog beside it — en.ts is the source of truth, fr.ts ships');
+    console.error('complete or not at all. Components read it at render time through');
+    console.error('useStrings(); a sentence with styled or interactive segments is ONE');
+    console.error('message rendered through <Template>, never fragments joined in JSX.');
+    console.error('Non-copy glyphs, commands, wire examples and the brand go in');
+    console.error('ui/src/l10n/tokens.ts. French typography is docs/glossary-fr.md');
+    console.error('decision 7 — U+202F before ; ! ? %, U+00A0 before :, U+2019, U+2026,');
+    console.error('guillemets. A French value that is right in English anyway goes in');
+    console.error('IDENTICAL_ALLOWLIST with the reason. Deliberate one-off exceptions:');
+    console.error('`// i18n-exempt: <reason>` on the line or the line above.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log('check-ui-i18n: OK — catalogs are complete, translated, and typographically French.');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) main();

--- a/scripts/check-ui-i18n.test.mjs
+++ b/scripts/check-ui-i18n.test.mjs
@@ -1,0 +1,509 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, test } from 'node:test';
+
+import {
+  CATALOG_INTERFACE,
+  EXEMPT_FILES,
+  IDENTICAL_ALLOWLIST,
+  LOCALE_FILES,
+  checkUiI18n,
+  identityExemption,
+  parseCatalogInterface,
+  parseLocaleCatalog,
+  scanComponentLiterals,
+  scanSource,
+} from './check-ui-i18n.mjs';
+
+// Every rule gets a fixture that PASSES and a fixture that FAILS. A gate is
+// only worth its runtime if both are true of it: a rule that cannot fire is
+// decoration, and a rule that fires on correct input is worse than none.
+
+const tempRoots = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/** A fixture repository. `allowlist`/`exemptFiles` default to empty so a
+ *  fixture exercises the RULE, not today's exemptions. */
+function repo(files) {
+  const root = mkdtempSync(join(tmpdir(), 'jeliya-ui-i18n-'));
+  tempRoots.push(root);
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(root, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  return root;
+}
+
+function check(files, options = {}) {
+  return checkUiI18n({
+    repoRoot: repo(files),
+    scanLiterals: false,
+    allowlist: {},
+    exemptFiles: {},
+    ...options,
+  });
+}
+
+function codes(findings) {
+  return findings.map((entry) => entry.code);
+}
+
+const NNBSP = ' '; // narrow no-break space — before ; ! ? % and in « »
+const NBSP = ' '; // no-break space — before :
+
+function catalog(members) {
+  return `export interface Catalog {\n${members.map((line) => `  ${line}\n`).join('')}}\n`;
+}
+
+function locale(name, entries) {
+  return `import type { Catalog } from './catalog';\n\nexport const ${name}: Catalog = {\n${entries
+    .map((line) => `  ${line}\n`)
+    .join('')}};\n`;
+}
+
+/** The smallest tree that satisfies every rule: two keys, one plain and one
+ *  parameterized, translated, with French typography. */
+function cleanTree(overrides = {}) {
+  return {
+    [CATALOG_INTERFACE]: catalog([
+      'localeTag: string;',
+      'roomsCreate: Message;',
+      'roomsMemberCount: MessageFn<[n: number]>;',
+    ]),
+    [LOCALE_FILES.en]: locale('en', [
+      "localeTag: 'en',",
+      "roomsCreate: 'Create a room',",
+      'roomsMemberCount: (n) => `${n} members`,',
+    ]),
+    [LOCALE_FILES.fr]: locale('fr', [
+      "localeTag: 'fr',",
+      "roomsCreate: 'Créer un salon',",
+      'roomsMemberCount: (n) => `${n} membres`,',
+    ]),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The scanner the rules are built on
+// ---------------------------------------------------------------------------
+
+test('the scanner blanks comments, keeps line numbers, and splits template slots', () => {
+  const source = [
+    "// a commented 'literal' must not be a literal",
+    '/* nor',
+    '   a block one */',
+    "const value = 'kept';",
+    'const message = (n) => `${n} salons ouverts`;',
+  ].join('\n');
+  const { code, skeleton, literals } = scanSource(source);
+
+  assert.equal(code.split('\n').length, source.split('\n').length);
+  assert.equal(skeleton.split('\n').length, source.split('\n').length);
+  assert.ok(!code.includes('commented'));
+  assert.ok(!code.includes('block one'));
+  // The literal survives in `code` and is blanked in `skeleton`, so structural
+  // scanning can never trip over a brace inside copy.
+  assert.ok(code.includes("'kept'"));
+  assert.ok(!skeleton.includes('kept'));
+  assert.deepEqual(
+    literals.map((entry) => entry.value),
+    ['kept', '', ' salons ouverts'],
+  );
+});
+
+test('the interface parser reads member names and ignores MessageFn parameter labels', () => {
+  const parsed = parseCatalogInterface(
+    catalog([
+      '/** doc comment: notAKey: Message; */',
+      'localeTag: string;',
+      'roomsPin: MessageFn<[room: string, at: number]>;',
+      'roomsEmpty: Message;',
+    ]),
+  );
+
+  assert.deepEqual(parsed.errors, []);
+  assert.deepEqual(
+    parsed.keys.map((member) => member.key),
+    ['localeTag', 'roomsPin', 'roomsEmpty'],
+  );
+});
+
+test('a module that is not a catalog is reported rather than read as empty', () => {
+  const parsed = parseLocaleCatalog('export const fr = { roomsCreate: "x" };\n', 'fr.ts');
+  assert.deepEqual(codes(parsed.errors), ['catalog-unparsed']);
+
+  const spread = parseLocaleCatalog(
+    "export const fr: Catalog = {\n  ...base,\n  roomsCreate: 'Créer',\n};\n",
+    'fr.ts',
+  );
+  assert.deepEqual(codes(spread.errors), ['catalog-unparsed']);
+});
+
+// ---------------------------------------------------------------------------
+// Rule 1 — key parity
+// ---------------------------------------------------------------------------
+
+test('a complete, translated pair of catalogs passes every rule', () => {
+  assert.deepEqual(check(cleanTree()), []);
+});
+
+test('a key missing from one locale, or absent from the interface, is reported', () => {
+  const findings = check(
+    cleanTree({
+      [LOCALE_FILES.fr]: locale('fr', ["localeTag: 'fr',", "roomsSurprise: 'Surprise',"]),
+    }),
+  );
+
+  assert.deepEqual(
+    findings.map((entry) => [entry.code, entry.message.split(': ').at(-1)]),
+    [
+      ['key-missing', 'roomsCreate'],
+      ['key-missing', 'roomsMemberCount'],
+      ['key-undeclared', 'roomsSurprise'],
+    ],
+  );
+});
+
+test('a missing locale file fails the gate rather than passing vacuously', () => {
+  const tree = cleanTree();
+  delete tree[LOCALE_FILES.fr];
+  assert.deepEqual(codes(check(tree)), ['catalog-missing']);
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2 — empty values
+// ---------------------------------------------------------------------------
+
+test('an empty or whitespace-only value is reported in either locale', () => {
+  const findings = check(
+    cleanTree({
+      [LOCALE_FILES.en]: locale('en', [
+        "localeTag: 'en',",
+        "roomsCreate: '',",
+        'roomsMemberCount: (n) => `${n} members`,',
+      ]),
+      [LOCALE_FILES.fr]: locale('fr', [
+        "localeTag: 'fr',",
+        "roomsCreate: '   ',",
+        'roomsMemberCount: (n) => `${n} membres`,',
+      ]),
+    }),
+  );
+
+  assert.deepEqual(codes(findings), ['value-empty', 'value-empty']);
+  assert.ok(findings.some((entry) => entry.file === LOCALE_FILES.en));
+  assert.ok(findings.some((entry) => entry.file === LOCALE_FILES.fr));
+});
+
+test('a message that renders a bare value opts out with i18n-exempt', () => {
+  const bare = (name, tag) =>
+    `import type { Catalog } from './catalog';\n\nexport const ${name}: Catalog = {\n` +
+    `  localeTag: '${tag}',\n` +
+    `  roomsCreate: 'x',\n` +
+    '  // i18n-exempt: the count IS the message on a badge — no words to translate.\n' +
+    '  roomsMemberCount: (n) => `${n}`,\n};\n';
+
+  assert.deepEqual(
+    codes(
+      check(
+        cleanTree({
+          [LOCALE_FILES.en]: bare('en', 'en'),
+          [LOCALE_FILES.fr]: bare('fr', 'fr'),
+        }),
+      ),
+    ),
+    // Both values are now the bare slot: identical, but exempt as punctuation.
+    [],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Rule 3 — French left in English
+// ---------------------------------------------------------------------------
+
+test('a French value byte-identical to English is reported', () => {
+  const findings = check(
+    cleanTree({
+      [LOCALE_FILES.fr]: locale('fr', [
+        "localeTag: 'fr',",
+        "roomsCreate: 'Create a room',",
+        'roomsMemberCount: (n) => `${n} membres`,',
+      ]),
+    }),
+  );
+
+  assert.deepEqual(codes(findings), ['fr-untranslated']);
+  assert.match(findings[0].message, /roomsCreate/);
+});
+
+test('identity is legitimate for the never-translate lexicon and for wordless values', () => {
+  for (const [key, value] of [
+    ['roomsCreate', 'Jeliya'],
+    ['roomsCreate', 'Ticket'],
+    ['roomsCreate', 'Agent'],
+    ['roomsCreate', 'Pipe'],
+    ['roomsCreate', 'jeliyad'],
+    ['roomsCreate', 'direct'],
+    ['roomsCreate', 'relay'],
+    ['roomsCreate', 'unauthorized'],
+    ['roomsCreate', '—'],
+    ['roomsCreate', '99+'],
+  ]) {
+    assert.ok(identityExemption(key, value, {}), `${value} should be exempt automatically`);
+  }
+  assert.equal(identityExemption('roomsCreate', 'Create a room', {}), null);
+});
+
+test('an allowlist entry exempts a key, and a stale one is reported', () => {
+  const identical = {
+    [LOCALE_FILES.fr]: locale('fr', [
+      "localeTag: 'fr',",
+      "roomsCreate: 'Create a room',",
+      'roomsMemberCount: (n) => `${n} membres`,',
+    ]),
+  };
+  const reason = 'test fixture: the English happens to be the French.';
+
+  assert.deepEqual(
+    codes(check(cleanTree(identical), { allowlist: { roomsCreate: reason } })),
+    [],
+  );
+  // Stale, sense 1: the values are no longer identical, so the exemption is
+  // now a claim about copy nobody has re-read.
+  assert.deepEqual(
+    codes(check(cleanTree(), { allowlist: { roomsCreate: reason } })),
+    ['allowlist-stale'],
+  );
+  // Stale, sense 2: the key is gone entirely.
+  assert.deepEqual(
+    codes(check(cleanTree(), { allowlist: { roomsRenamedAway: reason } })),
+    ['allowlist-stale'],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Rule 4 — French typography
+// ---------------------------------------------------------------------------
+
+test('correct French typography passes', () => {
+  const findings = check({
+    [CATALOG_INTERFACE]: catalog([
+      'localeTag: string;',
+      'a: Message;',
+      'b: Message;',
+      'c: Message;',
+      'd: MessageFn<[n: number]>;',
+    ]),
+    [LOCALE_FILES.en]: locale('en', [
+      "localeTag: 'en',",
+      "a: 'Really leave?',",
+      "b: 'Identity: unknown',",
+      "c: 'The room “Build” is archived…',",
+      'd: (n) => `${n}% synced`,',
+    ]),
+    [LOCALE_FILES.fr]: locale('fr', [
+      "localeTag: 'fr',",
+      `a: 'Vraiment quitter${NNBSP}?',`,
+      `b: 'Identité${NBSP}: inconnue',`,
+      `c: 'Le salon «${NNBSP}Build${NNBSP}» est archivé…',`,
+      `d: (n) => \`\${n}${NNBSP}% synchronisé\`,`,
+    ]),
+  });
+
+  assert.deepEqual(findings, []);
+});
+
+test('every typography violation is reported, including inside a MessageFn', () => {
+  const findings = check({
+    [CATALOG_INTERFACE]: catalog([
+      'localeTag: string;',
+      'a: Message;',
+      'b: Message;',
+      'c: Message;',
+      'd: Message;',
+      'e: Message;',
+      'f: MessageFn<[n: number]>;',
+    ]),
+    [LOCALE_FILES.en]: locale('en', [
+      "localeTag: 'en',",
+      "a: 'Leave A?',",
+      "b: 'Identity: A',",
+      "c: 'Identity of A',",
+      "d: 'The room “A”',",
+      "e: 'Loading A',",
+      'f: (n) => `${n} percent of A`,',
+    ]),
+    [LOCALE_FILES.fr]: locale('fr', [
+      "localeTag: 'fr',",
+      // Plain space before '?' — must be U+202F.
+      "a: 'Quitter B ?',",
+      // Plain space before ':' — must be U+00A0.
+      "b: 'Identité B :',",
+      // Straight apostrophe — must be U+2019.
+      "c: \"L'identité de B\",",
+      // Curly double quotes — must be guillemets, and ... must be U+2026.
+      "d: 'Le salon “B”...',",
+      // Guillemets without the inner narrow space.
+      "e: 'Le salon «B»',",
+      // A break that straddles a slot boundary is still one sentence.
+      'f: (n) => `${n} % de B`,',
+    ]),
+  });
+
+  assert.deepEqual(codes(findings).sort(), [
+    'fr-apostrophe',
+    'fr-ellipsis',
+    'fr-guillemet-space',
+    'fr-narrow-space',
+    'fr-narrow-space',
+    'fr-no-break-space',
+    'fr-quotes',
+  ]);
+  assert.ok(findings.every((entry) => entry.file === LOCALE_FILES.fr));
+});
+
+test('a no-break space where a NARROW one belongs is still reported', () => {
+  const findings = check({
+    [CATALOG_INTERFACE]: catalog(['localeTag: string;', 'a: Message;']),
+    [LOCALE_FILES.en]: locale('en', ["localeTag: 'en',", "a: 'Leave?',"]),
+    [LOCALE_FILES.fr]: locale('fr', ["localeTag: 'fr',", `a: 'Quitter${NBSP}?',`]),
+  });
+
+  assert.deepEqual(codes(findings), ['fr-narrow-space']);
+  assert.match(findings[0].message, /U\+00A0/);
+});
+
+// ---------------------------------------------------------------------------
+// Rule 5 — literals that never reach the catalog
+// ---------------------------------------------------------------------------
+
+test('a migrated component has no user-visible literals', () => {
+  const source = `import { Glyph } from '../l10n/tokens';
+import { useStrings } from '../l10n/strings';
+
+export function RoomNav({ onCreate }: { onCreate(): void }) {
+  const s = useStrings();
+  return (
+    <nav aria-label={s.destRooms} className="room-nav">
+      <span aria-hidden="true">{Glyph.rooms}</span>
+      <button type="button" title={s.roomsCreate} onClick={onCreate}>
+        {s.roomsCreate}
+      </button>
+    </nav>
+  );
+}
+`;
+  assert.deepEqual(scanComponentLiterals('ui/src/components/RoomNav.tsx', source), []);
+});
+
+test('JSX text, copy attributes, and copy tables are reported', () => {
+  const source = `const TABS = [{ key: 'rooms', label: 'Your Rooms' }];
+
+export function Bar() {
+  return (
+    <nav aria-label="Primary">
+      <h1>Your Rooms</h1>
+      <input placeholder="Search rooms" />
+      <button title="Create a room">{TABS[0].label}</button>
+    </nav>
+  );
+}
+`;
+  const findings = scanComponentLiterals('ui/src/components/Bar.tsx', source);
+
+  assert.deepEqual(codes(findings).sort(), [
+    'copy-attribute',
+    'copy-attribute',
+    'copy-attribute',
+    'copy-attribute',
+    'jsx-text',
+  ]);
+  assert.ok(findings.every((entry) => entry.file === 'ui/src/components/Bar.tsx'));
+});
+
+test('rule 5 ignores comments, class names, and i18n-exempt lines', () => {
+  const source = `// A comment mentioning <b>copy like this</b> is not copy.
+export function Panel({ open }: { open: boolean }) {
+  /* Nor is a title="Blocked" inside a block comment. */
+  return (
+    <div className="panel is-open" data-state={open ? 'open' : 'closed'}>
+      {/* i18n-exempt: the wire value IS the label here — docs/i18n.md rule 3. */}
+      <code className="mono">hash_mismatch</code>
+      <span aria-hidden="true">{'\\u25a6'}</span>
+    </div>
+  );
+}
+`;
+  assert.deepEqual(scanComponentLiterals('ui/src/components/Panel.tsx', source), []);
+});
+
+test('rule 5 skips the modules that stay English by decision', () => {
+  const tree = cleanTree({
+    'ui/src/App.tsx': 'export const App = () => <p>Untranslated copy here</p>;\n',
+    'ui/src/components/Ok.tsx': "export const Ok = () => <p>{s.commonRetry}</p>;\n",
+    'ui/src/lib/diagnostics.ts': "export const label = 'Daemon unreachable';\n",
+  });
+  const root = repo(tree);
+
+  const withScan = checkUiI18n({
+    repoRoot: root,
+    scanLiterals: true,
+    allowlist: {},
+    exemptFiles: { 'ui/src/lib/diagnostics.ts': 'support artifact stays English' },
+  });
+  assert.deepEqual(
+    withScan.map((entry) => [entry.file, entry.code]),
+    [['ui/src/App.tsx', 'jsx-text']],
+  );
+
+  // And the same tree passes with the scan staged off, so an integrator can
+  // ship rules 1-4 before the migration finishes.
+  assert.deepEqual(
+    checkUiI18n({ repoRoot: root, scanLiterals: false, allowlist: {}, exemptFiles: {} }),
+    [],
+  );
+});
+
+test('an exemption that names a file which no longer exists is reported', () => {
+  const findings = check(cleanTree(), {
+    exemptFiles: { 'ui/src/lib/moved-away.ts': 'a reason that outlived its file' },
+  });
+  assert.deepEqual(codes(findings), ['exempt-stale']);
+});
+
+// ---------------------------------------------------------------------------
+// The real tree
+// ---------------------------------------------------------------------------
+
+test('the repository catalogs are complete, translated, and typographically French', () => {
+  const findings = checkUiI18n({ scanLiterals: false });
+  assert.deepEqual(
+    findings.map((entry) => `${entry.file}:${entry.line} [${entry.code}] ${entry.message}`),
+    [],
+  );
+});
+
+test('every shipped exemption names a file that exists and gives a reason', () => {
+  for (const [path, reason] of Object.entries(EXEMPT_FILES)) {
+    assert.match(path, /^ui\/src\//, `${path} must be a repo-relative ui path`);
+    assert.ok(reason.length > 40, `${path} needs a reason, not a label`);
+  }
+  for (const [key, reason] of Object.entries(IDENTICAL_ALLOWLIST)) {
+    assert.ok(reason.length > 40, `${key} needs a reason, not a label`);
+    assert.doesNotMatch(
+      reason,
+      /not translated|todo|later/i,
+      `${key}: "not translated yet" is the finding, not the exemption`,
+    );
+  }
+  // The stale halves of both rules run against the real tree here: if a listed
+  // file moved, or an allowlisted key was renamed, this is where it surfaces.
+  assert.deepEqual(codes(checkUiI18n({ scanLiterals: false })), []);
+});

--- a/ui/e2e/fixtures.ts
+++ b/ui/e2e/fixtures.ts
@@ -1,5 +1,24 @@
 import { expect, test as base } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { en } from '../src/l10n/en';
+
+/** COPY versus DATA — the distinction the whole file turns on (`docs/i18n.md`,
+ *  rule 6).
+ *
+ *  COPY is what the interface says: destination labels, filter chips, button
+ *  names. It is translated, so a spec must never contain it as a literal —
+ *  every occurrence resolves through the shared `en` catalog, and the same
+ *  spec then runs unchanged under a French text locale by swapping the catalog
+ *  the helpers read.
+ *
+ *  DATA is what the fixture contains: the room names in `MOCK_ROOMS`, message
+ *  bodies, file names. It is NOT translated — `mock.ts` serves the same bytes
+ *  in every locale — so pinning it as a literal is exactly right, and routing
+ *  it through a catalog would be a category error (a translator would be handed
+ *  "Build Iroh Rooms MVP" to localize).
+ *
+ *  The rule of thumb: if a French user would read something different there, it
+ *  is copy and belongs in the catalog. */
 
 /** The shell boundaries (docs/room-workbench.md, decision 3; ui/src/lib/shell.ts).
  *  Compact stops just below 900 — 900 itself is the first medium width, which
@@ -14,11 +33,100 @@ export function shellForWidth(width: number): Shell {
   return width >= WIDE_MIN_WIDTH ? 'wide' : 'medium';
 }
 
-/** The global destinations — the only three (docs/room-workbench.md). */
-export type GlobalDest = 'Rooms' | 'Agent Fleet' | 'Settings';
+/* -- destinations, as KEYS rather than English labels ------------------------
+ *
+ *  These used to be string-literal unions of the English labels:
+ *
+ *      export type GlobalDest = 'Rooms' | 'Agent Fleet' | 'Settings';
+ *
+ *  which made every spec depend on English at the TYPE level, not merely at
+ *  runtime: no spec could be parameterized by locale while `'Agent Fleet'` was
+ *  the only value the compiler would accept. A destination is now named by its
+ *  CATALOG KEY, and the label is resolved from `en` at use — so pointing the
+ *  helpers at `fr` is a one-line change here rather than an edit in 20 specs.
+ *
+ *  MIGRATION PATH. The ~20 existing specs pass the label (`navigate('Agent
+ *  Fleet')`, `roomTab('Files')`), and they are not edited in this change, so
+ *  the English label stays accepted as a DEPRECATED ALIAS that maps to the key.
+ *  Both forms resolve through the same catalog lookup — the alias only decides
+ *  which key you meant, it never becomes the selector text. To finish:
+ *
+ *   1. Per spec, replace each label argument with its key
+ *      (`'Agent Fleet'` → `'destFleet'`, `'Files'` → `'roomDestFiles'`).
+ *   2. Delete the three `*_ALIAS` maps and the alias arm of each `Dest` union;
+ *      the compiler then lists every remaining label call site for you.
+ *   3. Add the locale dimension to the Playwright projects and have `destKey`
+ *      read the catalog for the project's locale instead of `en`.
+ *
+ *  Step 3 is the point of the exercise; steps 1 and 2 are mechanical. */
 
-/** The room destinations, as they are labelled. */
-export type RoomDestLabel = 'Activity' | 'People' | 'Agents & Runs' | 'Files' | 'Pipes';
+/** The global destinations — the only three (docs/room-workbench.md). */
+export type GlobalDestKey = 'destRooms' | 'destFleet' | 'destSettings';
+
+/** The room destinations. */
+export type RoomDestKey =
+  | 'roomDestActivity'
+  | 'roomDestPeople'
+  | 'roomDestAgents'
+  | 'roomDestFiles'
+  | 'roomDestPipes';
+
+/** The rooms-list lifecycle filter chips. */
+export type RoomFilterKey = 'roomsFilterAll' | 'roomsFilterActive' | 'roomsFilterDeparted';
+
+/** @deprecated Pass the key instead. Kept so the unmigrated specs compile. */
+const GLOBAL_DEST_ALIAS = {
+  Rooms: 'destRooms',
+  'Agent Fleet': 'destFleet',
+  Settings: 'destSettings',
+} as const satisfies Record<string, GlobalDestKey>;
+
+/** @deprecated Pass the key instead. Kept so the unmigrated specs compile. */
+const ROOM_DEST_ALIAS = {
+  Activity: 'roomDestActivity',
+  People: 'roomDestPeople',
+  'Agents & Runs': 'roomDestAgents',
+  Files: 'roomDestFiles',
+  Pipes: 'roomDestPipes',
+} as const satisfies Record<string, RoomDestKey>;
+
+/** @deprecated Pass the key instead. Kept so the unmigrated specs compile. */
+const ROOM_FILTER_ALIAS = {
+  All: 'roomsFilterAll',
+  Active: 'roomsFilterActive',
+  'Left & removed': 'roomsFilterDeparted',
+} as const satisfies Record<string, RoomFilterKey>;
+
+/** A destination, named by catalog key or — deprecated — by English label. */
+export type GlobalDest = GlobalDestKey | keyof typeof GLOBAL_DEST_ALIAS;
+export type RoomDest = RoomDestKey | keyof typeof ROOM_DEST_ALIAS;
+export type RoomFilter = RoomFilterKey | keyof typeof ROOM_FILTER_ALIAS;
+
+/** @deprecated The old name for {@link RoomDest}. */
+export type RoomDestLabel = RoomDest;
+
+/** Normalize either spelling to the catalog key. A key passes through; a label
+ *  is looked up. The two sets are disjoint by construction (keys are
+ *  lowerCamelCase, labels are the displayed words), so this can never be
+ *  ambiguous. */
+function destKey<K extends string>(alias: Record<string, K>, dest: string): K {
+  return (alias as Record<string, K | undefined>)[dest] ?? (dest as K);
+}
+
+/** The displayed label for a global destination, from the shared catalog. */
+export function globalDestLabel(dest: GlobalDest): string {
+  return en[destKey(GLOBAL_DEST_ALIAS, dest)];
+}
+
+/** The displayed label for a room destination, from the shared catalog. */
+export function roomDestLabel(dest: RoomDest): string {
+  return en[destKey(ROOM_DEST_ALIAS, dest)];
+}
+
+/** The displayed label for a lifecycle filter chip, from the shared catalog. */
+export function roomFilterLabel(filter: RoomFilter): string {
+  return en[destKey(ROOM_FILTER_ALIAS, filter)];
+}
 
 /** Room names from the populated mock fixture (ui/src/lib/mock.ts). Each is
  *  UNIQUE, so `roomItem(name)` matches exactly one row — the homonym pair below
@@ -87,7 +195,7 @@ export class AppDriver {
    *  wide the rail is always visible, so this is already true there. */
   async showRoomsList(): Promise<void> {
     if (this.currentShell() === 'compact' && !(await this.sidebar.isVisible())) {
-      await this.navigate('Rooms');
+      await this.navigate('destRooms');
     }
     await expect(this.roomItem(MOCK_ROOMS.main)).toBeVisible();
   }
@@ -95,6 +203,7 @@ export class AppDriver {
   /** Load the app with the fresh-onboarding fixture (`?mock=fresh`). */
   async gotoFresh(): Promise<void> {
     await this.goto({ mock: 'fresh' });
+    // TODO(#74 migration): literal — onboarding copy has no catalog key yet.
     await expect(this.page.getByRole('heading', { name: 'Create your identity' })).toBeVisible();
   }
 
@@ -121,8 +230,11 @@ export class AppDriver {
    *  buttons whose accessible names contain the room name, so a bare name match
    *  would resolve to three buttons per row. */
   roomItem(name: string, disambig?: string) {
+    // `name` is fixture DATA (a mock room name), so it is a literal by design.
+    // The landmark's accessible name is COPY — it is the Rooms destination
+    // word, so it resolves through the catalog like every other label.
     const byName = this.page
-      .getByRole('navigation', { name: 'Rooms' })
+      .getByRole('navigation', { name: en.destRooms })
       .getByRole('button', { name, exact: false })
       .and(this.page.locator('.room-select'));
     return disambig ? byName.filter({ hasText: disambig }) : byName;
@@ -131,10 +243,10 @@ export class AppDriver {
   /** A lifecycle filter chip ("All" / "Active" / "Left & removed"). Scoped to
    *  the filter group so it never collides with the same-named departed
    *  disclosure inside the room list. */
-  filterChip(label: 'All' | 'Active' | 'Left & removed') {
+  filterChip(filter: RoomFilter) {
     return this.page
-      .getByRole('group', { name: 'Filter rooms by lifecycle' })
-      .getByRole('button', { name: label, exact: true });
+      .getByRole('group', { name: en.roomsFilterLegend })
+      .getByRole('button', { name: roomFilterLabel(filter), exact: true });
   }
 
   /** Expand the collapsed "Left & removed" disclosure so a departed room's row
@@ -142,9 +254,12 @@ export class AppDriver {
    *  disclosure lives inside the Rooms navigation — scoped so it is not confused
    *  with the identically-labelled filter chip. */
   async showDeparted(): Promise<void> {
+    // Substring match rather than a regex: the label is catalog copy, and
+    // building a RegExp from translated text would need escaping in every
+    // locale (French copy carries « » and narrow no-break spaces).
     const toggle = this.page
-      .getByRole('navigation', { name: 'Rooms' })
-      .getByRole('button', { name: /Left & removed/ });
+      .getByRole('navigation', { name: en.destRooms })
+      .getByRole('button', { name: en.roomsFilterDeparted, exact: false });
     if ((await toggle.count()) > 0 && (await toggle.getAttribute('aria-expanded')) === 'false') {
       await toggle.click();
     }
@@ -173,14 +288,14 @@ export class AppDriver {
   /** The room's nested navigation — visible under the room header, and inside
    *  the inspector on compact. Exactly one of the two is on screen at a time,
    *  so this stays unambiguous on every shell. */
-  roomTab(label: RoomDestLabel) {
+  roomTab(dest: RoomDest) {
     // Not exact: a tab's accessible name absorbs its count badge ("Files5").
     // The five labels share no prefix, so a substring match stays unambiguous.
-    return this.page.getByRole('tab', { name: label, exact: false });
+    return this.page.getByRole('tab', { name: roomDestLabel(dest), exact: false });
   }
 
-  mobileTab(label: GlobalDest) {
-    return this.tabBar.getByRole('button', { name: label, exact: true });
+  mobileTab(dest: GlobalDest) {
+    return this.tabBar.getByRole('button', { name: globalDestLabel(dest), exact: true });
   }
 
   /** Open a room so its Activity is visible, whatever the shell. */
@@ -196,8 +311,10 @@ export class AppDriver {
    *  explicit send. Specs that are about scroll/filter behavior, not the send
    *  gesture itself, use this so they run unchanged on every viewport. */
   async sendMessage(body: string): Promise<void> {
+    // `body` is fixture DATA — a literal on purpose.
     await this.composerTextarea.fill(body);
     if (this.currentShell() === 'compact') {
+      // TODO(#74 migration): literal — the composer has no catalog key yet.
       await this.page.getByRole('button', { name: 'Send message' }).click();
     } else {
       await this.composerTextarea.press('Enter');
@@ -207,9 +324,11 @@ export class AppDriver {
   /** Go to a room destination. Activity closes the inspector; a tool opens it —
    *  a column on wide, a drawer on medium, the whole pane on compact, and one
    *  navigation on all three. */
-  async goToRoomDest(label: RoomDestLabel): Promise<void> {
-    await this.roomTab(label).click();
-    if (label === 'Activity') {
+  async goToRoomDest(dest: RoomDest): Promise<void> {
+    await this.roomTab(dest).click();
+    // Compared as a KEY, never as the visible label — the branch is about which
+    // destination this is, which must not change when the words do.
+    if (destKey(ROOM_DEST_ALIAS, dest) === 'roomDestActivity') {
       await expect(this.timeline).toBeVisible();
     } else {
       await expect(this.rightPanel).toBeVisible();
@@ -217,18 +336,21 @@ export class AppDriver {
   }
 
   /** Navigate to a global destination (room rail / compact tab bar). */
-  async navigate(label: GlobalDest): Promise<void> {
+  async navigate(dest: GlobalDest): Promise<void> {
     if (this.currentShell() === 'compact') {
       // Inside a room the bar gives way to the room's app bar; Back returns to
       // it, exactly as a user would have to.
       if (!(await this.tabBar.isVisible())) {
+        // TODO(#74 migration): still a literal — the back button's accessible
+        // name has no catalog key yet. It gets one when the room app bar is
+        // migrated, and this line becomes `en.roomBackToRooms`.
         await this.page.getByRole('button', { name: 'Back to Rooms' }).click();
       }
-      await this.mobileTab(label).click();
+      await this.mobileTab(dest).click();
     } else {
       await this.page
         .getByRole('navigation', { name: 'Primary', exact: true })
-        .getByRole('button', { name: label, exact: true })
+        .getByRole('button', { name: globalDestLabel(dest), exact: true })
         .click();
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:unit": "vitest run --exclude '**/node_modules/**' --exclude '**/conformance.daemon.test.ts'",
     "test:conformance": "vitest run src/lib/conformance",
+    "i18n:report": "node ../scripts/check-ui-i18n.mjs --report",
     "test:e2e": "tsc --noEmit -p e2e && playwright test"
   },
   "dependencies": {

--- a/ui/src/components/MobileTabBar.tsx
+++ b/ui/src/components/MobileTabBar.tsx
@@ -1,4 +1,7 @@
 import type { NavKey } from './Sidebar';
+import { useStrings } from '../l10n/strings';
+import { Glyph } from '../l10n/tokens';
+import type { Catalog } from '../l10n/catalog';
 
 /** The compact bottom bar carries the global destinations and nothing else
  *  (docs/room-workbench.md, decision 3).
@@ -7,16 +10,23 @@ import type { NavKey } from './Sidebar';
  *  look like a place you could stand without a room — and let the bar, the
  *  visible pane, and the panel's own tab strip disagree about where you were.
  *  Room tools are reached by entering a room; inside one, this bar gives way
- *  to the room's app bar (the behavior mockups/mobile-triptych.png shows). */
-const TABS: { key: NavKey; label: string; glyph: string }[] = [
-  { key: 'rooms', label: 'Rooms', glyph: '▦' },
-  { key: 'fleet', label: 'Agent Fleet', glyph: '✦' },
-  { key: 'settings', label: 'Settings', glyph: '⚙' },
+ *  to the room's app bar (the behavior mockups/mobile-triptych.png shows).
+ *
+ *  The labels come from the SAME catalog keys the rail uses (`Sidebar.tsx`),
+ *  not a second copy of the words. Decision 1 exists to stop a rail entry and a
+ *  tab naming one destination differently — two literal arrays were how that
+ *  would have happened first. The glyphs are decoration and live in `tokens.ts`,
+ *  outside the catalog, because a translator has nothing to do with `▦`. */
+const TABS: { key: NavKey; label: keyof Catalog; glyph: string }[] = [
+  { key: 'rooms', label: 'destRooms', glyph: Glyph.rooms },
+  { key: 'fleet', label: 'destFleet', glyph: Glyph.fleet },
+  { key: 'settings', label: 'destSettings', glyph: Glyph.settings },
 ];
 
 export function MobileTabBar({ active, onNav }: { active: NavKey; onNav(key: NavKey): void }) {
+  const s = useStrings();
   return (
-    <nav className="mobile-tabbar" aria-label="Primary (mobile)">
+    <nav className="mobile-tabbar" aria-label={s.shellNavPrimaryMobile}>
       {TABS.map((tab) => {
         const on = active === tab.key;
         return (
@@ -30,7 +40,7 @@ export function MobileTabBar({ active, onNav }: { active: NavKey; onNav(key: Nav
             <span className="mtab-glyph" aria-hidden="true">
               {tab.glyph}
             </span>
-            <span className="mtab-label">{tab.label}</span>
+            <span className="mtab-label">{s[tab.label] as string}</span>
           </button>
         );
       })}

--- a/ui/src/l10n/README.md
+++ b/ui/src/l10n/README.md
@@ -1,0 +1,101 @@
+# `src/l10n` — localization for the React client
+
+The normative rules live in [`docs/i18n.md`](../../../docs/i18n.md) (seven rules,
+binding on **both** clients) and the French terminology contract lives in
+[`docs/glossary-fr.md`](../../../docs/glossary-fr.md). This note is only the
+mechanics: where things are, and what to do when you add a string.
+
+## Where copy lives
+
+| File          | What it holds                                                          |
+| ------------- | ---------------------------------------------------------------------- |
+| `catalog.ts`  | The `Catalog` interface — the shape every locale must satisfy.          |
+| `en.ts`       | The source of truth. Written first, reviewed as product copy.           |
+| `fr.ts`       | Typed as `Catalog`, so a missing key is a **compile** error.            |
+| `tokens.ts`   | Strings that are **not** copy and never reach a translator.             |
+| `formats.ts`  | The single formatting seam (dates, bytes, counts, percent, rel. time).  |
+| `locale.ts`   | The two persisted locale preferences and the platform fallback.         |
+| `strings.tsx` | `useStrings()` / `useFormats()` — resolution at render time.            |
+| `template.tsx`| `<Template>` for one sentence containing styled/interactive segments.   |
+
+A component never holds a literal. It calls `useStrings()` in its render body
+and reads `s.someKey`. Never capture the catalog into state or a module
+constant — that is what makes a language switch apply live, with no restart.
+
+## Adding a key
+
+1. Add the field to `Catalog` in `catalog.ts`, in its area block, named
+   `<area><Key>` in lowerCamelCase (`roomsFilterActive`) — the same scheme the
+   Flutter ARB uses, so the two catalogs line up under review.
+2. Plain string → `Message`. Needs a value from the call site → `MessageFn<[…]>`,
+   which puts the argument list in the type and makes a missing one a type error
+   instead of a `{name}` on screen.
+3. Add the English value to `en.ts`, then the French to `fr.ts`. TypeScript
+   fails the build until `fr.ts` is complete.
+4. A sentence with a bolded name, a `<code>` id or a link is **one** message with
+   `{slot}` markers rendered through `<Template>` — never JSX fragments glued
+   together (rule 2). Independent facts on a meta line may be joined with
+   `Punct.metaSep`; a sentence may not.
+
+### French, briefly
+
+Sentence case, vouvoiement, `U+202F` before `; ! ?` and inside `« »`, `U+00A0`
+before `:`, `U+2019` for the apostrophe, `U+2026` for the ellipsis, octets
+(`o/Ko/Mo/Go`), `42 %` with `U+202F`. Compare against the Flutter
+`app/lib/src/l10n/arb/app_fr.arb`, which already follows the same contract —
+if a phrase exists there, reuse its wording rather than inventing a second one.
+
+## The never-translate module
+
+`tokens.ts` holds glyphs, shell commands, wire-format examples, the brand, the
+language endonyms and the issue URL. Some of these are a correctness matter,
+not a style one: a `direct` / `relay` path badge must render the daemon's own
+word, so "translating" it would be a lie about the network. Error **codes**
+(`unavailable`, `hash_mismatch`), `daemon`, `jeliyad`, `pipe`, endpoint and
+identity ids are the same — Tier 2 of the glossary. If a translator should
+never see it, it belongs here and deliberately outside `Catalog`.
+
+Protocol enums are never displayed raw either: they go through a display map
+with a raw passthrough default for forward compatibility, so the wire value and
+the display label are never the same constant.
+
+## The two locale preferences
+
+`textLocale` chooses the interface **language**; `formattingLocale` chooses
+date, number and calendar **conventions**. They are separate persisted
+preferences (glossary decision 4), and either may be unset, meaning "follow the
+platform". Someone may read French while formatting under `en-CA`. The
+deliberate exception, carried over from Flutter so the clients agree: byte-unit
+words and the Today/Yesterday/"ago" phrases follow the **text** locale, because
+they are vocabulary — only numeric and calendar conventions follow the
+formatting locale.
+
+Anything numeric or temporal goes through `useFormats()`. Never call
+`toLocaleString` / `Intl` at a call site.
+
+## How tests reference copy
+
+Rule 6: assert copy through the shared `en` catalog, never a literal, so
+translation work never breaks a test.
+
+```ts
+import { en } from '../src/l10n/en';
+expect(screen.getByRole('button', { name: en.roomsCreate })).toBeVisible();
+```
+
+Fixture **data** — room names in `MOCK_ROOMS`, message bodies, file names —
+stays literal. It is data, not copy; it is not translated, and pinning it is the
+point. `e2e/fixtures.ts` states that split at the top and resolves every
+destination label through `en`.
+
+## Running the gate
+
+```sh
+cd ui
+npx tsc --noEmit          # catalog completeness: fr.ts must satisfy Catalog
+npm test                  # unit tests
+npm run test:e2e          # typechecks e2e, then Playwright across the matrix
+```
+
+Completeness is a type error, not a runtime blank. The CI gate exists for what
+types cannot see — an empty string, or a key left in English.

--- a/ui/src/l10n/catalog.ts
+++ b/ui/src/l10n/catalog.ts
@@ -1,0 +1,503 @@
+/** The React catalog contract (issue #74).
+ *
+ *  The Flutter app resolves copy through a generated `AppStrings` class backed
+ *  by an ARB catalog with a translator description per key. React gets the same
+ *  contract, expressed in TypeScript rather than generated: `Catalog` is the
+ *  shape, `en` is the source of truth, and every other locale is typed as
+ *  `Catalog` — so a missing key is a COMPILE error, not a runtime blank.
+ *
+ *  Why not an i18n library. `ui/` ships exactly two runtime dependencies,
+ *  react and react-dom, and `docs/room-workbench.md` records that adding one is
+ *  a decision needing its own rationale — the repository went as far as
+ *  hand-vendoring a QR encoder in both clients to avoid a dependency. Nothing
+ *  here needs a runtime: message lookup is a property access, and every
+ *  formatting concern the acceptance criteria name (dates, durations, counts,
+ *  plurals, relative time) is already in the browser as `Intl`.
+ *
+ *  The seven rules this must honor are `docs/i18n.md`, which govern both
+ *  clients. The two that shape this file:
+ *
+ *   - Rule 1: copy is resolved AT RENDER TIME (`useStrings()`), never captured
+ *     into component state, or a locale switch would not reach it.
+ *   - Rule 2: no sentence is assembled from fragments. A sentence with styled
+ *     or interactive segments is ONE message with `{slot}` placeholders that
+ *     the call site fills — see `Template` in `template.tsx`.
+ */
+
+/** A message with no placeholders. */
+export type Message = string;
+
+/** A message the call site completes. Kept as a function so the catalog itself
+ *  states which values a translator may reorder, and so a missing argument is a
+ *  type error rather than a `{name}` leaking onto the screen. */
+export type MessageFn<A extends unknown[]> = (...args: A) => string;
+
+/** Every user-visible string in the React client.
+ *
+ *  Names follow the Flutter scheme — `<area><Key>` in lowerCamelCase — so a
+ *  reviewer comparing the two catalogs can line them up, and so the two clients
+ *  cannot drift into different words for the same thing. The areas mirror the
+ *  destinations in `docs/room-workbench.md`.
+ *
+ *  Ordered by area, and within an area by where the string appears on screen.
+ */
+export interface Catalog {
+  /** BCP 47 tag this catalog is written in. Used for `<html lang>` and as the
+   *  default formatting locale when the user has not chosen one separately. */
+  readonly localeTag: string;
+
+  // -- common ------------------------------------------------------------------
+  commonRetry: Message;
+  commonCancel: Message;
+  commonClose: Message;
+  commonClear: Message;
+  commonSave: Message;
+  commonBack: Message;
+  commonCopy: Message;
+  commonCopied: Message;
+  commonReconnecting: Message;
+  /** The em-dash-free "not available" placeholder for an absent value. */
+  commonUnknown: Message;
+  /** The parenthetical marking an input a user may leave blank. Rendered beside
+   *  a field label, so it is a fragment of a LABEL, never of a sentence. */
+  commonOptional: Message;
+
+  // -- boot --------------------------------------------------------------------
+  bootSyncing: Message;
+  bootNotConnected: Message;
+  bootContacting: Message;
+  /** Two mono slots: `{daemon}` is the daemon binary name and `{port}` the port
+   *  query parameter — both machine text (`tokens.ts`), so they are slots the
+   *  sentence moves around rather than words to translate. */
+  bootRetryingHint: Message;
+
+  // -- shell / connection ------------------------------------------------------
+  /** @param transport the daemon address the client is dialing, e.g.
+   *         "ws://127.0.0.1:8080/ws". Never translated. */
+  shellConnectionLost: MessageFn<[transport: string]>;
+  shellDisconnected: Message;
+  shellSkipToMain: Message;
+  shellSkipToComposer: Message;
+  /** The four connection states, as the rail's badge names them. Display labels
+   *  for the wire `ConnectionState` — never the wire value itself (rule 3). */
+  shellConnConnected: Message;
+  shellConnConnecting: Message;
+  shellConnReconnecting: Message;
+  shellConnDisconnected: Message;
+  /** Accessible names for the two primary navigations. They are distinct because
+   *  the rail and the compact tab bar are both mounted on some shells, and two
+   *  identically-named landmarks are useless to landmark navigation. */
+  shellNavPrimary: Message;
+  shellNavPrimaryMobile: Message;
+
+  // -- global destinations (docs/room-workbench.md, decision 1) -----------------
+  //
+  // The rail entry, the compact tab and the page title all read these — one
+  // destination is named ONCE, so a tab reading "Rooms" cannot open a page
+  // titled something else.
+  destRooms: Message;
+  destFleet: Message;
+  destSettings: Message;
+
+  // -- room destinations -------------------------------------------------------
+  roomDestActivity: Message;
+  roomDestPeople: Message;
+  roomDestAgents: Message;
+  roomDestFiles: Message;
+  roomDestPipes: Message;
+
+  // -- rooms list --------------------------------------------------------------
+  roomsYourRooms: Message;
+  roomsChoose: Message;
+  /** The rail's create button, its icon-button label, and the Create dialog's
+   *  submit — one action, one name. */
+  roomsCreate: Message;
+  /** The rail's join button AND the Join dialog's title. */
+  roomsJoinWithTicket: Message;
+  roomsSearchPlaceholder: Message;
+  roomsSearchLabel: Message;
+  roomsFilterLegend: Message;
+  roomsFilterAll: Message;
+  roomsFilterActive: Message;
+  roomsFilterDeparted: Message;
+  roomsSectionPinned: Message;
+  roomsSectionArchived: Message;
+  /** @param n how many rooms the collapsed section holds. */
+  roomsSectionCount: MessageFn<[n: number]>;
+  roomsEmpty: Message;
+  /** @param query the text the user typed into the room search box. */
+  roomsNoMatch: MessageFn<[query: string]>;
+  roomsNoneInFilter: Message;
+  roomsUnread: Message;
+  /** @param n how many members the room's roster holds. Needs one/other in
+   *  English; French agrees, and treats 0 as singular. */
+  roomsMemberCount: MessageFn<[n: number]>;
+  roomsUntitled: Message;
+  /** The settled status vocabulary (docs/room-workbench.md, decision 4).
+   *  `Open`/`Closed` is whether THIS daemon holds a live session; `Left`/
+   *  `Removed` is signed membership. Display labels for wire values, never the
+   *  wire values themselves (rule 3). "Active" is retired and must not return. */
+  roomsStateOpen: Message;
+  roomsStateClosed: Message;
+  roomsStateLeft: Message;
+  roomsStateRemoved: Message;
+  roomsSessionOpen: Message;
+  /** Two separate keys, never one with a ternary slot: French needs different
+   *  agreement and word order for each branch. They also title the room-recovery
+   *  surfaces, which state the same signed fact — so it is worded once. */
+  roomsYouLeft: Message;
+  roomsYouWereRemoved: Message;
+  /** @param room the room's display name, as the row shows it. */
+  roomsPin: MessageFn<[room: string]>;
+  /** @param room the room's display name, as the row shows it. */
+  roomsUnpin: MessageFn<[room: string]>;
+  /** @param room the room's display name, as the row shows it. */
+  roomsArchive: MessageFn<[room: string]>;
+  /** @param room the room's display name, as the row shows it. */
+  roomsRestore: MessageFn<[room: string]>;
+  /** The same four actions as a bare tooltip, with no room name in them. */
+  roomsPinShort: Message;
+  roomsUnpinShort: Message;
+  roomsArchiveShort: Message;
+  roomsRestoreShort: Message;
+  /** Accessible name of the rail when it is a column beside the workspace
+   *  rather than the page itself. */
+  roomsRailLabel: Message;
+  /** Accessible name of the room LIST navigation inside the rail — not the
+   *  Rooms destination, which is `destRooms`. */
+  roomsListLabel: Message;
+  roomsProfile: Message;
+
+  // -- room recovery surfaces --------------------------------------------------
+  roomNotOnDevice: Message;
+  /** One slot: `{id}` is the room's short id, rendered mono. */
+  roomNotOnDeviceDetail: Message;
+  roomBackToRooms: Message;
+  /** Two keys for the same reason `roomsYouLeft` is two: French says "votre
+   *  départ" of a departure you chose and "votre retrait" of one you did not. */
+  roomLeftDetail: Message;
+  roomRemovedDetail: Message;
+
+  // -- identity ----------------------------------------------------------------
+  identitySelf: Message;
+  identityP2P: Message;
+  identityCopy: Message;
+  /** @param id the endpoint id, shortened. Tier 2 — the `ep` prefix and the id
+   *  itself stay verbatim in every locale. */
+  identityEndpointShort: MessageFn<[id: string]>;
+  /** @param id the full endpoint id, for the hover title. Tier 2. */
+  identityEndpointTitle: MessageFn<[id: string]>;
+
+  // -- modals (App.tsx) --------------------------------------------------------
+  /** One slot: `{combined}` is the literal shape of a combined invite,
+   *  `ticket#address`, rendered mono. A wire-format example, not a word. */
+  modalJoinCopy: Message;
+  modalTicketLabel: Message;
+  modalPeerAddrLabel: Message;
+  modalJoinSubmit: Message;
+  modalJoining: Message;
+  /** @param attempt the join attempt now running, 1-based.
+   *  @param max how many attempts the client will make in total. */
+  modalJoinAttempt: MessageFn<[attempt: number, max: number]>;
+  modalCreateTitle: Message;
+  modalRoomNameLabel: Message;
+  modalCreating: Message;
+  modalCreateHomonymWarning: Message;
+  modalLeaveTitle: Message;
+  /** Two slots: `{room}` is the room's name (emphasised) and `{id}` its short id
+   *  (mono). Both are always shown — the name alone cannot prove which room a
+   *  signed, irreversible departure applies to. */
+  modalLeaveCopy: Message;
+  modalLeaveSubmit: Message;
+  modalLeaving: Message;
+  modalRenameTitle: Message;
+  modalRenameCopy: Message;
+  modalRenameIdentityLabel: Message;
+  modalRenameAliasLabel: Message;
+  modalRenameClearAlias: Message;
+
+  // -- formatting vocabulary (formats.ts, rule 4) ------------------------------
+  //
+  // These follow the TEXT locale, not the formatting locale: they are
+  // vocabulary, and French writes octets where English writes bytes. Only the
+  // NUMBER inside them comes from the formatting locale, already formatted —
+  // which is why each takes a string, not a number.
+  formatToday: Message;
+  formatYesterday: Message;
+  /** @param n a byte count, already formatted under the formatting locale. */
+  formatBytesB: MessageFn<[n: string]>;
+  /** @param n a kilobyte count, already formatted. French unit: Ko. */
+  formatBytesKb: MessageFn<[n: string]>;
+  /** @param n a megabyte count, already formatted. French unit: Mo. */
+  formatBytesMb: MessageFn<[n: string]>;
+  /** @param n a gigabyte count, already formatted. French unit: Go. */
+  formatBytesGb: MessageFn<[n: string]>;
+  /** @param n a whole percentage, already formatted. The SPACING is the
+   *  localized part: French writes "42 %" with a narrow no-break space. */
+  formatPercent: MessageFn<[n: string]>;
+  formatJustNow: Message;
+
+  // -- wire enums and daemon errors ---------------------------------------------
+  //
+  // Declared here rather than in a separate fragment interface: the CI gate
+  // (scripts/check-ui-i18n.mjs) reads this file to learn which keys exist, and a
+  // fragment it cannot follow makes every key look undeclared — the parity rule
+  // then reports hundreds of false findings and hides the real ones.
+  // -- wire enums: roles, mid-sentence ----------------------------------------
+  /** Role word for the protocol role `owner`, lowercase for mid-sentence use
+   *  ("… joined as owner"). Capitalized pills use panelRoleOwner. The English
+   *  happens to match the raw wire value; translate it as the natural word for
+   *  a room owner — the wire value itself is never shown. */
+  wireRoleOwnerInline: Message;
+  /** Role word for the protocol role `member`, lowercase for mid-sentence use
+   *  ("… joined as member"). Capitalized pills use panelRoleMember. */
+  wireRoleMemberInline: Message;
+  /** Role word for the protocol role `agent` (an automated participant),
+   *  lowercase for mid-sentence use. Capitalized pills use panelRoleAgent. */
+  wireRoleAgentInline: Message;
+
+  // -- wire enums: roles, as a pill -------------------------------------------
+  /** Display label for the room-owner role on roster rows and pickers.
+   *  Translating it does not affect the wire role value. */
+  panelRoleOwner: Message;
+  /** Display label for the agent role (an automated member) on roster rows and
+   *  pickers. Translating it does not affect the wire role value. */
+  panelRoleAgent: Message;
+  /** Display label for the ordinary member role on roster rows and pickers.
+   *  Translating it does not affect the wire role value. */
+  panelRoleMember: Message;
+
+  // -- wire enums: member status ----------------------------------------------
+  /** Roster status for an identity whose signed membership is current
+   *  (protocol `active`). Display label only — deliberately NOT the word
+   *  "Active", which the room rail uses for a live local session. */
+  memberStatusMember: Message;
+  /** Roster/agent-card status: invited, has not joined yet (protocol
+   *  `invited`). Standalone capitalized word. */
+  wireStatusInvited: Message;
+  /** Roster/agent-card status: the member left the room voluntarily (protocol
+   *  `left`, past tense of "to leave"). Standalone capitalized word. */
+  wireStatusLeft: Message;
+  /** Roster/agent-card status: the member was removed by someone else
+   *  (protocol `removed`). Standalone capitalized word. */
+  wireStatusRemoved: Message;
+  /** Roster status shown when the daemon reports NO membership status at all.
+   *  Says so rather than guessing — never rendered as a normal state. */
+  memberStatusUnknown: Message;
+
+  // -- wire enums: peer path (Tier 2 — see wireDisplay.ts) ---------------------
+  /** Peer connection path in the room-header chip: traffic flows over a direct
+   *  peer-to-peer connection. Lowercase, mid-phrase. `docs/glossary-fr.md`
+   *  Tier 2: this is the daemon's own word — keep it verbatim in French. */
+  wirePathDirect: Message;
+  /** Peer connection path in the room-header chip: traffic is routed through a
+   *  relay server rather than directly. Lowercase, mid-phrase. Tier 2 — keep it
+   *  verbatim in French. */
+  wirePathRelay: Message;
+
+  // -- wire enums: daemon mode -------------------------------------------------
+  /** Daemon mode in the Settings daemon summary: local-only loopback mode (no
+   *  real networking; used for testing). Lowercase, mid-sentence. Prefer the
+   *  established networking term in the target language. */
+  wireModeLoopback: Message;
+  /** Daemon mode in the Settings daemon summary: normal networked operation, as
+   *  opposed to loopback test mode. Lowercase, mid-sentence. */
+  wireModeReal: Message;
+
+  // -- wire enums: client connection state, mid-sentence -----------------------
+  /** Connection state, lowercase for mid-sentence use: the app is connected to
+   *  its local daemon. Standalone capitalized badges use shellConn* instead. */
+  wireConnConnectedInline: Message;
+  /** Connection state, lowercase for mid-sentence use: the app is establishing
+   *  its first connection to the local daemon. */
+  wireConnConnectingInline: Message;
+  /** Connection state, lowercase for mid-sentence use: the connection dropped
+   *  and the app is trying to reconnect. */
+  wireConnReconnectingInline: Message;
+  /** Connection state, lowercase for mid-sentence use: the app has no
+   *  connection to the local daemon. */
+  wireConnDisconnectedInline: Message;
+
+  // -- errors: peer_unreachable ------------------------------------------------
+  /** Error headline: joining via an invite failed because the inviter (the room
+   *  admin) could not be reached over the network in time. No blame. */
+  errPeerUnreachableTitle: Message;
+  /** Explanation: the invite itself parsed fine; the network hop to the room
+   *  admin timed out. */
+  errPeerUnreachableMessage: Message;
+  /** Next step. "Combined invite" is a product term: an invite bundling the
+   *  ticket with fresh network address info. */
+  errPeerUnreachableAction: Message;
+
+  // -- errors: bad_ticket ------------------------------------------------------
+  /** Error headline: the invite's ticket is invalid for this user. "Invite" is
+   *  the user-facing word; the credential inside it is called a ticket. */
+  errBadTicketTitle: Message;
+  /** Explanation for an unusable invite. "Identity" is the user's cryptographic
+   *  identity on this device. */
+  errBadTicketMessage: Message;
+  /** Next step. "Identity ID" is the identifier shown in Settings — keep the
+   *  term consistent with that screen. */
+  errBadTicketAction: Message;
+
+  // -- errors: ticket_expired --------------------------------------------------
+  /** Error headline: the ticket passed its expiry time and the room rejected
+   *  it. */
+  errTicketExpiredTitle: Message;
+  /** Explanation for an expired invite. */
+  errTicketExpiredMessage: Message;
+  /** Next step: request a newly generated ticket from whoever invited you. */
+  errTicketExpiredAction: Message;
+
+  // -- errors: room_not_open ---------------------------------------------------
+  /** Error headline: the action requires a live room session first.
+   *  Imperative, instructional tone. */
+  errRoomNotOpenTitle: Message;
+  /** Explanation. "Daemon" is a never-translate term (the local background
+   *  process, jeliyad). */
+  errRoomNotOpenMessage: Message;
+  /** Next step: three sequential instructions, performed in order. */
+  errRoomNotOpenAction: Message;
+
+  // -- errors: not_a_member ----------------------------------------------------
+  /** Error headline: the room's records do not list this user as an active
+   *  member, so the action was refused. */
+  errNotAMemberTitle: Message;
+  /** Explanation. "Signed room history" is the cryptographically signed
+   *  membership log. */
+  errNotAMemberMessage: Message;
+  /** Next step: two alternatives joined with "or". */
+  errNotAMemberAction: Message;
+
+  // -- errors: room_unknown ----------------------------------------------------
+  /** Error headline: this device has no local copy of the room's history.
+   *  "Local" means stored on this device. */
+  errRoomUnknownTitle: Message;
+  /** Explanation. "Daemon" is never translated. */
+  errRoomUnknownMessage: Message;
+  /** Next step. "Peer hint" is a product term: address information for a
+   *  reachable member that helps the device find the room. */
+  errRoomUnknownAction: Message;
+
+  // -- errors: file_unauthorized -----------------------------------------------
+  /** Error headline: a file download was refused — this user is not authorized
+   *  for the file. */
+  errFileUnauthorizedTitle: Message;
+  /** Explanation. "Provider" is a product term: a device that can serve the
+   *  file's bytes. */
+  errFileUnauthorizedMessage: Message;
+  /** Next step: two alternatives from the sender, then retry. */
+  errFileUnauthorizedAction: Message;
+
+  // -- errors: hash_mismatch ---------------------------------------------------
+  /** Error headline: downloaded bytes failed the cryptographic hash check.
+   *  Serious security tone. */
+  errHashMismatchTitle: Message;
+  /** Explanation. "Hard stop" means the app refuses to proceed at all; the
+   *  downloaded copy is deleted and never displayed. Contains an em dash. */
+  errHashMismatchMessage: Message;
+  /** Next step. The second sentence is a firm prohibition — retrying the same
+   *  copy would fail again and could be unsafe. */
+  errHashMismatchAction: Message;
+
+  // -- errors: connection_lost -------------------------------------------------
+  /** Error headline: the app lost its connection to the local background
+   *  process. "Daemon" is never translated. */
+  errConnectionLostTitle: Message;
+  /** Explanation. "jeliyad" is the daemon binary's name — never translate, keep
+   *  the exact lowercase spelling. */
+  errConnectionLostMessage: Message;
+  /** Next step: the app reconnects automatically; the user waits and retries. */
+  errConnectionLostAction: Message;
+
+  // -- errors: invalid_params --------------------------------------------------
+  /** Error headline: the daemon rejected the request because one of its input
+   *  values was invalid (usually something the user typed). */
+  errInvalidParamsTitle: Message;
+  /** Explanation for an invalid request. */
+  errInvalidParamsMessage: Message;
+  /** Next step: re-check the entered values and retry. */
+  errInvalidParamsAction: Message;
+
+  // -- errors: identity_missing ------------------------------------------------
+  /** Error headline: the action needs a user identity but none has been created
+   *  on this device yet. */
+  errIdentityMissingTitle: Message;
+  /** Explanation. "Here" means on this device/daemon. */
+  errIdentityMissingMessage: Message;
+  /** Next step: create the identity (onboarding/Settings) before retrying. */
+  errIdentityMissingAction: Message;
+
+  // -- errors: identity_exists -------------------------------------------------
+  /** Error headline: identity creation was refused because this device's daemon
+   *  already holds one identity (only one is allowed). */
+  errIdentityExistsTitle: Message;
+  /** Explanation for the duplicate-identity error. Contains an em dash. */
+  errIdentityExistsMessage: Message;
+  /** Next step. "Settings" names the app's Settings screen — keep consistent
+   *  with that screen's title. */
+  errIdentityExistsAction: Message;
+
+  // -- errors: file_unavailable ------------------------------------------------
+  /** Error headline: the file cannot be downloaded right now because no device
+   *  holding it is online. Temporary condition, calm tone. */
+  errFileUnavailableTitle: Message;
+  /** Explanation. "Provider" is a product term: a device that can serve the
+   *  file's bytes. */
+  errFileUnavailableMessage: Message;
+  /** Next step: try again later, once the sender's device is online. */
+  errFileUnavailableAction: Message;
+
+  // -- errors: file_too_large --------------------------------------------------
+  /** Error headline: the user tried to share a file above the size limit. */
+  errFileTooLargeTitle: Message;
+  /** Explanation. "100 MiB" is the fixed limit — keep the number and the
+   *  mebibyte unit "MiB" exactly as-is. */
+  errFileTooLargeMessage: Message;
+  /** Next step: two alternatives, joined with "or". */
+  errFileTooLargeAction: Message;
+
+  // -- errors: file_unreadable -------------------------------------------------
+  /** Error headline: the file the user picked to share could not be read from
+   *  local disk. */
+  errFileUnreadableTitle: Message;
+  /** Explanation. "Picked" refers to the file chosen in the file picker. */
+  errFileUnreadableMessage: Message;
+  /** Next step: verify it still exists with read permission, then retry. */
+  errFileUnreadableAction: Message;
+
+  // -- errors: pipe_denied -----------------------------------------------------
+  /** Error headline: access to a pipe was refused. "Pipe" is a never-translate
+   *  protocol term (a named byte-stream endpoint shared between peers). */
+  errPipeDeniedTitle: Message;
+  /** Explanation for denied pipe access. */
+  errPipeDeniedMessage: Message;
+  /** Next step. "Expose" is the product verb for granting a pipe to an
+   *  identity; "pipe" is never translated. */
+  errPipeDeniedAction: Message;
+
+  // -- errors: internal --------------------------------------------------------
+  /** Error headline for an internal (unclassified) daemon failure. */
+  errInternalTitle: Message;
+  /** Explanation: even the daemon does not know a more specific cause. */
+  errInternalMessage: Message;
+  /** Next step. "Settings" names the app's Settings screen, which has a
+   *  copy-diagnostics feature — keep consistent with that screen's title. */
+  errInternalAction: Message;
+
+  // -- errors: unknown / future codes ------------------------------------------
+  /** Fallback headline for any error code this app version has no specific copy
+   *  for (unknown or future codes). */
+  errUnknownTitle: Message;
+  /** Fallback explanation. The raw error stays visible in the card's collapsed
+   *  "Technical details" section. */
+  errUnknownMessage: Message;
+  /** Fallback next step. "Technical details" names the collapsed section on the
+   *  same error card — it must match that section's label exactly. */
+  errUnknownAction: Message;
+}
+
+/** A locale's catalog. Typed as the full `Catalog`, so TypeScript rejects an
+ *  incomplete translation before the CI completeness gate ever runs — the gate
+ *  exists for what types cannot see (an empty string, a key left in English). */
+export type LocaleCatalog = Catalog;

--- a/ui/src/l10n/en.ts
+++ b/ui/src/l10n/en.ts
@@ -1,0 +1,262 @@
+/** English — the source of truth (issue #74).
+ *
+ *  Every other locale is typed as `Catalog`, so this file's shape is the
+ *  contract: add a key here and `fr.ts` stops compiling until it is translated.
+ *
+ *  Where a string already exists in the Flutter catalog
+ *  (`app/lib/src/l10n/arb/app_en.arb`) its wording is REUSED verbatim rather
+ *  than re-written. The two clients ship the same product; a rail that says
+ *  "Left & removed" in one and "Departed" in the other is a translation bug in
+ *  both languages at once.
+ *
+ *  Casing is sentence case, matching the Flutter catalog's normalization pass.
+ *  All-caps treatments are `toUpperCase()` at render time (rule 7), never here.
+ */
+
+import type { LocaleCatalog } from './catalog';
+
+export const en: LocaleCatalog = {
+  // -- wire enums and daemon errors ---------------------------------------------
+  //
+  // Inlined rather than spread from another module ON PURPOSE: the CI gate
+  // (scripts/check-ui-i18n.mjs) reads these files with a restricted scanner, and
+  // a spread it cannot follow makes the parity, emptiness and typography rules
+  // silently stop running — a gate that reports nothing looks identical to a gate
+  // that finds nothing. One locale, one file, every value visible.
+  wireRoleOwnerInline: 'owner',
+  wireRoleMemberInline: 'member',
+  wireRoleAgentInline: 'agent',
+
+  panelRoleOwner: 'Owner',
+  panelRoleAgent: 'Agent',
+  panelRoleMember: 'Member',
+
+  memberStatusMember: 'Member',
+  wireStatusInvited: 'Invited',
+  wireStatusLeft: 'Left',
+  wireStatusRemoved: 'Removed',
+  memberStatusUnknown: 'Unknown',
+
+  wirePathDirect: 'direct',
+  wirePathRelay: 'relay',
+
+  wireModeLoopback: 'loopback',
+  wireModeReal: 'real',
+
+  wireConnConnectedInline: 'connected',
+  wireConnConnectingInline: 'connecting',
+  wireConnReconnectingInline: 'reconnecting',
+  wireConnDisconnectedInline: 'disconnected',
+
+  errPeerUnreachableTitle: "Couldn't reach the inviter",
+  errPeerUnreachableMessage:
+    'The invite is readable, but this device could not reach the room admin in time.',
+  errPeerUnreachableAction:
+    'Ask the inviter to keep the room open, then retry. A fresh combined invite can help if the address changed.',
+
+  errBadTicketTitle: "This invite can't be used",
+  errBadTicketMessage:
+    'The ticket is invalid for this identity, malformed, or no longer matches the room invite.',
+  errBadTicketAction: 'Ask for a new invite generated for your current identity ID.',
+
+  errTicketExpiredTitle: 'This invite expired',
+  errTicketExpiredMessage: 'The room rejected the ticket because its expiry time has passed.',
+  errTicketExpiredAction: 'Ask the inviter to generate a fresh ticket.',
+
+  errRoomNotOpenTitle: 'Open the room first',
+  errRoomNotOpenMessage: 'This action needs a live room session on your daemon.',
+  errRoomNotOpenAction: 'Open the room, wait for it to sync, then try again.',
+
+  errNotAMemberTitle: "You're not an active member",
+  errNotAMemberMessage:
+    'The signed room history does not currently admit this identity as an active member.',
+  errNotAMemberAction: 'Use a valid invite for this identity or ask the room owner to re-add you.',
+
+  errRoomUnknownTitle: "This room isn't local yet",
+  errRoomUnknownMessage: 'The daemon does not have enough room history to open this room.',
+  errRoomUnknownAction: 'Join with an invite, or open the room with a reachable peer hint.',
+
+  errFileUnauthorizedTitle: 'Not authorized for this file',
+  errFileUnauthorizedMessage:
+    'Every reachable provider refused the transfer because the signed history does not admit this identity for it.',
+  errFileUnauthorizedAction: 'Ask the sender to re-share the file or re-invite you, then retry.',
+
+  errHashMismatchTitle: 'Security check failed',
+  errHashMismatchMessage:
+    'The fetched bytes did not match the file hash. This is a hard stop — the copy is discarded, never shown.',
+  errHashMismatchAction: 'Ask the sender to re-share the file. Do not retry the same copy.',
+
+  errConnectionLostTitle: 'Daemon connection lost',
+  errConnectionLostMessage: 'The local UI is not connected to jeliyad right now.',
+  errConnectionLostAction: 'Wait for reconnect, then retry the action.',
+
+  errInvalidParamsTitle: "This request wasn't valid",
+  errInvalidParamsMessage: 'The daemon rejected one of the values in this request.',
+  errInvalidParamsAction: 'Check what you entered, then try again.',
+
+  errIdentityMissingTitle: 'No identity on this daemon yet',
+  errIdentityMissingMessage: 'This action needs your identity, and one has not been created here.',
+  errIdentityMissingAction: 'Create your identity first, then retry.',
+
+  errIdentityExistsTitle: 'An identity already exists',
+  errIdentityExistsMessage: 'This daemon already holds an identity — a second one cannot be created.',
+  errIdentityExistsAction: 'Use the existing identity shown in Settings.',
+
+  errFileUnavailableTitle: 'File not available right now',
+  errFileUnavailableMessage: 'No provider is online for this file yet.',
+  errFileUnavailableAction: 'Recheck when the sender is back online.',
+
+  errFileTooLargeTitle: 'This file is too large to share',
+  errFileTooLargeMessage: 'Shares are capped at 100 MiB per file.',
+  errFileTooLargeAction: 'Pick a smaller file, or split the content.',
+
+  errFileUnreadableTitle: "This file couldn't be read",
+  errFileUnreadableMessage: 'The picked file could not be opened from disk.',
+  errFileUnreadableAction: 'Check the file still exists and is readable, then retry.',
+
+  errPipeDeniedTitle: 'Pipe access denied',
+  errPipeDeniedMessage: 'This pipe does not authorize your identity.',
+  errPipeDeniedAction: 'Ask the pipe owner to expose it to your identity.',
+
+  errInternalTitle: 'The daemon hit an unexpected failure',
+  errInternalMessage: 'This request failed for a reason the daemon could not classify.',
+  errInternalAction: 'Retry; if it keeps failing, copy diagnostics from Settings and report it.',
+
+  errUnknownTitle: 'Something went wrong',
+  errUnknownMessage: 'The daemon reported an error this app has no specific copy for.',
+  errUnknownAction: 'Open Technical details for the exact error, then retry.',
+
+  localeTag: 'en',
+
+  // -- common ------------------------------------------------------------------
+  commonRetry: 'Retry',
+  commonCancel: 'Cancel',
+  commonClose: 'Close',
+  commonClear: 'Clear',
+  commonSave: 'Save',
+  commonBack: 'Back',
+  commonCopy: 'Copy',
+  commonCopied: 'Copied ✓',
+  commonReconnecting: 'Reconnecting…',
+  commonUnknown: 'Unknown',
+  commonOptional: '(optional)',
+
+  // -- boot --------------------------------------------------------------------
+  bootSyncing: 'Syncing…',
+  bootNotConnected: 'Not connected.',
+  bootContacting: 'Contacting daemon…',
+  bootRetryingHint: 'Retrying with backoff — start {daemon} or pass {port}.',
+
+  // -- shell / connection ------------------------------------------------------
+  shellConnectionLost: (transport) => `Connection to daemon lost — reconnecting… (${transport})`,
+  shellDisconnected: 'Disconnected from daemon.',
+  shellSkipToMain: 'Skip to main content',
+  shellSkipToComposer: 'Skip to message composer',
+  shellConnConnected: 'Connected',
+  shellConnConnecting: 'Connecting…',
+  shellConnReconnecting: 'Reconnecting…',
+  shellConnDisconnected: 'Disconnected',
+  shellNavPrimary: 'Primary',
+  shellNavPrimaryMobile: 'Primary (mobile)',
+
+  // -- global destinations -----------------------------------------------------
+  destRooms: 'Rooms',
+  destFleet: 'Agent Fleet',
+  destSettings: 'Settings',
+
+  // -- room destinations -------------------------------------------------------
+  roomDestActivity: 'Activity',
+  roomDestPeople: 'People',
+  roomDestAgents: 'Agents & Runs',
+  roomDestFiles: 'Files',
+  roomDestPipes: 'Pipes',
+
+  // -- rooms list --------------------------------------------------------------
+  roomsYourRooms: 'Your Rooms',
+  roomsChoose: 'Choose a room.',
+  roomsCreate: 'Create room',
+  roomsJoinWithTicket: 'Join with a ticket',
+  roomsSearchPlaceholder: 'Search rooms…',
+  roomsSearchLabel: 'Search rooms by name or short id',
+  roomsFilterLegend: 'Filter rooms by lifecycle',
+  roomsFilterAll: 'All',
+  roomsFilterActive: 'Active',
+  roomsFilterDeparted: 'Left & removed',
+  roomsSectionPinned: 'Pinned',
+  roomsSectionArchived: 'Archived',
+  roomsSectionCount: (n) => `(${n})`,
+  roomsEmpty: 'No rooms yet',
+  roomsNoMatch: (query) => `No rooms match “${query}”.`,
+  roomsNoneInFilter: 'No rooms in this filter.',
+  roomsUnread: 'Unread',
+  roomsMemberCount: (n) => (n === 1 ? `${n} member` : `${n} members`),
+  roomsUntitled: 'Untitled room',
+  roomsStateOpen: 'Open',
+  roomsStateClosed: 'Closed',
+  roomsStateLeft: 'Left',
+  roomsStateRemoved: 'Removed',
+  roomsSessionOpen: 'Session open',
+  roomsYouLeft: 'You left this room',
+  roomsYouWereRemoved: 'You were removed from this room',
+  roomsPin: (room) => `Pin ${room}`,
+  roomsUnpin: (room) => `Unpin ${room}`,
+  roomsArchive: (room) => `Archive ${room}`,
+  roomsRestore: (room) => `Restore ${room}`,
+  roomsPinShort: 'Pin',
+  roomsUnpinShort: 'Unpin',
+  roomsArchiveShort: 'Archive',
+  roomsRestoreShort: 'Restore from archive',
+  roomsRailLabel: 'Room rail',
+  roomsListLabel: 'Rooms',
+  roomsProfile: 'Profile & settings',
+
+  // -- room recovery surfaces --------------------------------------------------
+  roomNotOnDevice: 'That room isn’t on this device',
+  roomNotOnDeviceDetail:
+    'Nothing here matches {id}. It may live on another device, or you may not have joined it yet.',
+  roomBackToRooms: 'Back to Rooms',
+  roomLeftDetail: 'Your departure is published to the room’s signed log. You’ll need a new invite to rejoin.',
+  roomRemovedDetail: 'Your removal is published to the room’s signed log. You’ll need a new invite to rejoin.',
+
+  // -- identity ----------------------------------------------------------------
+  identitySelf: 'You',
+  identityP2P: 'P2P Identity',
+  identityCopy: 'Copy identity ID',
+  identityEndpointShort: (id) => `ep ${id}`,
+  identityEndpointTitle: (id) => `endpoint ${id}`,
+
+  // -- modals ------------------------------------------------------------------
+  modalJoinCopy:
+    'Paste the invite you received. A combined invite ({combined}) fills in the peer address automatically.',
+  modalTicketLabel: 'Ticket',
+  modalPeerAddrLabel: 'Peer address',
+  modalJoinSubmit: 'Join room',
+  modalJoining: 'Joining…',
+  modalJoinAttempt: (attempt, max) => `Attempt ${attempt}/${max}`,
+  modalCreateTitle: 'Create a room',
+  modalRoomNameLabel: 'Room name',
+  modalCreating: 'Creating…',
+  modalCreateHomonymWarning:
+    'A room with that name already exists on this device — this one will get its own ID.',
+  modalLeaveTitle: 'Leave room',
+  modalLeaveCopy:
+    'Leaving {room} {id} publishes a signed membership departure. This is different from closing the local ' +
+    'session; you’ll need a new invite to join again.',
+  modalLeaveSubmit: 'Leave room',
+  modalLeaving: 'Leaving…',
+  modalRenameTitle: 'Name this peer',
+  modalRenameCopy: 'Local alias only — names never leave this machine.',
+  modalRenameIdentityLabel: 'Identity:',
+  modalRenameAliasLabel: 'Alias',
+  modalRenameClearAlias: 'Clear alias',
+
+  // -- formatting vocabulary ---------------------------------------------------
+  formatToday: 'Today',
+  formatYesterday: 'Yesterday',
+  formatBytesB: (n) => `${n} B`,
+  formatBytesKb: (n) => `${n} KB`,
+  formatBytesMb: (n) => `${n} MB`,
+  formatBytesGb: (n) => `${n} GB`,
+  formatPercent: (n) => `${n}%`,
+  formatJustNow: 'just now',
+};

--- a/ui/src/l10n/errorDisplay.ts
+++ b/ui/src/l10n/errorDisplay.ts
@@ -1,0 +1,174 @@
+/** Friendly error copy (issue #74; `docs/i18n.md` rule 3).
+ *
+ *  The daemon error code → designed-copy mapping every error surface uses,
+ *  resolved AT RENDER TIME from the catalog the caller already holds, so a live
+ *  language switch re-resolves error copy too. Mirrors Flutter's
+ *  `app/lib/src/l10n/error_display.dart` code for code.
+ *
+ *  Why the daemon's own words are not the copy
+ *  -------------------------------------------
+ *  `docs/glossary-fr.md` decision 1: daemon and CLI output stays English.
+ *  Operators and agents grep logs and search error text, so translating
+ *  diagnostics is a support liability. The consequence for the UI is strict —
+ *  the daemon's `message` and `hint` are TECHNICAL DETAIL, never the designed
+ *  sentence. They belong in the collapsed "Technical details" disclosure, the
+ *  Settings diagnostics card, and the diagnostics report; nowhere else.
+ *
+ *  This is exactly where `lib/errors.ts` went wrong. It covered nine codes, and
+ *  its `default` branch returned `error.message` as the message and `error.hint`
+ *  as the action — so under a French interface, any unmapped code (eight of the
+ *  seventeen, including every share-staging and pipe error) rendered an English
+ *  daemon string as the primary, designed copy of the card. The generic lead
+ *  below is not a downgrade from that; it is the honest version, and it sits
+ *  next to a disclosure that still shows the operator the exact raw error.
+ *
+ *  `lib/errors.ts` should be retired by the integrator: this file supersedes it
+ *  wholesale, and the two must not both exist once call sites move, or the
+ *  untranslated one will quietly be the one someone imports next.
+ *
+ *  Codes cover the fourteen the daemon can put on the wire plus the three the
+ *  client synthesizes (`connection_lost` from the transport, `file_too_large`
+ *  and `file_unreadable` from share staging before any wire call), and unknown.
+ */
+
+import type { Catalog } from './catalog';
+
+/** The catalog subset this file reads. */
+type S = Catalog;
+
+/** Plain-language title/message/action triple. The shape `lib/errors.ts`
+ *  exported, kept so call sites move over without rewriting their JSX. */
+export interface FriendlyError {
+  title: string;
+  message: string;
+  action?: string;
+}
+
+/** The minimum an error needs to be narrated. Structural, so a caller can pass
+ *  a `DaemonErrorShape`, a `RequestError`, or anything else carrying a code —
+ *  `lib/protocol.ts` types stay out of the l10n layer (rule 5: shared protocol
+ *  modules compose no user-visible English, and the l10n layer returns the
+ *  favor by not depending on them). */
+export interface CodedError {
+  code: string;
+}
+
+/** Map a daemon error to designed copy.
+ *
+ *  Unknown and future codes get the generic lead — never the daemon's English
+ *  message or hint as primary copy. The raw `{code, message, hint}` stays
+ *  available to the caller for the "Technical details" disclosure; this
+ *  function deliberately does not read them, so there is no path by which they
+ *  reach a title or a message. */
+export function friendlyError(s: S, error: CodedError): FriendlyError {
+  switch (error.code) {
+    case 'peer_unreachable':
+      return {
+        title: s.errPeerUnreachableTitle,
+        message: s.errPeerUnreachableMessage,
+        action: s.errPeerUnreachableAction,
+      };
+    case 'bad_ticket':
+      return {
+        title: s.errBadTicketTitle,
+        message: s.errBadTicketMessage,
+        action: s.errBadTicketAction,
+      };
+    case 'ticket_expired':
+      return {
+        title: s.errTicketExpiredTitle,
+        message: s.errTicketExpiredMessage,
+        action: s.errTicketExpiredAction,
+      };
+    case 'room_not_open':
+      return {
+        title: s.errRoomNotOpenTitle,
+        message: s.errRoomNotOpenMessage,
+        action: s.errRoomNotOpenAction,
+      };
+    case 'not_a_member':
+      return {
+        title: s.errNotAMemberTitle,
+        message: s.errNotAMemberMessage,
+        action: s.errNotAMemberAction,
+      };
+    case 'room_unknown':
+      return {
+        title: s.errRoomUnknownTitle,
+        message: s.errRoomUnknownMessage,
+        action: s.errRoomUnknownAction,
+      };
+    case 'file_unauthorized':
+      return {
+        title: s.errFileUnauthorizedTitle,
+        message: s.errFileUnauthorizedMessage,
+        action: s.errFileUnauthorizedAction,
+      };
+    case 'hash_mismatch':
+      return {
+        title: s.errHashMismatchTitle,
+        message: s.errHashMismatchMessage,
+        action: s.errHashMismatchAction,
+      };
+    case 'connection_lost':
+      return {
+        title: s.errConnectionLostTitle,
+        message: s.errConnectionLostMessage,
+        action: s.errConnectionLostAction,
+      };
+    case 'invalid_params':
+      return {
+        title: s.errInvalidParamsTitle,
+        message: s.errInvalidParamsMessage,
+        action: s.errInvalidParamsAction,
+      };
+    case 'identity_missing':
+      return {
+        title: s.errIdentityMissingTitle,
+        message: s.errIdentityMissingMessage,
+        action: s.errIdentityMissingAction,
+      };
+    case 'identity_exists':
+      return {
+        title: s.errIdentityExistsTitle,
+        message: s.errIdentityExistsMessage,
+        action: s.errIdentityExistsAction,
+      };
+    case 'file_unavailable':
+      return {
+        title: s.errFileUnavailableTitle,
+        message: s.errFileUnavailableMessage,
+        action: s.errFileUnavailableAction,
+      };
+    case 'file_too_large':
+      return {
+        title: s.errFileTooLargeTitle,
+        message: s.errFileTooLargeMessage,
+        action: s.errFileTooLargeAction,
+      };
+    case 'file_unreadable':
+      return {
+        title: s.errFileUnreadableTitle,
+        message: s.errFileUnreadableMessage,
+        action: s.errFileUnreadableAction,
+      };
+    case 'pipe_denied':
+      return {
+        title: s.errPipeDeniedTitle,
+        message: s.errPipeDeniedMessage,
+        action: s.errPipeDeniedAction,
+      };
+    case 'internal':
+      return {
+        title: s.errInternalTitle,
+        message: s.errInternalMessage,
+        action: s.errInternalAction,
+      };
+    default:
+      return {
+        title: s.errUnknownTitle,
+        message: s.errUnknownMessage,
+        action: s.errUnknownAction,
+      };
+  }
+}

--- a/ui/src/l10n/formats.ts
+++ b/ui/src/l10n/formats.ts
@@ -1,0 +1,117 @@
+/** The single formatting seam (issue #74; `docs/i18n.md` rule 4).
+ *
+ *  Nothing else in the React client may format a date, a number, a byte size or
+ *  a relative time. Before this, `lib/format.ts` hardcoded English words AND
+ *  called `toLocaleTimeString([], …)` with an empty locale list — meaning it
+ *  formatted under the BROWSER's locale while spelling its words in English, so
+ *  a French user on an English browser got neither.
+ *
+ *  Text locale versus formatting locale
+ *  ------------------------------------
+ *  These are SEPARATE (`docs/glossary-fr.md`, decision 4, settled before the
+ *  first string was written). Someone may read the interface in French while
+ *  expecting dates and numbers in their region's conventions, or read English
+ *  while living somewhere that writes 1 234,56. Collapsing them into one
+ *  "locale" is the mistake this design exists to avoid, and Flutter already
+ *  models it this way — `PrefsStore.textLocale` and `.formattingLocale` are two
+ *  persisted preferences.
+ *
+ *  The accepted deviation, carried over from Flutter so the two clients agree:
+ *  byte-unit WORDS and the Today/Yesterday/"ago" phrases follow the TEXT
+ *  locale, because they are vocabulary. Only numeric and calendar conventions
+ *  follow the formatting locale.
+ *
+ *  No dependency: `Intl` has been in every browser this app supports for years.
+ */
+
+import type { Catalog } from './catalog';
+
+export class Formats {
+  /** @param strings the TEXT-locale catalog — supplies unit words and phrases.
+   *  @param localeTag the FORMATTING locale — supplies numeric and calendar
+   *         conventions. Deliberately not `strings.localeTag`. */
+  constructor(
+    private readonly strings: Catalog,
+    readonly localeTag: string,
+  ) {}
+
+  /** Clock time, e.g. "9:41 AM" or "09:41". */
+  clock(ts: number): string {
+    return new Intl.DateTimeFormat(this.localeTag, { hour: 'numeric', minute: '2-digit' }).format(ts);
+  }
+
+  /** A day divider: Today / Yesterday from the TEXT locale, otherwise a date
+   *  under the FORMATTING locale's calendar conventions. */
+  dayLabel(ts: number): string {
+    const date = new Date(ts);
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    if (date.toDateString() === today.toDateString()) return this.strings.formatToday;
+    if (date.toDateString() === yesterday.toDateString()) return this.strings.formatYesterday;
+    return new Intl.DateTimeFormat(this.localeTag, { month: 'short', day: 'numeric', year: 'numeric' }).format(date);
+  }
+
+  /** Byte sizes. Unit words come from the catalog because French writes octets
+   *  (o/Ko/Mo/Go), not bytes — the number's decimal separator comes from the
+   *  formatting locale. `?` for a value that is not a real size, never a
+   *  fabricated 0. */
+  bytes(n: number): string {
+    if (!Number.isFinite(n) || n < 0) return '?';
+    const num = (value: number, digits = 0) =>
+      new Intl.NumberFormat(this.localeTag, {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(value);
+    if (n < 1024) return this.strings.formatBytesB(num(n));
+    if (n < 1024 * 1024) return this.strings.formatBytesKb(num(Math.round(n / 1024)));
+    if (n < 1024 ** 3) return this.strings.formatBytesMb(num(n / 1024 ** 2, 1));
+    return this.strings.formatBytesGb(num(n / 1024 ** 3, 1));
+  }
+
+  /** A whole number under the formatting locale's grouping conventions. */
+  count(n: number): string {
+    return new Intl.NumberFormat(this.localeTag).format(n);
+  }
+
+  /** A percentage. Renders through the catalog because SPACING is
+   *  locale-dependent: French writes "42 %" with a narrow no-break space that
+   *  English does not have. */
+  percent(n: number): string {
+    return this.strings.formatPercent(this.count(Math.round(n)));
+  }
+
+  /** Relative time from a real event timestamp — display only, never a
+   *  liveness claim.
+   *
+   *  Clamped at zero: a timestamp in the future (clock skew, a bad caller)
+   *  must render "just now", never "-2m ago". */
+  relTime(ts: number): string {
+    const delta = Math.max(0, Date.now() - ts);
+    if (delta < 45_000) return this.strings.formatJustNow;
+    const rtf = new Intl.RelativeTimeFormat(this.localeTag, { numeric: 'auto', style: 'narrow' });
+    const mins = Math.round(delta / 60_000);
+    if (mins < 60) return rtf.format(-mins, 'minute');
+    const hours = Math.round(delta / 3_600_000);
+    if (hours < 24) return rtf.format(-hours, 'hour');
+    return rtf.format(-Math.round(delta / 86_400_000), 'day');
+  }
+}
+
+/** Resolve the formatting locale actually in effect.
+ *
+ *  Order: the explicit preference, else the text locale, else the platform.
+ *  A tag the runtime cannot honor falls back rather than throwing — a bad
+ *  stored preference must not brick the interface. */
+export function resolveFormattingLocale(preferred: string | null, textLocale: string): string {
+  const candidates = [preferred, textLocale].filter((t): t is string => Boolean(t));
+  for (const tag of candidates) {
+    try {
+      // Throws RangeError on a malformed tag; returns [] when unsupported.
+      if (Intl.DateTimeFormat.supportedLocalesOf([tag]).length > 0) return tag;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return textLocale;
+}

--- a/ui/src/l10n/fr.ts
+++ b/ui/src/l10n/fr.ts
@@ -1,0 +1,303 @@
+/** French — `docs/glossary-fr.md`, decision 7 (typographie), Tier 1–3 vocabulary.
+ *
+ *  Typographie (non-negotiable, `docs/glossary-fr.md` decision 7). The two
+ *  invisible spaces are written as ESCAPES, never as literal characters, so a
+ *  reviewer can see the contract in the diff instead of trusting a glyph they
+ *  cannot see:
+ *
+ *    \u202f  narrow no-break space — before `; ! ?` and inside « guillemets »
+ *    \u00a0  no-break space — before `:`
+ *    U+2019 `’` and U+2026 `…` are typed directly: they are visible, and are
+ *    already the English catalog's norm.
+ *
+ *  Two places where the Flutter `app_fr.arb` does NOT meet decision 7 and this
+ *  catalog does: the guillemets in `roomsNoMatch` (Flutter's
+ *  `sidebarNoRoomsMatch` has no inner narrow spaces) and the percent sign in
+ *  `formatPercent` (Flutter's `commonPercent` uses a plain space). Both are
+ *  worth fixing there; neither is worth copying here.
+ *
+ *  Register: vouvoiement, sentence case (never Title Case), accents kept on
+ *  capitals, calm and concrete — the honest tone of the English catalog, not a
+ *  marketing one.
+ *
+ *  Vocabulary: Tier 1 is translated consistently (room → salon, member →
+ *  membre, settings → réglages, Your Rooms → Vos salons). Tier 2 is verbatim in
+ *  every locale — `direct`/`relay`, error codes, `daemon`, `jeliyad`, `pipe`,
+ *  endpoint and identity ids — and most of it lives in `tokens.ts`, outside this
+ *  file entirely. Tier 3, the brand, is never translated.
+ *
+ *  Where the Flutter catalog already translates a string, its French is REUSED
+ *  verbatim. The two clients must not ship two French words for one English one.
+ */
+
+import type { LocaleCatalog } from './catalog';
+
+export const fr: LocaleCatalog = {
+  // -- wire enums and daemon errors ---------------------------------------------
+  //
+  // Inlined rather than spread from another module ON PURPOSE: the CI gate
+  // (scripts/check-ui-i18n.mjs) reads these files with a restricted scanner, and
+  // a spread it cannot follow makes the parity, emptiness and typography rules
+  // silently stop running — a gate that reports nothing looks identical to a gate
+  // that finds nothing. One locale, one file, every value visible.
+  wireRoleOwnerInline: 'propriétaire',
+  wireRoleMemberInline: 'membre',
+  wireRoleAgentInline: 'agent',
+
+  panelRoleOwner: 'Propriétaire',
+  panelRoleAgent: 'Agent',
+  panelRoleMember: 'Membre',
+
+  memberStatusMember: 'Membre',
+  wireStatusInvited: 'Invité',
+  wireStatusLeft: 'Parti',
+  wireStatusRemoved: 'Exclu',
+  memberStatusUnknown: 'Inconnu',
+
+  // Tier 2 (docs/glossary-fr.md): the daemon's own word, never translated.
+  wirePathDirect: 'direct',
+  wirePathRelay: 'relay',
+
+  wireModeLoopback: 'loopback',
+  wireModeReal: 'réel',
+
+  wireConnConnectedInline: 'connecté',
+  wireConnConnectingInline: 'en cours de connexion',
+  wireConnReconnectingInline: 'en cours de reconnexion',
+  wireConnDisconnectedInline: 'déconnecté',
+
+  errPeerUnreachableTitle: 'Impossible de joindre l’invitant',
+  errPeerUnreachableMessage:
+    'L’invitation est lisible, mais cet appareil n’a pas pu joindre l’administrateur du salon à temps.',
+  errPeerUnreachableAction:
+    'Demandez à l’invitant de garder le salon ouvert, puis réessayez. Une nouvelle invitation combinée peut aider si l’adresse a changé.',
+
+  errBadTicketTitle: 'Cette invitation ne peut pas être utilisée',
+  errBadTicketMessage:
+    'Le ticket est invalide pour cette identité, mal formé, ou ne correspond plus à l’invitation du salon.',
+  errBadTicketAction: 'Demandez une nouvelle invitation générée pour votre identifiant d’identité actuel.',
+
+  errTicketExpiredTitle: 'Cette invitation a expiré',
+  errTicketExpiredMessage: 'Le salon a rejeté le ticket parce que sa date d’expiration est dépassée.',
+  errTicketExpiredAction: 'Demandez à l’invitant de générer un nouveau ticket.',
+
+  errRoomNotOpenTitle: 'Ouvrez d’abord le salon',
+  errRoomNotOpenMessage: 'Cette action nécessite une session de salon active sur votre daemon.',
+  errRoomNotOpenAction: 'Ouvrez le salon, attendez la fin de la synchronisation, puis réessayez.',
+
+  errNotAMemberTitle: 'Vous n’êtes pas membre actif',
+  errNotAMemberMessage:
+    'L’historique signé du salon n’admet pas actuellement cette identité comme membre actif.',
+  errNotAMemberAction:
+    'Utilisez une invitation valide pour cette identité, ou demandez au propriétaire du salon de vous ajouter à nouveau.',
+
+  errRoomUnknownTitle: 'Ce salon n’est pas encore sur cet appareil',
+  errRoomUnknownMessage: 'Le daemon ne dispose pas de suffisamment d’historique pour ouvrir ce salon.',
+  errRoomUnknownAction:
+    'Rejoignez le salon avec une invitation, ou ouvrez-le avec un indice de pair joignable.',
+
+  errFileUnauthorizedTitle: 'Accès non autorisé à ce fichier',
+  errFileUnauthorizedMessage:
+    'Tous les fournisseurs joignables ont refusé le transfert, car l’historique signé n’admet pas cette identité pour ce fichier.',
+  errFileUnauthorizedAction:
+    'Demandez à l’expéditeur de partager à nouveau le fichier ou de vous réinviter, puis réessayez.',
+
+  errHashMismatchTitle: 'Échec du contrôle de sécurité',
+  errHashMismatchMessage:
+    'Les octets récupérés ne correspondent pas à l’empreinte du fichier. C’est un arrêt définitif — la copie est supprimée, jamais affichée.',
+  errHashMismatchAction:
+    'Demandez à l’expéditeur de partager à nouveau le fichier. Ne réessayez pas avec la même copie.',
+
+  errConnectionLostTitle: 'Connexion au daemon perdue',
+  errConnectionLostMessage: 'L’interface locale n’est pas connectée à jeliyad pour le moment.',
+  errConnectionLostAction: 'Attendez la reconnexion, puis réessayez l’action.',
+
+  errInvalidParamsTitle: 'Cette requête n’était pas valide',
+  errInvalidParamsMessage: 'Le daemon a rejeté l’une des valeurs de cette requête.',
+  errInvalidParamsAction: 'Vérifiez ce que vous avez saisi, puis réessayez.',
+
+  errIdentityMissingTitle: 'Pas encore d’identité sur ce daemon',
+  errIdentityMissingMessage: 'Cette action nécessite votre identité, et aucune n’a encore été créée ici.',
+  errIdentityMissingAction: 'Créez d’abord votre identité, puis réessayez.',
+
+  errIdentityExistsTitle: 'Une identité existe déjà',
+  errIdentityExistsMessage: 'Ce daemon détient déjà une identité — il est impossible d’en créer une seconde.',
+  errIdentityExistsAction: 'Utilisez l’identité existante affichée dans Réglages.',
+
+  errFileUnavailableTitle: 'Fichier indisponible pour le moment',
+  errFileUnavailableMessage: 'Aucun fournisseur n’est encore en ligne pour ce fichier.',
+  errFileUnavailableAction: 'Revérifiez quand l’expéditeur sera de nouveau en ligne.',
+
+  errFileTooLargeTitle: 'Ce fichier est trop volumineux pour être partagé',
+  errFileTooLargeMessage: 'Les partages sont limités à 100 MiB par fichier.',
+  errFileTooLargeAction: 'Choisissez un fichier plus petit, ou divisez le contenu.',
+
+  errFileUnreadableTitle: 'Ce fichier n’a pas pu être lu',
+  errFileUnreadableMessage: 'Le fichier choisi n’a pas pu être ouvert depuis le disque.',
+  errFileUnreadableAction: 'Vérifiez que le fichier existe toujours et qu’il est lisible, puis réessayez.',
+
+  errPipeDeniedTitle: 'Accès au pipe refusé',
+  errPipeDeniedMessage: 'Ce pipe n’autorise pas votre identité.',
+  errPipeDeniedAction: 'Demandez au propriétaire du pipe de l’exposer à votre identité.',
+
+  errInternalTitle: 'Le daemon a rencontré une défaillance inattendue',
+  errInternalMessage: 'Cette requête a échoué pour une raison que le daemon n’a pas pu classer.',
+  // U+202F before the semicolon (decision 7).
+  errInternalAction:
+    'Réessayez ; si l’échec persiste, copiez les diagnostics depuis Réglages et signalez le problème.',
+
+  errUnknownTitle: 'Une erreur s’est produite',
+  errUnknownMessage:
+    'Le daemon a signalé une erreur pour laquelle cette application n’a pas de message spécifique.',
+  // U+202F inside the guillemets (decision 7) — « Détails techniques » must
+  // match the disclosure's own label.
+  errUnknownAction:
+    'Ouvrez « Détails techniques » pour voir l’erreur exacte, puis réessayez.',
+
+  localeTag: 'fr',
+
+  // -- common ------------------------------------------------------------------
+  commonRetry: 'Réessayer',
+  commonCancel: 'Annuler',
+  commonClose: 'Fermer',
+  commonClear: 'Effacer',
+  commonSave: 'Enregistrer',
+  commonBack: 'Retour',
+  commonCopy: 'Copier',
+  commonCopied: 'Copié ✓',
+  commonReconnecting: 'Reconnexion…',
+  commonUnknown: 'Inconnu',
+  commonOptional: '(facultative)',
+
+  // -- boot --------------------------------------------------------------------
+  bootSyncing: 'Synchronisation…',
+  bootNotConnected: 'Non connecté.',
+  bootContacting: 'Connexion au daemon…',
+  bootRetryingHint: 'Nouvelles tentatives avec délai progressif — lancez {daemon} ou passez {port}.',
+
+  // -- shell / connection ------------------------------------------------------
+  shellConnectionLost: (transport) => `Connexion au daemon perdue — reconnexion… (${transport})`,
+  shellDisconnected: 'Déconnecté du daemon.',
+  shellSkipToMain: 'Aller au contenu principal',
+  shellSkipToComposer: 'Aller au champ de message',
+  shellConnConnected: 'Connecté',
+  shellConnConnecting: 'Connexion…',
+  shellConnReconnecting: 'Reconnexion…',
+  shellConnDisconnected: 'Déconnecté',
+  shellNavPrimary: 'Principal',
+  shellNavPrimaryMobile: 'Principal (mobile)',
+
+  // -- global destinations -----------------------------------------------------
+  destRooms: 'Salons',
+  destFleet: 'Flotte d’agents',
+  destSettings: 'Réglages',
+
+  // -- room destinations -------------------------------------------------------
+  roomDestActivity: 'Activité',
+  roomDestPeople: 'Personnes',
+  roomDestAgents: 'Agents et exécutions',
+  roomDestFiles: 'Fichiers',
+  roomDestPipes: 'Pipes',
+
+  // -- rooms list --------------------------------------------------------------
+  roomsYourRooms: 'Vos salons',
+  roomsChoose: 'Choisissez un salon.',
+  roomsCreate: 'Créer un salon',
+  roomsJoinWithTicket: 'Rejoindre avec un ticket',
+  roomsSearchPlaceholder: 'Rechercher des salons…',
+  roomsSearchLabel: 'Rechercher des salons par nom ou identifiant court',
+  roomsFilterLegend: 'Filtrer les salons par cycle de vie',
+  roomsFilterAll: 'Tous',
+  roomsFilterActive: 'Actifs',
+  roomsFilterDeparted: 'Quittés et retirés',
+  roomsSectionPinned: 'Épinglés',
+  roomsSectionArchived: 'Archivés',
+  roomsSectionCount: (n) => `(${n})`,
+  roomsEmpty: 'Aucun salon pour l’instant',
+  // Guillemets with their inner narrow no-break spaces (decision 7). The Flutter
+  // catalog's `sidebarNoRoomsMatch` is missing them; this follows the contract.
+  roomsNoMatch: (query) => `Aucun salon ne correspond à «\u202f${query}\u202f».`,
+  roomsNoneInFilter: 'Aucun salon dans ce filtre.',
+  roomsUnread: 'Non lu',
+  // French treats 0 as singular, unlike English: « 0 membre », « 1 membre »,
+  // « 2 membres ». Pinned the same way the Flutter `strings_fr_test` pins it.
+  roomsMemberCount: (n) => (n < 2 ? `${n} membre` : `${n} membres`),
+  roomsUntitled: 'Salon sans titre',
+  roomsStateOpen: 'Ouvert',
+  roomsStateClosed: 'Fermé',
+  roomsStateLeft: 'Quitté',
+  roomsStateRemoved: 'Retiré',
+  roomsSessionOpen: 'Session ouverte',
+  roomsYouLeft: 'Vous avez quitté ce salon',
+  roomsYouWereRemoved: 'Vous avez été retiré de ce salon',
+  roomsPin: (room) => `Épingler ${room}`,
+  roomsUnpin: (room) => `Désépingler ${room}`,
+  roomsArchive: (room) => `Archiver ${room}`,
+  roomsRestore: (room) => `Restaurer ${room}`,
+  roomsPinShort: 'Épingler',
+  roomsUnpinShort: 'Désépingler',
+  roomsArchiveShort: 'Archiver',
+  roomsRestoreShort: 'Restaurer depuis l’archive',
+  roomsRailLabel: 'Barre latérale des salons',
+  roomsListLabel: 'Salons',
+  roomsProfile: 'Profil et réglages',
+
+  // -- room recovery surfaces --------------------------------------------------
+  roomNotOnDevice: 'Ce salon n’est pas sur cet appareil',
+  roomNotOnDeviceDetail:
+    'Rien ici ne correspond à {id}. Il se trouve peut-être sur un autre appareil, ou vous ne l’avez pas ' +
+    'encore rejoint.',
+  roomBackToRooms: 'Retour aux salons',
+  roomLeftDetail:
+    'Votre départ est publié dans le journal signé du salon. Il vous faudra une nouvelle invitation pour le ' +
+    'rejoindre.',
+  roomRemovedDetail:
+    'Votre retrait est publié dans le journal signé du salon. Il vous faudra une nouvelle invitation pour le ' +
+    'rejoindre.',
+
+  // -- identity ----------------------------------------------------------------
+  identitySelf: 'Vous',
+  identityP2P: 'Identité P2P',
+  identityCopy: 'Copier l’identifiant d’identité',
+  // Tier 2: `ep` and `endpoint` are the daemon's own words for a wire id.
+  identityEndpointShort: (id) => `ep ${id}`,
+  identityEndpointTitle: (id) => `endpoint ${id}`,
+
+  // -- modals ------------------------------------------------------------------
+  modalJoinCopy:
+    'Collez l’invitation que vous avez reçue. Une invitation combinée ({combined}) renseigne automatiquement ' +
+    'l’adresse du pair.',
+  modalTicketLabel: 'Ticket',
+  modalPeerAddrLabel: 'Adresse du pair',
+  modalJoinSubmit: 'Rejoindre le salon',
+  modalJoining: 'Connexion…',
+  modalJoinAttempt: (attempt, max) => `Tentative ${attempt}/${max}`,
+  modalCreateTitle: 'Créer un salon',
+  modalRoomNameLabel: 'Nom du salon',
+  modalCreating: 'Création…',
+  modalCreateHomonymWarning:
+    'Un salon portant ce nom existe déjà sur cet appareil — celui-ci aura son propre identifiant.',
+  modalLeaveTitle: 'Quitter le salon',
+  modalLeaveCopy:
+    'Quitter {room} {id} publie une annonce de départ signée. Ce n’est pas la même chose que fermer la ' +
+    'session locale\u202f; il vous faudra une nouvelle invitation pour rejoindre le salon à nouveau.',
+  modalLeaveSubmit: 'Quitter le salon',
+  modalLeaving: 'Départ…',
+  modalRenameTitle: 'Nommer ce pair',
+  modalRenameCopy: 'Alias local uniquement — les noms ne quittent jamais cette machine.',
+  modalRenameIdentityLabel: 'Identité\u00a0:',
+  modalRenameAliasLabel: 'Alias',
+  modalRenameClearAlias: 'Supprimer l’alias',
+
+  // -- formatting vocabulary ---------------------------------------------------
+  formatToday: 'Aujourd’hui',
+  formatYesterday: 'Hier',
+  // Octets, not bytes (decision 7). Unit WORDS follow the text locale; the
+  // number inside them already came from the formatting locale.
+  formatBytesB: (n) => `${n} o`,
+  formatBytesKb: (n) => `${n} Ko`,
+  formatBytesMb: (n) => `${n} Mo`,
+  formatBytesGb: (n) => `${n} Go`,
+  formatPercent: (n) => `${n}\u202f%`,
+  formatJustNow: 'à l’instant',
+};

--- a/ui/src/l10n/l10n.test.ts
+++ b/ui/src/l10n/l10n.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { en } from './en';
+import { fr } from './fr';
+import { Formats } from './formats';
+import { fillTemplate, templateParts } from './template';
+import { isSupported, SUPPORTED_LOCALES } from './locale';
+
+/** The catalog contract, asserted rather than assumed (issue #74).
+ *
+ *  `scripts/check-ui-i18n.mjs` is the CI gate over catalog CONTENT — parity,
+ *  emptiness, French left in English, typography. These are the behaviours the
+ *  gate cannot see: that formatting actually varies by locale, that the slot
+ *  mechanism fails visibly rather than silently, and that the vocabulary the
+ *  two clients share stays shared.
+ */
+
+const catalogs = { en, fr };
+
+describe('catalog parity', () => {
+  it('declares the same keys in every locale', () => {
+    const enKeys = Object.keys(en).sort();
+    for (const [tag, catalog] of Object.entries(catalogs)) {
+      expect(Object.keys(catalog).sort(), `${tag} has a different key set from en`).toEqual(enKeys);
+    }
+  });
+
+  it('tags each catalog with its own locale', () => {
+    for (const [tag, catalog] of Object.entries(catalogs)) {
+      expect(catalog.localeTag).toBe(tag);
+    }
+  });
+
+  it('covers every supported locale', () => {
+    for (const tag of SUPPORTED_LOCALES) {
+      expect(isSupported(tag)).toBe(true);
+      expect(catalogs[tag], `no catalog for the supported locale ${tag}`).toBeDefined();
+    }
+  });
+});
+
+describe('the French typography contract', () => {
+  // docs/glossary-fr.md decision 7. These are invisible in review, which is
+  // exactly why they are asserted.
+  const values = Object.entries(fr).filter(([, v]) => typeof v === 'string') as [string, string][];
+
+  it('never puts a plain space before a high punctuation mark', () => {
+    for (const [key, value] of values) {
+      expect(value, `fr.${key} uses a breaking space before ; ! or ?`).not.toMatch(/ [;!?]/);
+      expect(value, `fr.${key} uses a breaking space before :`).not.toMatch(/ :/);
+    }
+  });
+
+  it('uses the typographic apostrophe, never the ASCII one', () => {
+    for (const [key, value] of values) {
+      expect(value, `fr.${key} uses a straight apostrophe`).not.toMatch(/\w'\w/);
+    }
+  });
+});
+
+describe('the vocabulary both clients share', () => {
+  it('keeps the retired status words retired', () => {
+    // docs/room-workbench.md decision 4 retired these as STATE labels. The
+    // lifecycle filter chip legitimately reads "Active", so this checks the
+    // state keys specifically rather than banning the word outright.
+    const stateKeys = Object.keys(en).filter((k) => k.startsWith('roomsState'));
+    expect(stateKeys.length).toBeGreaterThan(0);
+    for (const key of stateKeys) {
+      expect((en as Record<string, unknown>)[key]).not.toBe('Active');
+    }
+  });
+
+  it('never translates a wire path badge', () => {
+    // Tier 2: the badge shows the daemon's own word, in every language, or it
+    // is claiming a network fact the daemon did not report.
+    expect(fr.wirePathDirect).toBe(en.wirePathDirect);
+    expect(fr.wirePathRelay).toBe(en.wirePathRelay);
+  });
+});
+
+describe('Formats', () => {
+  it('formats byte units with the text locale s words', () => {
+    // The accepted deviation carried over from Flutter: unit WORDS follow the
+    // text locale (they are vocabulary), numeric conventions follow the
+    // formatting locale.
+    expect(new Formats(en, 'en').bytes(2048)).toMatch(/KB/);
+    expect(new Formats(fr, 'fr').bytes(2048)).toMatch(/Ko/);
+  });
+
+  it('separates the text locale from the formatting locale', () => {
+    // The whole point of two preferences: French words, German numbers.
+    const mixed = new Formats(fr, 'de-DE');
+    expect(mixed.bytes(1024 * 1024 * 3.5)).toContain('Mo'); // vocabulary: French
+    expect(mixed.bytes(1024 * 1024 * 3.5)).toContain(','); // convention: German decimal comma
+  });
+
+  it('never renders a negative age from a future timestamp', () => {
+    // Clock skew must read "just now", never "-2m ago".
+    const f = new Formats(en, 'en');
+    expect(f.relTime(Date.now() + 60_000)).toBe(en.formatJustNow);
+  });
+
+  it('refuses to invent a size for a non-size', () => {
+    const f = new Formats(en, 'en');
+    expect(f.bytes(-1)).toBe('?');
+    expect(f.bytes(Number.NaN)).toBe('?');
+  });
+});
+
+describe('Template', () => {
+  it('splits a sentence into literals and slots', () => {
+    expect(templateParts('Leaving {room} {id} publishes a departure.')).toEqual([
+      { text: 'Leaving ' },
+      { slot: 'room' },
+      { text: ' ' },
+      { slot: 'id' },
+      { text: ' publishes a departure.' },
+    ]);
+  });
+
+  it('renders an unknown slot literally rather than dropping it', () => {
+    // A silently dropped slot is a sentence that reads fine and says the wrong
+    // thing. A visible {marker} is a bug report from the screen.
+    expect(fillTemplate('a {missing} b', {})).toBe('a {missing} b');
+  });
+
+  it('lets a translator reorder slots', () => {
+    // The property that makes this mechanism worth having.
+    const slots = { one: 'X', two: 'Y' };
+    expect(fillTemplate('{one} then {two}', slots)).toBe('X then Y');
+    expect(fillTemplate('{two} avant {one}', slots)).toBe('Y avant X');
+  });
+});

--- a/ui/src/l10n/locale.ts
+++ b/ui/src/l10n/locale.ts
@@ -1,0 +1,105 @@
+/** Locale selection and persistence (issue #74).
+ *
+ *  TWO preferences, not one (`docs/glossary-fr.md`, decision 4): the TEXT
+ *  locale chooses the interface language, the FORMATTING locale chooses date,
+ *  number and calendar conventions. Either may be unset, and unset means
+ *  "follow the platform" — a documented fallback rather than a silent default
+ *  to English.
+ *
+ *  Storage follows the pattern already used by `lib/names.ts`,
+ *  `lib/roomFlags.ts` and `lib/lastSeen.ts`: a `jeliya.*` key, read and written
+ *  through try/catch because storage can be unavailable (private browsing, a
+ *  disabled cookie policy) and a preference is never worth an exception.
+ */
+
+import { resolveFormattingLocale } from './formats';
+
+const TEXT_KEY = 'jeliya.textLocale';
+const FORMATTING_KEY = 'jeliya.formattingLocale';
+
+/** The locales with a complete catalog. A tag outside this set falls back;
+ *  shipping a half-translated interface is worse than shipping one language. */
+export const SUPPORTED_LOCALES = ['en', 'fr'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+export const FALLBACK_LOCALE: SupportedLocale = 'en';
+
+export function isSupported(tag: string | null | undefined): tag is SupportedLocale {
+  return tag != null && (SUPPORTED_LOCALES as readonly string[]).includes(tag);
+}
+
+/** The platform's preferred language, narrowed to one we have a catalog for.
+ *
+ *  Matches on the PRIMARY subtag, so `fr-CA` and `fr-BE` both resolve to the
+ *  French catalog — a Canadian French speaker should not silently get English
+ *  because the region differs. */
+export function platformLocale(): SupportedLocale {
+  const candidates = typeof navigator === 'undefined' ? [] : (navigator.languages ?? [navigator.language]);
+  for (const tag of candidates) {
+    if (!tag) continue;
+    const primary = tag.split('-')[0].toLowerCase();
+    if (isSupported(primary)) return primary;
+  }
+  return FALLBACK_LOCALE;
+}
+
+function read(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: string | null): void {
+  try {
+    if (value === null) localStorage.removeItem(key);
+    else localStorage.setItem(key, value);
+  } catch {
+    /* a preference is never worth throwing over */
+  }
+}
+
+/** The stored TEXT-locale preference, or null for "follow the platform". */
+export function loadTextLocale(): SupportedLocale | null {
+  const stored = read(TEXT_KEY);
+  return isSupported(stored) ? stored : null;
+}
+
+export function saveTextLocale(tag: SupportedLocale | null): void {
+  write(TEXT_KEY, tag);
+}
+
+/** The stored FORMATTING-locale preference, or null for "follow the text
+ *  locale". Any BCP 47 tag is allowed here — unlike the text locale it needs no
+ *  catalog, only `Intl` support, so a user may read English while formatting
+ *  under `de-CH`. */
+export function loadFormattingLocale(): string | null {
+  return read(FORMATTING_KEY);
+}
+
+export function saveFormattingLocale(tag: string | null): void {
+  write(FORMATTING_KEY, tag);
+}
+
+export interface ResolvedLocales {
+  /** The catalog to render copy from. */
+  text: SupportedLocale;
+  /** The tag `Intl` formats under. */
+  formatting: string;
+  /** True when the text locale came from the platform rather than a choice —
+   *  the Settings picker shows this as "follow system" rather than pretending
+   *  the user picked it. */
+  textFollowsSystem: boolean;
+}
+
+/** Resolve both locales from storage plus the platform. */
+export function resolveLocales(): ResolvedLocales {
+  const storedText = loadTextLocale();
+  const text = storedText ?? platformLocale();
+  return {
+    text,
+    formatting: resolveFormattingLocale(loadFormattingLocale(), text),
+    textFollowsSystem: storedText === null,
+  };
+}

--- a/ui/src/l10n/strings.tsx
+++ b/ui/src/l10n/strings.tsx
@@ -1,0 +1,121 @@
+/** Render-time copy resolution (issue #74; `docs/i18n.md` rule 1).
+ *
+ *  Copy is resolved AT RENDER TIME through `useStrings()`, never captured into
+ *  component state. That is what makes a language switch apply live: every
+ *  consumer re-reads on the next render, so there is no restart and no stale
+ *  half-translated screen. Flutter's `context.strings` is the same contract.
+ *
+ *  `useFormats()` is its companion for anything numeric or temporal, under the
+ *  separately-chosen formatting locale.
+ */
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Catalog } from './catalog';
+import { Formats, resolveFormattingLocale } from './formats';
+import {
+  FALLBACK_LOCALE,
+  loadFormattingLocale,
+  loadTextLocale,
+  resolveLocales,
+  saveFormattingLocale,
+  saveTextLocale,
+} from './locale';
+import type { SupportedLocale } from './locale';
+import { en } from './en';
+import { fr } from './fr';
+
+const CATALOGS: Record<SupportedLocale, Catalog> = { en, fr };
+
+export interface L10n {
+  /** The catalog for the current TEXT locale. */
+  strings: Catalog;
+  /** Formatting under the current FORMATTING locale. */
+  formats: Formats;
+  /** The chosen text locale, or null when following the platform. */
+  textLocale: SupportedLocale | null;
+  /** The chosen formatting locale, or null when following the text locale. */
+  formattingLocale: string | null;
+  /** The tags actually in effect, after fallback. */
+  resolved: { text: SupportedLocale; formatting: string };
+  setTextLocale(tag: SupportedLocale | null): void;
+  setFormattingLocale(tag: string | null): void;
+}
+
+const L10nContext = createContext<L10n | null>(null);
+
+export function L10nProvider({ children }: { children: ReactNode }) {
+  const [textLocale, setTextState] = useState<SupportedLocale | null>(loadTextLocale);
+  const [formattingLocale, setFormattingState] = useState<string | null>(loadFormattingLocale);
+
+  const value = useMemo<L10n>(() => {
+    const platform = resolveLocales();
+    const text = textLocale ?? platform.text;
+    const formatting = resolveFormattingLocale(formattingLocale, text);
+    const strings = CATALOGS[text] ?? CATALOGS[FALLBACK_LOCALE];
+    return {
+      strings,
+      formats: new Formats(strings, formatting),
+      textLocale,
+      formattingLocale,
+      resolved: { text, formatting },
+      setTextLocale: (tag) => {
+        saveTextLocale(tag);
+        setTextState(tag);
+      },
+      setFormattingLocale: (tag) => {
+        saveFormattingLocale(tag);
+        setFormattingState(tag);
+      },
+    };
+  }, [textLocale, formattingLocale]);
+
+  // Keep the document in step with the interface. `lang` drives the screen
+  // reader's pronunciation and the browser's own hyphenation — a French
+  // interface announced by an English voice is the failure this prevents.
+  useEffect(() => {
+    document.documentElement.lang = value.resolved.text;
+  }, [value.resolved.text]);
+
+  return <L10nContext.Provider value={value}>{children}</L10nContext.Provider>;
+}
+
+function useL10n(): L10n {
+  const ctx = useContext(L10nContext);
+  if (ctx === null) {
+    // A missing provider is a wiring bug, and silently falling back to English
+    // would hide it until someone switched language in production.
+    throw new Error('useStrings/useFormats used outside <L10nProvider>');
+  }
+  return ctx;
+}
+
+/** The catalog for the current text locale. Call it in render, never store it. */
+export function useStrings(): Catalog {
+  return useL10n().strings;
+}
+
+/** Formatting under the current formatting locale. */
+export function useFormats(): Formats {
+  return useL10n().formats;
+}
+
+/** Locale selection, for the Settings language card. */
+export function useLocaleSettings(): L10n {
+  return useL10n();
+}
+
+/** Test/root helper: build an L10n value without React state. */
+export function makeL10n(text: SupportedLocale, formatting?: string): Omit<L10n, 'setTextLocale' | 'setFormattingLocale'> {
+  const strings = CATALOGS[text];
+  const tag = resolveFormattingLocale(formatting ?? null, text);
+  return {
+    strings,
+    formats: new Formats(strings, tag),
+    textLocale: text,
+    formattingLocale: formatting ?? null,
+    resolved: { text, formatting: tag },
+  };
+}
+
+export { CATALOGS };

--- a/ui/src/l10n/template.tsx
+++ b/ui/src/l10n/template.tsx
@@ -1,0 +1,72 @@
+/** Sentences with styled or interactive segments (`docs/i18n.md` rule 2).
+ *
+ *  A sentence must never be assembled from fragments in a component tree. This
+ *  is not a style preference — it is the difference between a translatable
+ *  string and an untranslatable one. JSX like
+ *
+ *      <p>Leaving <strong>{room}</strong> <code>{id}</code> publishes a signed
+ *         departure.</p>
+ *
+ *  hands a translator three disconnected pieces and fixes English word order
+ *  permanently. French needs the slots in a different place, and no amount of
+ *  translating the fragments can move them.
+ *
+ *  So the whole sentence is ONE catalog message carrying `{slot}` markers, and
+ *  the call site supplies what each marker renders as:
+ *
+ *      <Template template={s.roomLeaveWarning} slots={{
+ *        room: <strong>{name}</strong>,
+ *        id: <code className="mono">{shortId(roomId)}</code>,
+ *      }} />
+ *
+ *  The translator moves `{room}` and `{id}` wherever the sentence needs them.
+ *  Flutter does exactly this in `widgets/template_text.dart`.
+ */
+
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+
+const MARKER = /\{(\w+)\}/g;
+
+/** Split a template into literal text and slot names. Exported for the plain
+ *  string case and for tests. */
+export function templateParts(template: string): ({ text: string } | { slot: string })[] {
+  const parts: ({ text: string } | { slot: string })[] = [];
+  let last = 0;
+  for (const match of template.matchAll(MARKER)) {
+    if (match.index > last) parts.push({ text: template.slice(last, match.index) });
+    parts.push({ slot: match[1] });
+    last = match.index + match[0].length;
+  }
+  if (last < template.length) parts.push({ text: template.slice(last) });
+  return parts;
+}
+
+export function Template({
+  template,
+  slots,
+}: {
+  template: string;
+  slots: Record<string, ReactNode>;
+}) {
+  return (
+    <>
+      {templateParts(template).map((part, i) => {
+        if ('text' in part) return <Fragment key={i}>{part.text}</Fragment>;
+        // An unknown marker renders LITERALLY rather than disappearing. A
+        // silently dropped slot is a sentence that reads fine and says the
+        // wrong thing — a visible `{room}` is a bug report from the screen.
+        const value = part.slot in slots ? slots[part.slot] : `{${part.slot}}`;
+        return <Fragment key={i}>{value}</Fragment>;
+      })}
+    </>
+  );
+}
+
+/** The plain-string variant, for an `aria-label` or a `title` where a
+ *  ReactNode cannot go. */
+export function fillTemplate(template: string, slots: Record<string, string>): string {
+  return templateParts(template)
+    .map((part) => ('text' in part ? part.text : (slots[part.slot] ?? `{${part.slot}}`)))
+    .join('');
+}

--- a/ui/src/l10n/tokens.ts
+++ b/ui/src/l10n/tokens.ts
@@ -1,0 +1,90 @@
+/** Strings that are NOT copy, and must never reach a translator.
+ *
+ *  The Flutter client keeps these in `l10n/tokens.dart` for the same reason
+ *  (`docs/i18n.md`, rule 1): a naive extractor sweeps glyphs, shell commands
+ *  and wire-format examples into the catalog, where a translator is then asked
+ *  to localize `jeliyad` or `▦`. Worse, `docs/glossary-fr.md` Tier 2 makes some
+ *  of these a correctness matter — a connection path badge must render exactly
+ *  what the daemon reported, so "translating" `direct` would be a lie about the
+ *  network.
+ *
+ *  Everything here is deliberately outside `Catalog`.
+ */
+
+/** Decorative glyphs. Every one of these is `aria-hidden` at its call site —
+ *  they carry no information the adjacent label does not already give. */
+export const Glyph = {
+  rooms: '▦',
+  fleet: '✦',
+  settings: '⚙',
+  hex: '⬡',
+  copy: '⧉',
+  send: '➤',
+  close: '✕',
+  chevronDown: '⌄',
+  disclosureOpen: '▾',
+  disclosureClosed: '▸',
+  back: '‹',
+  more: '⋮',
+  pinOn: '★',
+  pinOff: '☆',
+  archive: '⇩',
+  restore: '⇧',
+  create: '⊕',
+  join: '⇥',
+  add: '＋',
+  externalLink: '↗',
+  share: '↗',
+  verified: '✓',
+  failed: '✕',
+} as const;
+
+/** Punctuation and layout separators. Not sentences — a list of independent
+ *  facts may be joined with these, but a SENTENCE may not (rule 2). */
+export const Punct = {
+  /** The decorative separator between independent facts on a meta line. */
+  metaSep: ' · ',
+  emDash: '—',
+  /** Shown where a value is genuinely absent, never as a zero. */
+  missingValue: '—',
+  /** Count cap on a tab badge. */
+  countCap: '99+',
+} as const;
+
+/** The brand. Never translated, never re-derived — DESIGN.md makes the wordmark
+ *  a single source of truth. */
+export const BRAND = 'Jeliya';
+
+/** Language endonyms for the picker. A language is named in ITSELF, so these
+ *  are the one set of language names that must never be translated — and a
+ *  picker showing a bare ISO code is a bug the locale test catches. */
+export const LANGUAGE_NAMES: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+};
+
+/** Wire-format examples used as input placeholders. These show the user the
+ *  SHAPE of a machine value; translating them would teach the wrong shape. */
+export const Example = {
+  ticket: 'roomtkt1… or roomtkt1…#<endpoint_id>@host:port',
+  peerAddress: '<endpoint_id>@203.0.113.7:4242',
+  pipeTarget: '127.0.0.1:3000',
+  expirySeconds: '3600',
+  identityId: '64-hex identity id',
+  roomName: 'Build Iroh Rooms MVP',
+  alias: 'e.g. Maya R.',
+  selfLabel: 'e.g. Alex',
+} as const;
+
+/** Shell commands and paths. Copy-pasteable machine input — a translated
+ *  command does not run. */
+export const Command = {
+  daemon: 'jeliyad',
+  daemonPortParam: '?daemon=<port>',
+  npmInstall: 'npm install',
+  daemonPath: 'JELIYAD="$(command -v jeliyad)"',
+  agentGuide: 'docs/agent-guide.md',
+} as const;
+
+/** The issue tracker. A URL is not copy. */
+export const ISSUE_URL = 'https://github.com/kortiene/jeliya/issues/new';

--- a/ui/src/l10n/wireDisplay.ts
+++ b/ui/src/l10n/wireDisplay.ts
@@ -1,0 +1,187 @@
+/** Display words for protocol wire enums (issue #74; `docs/i18n.md` rule 3).
+ *
+ *  PROTOCOL.md values in, UI copy out. This is the only place in the React
+ *  client that turns a role, a member status, a peer path, a daemon mode or a
+ *  connection state into a word on the screen, and it mirrors Flutter's
+ *  `app/lib/src/l10n/wire_display.dart` map for map so the two clients cannot
+ *  drift into different words for the same protocol value.
+ *
+ *  Why the seam exists at all
+ *  --------------------------
+ *  The wire says `active`; the screen says **Member**. The roster used to
+ *  title-case the wire value straight onto the screen, so one word ("Active")
+ *  meant three different things: signed membership here, a live local session
+ *  in the room rail, and a live forwarding session on a pipe chip. Display
+ *  labels and wire values are never the same constant — renaming a label must
+ *  rename no wire value, and translating one must not change what the daemon
+ *  is told (`docs/room-workbench.md`, decision 4).
+ *
+ *  Raw passthrough is the contract, not a gap
+ *  ------------------------------------------
+ *  Every map's default returns the value ITSELF. A daemon newer than this
+ *  client will send statuses and paths this build has never heard of; the
+ *  honest rendering of an unrecognized fact is the fact. Not "Unknown" (which
+ *  claims the daemon said nothing — `memberStatusUnknown` is reserved for the
+ *  genuinely-empty status), and not a crash. Forward compatibility here is a
+ *  one-line default, and it is the difference between a client that ages and a
+ *  client that breaks.
+ *
+ *  Peer path is a passthrough seam, not a translation
+ *  --------------------------------------------------
+ *  `direct` / `relay` are Tier 2 in `docs/glossary-fr.md`: never translated,
+ *  because the badge reports what the DAEMON observed about the network. The
+ *  French catalog therefore holds `direct` and `relay` verbatim. So why route
+ *  them through the catalog at all? Because the honesty rule is about the
+ *  VALUE, not the mechanism — a locale that does have an established local term
+ *  for a network relay may use it, while French deliberately does not, and only
+ *  a catalog entry lets a translator record that decision instead of a
+ *  hardcoded string silently deciding for every language at once. The rule this
+ *  file enforces is that the badge never shows a path the daemon did not
+ *  report; it is not "the badge is exempt from the catalog".
+ *
+ *  What this file must NOT be used for
+ *  -----------------------------------
+ *  `labelTone()` in `lib/format.ts` is an ENGLISH-TOKEN CONTRACT (docs/
+ *  PROTOCOL.md, `docs/glossary-fr.md` decision 3, mirrored in Dart): it derives
+ *  chip and dot tone from known English tokens in a free-form agent-status
+ *  label. It must keep receiving the RAW wire label. Translating before
+ *  `labelTone` would make every French label render neutral — or worse,
+ *  fabricate green for a word that happened to match. Green is earned. Feed
+ *  `labelTone` the wire value and this file's output to the eye, never the
+ *  reverse.
+ *
+ *  Resolved at render time: every function takes the catalog the caller already
+ *  got from `useStrings()`, so a language switch re-resolves on the next render
+ *  (rule 1). Nothing here is cached.
+ */
+
+import type { Catalog } from './catalog';
+
+/** The catalog subset these functions read. Typed as the fragment rather than
+ *  the whole `Catalog` so a caller can pass either, and so the dependency is
+ *  legible: this file needs nineteen keys, not the catalog. */
+type S = Catalog;
+
+/** Mid-sentence role word — "… joined as owner". Pills use {@link rolePill}.
+ *  Unknown roles pass through raw. */
+export function roleInline(s: S, role: string): string {
+  switch (role) {
+    case 'owner':
+      return s.wireRoleOwnerInline;
+    case 'agent':
+      return s.wireRoleAgentInline;
+    case 'member':
+      return s.wireRoleMemberInline;
+    default:
+      return role;
+  }
+}
+
+/** Capitalized role pill / roster label. Unknown roles pass through raw.
+ *
+ *  Replaces `displayRole()` in `components/RightPanel.tsx`, which returned
+ *  'Member' for anything that was not owner or agent — mislabeling a future
+ *  role as an ordinary member rather than showing what the daemon actually
+ *  said. */
+export function rolePill(s: S, role: string): string {
+  switch (role) {
+    case 'owner':
+      return s.panelRoleOwner;
+    case 'agent':
+      return s.panelRoleAgent;
+    case 'member':
+      return s.panelRoleMember;
+    default:
+      return role;
+  }
+}
+
+/** Member status pill / agent-card footer word — signed membership, and nothing
+ *  else.
+ *
+ *  The empty string is the one value that maps to "Unknown": a daemon that
+ *  reported NO status told us nothing, and saying so is honest. A status this
+ *  build does not recognize is different — the daemon did say something, so it
+ *  passes through raw.
+ *
+ *  Replaces `displayStatus()` in `components/RightPanel.tsx`, whose `default`
+ *  branch collapsed every unrecognized status into 'Unknown' and so erased a
+ *  fact the daemon had actually sent. */
+export function memberStatus(s: S, status: string): string {
+  switch (status) {
+    case 'active':
+      return s.memberStatusMember;
+    case 'invited':
+      return s.wireStatusInvited;
+    case 'left':
+      return s.wireStatusLeft;
+    case 'removed':
+      return s.wireStatusRemoved;
+    case '':
+      return s.memberStatusUnknown;
+    default:
+      return status;
+  }
+}
+
+/** Peer connection path — the room-header chip's state label.
+ *
+ *  Takes a non-null path on purpose. `PeerStatus.path` is nullable WHILE
+ *  `state` is already `connected`: the SDK knows the link is up before it knows
+ *  how it got there, and "not claimed yet" is a different fact from "direct" or
+ *  "relay" (`components/RoomHeader.tsx` records this). Resolve that absence at
+ *  the call site — this function will not invent a path for you.
+ *
+ *  Unknown paths pass through raw; see the file docstring for why that is the
+ *  honest behavior here specifically. */
+export function peerPath(s: S, path: string): string {
+  switch (path) {
+    case 'direct':
+      return s.wirePathDirect;
+    case 'relay':
+      return s.wirePathRelay;
+    default:
+      return path;
+  }
+}
+
+/** Daemon mode, for the Settings daemon summary. Unknown modes pass through
+ *  raw.
+ *
+ *  `components/SettingsPanel.tsx` renders `{status?.mode ?? '-'}` today — the
+ *  wire value straight onto the screen. */
+export function daemonMode(s: S, mode: string): string {
+  switch (mode) {
+    case 'loopback':
+      return s.wireModeLoopback;
+    case 'real':
+      return s.wireModeReal;
+    default:
+      return mode;
+  }
+}
+
+/** Client connection state, mid-sentence. Standalone capitalized badges (the
+ *  Sidebar's `CONN_LABEL`) use the shell area's `shellConn*` keys instead —
+ *  Flutter draws the same line, and a badge is not a clause.
+ *
+ *  `ConnectionState` is a closed union in `lib/protocol.ts`, so all four arms
+ *  are covered; the parameter is widened to `string` and the default passes
+ *  through anyway, because the value crosses a JSON boundary before it gets
+ *  here and a type is not a runtime guarantee.
+ *
+ *  `components/SettingsPanel.tsx` renders `{conn}` raw today. */
+export function connStateInline(s: S, state: string): string {
+  switch (state) {
+    case 'connected':
+      return s.wireConnConnectedInline;
+    case 'connecting':
+      return s.wireConnConnectingInline;
+    case 'reconnecting':
+      return s.wireConnReconnectingInline;
+    case 'disconnected':
+      return s.wireConnDisconnectedInline;
+    default:
+      return state;
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { createClient } from './lib/client';
+import { L10nProvider } from './l10n/strings';
 import './styles.css';
 
 // One client for the whole app lifetime (WebSocket or VITE_MOCK=1 fixtures).
@@ -12,4 +13,12 @@ const client = createClient();
 // attaching to a dev server that talks to a real daemon.
 document.documentElement.dataset.jeliyaTransport = client.describe();
 
-createRoot(document.getElementById('root')!).render(<App client={client} />);
+// The provider sits ABOVE the app so every consumer — including the dialogs
+// that render through portals — resolves copy from the same locale, and so a
+// language switch reaches all of them on the next render (docs/i18n.md, rule 1:
+// copy is resolved at render time, never captured into state).
+createRoot(document.getElementById('root')!).render(
+  <L10nProvider>
+    <App client={client} />
+  </L10nProvider>,
+);


### PR DESCRIPTION
Part of #74 — the first of the slices the issue's own delivery note asks for ("split infrastructure, catalog extraction, and parity verification into reviewable slices"). **Does not close the issue**; the remainder is enumerated at the bottom.

## What lands

The React client had **zero** localization: every user-visible string was a hardcoded English literal, `<html lang>` was static, and `scripts/i18n-gate.mjs` scanned only `app/` — nothing had ever checked `ui/`.

**No new dependency.** `ui/` ships react + react-dom, and `docs/room-workbench.md` records that adding one is a decision needing its own rationale — this repo hand-vendored a QR encoder in *both* clients to avoid a dependency. Nothing here needs a runtime: lookup is a property access, and every formatting concern the criteria name is already in the browser as `Intl`.

### The five seams, mirroring Flutter's

| Seam | Replaces |
|---|---|
| `catalog.ts` | **181 keys**, `<area><Key>` like the ARB. Both locales typed as `Catalog`, so a missing key is a *compile* error. |
| `tokens.ts` | Glyphs, shell commands, wire examples, the brand, language endonyms — never reaches a translator. |
| `formats.ts` | `lib/format.ts`, which hardcoded English words **and** called `toLocaleTimeString([], …)` with an empty locale list — so it formatted under the *browser's* locale while spelling its words in English. |
| `wireDisplay.ts` / `errorDisplay.ts` | Scattered maps and `lib/errors.ts`, which covered 10 of 17 daemon codes and returned the daemon's English as *primary* copy — which `glossary-fr` decision 1 forbids. |
| `template.tsx` | JSX sentence-concatenation. A sentence with styled segments is now ONE message a translator can reorder. |

### Text locale and formatting locale are separate

Two persisted preferences, per `glossary-fr` decision 4 — settled before the first string was written. Someone may read French while expecting German number conventions. A test pins exactly that: French unit words (`Mo`), German decimal comma. Unset means follow the platform, a *documented* fallback rather than a silent default to English.

## The gate

`scripts/check-ui-i18n.mjs` checks key parity, empty values, French left byte-identical to English (with a **stale-checked** allowlist — a dead exemption is reported too), and the typography contract: U+202F before `; ! ?`, U+00A0 before `:`, U+2019, guillemets. That last rule is the one most likely to rot, because every violation of it is invisible in review.

**Rule 5 (literals outside the catalog) ships staged, not enabled.** 291 findings across the eight unmigrated surfaces, and a gate that fails on known findings the day it lands teaches everyone to ignore it. Rules 1–4 run and block. `npm run i18n:report` prints the remaining count per file so the number stays visible, and the companion test keeps exercising rule 5's logic so it cannot rot while switched off. Turn it on in the PR that migrates the last component.

```
$ npm run i18n:report
check-ui-i18n --report: 291 literal(s) still outside the catalog
    47  ui/src/components/RightPanel.tsx
    41  ui/src/components/FleetDashboard.tsx
    37  ui/src/components/InviteModal.tsx
    36  ui/src/App.tsx
    ...
```

## Things found on the way

- **Two Flutter bugs, deliberately not copied.** `sidebarNoRoomsMatch` renders guillemets without inner narrow no-break spaces, and `commonPercent` uses a plain space before `%`. Both violate `glossary-fr` decision 7. The React equivalents are correct and the divergence is recorded in `fr.ts` — worth a follow-up on the Flutter side.
- **`Sidebar` built a sentence from a ternary fragment**: `You ${status === 'left' ? 'left' : 'were removed from'} this room`. French cannot express that — different agreement and word order per branch. It is two keys now.
- **90 of the 107 shell keys reuse Flutter's exact English *and* French**, rather than being re-translated, so the two clients cannot ship different words for the same thing.

## What is NOT done

Timeline, RightPanel, FleetDashboard, InviteModal, Onboarding, SettingsPanel, RoomHeader and Composer still read literals.

The e2e harness *is* prepared — destinations are keys resolved through the `en` catalog, with the English label kept as a deprecated alias so the ~20 existing specs compile untouched — but the **101 label call sites across 16 specs** are not migrated, and the bilingual browser matrix the criteria ask for depends on that. One of those sites is non-mechanical: `a11y.spec.ts` reuses a destination label in both a test title and a URL path, so it needs a key→route mapping.

## Verification

- `npx tsc --noEmit` and `-p e2e` — clean
- `npm run test:unit` — **207** (14 new l10n contract tests, including the mixed French-words/German-numbers case)
- `npm run test:e2e` — **478** across 1440×900, 920×800, 390×844, 320×568
- `check-docs`, `check-design-tokens`, `i18n-gate`, `check-ui-i18n` — all OK
- `node --test scripts/check-ui-i18n.test.mjs` — 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)