### PR TITLE
ci: run the network evidence harness last, not first (#128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,13 +372,11 @@ jobs:
           test -s target/debug/libjeliya_ffi.so
           command -v lsof >/dev/null
 
-      - name: Network evidence harness safety and loopback qualification
-        run: |
-          set -euo pipefail
-          test -x target/debug/jeliyad
-          node --test scripts/realnet-evidence.test.mjs
-          node scripts/realnet-evidence.mjs --local-dryrun --with-third
-
+      # Step order matters: the deterministic checks below run BEFORE the
+      # network evidence harness at the end of this job. A step that fails
+      # skips every later step, so putting the slowest and least deterministic
+      # check first meant one flake hid every result after it. Keep new
+      # deterministic steps above the harness.
       - name: Dart protocol (analysis + daemon and FFI conformance)
         working-directory: dart/jeliya_protocol
         run: |
@@ -416,6 +414,18 @@ jobs:
 
       - name: Fleet orchestration E2E
         run: node scripts/fleet-e2e.mjs --trials 5
+
+      # Last on purpose: this is the slowest step in the job and the only one
+      # that has flaked on unrelated changes (it waits up to 120s for a third
+      # loopback peer to settle a direct path). It consumes nothing the steps
+      # above produce and uses a port none of them touch, so running it last
+      # costs nothing and stops a flake here from skipping real results.
+      - name: Network evidence harness safety and loopback qualification
+        run: |
+          set -euo pipefail
+          test -x target/debug/jeliyad
+          node --test scripts/realnet-evidence.test.mjs
+          node scripts/realnet-evidence.mjs --local-dryrun --with-third
 
   msrv:
     name: MSRV 1.91.0


### PR DESCRIPTION
## The defect

The network evidence harness was the first non-setup step in `Rust + Dart + smoke + E2E + protocol
conformance`. In GitHub Actions a failing step skips every later step, so a flake in the slowest,
least deterministic check discarded every result behind it.

This is not hypothetical — it happened on #125:

```
failure  Network evidence harness safety and loopback qualification
skipped  Dart protocol / TypeScript conformance / smoke / sidecar
skipped  Two-peer loopback E2E
skipped  Agent authorization E2E     <- failing for real
skipped  Fleet orchestration E2E
```

The `file.fetch` confinement in that PR genuinely broke `scripts/agent-e2e.mjs`. The run reported a
flake in an unrelated harness and hid the actual regression. A review bot caught it by reading the
diff — CI structurally could not.

## The change

The harness moves to the end of the job. Nothing else changes: same steps, same commands, same
required context name.

| | Before | After |
|---|---|---|
| First check to run | network harness (~2 min, flaky) | `cargo fmt` |
| `Agent authorization E2E` | step 7 of 14, skipped on any earlier failure | step 17 of 19 |
| Network harness | step 6 | step 19, last |

## Why it is safe to move

- **No downstream consumer.** Its `.jeliya-gatea` output is read only by `scripts/gate-a.mjs`,
  which this job does not run.
- **No port contention.** It binds 7456. Every other step in the job uses a disjoint range —
  smoke 7431, two-peer E2E 7411/7412, agent E2E 7462-7464, fleet E2E 7482-7487.
- **No build dependency.** Like every step after `Build required live-test binaries`, it needs only
  `target/debug/jeliyad`.

## Secondary benefit

Deterministic checks now fail fast. A `cargo fmt` or clippy failure surfaces in about a minute
instead of behind a two-minute network harness.

## What this deliberately does not do

It does not touch the flake, which is filed separately as #128. The step stays blocking and gains
no retry: a blind retry on a network qualification harness would mask exactly the class of
regression it exists to catch. #128 asks for better diagnostics first — in particular *which*
settlement stage the third peer reached, rather than only that it timed out.

A comment above the first moved step records the invariant, so new deterministic steps are not
appended after the harness out of habit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)