### PR TITLE
fix(core): confine file.fetch's destination to the downloads tree (#122)

### DIFF
--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -281,6 +281,73 @@ impl RoomSupervisor {
         .map_err(|e| internal("could not open the event store", e))
     }
 
+    /// Confine `file.fetch`'s destination to the downloads tree and resolve it.
+    ///
+    /// `assert_shareable_path` confines the read direction; this confines the
+    /// write direction, which was previously unconfined. `file.fetch` writes
+    /// attacker-influenced bytes — any blob a room peer shared — under a
+    /// mostly attacker-influenced name, so an arbitrary destination is an
+    /// arbitrary-file-write primitive: `~/.config/autostart/x.desktop` or
+    /// `~/Library/LaunchAgents/` turn it into local code execution as the user,
+    /// in the one process that holds the identity keys. Confining to the
+    /// downloads tree also keeps a caller from writing beside the identity and
+    /// secret files at the data-dir root.
+    ///
+    /// The destination need not exist yet, so the deepest existing ancestor is
+    /// canonicalized: a symlink planted inside the tree must not redirect the
+    /// write outside it.
+    fn resolve_fetch_dir(&self, save_dir: Option<&str>) -> CoreResult<PathBuf> {
+        let root = std::fs::canonicalize(&self.data_dir)
+            .map_err(|e| internal("could not resolve the data dir", e))?
+            .join(DOWNLOADS_DIR);
+        let Some(raw) = save_dir.map(str::trim).filter(|s| !s.is_empty()) else {
+            return Ok(root);
+        };
+
+        let refuse = |candidate: &Path| {
+            Err(CoreError::invalid(format!(
+                "file.fetch is confined to the downloads dir; refusing to write {}",
+                candidate.display()
+            ))
+            .with_hint("omit save_dir, or pass a path inside <data-dir>/downloads"))
+        };
+
+        let requested = PathBuf::from(raw);
+        let candidate = if requested.is_absolute() {
+            requested
+        } else {
+            root.join(requested)
+        };
+        // Reject traversal before touching the filesystem: `..` can escape the
+        // prefix check below even when every component resolves.
+        if candidate
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return refuse(&candidate);
+        }
+
+        // Canonicalize the deepest existing ancestor, then re-attach the part
+        // that does not exist yet.
+        let mut existing = candidate.as_path();
+        while !existing.exists() {
+            match existing.parent() {
+                Some(parent) => existing = parent,
+                None => return refuse(&candidate),
+            }
+        }
+        let resolved = std::fs::canonicalize(existing)
+            .map_err(|e| internal("could not resolve the save directory", e))?;
+        let remainder = candidate
+            .strip_prefix(existing)
+            .unwrap_or_else(|_| Path::new(""));
+        let target = resolved.join(remainder);
+        if target != root && !target.starts_with(&root) {
+            return refuse(&candidate);
+        }
+        Ok(target)
+    }
+
     /// Confine `file.share` to files inside the daemon's data dir, excluding the
     /// daemon's own blob store and secret/state files.
     ///
@@ -1977,8 +2044,9 @@ impl RoomSupervisor {
         };
 
         // Save atomically under save_dir (default <data-dir>/downloads),
-        // never overwriting an existing file.
-        let dir = save_dir.map_or_else(|| self.data_dir.join(DOWNLOADS_DIR), PathBuf::from);
+        // never overwriting an existing file. The destination is confined to
+        // the downloads tree so this is not an arbitrary-file-write primitive.
+        let dir = self.resolve_fetch_dir(save_dir)?;
         std::fs::create_dir_all(&dir)
             .map_err(|e| internal("could not create the save directory", e))?;
         let mut target = dir.join(sanitize_name(&shared.name, file_id));
@@ -4576,5 +4644,85 @@ mod tests {
         // refused share returns before importing anything either way).
         assert!(sup.open_rooms().contains(&room_id));
         sup.close_room(&room_id).await.unwrap();
+    }
+
+    #[test]
+    fn fetch_dir_confined_to_the_downloads_tree() {
+        // Issue #122: file.fetch's destination was an arbitrary-file-write
+        // primitive. Confinement is asserted here rather than through
+        // fetch_file, which needs a live provider before it reaches the sink.
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let root = std::fs::canonicalize(dir.path())
+            .unwrap()
+            .join(super::DOWNLOADS_DIR);
+
+        // Omitted and empty both fall back to the documented default.
+        assert_eq!(sup.resolve_fetch_dir(None).unwrap(), root);
+        assert_eq!(sup.resolve_fetch_dir(Some("  ")).unwrap(), root);
+
+        // A relative path resolves under the downloads tree, not the cwd.
+        assert_eq!(
+            sup.resolve_fetch_dir(Some("nested")).unwrap(),
+            root.join("nested")
+        );
+
+        // The destination need not exist yet.
+        let deep = root.join("a").join("b");
+        assert_eq!(
+            sup.resolve_fetch_dir(Some(deep.to_str().unwrap())).unwrap(),
+            deep
+        );
+
+        // The code-execution primitive: an absolute path outside the tree.
+        let outside = tempdir().unwrap();
+        let autostart = outside.path().join(".config/autostart");
+        let err = sup
+            .resolve_fetch_dir(Some(autostart.to_str().unwrap()))
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
+
+        // Traversal out of the tree is refused before the filesystem is touched.
+        for escape in ["../..", "nested/../../..", "/tmp/../etc"] {
+            let err = sup.resolve_fetch_dir(Some(escape)).unwrap_err();
+            assert_eq!(err.kind, ErrorKind::InvalidParams, "escape: {escape}");
+        }
+
+        // The data-dir root itself is refused, so a caller cannot land a file
+        // beside the identity and secret files.
+        let err = sup
+            .resolve_fetch_dir(Some(dir.path().to_str().unwrap()))
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fetch_dir_refuses_a_symlink_out_of_the_downloads_tree() {
+        // A symlink planted inside the tree must not redirect the write out of
+        // it: the deepest existing ancestor is canonicalized before the check.
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let root = std::fs::canonicalize(dir.path())
+            .unwrap()
+            .join(super::DOWNLOADS_DIR);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let outside = tempdir().unwrap();
+        let escape = root.join("escape");
+        std::os::unix::fs::symlink(outside.path(), &escape).unwrap();
+
+        let err = sup
+            .resolve_fetch_dir(Some(escape.to_str().unwrap()))
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
+
+        // And through the symlink into a subdirectory that does not exist yet.
+        let err = sup
+            .resolve_fetch_dir(Some(escape.join("deep").to_str().unwrap()))
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
     }
 }

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -300,9 +300,6 @@ impl RoomSupervisor {
         let root = std::fs::canonicalize(&self.data_dir)
             .map_err(|e| internal("could not resolve the data dir", e))?
             .join(DOWNLOADS_DIR);
-        let Some(raw) = save_dir.map(str::trim).filter(|s| !s.is_empty()) else {
-            return Ok(root);
-        };
 
         let refuse = |candidate: &Path| {
             Err(CoreError::invalid(format!(
@@ -312,11 +309,20 @@ impl RoomSupervisor {
             .with_hint("omit save_dir, or pass a path inside <data-dir>/downloads"))
         };
 
-        let requested = PathBuf::from(raw);
-        let candidate = if requested.is_absolute() {
-            requested
-        } else {
-            root.join(requested)
+        // The default destination is validated too: `<data-dir>/downloads` can
+        // itself be a symlink out of the data dir, and skipping the checks
+        // below for the omitted case would leave the path the UI actually uses
+        // outside the confinement.
+        let candidate = match save_dir.map(str::trim).filter(|s| !s.is_empty()) {
+            None => root.clone(),
+            Some(raw) => {
+                let requested = PathBuf::from(raw);
+                if requested.is_absolute() {
+                    requested
+                } else {
+                    root.join(requested)
+                }
+            }
         };
         // Reject traversal before touching the filesystem: `..` can escape the
         // prefix check below even when every component resolves.
@@ -1967,6 +1973,11 @@ impl RoomSupervisor {
             }
         }
 
+        // Resolve the destination before any network work. A bad `save_dir`
+        // must not cost peer connections and a full transfer first, and must
+        // not surface as `file_unavailable` when every provider is offline.
+        let dir = self.resolve_fetch_dir(save_dir)?;
+
         let provider_devices: Vec<DeviceKey> = match &shared.providers {
             Some(list) if !list.is_empty() => list.clone(),
             _ => vec![author_device],
@@ -2043,10 +2054,8 @@ impl RoomSupervisor {
             ));
         };
 
-        // Save atomically under save_dir (default <data-dir>/downloads),
-        // never overwriting an existing file. The destination is confined to
-        // the downloads tree so this is not an arbitrary-file-write primitive.
-        let dir = self.resolve_fetch_dir(save_dir)?;
+        // Save atomically under the destination resolved before the fetch
+        // (default <data-dir>/downloads), never overwriting an existing file.
         std::fs::create_dir_all(&dir)
             .map_err(|e| internal("could not create the save directory", e))?;
         let mut target = dir.join(sanitize_name(&shared.name, file_id));
@@ -4724,5 +4733,64 @@ mod tests {
             .resolve_fetch_dir(Some(escape.join("deep").to_str().unwrap()))
             .unwrap_err();
         assert_eq!(err.kind, ErrorKind::InvalidParams);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fetch_dir_refuses_a_symlinked_default_downloads_dir() {
+        // Review finding on #125: the omitted-save_dir fallback originally
+        // returned the default without validating it, so a `downloads`
+        // symlink pointing out of the data dir escaped the confinement on the
+        // exact path the UI uses. The default must go through the same checks.
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+
+        let outside = tempdir().unwrap();
+        let downloads = std::fs::canonicalize(dir.path())
+            .unwrap()
+            .join(super::DOWNLOADS_DIR);
+        std::os::unix::fs::symlink(outside.path(), &downloads).unwrap();
+
+        for arg in [None, Some("  ")] {
+            let err = sup.resolve_fetch_dir(arg).unwrap_err();
+            assert_eq!(err.kind, ErrorKind::InvalidParams, "arg: {arg:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_a_bad_save_dir_before_contacting_providers() {
+        // Review finding on #125: an invalid save_dir was only caught after the
+        // provider loop had run, so a bad request cost peer connections and a
+        // full transfer, and surfaced as file_unavailable when every provider
+        // was offline. The parameter error must win, and must come first.
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Files").unwrap();
+        sup.open_room(&room_id, &[]).await.unwrap();
+
+        let payload = dir.path().join("payload.txt");
+        std::fs::write(&payload, b"payload").unwrap();
+        let shared = sup
+            .share_file(&room_id, payload.to_str().unwrap(), None, None)
+            .await
+            .unwrap();
+        let file_id = shared["file_id"].as_str().unwrap().to_string();
+
+        // No other peer is online, so an unvalidated destination would return
+        // FileUnavailable from the provider loop instead of the real error.
+        let outside = tempdir().unwrap();
+        let err = sup
+            .fetch_file(
+                &room_id.to_string(),
+                &file_id,
+                Some(outside.path().to_str().unwrap()),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidParams);
+
+        sup.close_room(&room_id).await.unwrap();
     }
 }

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -147,6 +147,18 @@ then delete the staged copy after the call returns (the daemon has imported
 the blob by then). This mirrors what the daemon itself does for browser
 uploads on `POST /api/files/share`.
 
+`file.fetch {room_id, file_id, save_dir?}` is confined in the opposite
+direction: `save_dir` must resolve inside `<data_dir>/downloads`, and a
+relative value resolves against that directory rather than the daemon's working
+directory. Symlinks are resolved before the check, and `..` is refused outright.
+Without this the method is an arbitrary-file-write primitive — it writes bytes
+chosen by whoever shared the blob, under a name largely chosen by the same
+party, into a process that holds the identity keys. A native client that wants
+the file elsewhere **unstages** it: fetch into the downloads tree, copy to the
+user-chosen destination under the client's own authority, then delete the
+staged copy. Choosing a destination outside the data dir is a user-consented
+native capability, not a daemon capability.
+
 ## Envelope
 
 Client → server (request):
@@ -371,7 +383,7 @@ for exactly-once reconciliation — but that requires a field on the signed
 |---|---|---|
 | `file.share` | `{ room_id, path, name?, mime? }` | `{ file_id, event_id }` — imports into the blob store and authors `file.shared`; `path` MUST resolve inside the daemon data dir (see *Native file sharing*), file size ≤ **100 MiB** (`104_857_600` bytes) |
 | `file.list` | `{ room_id }` | `{ files: [{ file_id, name, size, mime, sender_id, ts, available, providers, fetched?, local_path?, local_bytes?, fetched_at_ms? }] }` — see the availability note below |
-| `file.fetch` | `{ room_id, file_id, save_dir? }` | `{ path, bytes, verified: true }` — writes into `save_dir`, defaulting to **`<data_dir>/downloads`** when omitted; distinctive errors `file_unavailable` / `file_unauthorized` / `hash_mismatch`, never a silent partial. `hash_mismatch` is a hard stop (discard, no retry) |
+| `file.fetch` | `{ room_id, file_id, save_dir? }` | `{ path, bytes, verified: true }` — writes into `save_dir`, defaulting to **`<data_dir>/downloads`** when omitted; `save_dir` MUST resolve inside `<data_dir>/downloads` (see *Native file sharing*), and a relative value resolves against it; distinctive errors `file_unavailable` / `file_unauthorized` / `hash_mismatch`, never a silent partial. `hash_mismatch` is a hard stop (discard, no retry) |
 
 **`available` and `providers` (file.list) — read carefully, the meaning is
 non-obvious:**

--- a/scripts/agent-e2e.mjs
+++ b/scripts/agent-e2e.mjs
@@ -202,6 +202,20 @@ function assert(cond, msg) {
   console.log(`agent-e2e: ok — ${msg}`);
 }
 
+/** Assert a call is refused with `invalid_params` rather than succeeding. */
+async function expectRefused(client, method, params, msg) {
+  let refused = false;
+  try {
+    await client.call(method, params, 30_000);
+  } catch (error) {
+    if (error?.code !== "invalid_params") {
+      fail(`${msg} — refused with ${error?.code ?? error?.message} instead of invalid_params`);
+    }
+    refused = true;
+  }
+  assert(refused, msg);
+}
+
 async function pollUntil(fn, timeoutMs, what, intervalMs = 300) {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
@@ -248,8 +262,9 @@ const humanData = scratchDir("human-data");
 const agentData = scratchDir("agent-data");
 const intruderData = scratchDir("intruder-data");
 const workDir = scratchDir("work");
-const fetchDir1 = scratchDir("fetch1");
-const fetchDir2 = scratchDir("fetch2");
+// #122: an out-of-tree destination for file.fetch, kept only to assert it is
+// refused. Fetches themselves land in the daemon's confined downloads tree.
+const outOfTreeFetchDir = scratchDir("out-of-tree-fetch");
 
 try {
   // ---- 1. human daemon: identity + room + open -----------------------------
@@ -433,9 +448,18 @@ try {
   );
   assert(true, "human: file.list shows result.txt shared by the agent, available");
 
+  // #122: file.fetch is confined to <data-dir>/downloads. An out-of-tree
+  // destination is the arbitrary-file-write primitive; assert it stays refused.
+  await expectRefused(
+    human,
+    "file.fetch",
+    { room_id: roomId, file_id: fileRow.file_id, save_dir: outOfTreeFetchDir },
+    "human: file.fetch refuses a save_dir outside the downloads tree",
+  );
+
   const fetched = await human.call(
     "file.fetch",
-    { room_id: roomId, file_id: fileRow.file_id, save_dir: fetchDir1 },
+    { room_id: roomId, file_id: fileRow.file_id },
     120_000,
   );
   assert(fetched.verified === true, "human: file.fetch reports verified:true");
@@ -535,9 +559,11 @@ try {
     60_000,
     "the second task's result.txt",
   );
+  // #122: a relative save_dir resolves under the downloads tree, not the
+  // daemon's working directory, so this stays inside the confinement.
   const fetched2 = await human.call(
     "file.fetch",
-    { room_id: roomId, file_id: file2.file_id, save_dir: fetchDir2 },
+    { room_id: roomId, file_id: file2.file_id, save_dir: "second-fetch" },
     120_000,
   );
   assert(fetched2.verified === true, "second fetch verified:true");


### PR DESCRIPTION
Closes #122 (the `save_dir` half — see *Deliberately out of scope* below).

## The defect

`file.fetch` resolved `save_dir` with a bare `PathBuf::from` and handed it
straight to `create_dir_all`, with no confinement of any kind. `sanitize_name`
guarded only the filename, never the directory.

That makes the method an arbitrary-file-write primitive. It writes bytes chosen
by whoever shared the blob, under a name largely chosen by the same party, into
any directory the daemon can create. `~/.config/autostart/x.desktop` or
`~/Library/LaunchAgents/` turn it into local code execution as the user — in the
one process that holds the identity keys.

The asymmetry was stark and documented: `file.share` has been confined since #9
by `assert_shareable_path`, with a doc comment explaining the exfiltration
primitive it closes. `file.fetch` had no equivalent.

## The fix

`resolve_fetch_dir` mirrors it in the write direction:

- confines `save_dir` to `<data_dir>/downloads`;
- resolves a relative value against that tree, not the daemon's working
  directory;
- refuses `..` before touching the filesystem;
- canonicalizes the deepest existing ancestor, so a symlink planted inside the
  tree cannot redirect the write out of it, and so a destination that does not
  exist yet still validates.

Confining to the downloads subtree rather than the whole data dir also stops a
caller landing a file beside the identity and secret files at the root.

## Why this is safe to narrow

**Correction to an earlier version of this description.** It claimed no caller
sends `save_dir`. That was wrong: I checked `ui/` and `app/` but not `scripts/`.
`scripts/agent-e2e.mjs` passed a scratch directory under `os.tmpdir()`, which
the confinement refuses, and the second commit here fixes that harness.

No *product* client sends `save_dir` — the React UI calls `file.fetch` with only
`{room_id, file_id}` (`ui/src/App.tsx:734`), and no Flutter call site passes it.
So this narrows a documented parameter whose only caller was a test harness.

Choosing a destination outside the data dir becomes a user-consented native
capability rather than a daemon capability: fetch into the tree, copy out under
the client's own authority, delete the staged copy. `PROTOCOL.md` records the
constraint and that unstaging convention next to the existing staging
convention for `file.share`.

**This is a protocol contract change.** The `file.fetch` row previously placed
no constraint on `save_dir`. Worth a look even though nothing calls it.

## Reachability

Currently unreachable remotely — `jeliyad` binds `127.0.0.1` only. It becomes
reachable the moment a non-loopback transport reaches the engine, which is
exactly what the companion in #113 introduces. That is why this lands ahead of
the architecture decision rather than behind it.

## Deliberately out of scope

Issue #122 also asks that surfaces excluded from the first production slice be
removed at compile time via cargo features rather than gated at runtime. That
depends on the companion crate, which does not exist yet, so #122 stays open
after this merges.

## Verification

- `cargo test -p jeliya-core -p jeliyad` — 73 pass, 1 ignored (71 before, plus
  the 2 added here)
- `cargo clippy -p jeliya-core --all-targets` — clean
- `cargo fmt --check` — clean
- `node scripts/check-docs.mjs` — clean

New tests cover the default and empty-string fallbacks, relative resolution,
a not-yet-existing destination, the absolute-path escape, three traversal
escapes, the data-dir root, and (on Unix) symlink redirection both directly and
through a non-existent subdirectory.

Found by the review recorded in `docs/production-deployment-review.md` (F8),
added in #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
