### PR TITLE
fix(deps): repin iroh-rooms past upstream security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Repinned `iroh-rooms` from tag `v0.1.0-rc.3` (`71fbb500…`) to the
+  deliberately untagged upstream merge `a5d98b70…`, the first `main` revision
+  carrying the provisional-peer fanout fix, connection-generation teardown
+  guards, and bounded store-insert recovery with durable critical degradation
+  reporting. Exact-revision upstream, workspace, and loopback qualification
+  passes. Signed direct and forced-relay evidence at the prior pin remains
+  valid for that snapshot but does not transfer to the new candidate.
+
 ## [0.6.0] - 2026-07-16
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "iroh-rooms"
 version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
+source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
 dependencies = [
  "iroh",
  "iroh-rooms-core",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "iroh-rooms-core"
 version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
+source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "iroh-rooms-net"
 version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=71fbb5007bef4ce83631c94762ec68c2beef3d79#71fbb5007bef4ce83631c94762ec68c2beef3d79"
+source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.91"
 
 [workspace.dependencies]
-# Pinned to the published v0.1.0-rc.3 tag commit (carries the cross-room
-# isolation remediation, relay seam, join-after-conversation fix, and the
-# join-bootstrap capability gate). The local ~/TAC/iroh-room working tree is
-# intentionally NOT used (it drifts).
-iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "71fbb5007bef4ce83631c94762ec68c2beef3d79", features = ["experimental"] }
+# Pinned to the first upstream main commit carrying the provisional-peer gate
+# and store-insert recovery fixes, including the connection-generation follow-ups.
+# This revision is deliberately untagged: rc.3 predates the fixes, while later
+# main adds CLI-only code Jeliya does not consume. Local working trees may drift.
+iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "a5d98b70d717f35d3ce60953a88e12e646f2e871", features = ["experimental"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/docs/agent-orchestration.md
+++ b/docs/agent-orchestration.md
@@ -3,7 +3,7 @@ type: "Reference"
 title: "Agent orchestration contract (v1)"
 description: "Normative contract for agent liveness, task claims, fleet reads, and UI projections."
 tags: ["agents", "fleet", "orchestration", "protocol"]
-timestamp: "2026-07-16T15:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -17,8 +17,8 @@ The pinned contract across four implementation surfaces:
 
 - **Rust daemon** (`crates/jeliyad` + `crates/jeliya-core`) — implements the
   fleet read RPCs and the liveness derivation. `jeliya-core` remains the sole
-  consumer of `iroh_rooms` (SDK pinned at published tag `v0.1.0-rc.3`,
-  rev `71fbb50`).
+  consumer of `iroh_rooms` (SDK pinned at public, deliberately untagged
+  revision `a5d98b70...`).
 - **JS runner** (`scripts/jeliya-agent.mjs`, `scripts/jeliya-fleet.mjs`)
   — implements the status-vocabulary additions and the task-claim protocol.
   Node 22 (global `WebSocket`), zero npm deps.

--- a/docs/capability-status.md
+++ b/docs/capability-status.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Capability status"
 description: "Evidence-aware capability matrix for the v0.5.0 technical-preview candidate and the latest public release."
 tags: ["capabilities", "release", "status", "verification"]
-timestamp: "2026-07-18T13:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -15,55 +15,57 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 
 This page separates implementation, verification, and public availability.
 `v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease backed by signed,
-certifying direct and forced-relay evidence. Current `main` is the
-`v0.6.0` candidate: it repins `iroh-rooms` to `v0.1.0-rc.3`. The `v0.5.0`
-evidence does not transfer to that pin, so fresh certifying direct and
-forced-relay runs were executed at the candidate on 2026-07-16; `v0.6.0` is
-qualified but not yet published.
+certifying direct and forced-relay evidence. The current `v0.6.0` source
+candidate repins `iroh-rooms` to untagged upstream revision `a5d98b70...`, the
+first `main` merge carrying the provisional-peer and store-degradation fixes.
+It is locally qualified but not network-qualified or published. Signed runs at
+the earlier `55024a4...` + `71fbb500...` snapshot remain valid for that exact
+pair and do not transfer to the current dependency.
 
 ## Snapshot boundary
 
 | Field | Value |
 |---|---|
 | Released milestone | `v0.5.0 — Evidence-Backed Technical Preview`, published 2026-07-14 as a prerelease: five daemon+embedded-UI archives with `.sha256` sidecars |
-| Network-qualified commit (`v0.6.0` candidate) | `55024a46b3e112796ba2acf1dc408dab26dbba2e` with `iroh-rooms` pin `71fbb500…` (published tag `v0.1.0-rc.3`) |
-| Certified evidence (`v0.6.0` candidate) | signed schema 2 direct (`1ca39cfa`) and forced-relay (`cf28bc63`) runs of 2026-07-16; `certifiable: true`; see [Verification evidence](verification-evidence.md) |
-| Candidate `iroh-rooms` pin (`main`) | `71fbb5007bef4ce83631c94762ec68c2beef3d79` — published tag `v0.1.0-rc.3`; adds the join-after-conversation fix, the join-bootstrap capability gate, size-independent membership sync, and deep gap healing |
-| Candidate network verification | certified — signed direct and forced-relay runs bind `55024a4` + `71fbb500`. The superseded `v0.5.0` evidence binds `c5f740e` + `d0ceb0b` and does not transfer. Neither run certifies room-scoped synchronization isolation (`synchronization_isolation_claimed: false`); that rests on the upstream suite at the pin |
+| Current source candidate | `42614709c03277acdb001b1a855952c6d5427625` with Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` |
+| Last network-qualified `v0.6.0` snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` with Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
+| Retained certified evidence | signed schema 2 direct (`1ca39cfa`) and forced-relay (`cf28bc63`) runs of 2026-07-16; valid for the last network-qualified snapshot only |
+| Candidate `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first merge carrying the `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus `kortiene/iroh-room#126` follow-ups; later `main` changes only an unconsumed CLI crate |
+| Candidate verification | exact-revision upstream fanout, isolation, and store-degradation tests pass; full Jeliya workspace and 67-assertion loopback suites pass. Fresh signed direct and forced-relay evidence is required |
 | Historical network verification | schema 1 runs at Jeliya `fe870c7…` with local upstream `3702e8c…`, and the schema 2 preview run at `0f6769a…` with pre-remediation pin `3cb9bfd…`; functional evidence only |
-| Status captured | 2026-07-16 21:00 UTC |
+| Status captured | 2026-07-19 15:15 UTC |
 
 See [Release versus main](release-vs-main.md) for the revision boundaries and
 [Verification evidence](verification-evidence.md) for the complete ledger.
 The released `v0.5.0` pins `d0ceb0b…`, which predates upstream's
 join-after-conversation fix: an invite minted after any non-admin chat cannot
-complete `room.join` on `v0.5.0` — the rc.3 repin on `main` fixes this for
-the `v0.6.0` candidate. Mixed `v0.5.0`/candidate rooms cannot complete joins in
-either direction, so a room's members, especially its admin, must move
-together.
+complete `room.join` on `v0.5.0` — the current repin carries that fix plus the
+later provisional-peer and store-degradation fixes. Mixed `v0.5.0`/candidate
+rooms cannot complete joins in either direction, so a room's members,
+especially its admin, must move together.
 
 ## Capability matrix
 
 | Capability | Implementation | Verification | Public release | Honest current claim |
 |---|---|---|---|---|
 | `jeliyad` with embedded React UI | implemented | certified for `v0.5.0` | released in `v0.5.0` (prerelease) | The complete five-target daemon+embedded-UI archive set with `.sha256` sidecars is published. Signed schema 2 direct and forced-relay runs certified the released revision pair. |
-| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Three-peer join, message convergence, reconnect, and resynchronization passed in both certifying runs. Known `v0.5.0` limitation: its pin predates upstream's join-after-conversation fix, so an invite minted after non-admin chat cannot complete `room.join`; the rc.3 candidate on `main` fixes this and has no network run yet. |
+| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.5.0`; current pin passes local integration | released in `v0.5.0` | Known `v0.5.0` limitation: an invite minted after non-admin chat cannot complete `room.join`. The current candidate fixes this and passes all 67 loopback assertions; fresh current-pin network runs remain required. |
 | Files and BLAKE3 fetch verification | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Cross-network transfer, byte equality, and hash verification passed in both certifying runs. |
 | Pipes | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in both certifying runs. |
-| Direct cross-network P2P | implemented | certified for `v0.5.0` and for the `v0.6.0` candidate | released in `v0.5.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) at `55024a4…` + `71fbb500…` passed every recorded assertion across three distinct public egresses and two ASNs; `certifiable: true`. The [`v0.5.0` run `3b86ac67`](evidence/v0.5.0/direct.json) certified the released pin pair `c5f740e…` + `d0ceb0b…`. |
-| Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for `v0.5.0` and for the `v0.6.0` candidate | released in `v0.5.0` | [Signed schema 2 relay run `cf28bc63`](evidence/v0.6.0/relay.json) at `55024a4…` + `71fbb500…`: the relay-only build self-attested on the operator host and both remote hosts, then every role held relay; `certifiable: true`. The [`v0.5.0` run `a3c76859`](evidence/v0.5.0/relay.json) certified the released pin pair. |
+| Direct cross-network P2P | implemented | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending | released in `v0.5.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) certifies `55024a4…` + `71fbb500…`; it does not transfer to `4261470…` + `a5d98b70…`. |
+| Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending | released in `v0.5.0` | [Signed schema 2 relay run `cf28bc63`](evidence/v0.6.0/relay.json) certifies `55024a4…` + `71fbb500…`; a new relay-only source build and signed run are required. |
 | Public room-scoped RPC isolation | implemented | verified locally and in both certifying runs | released in `v0.5.0` | A centralized guard covers the public room-scoped surface. Seventeen negative RPC checks, local-file denial, and aggregate filtering passed over the public network in the certifying runs. |
-| Room isolation in upstream synchronization | remediated in the published pin certified for `v0.5.0` (`d0ceb0b…`); the rc.3 candidate keeps the fix and adds the join-bootstrap capability gate | certified by the `v0.5.0` runs; at the rc.3 tag the upstream isolation regressions and full suites pass locally (523/523 core, 232/232 net) | released in `v0.5.0` | The `v0.5.0` isolation claim is certified at `d0ceb0b…`. The rc.3 candidate is locally requalified; a fresh signed schema 2 qualification is required before the claim transfers to the next release. |
+| Upstream synchronization and provisional-peer isolation | remediated at current pin `a5d98b70…` | targeted isolation, provisional-fanout, and store-degradation regressions pass; core/net all-targets suite passes 806 tests with two ignores | released baseline in `v0.5.0`; new fixes unreleased | Local exact-revision evidence covers the upstream internals. Fresh signed network evidence is still required for Jeliya integration at the new pin. |
 | Agent runner and fleet | implemented | local pass | released as source through `v0.5.0` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
-| Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 release build, X11/Xvfb lifecycle, sidecar smoke, dependency, archive, and checksum gates pass locally; the equivalent x86_64 hosted gate and Wayland lifecycle have no result yet | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
+| Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland lifecycle remain pending | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
 | Android in-process FFI engine | implemented | local device smoke only | unreleased | App-private identity state is excluded from cloud backup and device transfer. It is not Android Keystore-backed, and Android direct, relay, NAT, and cross-network behavior remain unverified. |
 | Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | release gates passed for `v0.5.0` | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
-| CI matrix | implemented | hosted runs pass on `main` | exercised for `v0.5.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined; the six pre-existing required jobs pass on hosted `main` runs, including Windows installer integrity. The new `linux-flutter` job (release binaries, integrated bundle under Xvfb, dependency/archive/checksum checks) has no hosted execution yet. |
+| CI matrix | implemented | all jobs passed on public `main` run `29688515781` at `a24f223…`; current-candidate run pending | exercised for `v0.5.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. The hosted run includes Windows installer integrity and the `linux-flutter` release-build, Xvfb, dependency, archive, and checksum checks. |
 | Unix installer integrity | implemented | behavioral checks pass | released in `v0.5.0` | Unix installers fetch and verify the matching sidecar before extraction; `v0.5.0` installs via the version-pinned installer path. |
 | Windows installer integrity | implemented | hosted `windows-latest` job passes on `main` | released in `v0.5.0` | The Windows job executes checksum/tamper behavior, simulates reparse-point rejection, and runs native `jeliyad.exe --version`; a `v0.5.0` Windows zip and sidecar are published. |
 | Complete asset-set visibility and version consistency | implemented | executed for `v0.5.0` | released in `v0.5.0` | The publication workflow validated, sealed, smoked, and receipt-verified the complete five-archive set; the evidence key is provisioned and the signed evidence passed the release gate before publication. |
 | WCAG 2.1 AA | partial | automated gate on every pull request; manual checklist per release | partial | Enforced, not certified. CI rejects any critical or serious axe violation across every destination at 1440x900, 920x800, 390x844 and 320x568, and fails on clipped layout at 100/200/320% text in English and French; `docs/accessibility-checklist.md` covers the screen-reader and keyboard behaviours automation cannot decide. Not a conformance claim: the web client is English-only until localization lands, and `ui-e2e` is not yet a required status check, so the gate runs on every pull request without blocking merge. |
-| OKF-compatible documentation | implemented | locally checked; reconciled to the released `v0.5.0` and the rc.3 candidate | released posture documented | The profile separates lifecycle, implementation, verification, and release status. |
+| OKF-compatible documentation | implemented | locally checked; reconciled to the released `v0.5.0`, prior signed snapshot, and current untagged candidate | released posture documented | The profile separates lifecycle, implementation, verification, and release status. |
 
 ## Preview publication rule
 
@@ -75,7 +77,7 @@ gates are satisfied.
 
 No row becomes `verified` because code exists, and no row becomes `released`
 because it is on a branch. For the next release the same bar applies to the
-rc.3 candidate: fresh signed network evidence at its pin, passing hosted gates
-(including the new `linux-flutter` job), a matching tag, a complete verified
-artifact set, and explicit release authority. See
+current candidate: fresh signed network evidence at `a5d98b70...`, passing
+hosted gates (including the new `linux-flutter` job), a matching tag, a complete
+verified artifact set, and explicit release authority. See
 [Known gaps and roadmap](known-gaps-roadmap.md).

--- a/docs/gate-a-result.md
+++ b/docs/gate-a-result.md
@@ -80,8 +80,9 @@ achieved on that network pair); this run achieved neither caveat.
 This historical run matches neither the released `v0.5.0` nor the current
 candidate. `v0.5.0` satisfied Gate A's intent through its own certifying
 signed direct and forced-relay schema 2 runs at `c5f740e…` + `d0ceb0b…` (see
-[`verification-evidence.md`](verification-evidence.md)). The post-release
-candidate on `main` repins `iroh-rooms` to published `v0.1.0-rc.3`
-(`71fbb5007bef4ce83631c94762ec68c2beef3d79`) and needs its own direct and
-deliberately constrained relay runs at that exact commit and dependency
-revision before the next release.
+[`verification-evidence.md`](verification-evidence.md)). The prior
+post-release snapshot at Jeliya `55024a4…` + published Iroh Rooms `71fbb500…`
+has its own signed direct and forced-relay runs. The current source candidate
+repins to untagged `a5d98b70…`; those manifests do not transfer, so the current
+pair needs fresh direct and deliberately constrained relay runs before the next
+release.

--- a/docs/known-gaps-roadmap.md
+++ b/docs/known-gaps-roadmap.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Known gaps and roadmap"
 description: "Release blockers, deferred risks, owners, and next actions for the v0.5.0 evidence-backed technical preview."
 tags: ["gaps", "release", "risks", "roadmap"]
-timestamp: "2026-07-16T15:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -16,9 +16,9 @@ audience: ["contributors", "maintainers", "product", "release-engineers"]
 `v0.5.0` shipped on 2026-07-14: the release conditions the `NOW` phase tracked
 were met (published safe pin, signed certifying direct and relay evidence,
 hosted gates, complete verified artifact set). The table below records that
-closure and the gaps that carry forward to the post-release candidate on
-`main`, which repins `iroh-rooms` to `v0.1.0-rc.3` and must earn its own
-evidence.
+closure and the gaps that carry forward to the current post-release source
+candidate, which repins `iroh-rooms` to the untagged upstream revision
+`a5d98b70...` and must earn fresh signed network evidence at that exact pin.
 
 ## NOW — closure status
 
@@ -26,20 +26,20 @@ evidence.
 |---|---|---|---|---|
 | Public room-scoped authorization | centralized guard; 17 negative RPCs, local-file denial, and aggregate filtering passed locally and in both certifying network runs | preserve gates on the next candidate | core maintainer | closed for `v0.5.0` |
 | Accepted-room provenance | failure-injected create/join ordering, serialized concurrent updates, cached reads, owner-only Unix state, and durable replacement semantics pass; hosted Windows job passes on `main` | preserve on the next candidate | core maintainer | closed |
-| Upstream synchronization isolation | certified for `v0.5.0` at published pin `d0ceb0b…`; the rc.3 candidate keeps the fix, adds the join-bootstrap capability gate, and passes upstream store/engine isolation regressions plus the full Jeliya suites locally at `71fbb50…` | rerun signed network qualification at the rc.3 pin before the next release | upstream and core maintainer | certified for `v0.5.0`; rc.3 locally requalified |
+| Upstream synchronization, provisional-peer, and store integrity | certified baseline for `v0.5.0` at `d0ceb0b…`; current `a5d98b70…` pin passes targeted fanout, isolation, and store-degradation regressions plus 806 core/net tests and the full Jeliya suites locally | rerun signed direct and relay qualification at `a5d98b70…` before the next release | upstream and core maintainer | current pin locally requalified; network qualification pending |
 | Android and agent secrets | Android cloud/device-transfer exclusions, app-private no-backup identity storage, external agent data default, ignore and tracked-secret gates pass | keep controls; Keystore wrapping is defense-in-depth, not a current claim | mobile and agent maintainers | closed |
 | Dependency security | Cargo and npm report zero vulnerabilities; four unmaintained/yanked warnings have owner, mitigation, and expiry records | rerun against the next candidate's lockfiles | dependency owner | closed |
-| CI completeness | all required matrix jobs pass on hosted `main` runs; manual dispatch does not publish; Gradle is checksum-verified | hosted execution of the new `linux-flutter` job; keep two clean runs on the next final commit | CI maintainer | closed for the six pre-existing jobs |
+| CI completeness | all required matrix jobs, including `linux-flutter`, pass on public `main` run `29688515781` at `a24f223…`; manual dispatch does not publish; Gradle is checksum-verified | rerun all jobs twice on the next final commit | CI maintainer | prior-main pass; current candidate pending |
 | Agent/fleet reliability | agent E2E passes; fleet stability passed 5/5; Linux orphan/zombie cleanup verified on `demo1` under UID `65534` | repeat in the next candidate's hosted gates | agent maintainer | closed |
-| Linux Flutter source app | Ubuntu 24.04 ARM64 release package, X11/Xvfb lifecycle, bundled daemon smoke, dependency, archive, and checksum gates pass locally; a hosted x86_64 `linux-flutter` CI job is now defined | obtain hosted x86_64 and Wayland results; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
-| Direct network behavior | signed certifying schema 2 run `3b86ac67` at `c5f740e…` + `d0ceb0b…` | rerun at the rc.3 candidate pin before the next release | verification owner | certified for `v0.5.0` |
-| Forced relay behavior | signed certifying schema 2 relay run `a3c76859` with a self-attested relay-only build at the same revision pair; the rc.3 candidate verifier builds and attests locally | rerun at the rc.3 candidate pin before the next release | verification owner | certified for `v0.5.0` |
+| Linux Flutter source app | Ubuntu 24.04 ARM64 local qualification and the hosted x86_64 `linux-flutter` job pass; the hosted result binds public `main` at `a24f223…` | rerun at the current candidate; obtain a Wayland result; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
+| Direct network behavior | signed runs certify released `v0.5.0` and the prior `55024a4…` + `71fbb500…` snapshot | rerun at `4261470…` + `a5d98b70…` | verification owner | current candidate pending |
+| Forced relay behavior | signed runs certify released `v0.5.0` and the prior `55024a4…` + `71fbb500…` snapshot; the relay-only verifier still builds locally | rerun the source-built relay qualification at the current revision pair | verification owner | current candidate pending |
 | Evidence authenticity | detached Ed25519 signatures over both certifying manifests verify against the committed public SPKI; private-key custody is out of band | keep custody; sign the next candidate's runs | release authority | closed |
 | Unix installer integrity | behavioral checksum-before-extraction tests pass; `v0.5.0` installs via the version-pinned installer path | rerun against the next artifacts | release maintainer | closed |
 | Windows installer integrity | hosted `windows-latest` behavioral job passes on `main`; a `v0.5.0` Windows zip and sidecar are published | rerun against the next artifacts | release maintainer | closed |
 | Complete asset-set visibility | the publication workflow executed for `v0.5.0`: validation, sealing, isolated smoke, receipt verification, and draft-until-complete publication | re-execute for the next release under explicit authority | release authority | executed for `v0.5.0` |
 | Complete artifact set | `v0.5.0` published all five daemon-plus-embedded-UI archives with sidecars | build and verify the next candidate's set together | release maintainer | closed for `v0.5.0` |
-| Documentation alignment | status pages reconciled to the released `v0.5.0`, its certified evidence, and the rc.3 candidate boundary | re-reconcile at the next release cut | documentation owner | current for this snapshot |
+| Documentation alignment | status pages distinguish released `v0.5.0`, the prior signed `v0.6.0` snapshot, and the current untagged dependency candidate | bind fresh signed evidence after the network reruns | documentation owner | current for this snapshot |
 
 No reachable high or critical advisory is currently unresolved. The four
 maintenance/yank warnings are tracked with mitigation and an expiry of
@@ -64,12 +64,13 @@ maintenance/yank warnings are tracked with mitigation and an expiry of
   certified conformance;
 - member removal cannot recall data already copied by an authorized peer;
   revocation semantics require a separate protocol and product decision;
-- the pinned upstream `v0.1.0-rc.3` carries documented residuals: while a room
-  is accepting joins, an unproven provisionally-admitted dialer no longer
-  receives history but still receives live event fan-out until it disconnects
-  (upstream issue #121); a store hole left by a swallowed insert error heals
-  only from peers that re-serve the region (upstream issue #119); and mixed
-  pre/post-repin fleets cannot complete joins, so joiners and admins must
+- the current upstream pin is an immutable but untagged commit. It fixes the
+  provisional-peer fanout and store-hole residuals from `v0.1.0-rc.3`, but a
+  long-term tagged-release and maintenance path is still required;
+- exhausted store retries or queue overflow produce a durable critical
+  `store_degraded` decision. Operators still need a documented response to real
+  disk failure; and
+- mixed pre/post-repin fleets cannot complete joins, so joiners and admins must
   upgrade together.
 
 ## Exit criteria for the next release
@@ -78,8 +79,8 @@ maintenance/yank warnings are tracked with mitigation and an expiry of
 reaches a release-authority decision only when the same bar is met at the
 new candidate:
 
-1. the candidate's published pin (`v0.1.0-rc.3` at `71fbb50…`, or its
-   reviewed successor) is carried by the final public commit;
+1. the candidate's reviewed public pin (`a5d98b70…`, or a reviewed tagged
+   successor carrying the same fixes) is carried by the final public commit;
 2. signed direct and relay manifests bound to that commit and pin pass the
    release gate with `certifiable: true` (the `v0.5.0` evidence binds
    `c5f740e` + `d0ceb0b` and does not transfer);

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Platform matrix"
 description: "Implementation, verification, packaging, and release status for every Jeliya runtime and target platform."
 tags: ["packaging", "platforms", "release", "verification"]
-timestamp: "2026-07-16T15:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -14,28 +14,30 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Platform matrix
 
 The latest public release is `v0.5.0` (2026-07-14, daemon-only prerelease
-with certified network evidence). The `v0.6.0` candidate on `main` repins
-`iroh-rooms` to `v0.1.0-rc.3` and carries its own signed certifying direct and
-relay runs of 2026-07-16; it is qualified but not yet published. A source build
-or passing test is not a release.
+with certified network evidence). The current `v0.6.0` source candidate repins
+`iroh-rooms` to untagged `a5d98b70...`; local exact-revision and loopback
+qualification passes, but signed direct and relay reruns are pending. The
+retained 2026-07-16 runs certify only the prior `55024a4...` + `71fbb500...`
+snapshot. A source build or passing test is not a release.
 
 ## Daemon and embedded web UI
 
 | Target | Implementation | `v0.5.0` evidence | Latest public artifact | Preview status |
 |---|---|---|---|---|
 | macOS arm64 (`aarch64-apple-darwin`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
-| macOS x86_64 (`x86_64-apple-darwin`) | implemented | certifying signed schema 2 direct and relay runs pass (operator role); installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and re-certified at the `v0.6.0` candidate |
+| macOS x86_64 (`x86_64-apple-darwin`) | implemented | certifying signed schema 2 direct and relay runs pass (operator role); installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending |
 | Linux arm64 musl (`aarch64-unknown-linux-musl`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
-| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | certifying signed schema 2 direct and relay runs pass on Ubuntu x86_64 under UID `65534`; installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and re-certified at the `v0.6.0` candidate |
+| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | certifying signed schema 2 direct and relay runs pass on Ubuntu x86_64 under UID `65534`; installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending |
 | Windows x86_64 MSVC (`x86_64-pc-windows-msvc`) | implemented | hosted behavioral installer/checksum/tamper, simulated reparse, and native daemon smoke jobs pass on `main` | `v0.5.0` archive and sidecar | released; no platform network run |
 
 The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind macOS x86_64 and
 Linux x86_64 musl builds to Jeliya `55024a4…`, published Iroh Rooms pin
 `71fbb500…`, and the verified toolchain; both are signed and set
-`certifiable: true`. The `v0.5.0` manifests
+`certifiable: true` for that prior snapshot. They do not transfer to the
+current `4261470…` + `a5d98b70…` candidate. The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
-bind the released pair `c5f740e…` + `d0ceb0b…` and do not transfer to the rc.3
+bind the released pair `c5f740e…` + `d0ceb0b…` and do not transfer to another
 pin. The earlier unsigned
 [preview manifest](evidence/v0.5.0/preview-direct-schema2.json) at `0f6769a…`
 with pre-remediation pin `3cb9bfd…` remains historical.
@@ -52,7 +54,7 @@ local-remediation evidence only. See
 | Surface | Implementation | Verification evidence | Release status | `v0.5.0` decision |
 |---|---|---|---|---|
 | macOS Flutter app | application and DMG pipeline exist | local tests only; current app sidecar is loopback-only; signing/notarization inactive | no DMG published | excluded |
-| Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 release build, X11/Xvfb lifecycle, sidecar smoke, dependency, archive, and checksum gates pass locally; Wayland and the equivalent x86_64 hosted gate remain unverified | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
+| Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland remain pending | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
 | Android Flutter app with in-process Rust engine | application and three-ABI build path exist | Android 13 local lifecycle/FFI smoke only; no cross-network, NAT, direct, or relay evidence | no APK/AAB published | excluded |
 | Android identity storage | app-private no-backup storage with cloud and device-transfer exclusions | rules and validation pass | unreleased | included security control; not Keystore-backed |
 | iOS app | no scaffold or engine build | none | none | excluded |
@@ -63,15 +65,15 @@ local-remediation evidence only. See
 
 | Runtime | Local protocol | Cross-network direct | Forced relay | Reconnect/resync |
 |---|---|---|---|---|
-| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | certifying signed schema 2 direct pass across three distinct egresses and two ASNs at `55024a4…` + `71fbb500…` (and previously at `c5f740e…` + `d0ceb0b…` for `v0.5.0`) | certifying signed schema 2 relay pass with a self-attested relay-only build at the same revision pair | certified direct and relay reconnect/resync pass for `v0.5.0` and for the `v0.6.0` candidate |
+| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | signed direct pass at prior `55024a4…` + `71fbb500…` and released `c5f740e…` + `d0ceb0b…`; current candidate pending | signed relay pass with self-attestation at those same prior pairs; current candidate pending | local current-pin loopback passes; signed current-pin reconnect/resync pending |
 | Other daemon targets | implemented | no candidate evidence | no candidate evidence | no candidate evidence |
 | Android in-process engine | local device-smoke evidence | unverified | unverified | local lifecycle only; cross-peer unverified |
 | macOS Flutter sidecar | loopback-only configuration | unsupported by current app configuration | unsupported by current app configuration | local sidecar lifecycle only |
 | Linux Flutter sidecar | real networking configured through the bundled daemon | unverified | unverified | local ARM64 source-package lifecycle gate passes; cross-peer unverified |
 
-The certifying runs qualify `v0.5.0` exactly; they do not transfer to the
-rc.3 candidate, whose pin differs. “Real networking enabled” on Android means
-only `loopback: false`; it is not evidence of a peer path.
+The certifying runs qualify their recorded revision pairs exactly; they do not
+transfer to the current candidate, whose pin differs. “Real networking enabled”
+on Android means only `loopback: false`; it is not evidence of a peer path.
 
 ## Packaging trust status
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -3,7 +3,7 @@ type: "Architecture"
 title: "Production deployment architecture"
 description: "Repository-grounded assessment, target architecture, security boundaries, infrastructure plan, and phased gates for deploying Jeliya at app.jeliya.ai."
 tags: ["architecture", "deployment", "production", "security", "pwa", "iroh"]
-timestamp: "2026-07-18T20:29:18Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "proposal"
 implementation_status: "planned"
 verification_status: "partial"
@@ -55,21 +55,18 @@ Jeliya HEAD `4d4621c929e6f9678b31b7e4a3ee1c8d751b545b` on branch
 
 The exact qualification boundary is different:
 
-- [Capability status](capability-status.md) names Jeliya commit
+- Signed direct and forced-relay evidence binds the earlier Jeliya commit
   `55024a46b3e112796ba2acf1dc408dab26dbba2e` and Iroh Rooms commit
-  `71fbb5007bef4ce83631c94762ec68c2beef3d79` as the network-qualified
-  `v0.6.0` pair.
-- The assessed HEAD is 14 commits and 142 changed files after that Jeliya
-  commit. Evidence bound to the earlier commit does not qualify the later tree.
-- The Iroh Rooms dependency remains pinned to `71fbb500...` in
-  [`Cargo.toml`](../Cargo.toml), but dependency equality alone does not transfer
-  application-level qualification.
-- Some status pages contain stale contradictions: the top of capability status
-  records fresh candidate direct and relay runs while lower rows still say that
-  no candidate run exists or that another is required. The
-  [security threat model](security-threat-model.md) also retains a stale
-  statement that the public lockfile has not been repinned. Documentation
-  reconciliation is a release gate, not editorial cleanup.
+  `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`).
+- The current dependency candidate is Jeliya
+  `42614709c03277acdb001b1a855952c6d5427625` with the deliberately untagged
+  Iroh Rooms revision `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first upstream `main`
+  merge carrying the fixes for `kortiene/iroh-room#121` and
+  `kortiene/iroh-room#119` plus the intervening connection-generation fixes.
+- Exact-revision upstream regressions, the Jeliya workspace tests, and the
+  two-daemon loopback suite pass at the new pair. The older signed manifests do
+  not transfer: fresh signed direct and forced-relay runs must bind the new
+  public Jeliya commit and dependency revision before release qualification.
 
 Local verification performed during the assessment:
 
@@ -77,10 +74,12 @@ Local verification performed during the assessment:
 - Rust core and daemon: 71 unit tests passed; one opt-in performance test was
   ignored.
 - Documentation, secret-storage, and release-contract checks passed.
-- A full `cargo test --locked --workspace` could not build `jeliya-ffi` because
-  the local environment lacked Dart SDK headers. The core and daemon were then
-  tested separately and passed. This is an unverified local FFI prerequisite,
-  not evidence of a product failure or success.
+- During the initial assessment, a full `cargo test --locked --workspace` could
+  not build `jeliya-ffi` because the local environment lacked Dart SDK headers;
+  core and daemon tests passed separately.
+- Follow-up qualification on 2026-07-19 supplied the installed Dart SDK headers:
+  the full locked workspace passed 77 tests with one intentional performance
+  ignore at `4261470...` + `a5d98b70...`.
 - On 2026-07-17, `jeliya.ai` and `app.jeliya.ai` had no resolvable A, AAAA, or
   CNAME record from the assessment environment.
 
@@ -160,10 +159,14 @@ at `app.jeliya.ai`.
   surface. It must remain unavailable to the hosted browser product.
 - No component loader, signed package format, permission broker, quota model,
   upgrade rollback, or revocation path exists.
-- Upstream issue #121 leaves live fanout visible to an unproven provisional
-  dialer during an open join window. Upstream issue #119 leaves some store holes
-  incompletely healable. The former must be fixed or prevented before
-  production; the latter needs repair or a fail-loud integrity response.
+- Upstream `kortiene/iroh-room#121` and `kortiene/iroh-room#119` are fixed on
+  upstream `main` after tag `v0.1.0-rc.3`. Jeliya deliberately pins the first
+  merge carrying both fixes (`a5d98b70...`) and locally requalifies the
+  provisional-peer gate, connection-generation teardown, synchronization
+  isolation, and store retry/degradation behavior. Store retry exhaustion or
+  queue overflow fails loudly through a durable critical `store_degraded`
+  decision; it does not make disk failure impossible. Fresh signed network
+  evidence remains a Phase 0 gate.
 
 ## Why the loopback daemon must not be public
 
@@ -387,8 +390,9 @@ request or Referer header. Required controls are:
   than 24 hours for asynchronous invites.
 - Add `invite.cancel` and close the provisional join window immediately after
   redemption or cancellation.
-- Fix upstream issue #121 or suspend normal room fanout while an unproven
-  provisional connection exists.
+- Keep the upstream pin at or after `58aca4ba...` and require the
+  `uninvited_provisional_dialer_receives_no_live_fanout` regression to pass at
+  the exact resolved revision.
 
 Current tickets are bound to a known invitee identity. Preserve that property.
 New-user onboarding is therefore a two-step flow:
@@ -871,6 +875,11 @@ from the previous phase.
 Deliver:
 
 - reconcile status, threat, evidence, and platform documentation;
+- pin the exact public Iroh Rooms revision `a5d98b70...`, recording why the
+  first merge with both required fixes is used despite having no release tag;
+- requalify provisional-peer fanout, connection-generation teardown,
+  synchronization isolation, and store retry/degradation at that exact
+  revision;
 - select one exact clean candidate commit;
 - accept or reject the hybrid architecture through an ADR;
 - update the threat model for browser origin, companion, and relays;
@@ -881,11 +890,14 @@ Deliver:
 Go/no-go gate:
 
 - no contradictory release claim remains;
+- `Cargo.toml` and `Cargo.lock` both resolve Iroh Rooms `a5d98b70...`;
+- the named upstream fanout, connection-generation, isolation, and
+  store-degradation regressions pass at that revision, together with Jeliya's
+  join/loopback suite;
 - complete CI passes twice on one immutable SHA;
-- direct and forced-relay evidence is signed and bound to that SHA;
+- direct and forced-relay evidence is signed and bound to that SHA and
+  `a5d98b70...`;
 - a browser reaches a native test endpoint through an authenticated relay;
-- production work does not continue with upstream issue #121 exploitable and
-  unmitigated.
 
 ### Phase 1: production identity and protocol primitives, 3 to 5 weeks
 
@@ -897,7 +909,8 @@ Deliver:
 - invite default expiry and cancellation;
 - companion pairing/control protocol;
 - protocol version and capability negotiation;
-- store-hole detection, repair, or fail-loud response.
+- surface upstream's durable critical `store_degraded` decision and define the
+  operator response to exhausted store retries or queue overflow.
 
 Go/no-go gate:
 
@@ -1064,7 +1077,8 @@ capabilities they do not provide.
 4. Browser-origin/CDN compromise and the maximum authority granted to a web
    controller.
 5. Recovery usability and user custody for an accountless identity.
-6. Resolution of upstream issues #121 and #119.
+6. A tagged-release and maintenance path for the deliberately untagged
+   `a5d98b70...` Iroh Rooms revision.
 7. Native signing, notarization, SmartScreen, and Linux distribution timing.
 8. Relay bandwidth economics for browser file transfer.
 9. PWA storage behavior across real Safari/iOS and low-storage devices.
@@ -1075,6 +1089,8 @@ capabilities they do not provide.
 - [Iroh: WebAssembly and browsers](https://docs.iroh.computer/languages/wasm-browser) - Browser build instructions, relay-only connections, end-to-end encryption, feature flags, and wrapper guidance.
 - [Iroh: Use your own relay](https://docs.iroh.computer/add-a-relay) - Production relay guidance, authentication, stateless failover, and two-region recommendation.
 - [Iroh hosting](https://www.iroh.computer/services/hosting) - Public-service limitations and current managed-relay starting price.
+- [kortiene/iroh-room#121](https://github.com/kortiene/iroh-room/issues/121) and [iroh-room PR #125](https://github.com/kortiene/iroh-room/pull/125) - Provisional-peer fanout and handshake gating.
+- [kortiene/iroh-room#119](https://github.com/kortiene/iroh-room/issues/119) and [iroh-room PR #132](https://github.com/kortiene/iroh-room/pull/132) - Store-insert retry, local hole healing, and fail-loud degradation.
 - [MDN: Storage quotas and eviction criteria](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria) - Best-effort and persistent browser storage and eviction boundaries.
 - [MDN: Origin private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) - OPFS availability, worker support, and origin-private storage behavior.
 - [MDN: Offline and background operation](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation) - PWA offline and service-worker execution boundaries.

--- a/docs/realnet-runbook.md
+++ b/docs/realnet-runbook.md
@@ -3,7 +3,7 @@ type: "Runbook"
 title: "Real-network NAT runbook"
 description: "Operator procedure for collecting revision-bound direct and forced-relay evidence across three distinct public egress paths."
 tags: ["nat", "networking", "operations", "p2p"]
-timestamp: "2026-07-16T15:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -20,10 +20,10 @@ a diagnostic and historical reference; it cannot qualify a release.
 
 ## Current evidence status
 
-The certifying `v0.6.0` runs bind the published network-qualified Jeliya
-commit `55024a46b3e112796ba2acf1dc408dab26dbba2e` and published Iroh Rooms
-pin `71fbb500…` (tag `v0.1.0-rc.3`); both are signed and set
-`certifiable: true`:
+The retained certifying `v0.6.0` runs bind published Jeliya commit
+`55024a46b3e112796ba2acf1dc408dab26dbba2e` and Iroh Rooms pin `71fbb500…`
+(tag `v0.1.0-rc.3`); both are signed and set `certifiable: true` for that exact
+prior snapshot:
 
 | Path | Run | Evidence status |
 |---|---|---|
@@ -32,12 +32,19 @@ pin `71fbb500…` (tag `v0.1.0-rc.3`); both are signed and set
 
 Neither run certifies room-scoped synchronization isolation: both manifests set
 `synchronization_isolation_claimed: false`, so `WantEvents`, foreign-parent, and
-administrative-tip traversal rest on the upstream suite at the pinned revision.
+administrative-tip traversal rest on the upstream suite at the recorded
+revision.
+
+The current source candidate is Jeliya `4261470...` with the deliberately
+untagged Iroh Rooms pin `a5d98b70...`. Its local exact-revision qualification
+passes, but the retained manifests do not transfer. Run both procedures below
+from the clean public candidate and replace/sign the manifests together before
+marking the current release evidence gate ready.
 
 The superseded `v0.5.0` runs (direct `3b86ac67`,
 [manifest](evidence/v0.5.0/direct.json); forced relay `a3c76859`,
 [manifest](evidence/v0.5.0/relay.json)) bind `c5f740e…` + `d0ceb0b…` and
-authorized that prerelease; they do not transfer to the rc.3 pin. The earlier
+authorized that prerelease; they do not transfer to another pin. The earlier
 unsigned preview run
 (`20260712T231015Z-3c938c66`,
 [manifest](evidence/v0.5.0/preview-direct-schema2.json)) at `0f6769a…` with
@@ -305,12 +312,12 @@ both manifests to name the same network-qualified Jeliya commit and public
 upstream revision. That commit must be an ancestor of the release checkout,
 and only documentation paths may change after network qualification.
 
-The currently retained manifests intentionally have no `.sig` files, and
-`release/evidence-ed25519-public.pem` is absent. The current direct record
-remains non-certifying because its Jeliya commit is unpublished and its public
-dependency pin is unsafe. The historical records remain non-certifying because
-they use older schema 1 and unpublished local source. Signing any of these
-existing records would not make them releaseable.
+The retained `v0.6.0` manifests have valid adjacent signatures verified against
+`release/evidence-ed25519-public.pem`; they remain certifying for
+`55024a4...` + `71fbb500...`. Do not relabel or edit them to match the current
+candidate. Replace each manifest only with fresh source-bound output, then sign
+the final exact bytes. Historical schema 1 and preview records remain
+non-certifying and cannot be promoted by adding signatures.
 
 ## Evidence and log hygiene
 
@@ -339,9 +346,10 @@ The run is incomplete until its manifest reports all of the following:
 The harness validates exact run ownership before signaling a process or
 removing a directory. If it cannot prove ownership, preserve the object and
 report the blocker; do not broaden a command or remove unrelated data. After
-the current direct run and the historical runs, independent read-only checks
-found no run directories or processes remaining on `demo1` or `demo2`. The
-current relay build failed before remote mutation.
+the retained 2026-07-16 direct and relay runs and the historical runs,
+independent read-only checks found no run directories or processes remaining on
+`demo1` or `demo2`. The earlier pre-certification preview relay build failed
+before remote mutation.
 
 ## Legacy Gate A diagnostic
 

--- a/docs/release-vs-main.md
+++ b/docs/release-vs-main.md
@@ -3,10 +3,10 @@ type: "Status Report"
 title: "Release versus main"
 description: "Exact boundary between the latest published Jeliya artifacts, the audited baseline, and the v0.5.0 candidate."
 tags: ["artifacts", "main", "release", "versions"]
-timestamp: "2026-07-16T15:30:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "not-applicable"
-verification_status: "verified"
+verification_status: "partial"
 release_status: "not-applicable"
 audience: ["contributors", "maintainers", "operators", "release-engineers"]
 ---
@@ -14,16 +14,17 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Release versus main
 
 Git branches, test revisions, tags, and release assets answer different
-questions. `v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease;
-current `main` is the post-release candidate and must not be described as
-released.
+questions. `v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease. The
+post-release source line and the current branch candidate must not be described
+as released.
 
 ## Current boundary
 
 | Layer | Exact revision | Dependency state | Artifact/evidence state | Claim allowed |
 |---|---|---|---|---|
 | Latest public release | tag `v0.5.0` at `045d85cb1d066f16d564b6051363b9328063ee01` (prerelease) | pins published `iroh-rooms` `d0ceb0b…` (rc.2-era remediation) | five published daemon archives and five checksum sidecars; signed certifying direct (`3b86ac67`) and relay (`a3c76859`) manifests | behavior in those archives is released; known limitation: joins from invites minted after non-admin chat fail at this pin |
-| `v0.6.0` network-qualified candidate | `55024a46b3e112796ba2acf1dc408dab26dbba2e` on `main` | pins published `iroh-room` tag `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` (adds the join-after-conversation fix, join-bootstrap capability gate, bounded membership sync, gap healing) | signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests of 2026-07-16 bind this commit; `certifiable: true` | the certified evidence speaks for this revision pair; qualified but not yet published |
+| Current `v0.6.0` source candidate | `42614709c03277acdb001b1a855952c6d5427625` | pins untagged public Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first merge carrying `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus the `kortiene/iroh-room#126` follow-ups | exact-revision upstream, workspace, and 67-assertion loopback suites pass; fresh signed direct/relay evidence pending | locally qualified; not network-qualified or published |
+| Prior `v0.6.0` network-qualified snapshot | `55024a46b3e112796ba2acf1dc408dab26dbba2e` | pins `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind this exact pair | evidence remains valid for the snapshot but does not transfer to the current candidate |
 | Superseded `v0.5.0` network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` | pins `d0ceb0b…` | both `v0.5.0` certifying schema 2 runs bind this commit | the certified evidence speaks for that revision pair only; it does not transfer to the rc.3 pin |
 | Audited baseline | `1285b42037a3713840955fa518f2b81b19f2929f` | pins vulnerable `iroh-rooms` `3cb9bfd…` | no artifact for this commit | baseline source behavior only |
 | Initial hardening checkpoint | `4d0807a42ad79f7eb1b44edab48a62bf8813dd9c` | pinned `3cb9bfd…` at that checkpoint | historical checkpoint before provenance, cache, and protocol-contract follow-ups | historical only |
@@ -33,11 +34,12 @@ released.
 The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind the
 network-qualified commit `55024a4…` and published pin `71fbb500…`, carry
-detached Ed25519 signatures, and set `certifiable: true` — they qualify the
-`v0.6.0` candidate. The `v0.5.0` manifests
+detached Ed25519 signatures, and set `certifiable: true` — they qualify that
+prior `v0.6.0` snapshot. They do not qualify the current `4261470…` +
+`a5d98b70…` source candidate. The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
 bind `c5f740e…` + `d0ceb0b…` and authorized that prerelease; they do not
-transfer to the rc.3 pin. Neither generation certifies room-scoped
+transfer to another pin. Neither generation certifies room-scoped
 synchronization isolation — every manifest sets
 `synchronization_isolation_claimed: false`, so that control rests on the
 upstream suite at the pinned revision, not on network evidence.
@@ -57,9 +59,11 @@ prerelease only.
 
 ## Candidate changes are not released capabilities
 
-The post-release candidate on `main` repins `iroh-rooms` to `v0.1.0-rc.3`
-(join-after-conversation fix, join-bootstrap capability proof in `room.join`,
-bounded membership sync, gap healing) and adds a source-supported Linux
+The post-release candidate repins `iroh-rooms` to untagged `a5d98b70...`.
+Alongside the rc.3 join capability, bounded membership sync, and gap healing,
+this adds provisional-peer fanout/handshake gating, connection-generation
+teardown guards, and bounded store-insert recovery with durable critical
+degradation reporting. It also adds a source-supported Linux
 Flutter app with its packaging gate and `linux-flutter` CI job. The Linux app
 is an unsigned, unpublished developer package; it adds no released feature.
 Local tests and upstream regressions demonstrate implementation progress;
@@ -71,8 +75,8 @@ its archives contain, including its known join-after-chat limitation.
 `v0.5.0` met this gate and published. Before the next release tag can be
 published, the same public immutable commit must prove all of the following:
 
-1. the reviewed upstream pin (`v0.1.0-rc.3` or a reviewed successor) is
-   public and exactly pinned;
+1. the reviewed upstream pin (`a5d98b70…` or a reviewed tagged successor
+   carrying the same fixes) is public and exactly pinned;
 2. the approved evidence Ed25519 public key predates the qualifying network
    runs, and both retained manifests have valid detached signatures;
 3. direct and relay evidence is certifiable against the candidate's published
@@ -96,7 +100,8 @@ the ref and release operations requires operator inspection before retry.
 
 This snapshot records the released `v0.5.0` boundary (tag at `045d85c…`,
 certifying signed direct/relay manifests bound to `c5f740e…` + `d0ceb0b…`),
-the post-release rc.3 candidate on `main`, and the retained historical
+the post-release untagged dependency candidate, the prior signed rc.3 snapshot,
+and the retained historical
 manifests (the unsigned schema 2 preview run at `0f6769a…` and the schema 1
 local-remediation runs). Neither tickets, tokens, identity material, nor
 public IP addresses are retained. See

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -3,7 +3,7 @@ type: "Architecture"
 title: "Security and threat model"
 description: "Trust boundaries, assets, threats, controls, and residual risks for the v0.6.0 Jeliya candidate."
 tags: ["authorization", "privacy", "security", "threat-model"]
-timestamp: "2026-07-16T21:00:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -16,12 +16,12 @@ audience: ["contributors", "maintainers", "operators", "security-reviewers"]
 Jeliya is a local daemon or in-process mobile engine that stores identity keys,
 room state, files, and agent events while communicating with untrusted network
 peers. The `v0.6.0` target is a trustworthy technical preview, not a claim of
-complete security. The hardening implementation and functional verification
-are complete and certified: the public dependency pin now carries the
-room-scoped synchronization remediation and relay-only verification seam, and
-additionally gates the join bootstrap on an invite capability proof; the
-network-tested source is published, and the retained direct and forced-relay
-network evidence is signed and certifiable at this pin.
+complete security. The current dependency pin carries the room-scoped
+synchronization remediation, provisional-peer gate, store retry/degradation
+controls, and relay-only verification seam. Exact-revision local qualification
+passes. Signed direct and forced-relay evidence still binds the prior dependency
+pin and must be repeated before the current source candidate is network-
+qualified.
 
 ## Candidate boundary
 
@@ -29,20 +29,20 @@ Security conclusions must name the source being evaluated:
 
 | Surface | Revision | Security meaning |
 |---|---|---|
-| Public Jeliya dependency | Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (iroh-room tag `v0.1.0-rc.3`) | keeps the room-scoped event-lookup isolation remediation and relay-only seam certified for `v0.5.0`; adds the join-after-conversation fix, the join-bootstrap capability gate (`room.join` presents a `BootstrapProof`), bounded membership sync, and gap healing; qualified for `v0.6.0` |
-| Network-qualified Jeliya commit | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` | implements local RPC, durable provenance, secret, CI, evidence, and release controls; certifying schema 2 direct checks pass against public pin `71fbb500…` |
-| Forced-relay verification | Jeliya `55024a4…` plus public Iroh Rooms `71fbb500…` | certifying PASS; the relay-only build self-attests and forced-relay paths hold on roles A/B/C |
+| Current public Jeliya dependency | Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` (untagged upstream `main`) | first merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the `kortiene/iroh-room#126` connection-generation follow-ups; local fanout, isolation, and store-degradation qualification passes |
+| Current source candidate | Jeliya `42614709c03277acdb001b1a855952c6d5427625` | exact dependency pin in `Cargo.toml` and `Cargo.lock`; workspace and 67-assertion loopback suites pass; network qualification pending |
+| Last network-qualified snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` plus Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed direct and forced-relay schema 2 evidence remains valid for this exact prior pair only |
 | Superseded `v0.5.0` dependency | Iroh Rooms `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | carried the isolation remediation and relay-only seam; certified for the published `v0.5.0` at Jeliya `c5f740e67d043a1153cf285691e3bc5b2b9a7203`. Still fetchable by commit SHA, but no longer named by tag `v0.1.0-rc.2`, which was re-created upstream and now resolves elsewhere; the `v0.5.0` evidence binds the SHA, not the tag |
 | Historical local-remediation verification | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` plus local Iroh Rooms `3702e8cbcd5ac1808791124dd6bc44068be5f822` | schema 1 direct and forced-relay checks passed, but this older unpublished pair does not qualify a release |
 
-The certifying direct and forced-relay runs bind the published network-qualified
-commit `55024a4…` and the published, remediated public pin `71fbb500…`: they
+The retained certifying direct and forced-relay runs bind published Jeliya
+commit `55024a4…` and published Iroh Rooms pin `71fbb500…`: they
 establish direct and relay network operation and public-RPC non-disclosure. They
 do not establish room-scoped synchronization isolation — both manifests set
 `synchronization_isolation_claimed: false`; that control rests on the upstream
-suite at the pinned revision. Publication, immutable safe repinning, the direct
-and relay reruns, and the fresh signed evidence — all now complete at this pin —
-were security requirements, not release administration.
+suite at that revision. They do not transfer to `4261470…` + `a5d98b70…`.
+Fresh source-built direct and relay runs and signatures are security
+requirements, not release administration.
 
 ## Assets
 
@@ -76,19 +76,19 @@ implemented control.
 
 | Threat | Impact | Control | Evidence and remaining risk |
 |---|---|---|---|
-| Foreign-room data returned through a public RPC | cross-room confidentiality breach | one accepted-room preflight guard before any room-derived read or fold; `agents.fleet` and other aggregates enumerate/filter accepted rooms | local regressions pass; the certifying schema 2 direct and forced-relay runs deny all room-scoped RPCs, local-file access, and aggregate foreign-room/agent projections at `55024a4…` |
-| Foreign-room events served or admitted during synchronization | remote extraction or local-store contamination | room-scope `get`, `contains`, `WantEvents`, missing-parent traversal, and administrative tips; reject foreign envelopes and parents | the room-scoped remediation is published and pinned at `71fbb500...` (iroh-room tag v0.1.0-rc.3), carried forward from `d0ceb0b...`, and its rejection of foreign envelopes and parents passes the upstream suite at that revision. This control is **not** network-certified: both certifying manifests set `synchronization_isolation_claimed: false`, so the residual is that isolation is proven locally at the pin rather than over the public network |
-| Uninvited dialer pulls room history during an open join window | pre-join history disclosure | the rc.3 pin serves the join-bootstrap membership closure only after a verified invite capability proof (upstream issue #112); Jeliya's `room.join` presents the proof from the ticket | capability-gated join covered by the upstream join e2e suite and Jeliya's loopback join tests at the pin; residual: a still-connected unproven provisional dialer keeps receiving live event fan-out until it disconnects (upstream issue #121) — accept joins only while expecting them |
-| Store hole from a swallowed insert error | local store/fold divergence and unhealed history | the pinned upstream re-serves unplaced regions from peers; bounded backfill retries drive from recorded missing sets | upstream issue #119 remains open: a hole in a region no peer re-serves does not heal, and fold/store can disagree until restart; no Jeliya-side control beyond restart today |
+| Foreign-room data returned through a public RPC | cross-room confidentiality breach | one accepted-room preflight guard before any room-derived read or fold; `agents.fleet` and other aggregates enumerate/filter accepted rooms | local current-tree regressions pass; signed network denial evidence binds the prior `55024a4…` + `71fbb500…` snapshot and must be repeated at the current pin |
+| Foreign-room events served or admitted during synchronization | remote extraction or local-store contamination | room-scope `get`, `contains`, `WantEvents`, missing-parent traversal, and administrative tips; reject foreign envelopes and parents | exact-revision malicious `WantEvents`, foreign-parent, and administrative-tip oracles pass at `a5d98b70…`. This control is local upstream qualification, not a network-manifest claim |
+| Uninvited dialer pulls room history or live fanout during an open join window | pre-join history disclosure | serve the membership closure only after a verified invite capability proof; defer handshake/fanout until proof or membership promotion; generation-guard connection teardown | `uninvited_provisional_dialer_receives_no_live_fanout` and Jeliya's loopback join suite pass at the current pin; fresh direct/relay integration evidence pending |
+| Store hole from a swallowed insert error | local store/fold divergence and unhealed history | retain the accepted event, retry bounded inserts on ticks, defer feed/fanout until persistence, and record durable critical `store_degraded` on exhaustion or overflow | five deterministic recovery/degradation tests pass at `a5d98b70…`; real disk failure remains possible and requires an operator response |
 | Invite possession treated as accepted membership | pre-join data exposure | accepted-room index is authoritative; invite-only/never-joined rooms fail closed; joined-then-left archive behavior is explicit | negative never-joined cases and positive archive behavior pass locally |
 | Android identity copied through backup or device transfer | long-lived identity disclosure outside the device | `allowBackup=false`, explicit backup/data-extraction exclusions, `noBackupFilesDir`, fail-closed migration | repository validation passes; no Keystore protection and no claim against a rooted or compromised device |
 | Agent identity or state committed from a checkout | public secret disclosure and identity reuse | platform data directory outside the checkout, per-directory deny-all `.gitignore`, repository ignore rules, tracked-secret gate | six secret-storage tests plus repository validation pass locally |
 | Reachable vulnerable dependency | code execution, compromise, or denial of service | automated cargo/npm audits; high/critical findings block; explicit owned/expiring exception only when unavoidable | zero cargo/npm vulnerabilities; three maintenance warnings and one yanked version expire 2026-09-30 |
 | Compromised action or downloaded build tool | release supply-chain compromise | third-party Actions pinned to immutable revisions; Zig and Gradle distributions verified before execution; certifying network builds use the official complete Zig archive and exact tool bindings; least-privilege jobs | workflow and local contract tests pass; only the complete Zig archive is independently verified by schema 2, while other recorded tool digests are execution identities; the hosted double run executed for the published `v0.5.0` and executes again for `v0.6.0` on dispatch |
 | Partial, mismatched, or post-validation-modified release | incomplete, stale, mislabeled, or candidate-mutated binaries | validate and seal all five private archives in a no-execution job; smoke the immutable artifact separately; verify the receipt without execution before tag/release creation; expose the write token only to the final step | workflow and receipt negative tests pass locally, and the path executed end to end for the published `v0.5.0` five-archive set; it has not yet run for `v0.6.0` |
-| Installer extracts modified bytes | local code execution | fetch the matching published checksum, validate filename/format, verify SHA-256, then extract | Unix behavior passes; Windows behavioral and simulated-reparse gates are configured but have not executed on a hosted Windows runner |
-| Forged or edited verification record | false release confidence | retained exact manifest, canonical public key, detached Ed25519 signature, source/publication/ancestry checks | the certifying direct and forced-relay manifests are retained and signed with detached Ed25519 signatures that verify against the committed public SPKI; the release gate is READY |
-| Secrets copied into logs or evidence | credential or identity disclosure | transient logs confined to run-owned data directories, no address retention, and digest-only retained summaries | successful direct cleanup removed transient logs; the failed relay build made no remote mutation. Retained manifests keep only line/byte counts and stream SHA-256 digests and contain no tickets, tokens, seeds, private keys, excerpts, or IP addresses |
+| Installer extracts modified bytes | local code execution | fetch the matching published checksum, validate filename/format, verify SHA-256, then extract | Unix behavior passes; Windows checksum, tamper, and simulated-reparse behavior passed on public `main` run `29688515781` at `a24f223…`; current-candidate rerun pending |
+| Forged or edited verification record | false release confidence | retained exact manifest, canonical public key, detached Ed25519 signature, source/publication/ancestry checks | retained signatures verify for the prior snapshot; the current release gate is BLOCKED until replacement manifests bind the new revision pair |
+| Secrets copied into logs or evidence | credential or identity disclosure | transient logs confined to run-owned data directories, no address retention, and digest-only retained summaries | retained runs report completed cleanup. Manifests keep only line/byte counts and stream SHA-256 digests and contain no tickets, tokens, seeds, private keys, excerpts, or IP addresses |
 
 ## Authorization invariant
 
@@ -118,10 +118,10 @@ lookup must remain scoped to its room. Known event IDs, causal parents,
 administrative tips, and missing-event requests must never become cross-room
 read primitives.
 
-The local upstream remediation enforces that invariant and passes malicious
-`WantEvents`, foreign-parent, and administrative-tip tests. Because the public
-Jeliya lockfile does not yet resolve that code, upstream publication and Jeliya
-repinning are mandatory before release qualification.
+The pinned upstream revision enforces that invariant and passes malicious
+`WantEvents`, foreign-parent, and administrative-tip tests. The public Jeliya
+lockfile resolves that exact code. Fresh signed network evidence remains
+mandatory for current-candidate integration qualification.
 
 ## Secret-storage boundaries
 
@@ -151,11 +151,12 @@ task explicitly requires them.
 
 ## Network evidence boundary
 
-The current schema 2 three-peer direct run demonstrates direct connectivity
+The retained schema 2 three-peer direct run demonstrates direct connectivity
 across the observed operator/demo topology at Jeliya `55024a4…`. It also
 exercised messages, files, pipes, reconnect, and the public-RPC isolation
 boundary against the published, remediated public pin `71fbb500…`, which carries
-the room-scoped event-lookup isolation.
+the room-scoped event-lookup isolation. This is the last network-qualified
+snapshot, not the current `a5d98b70...` dependency candidate.
 
 Both certifying manifests set
 `functional_evidence.foreign_room_non_disclosure.synchronization_isolation_claimed`
@@ -166,10 +167,10 @@ filtering — and do **not** certify room-scoped synchronization isolation.
 the upstream test suite at the pinned revision, which is local qualification,
 not network evidence.
 
-The certifying forced-relay run passed. The relay-only source build compiles
+The retained certifying forced-relay run passed. Its relay-only source build compiles
 against the published seam, self-attests, and forces every role onto relay; its
-path assertions hold, so it exercises the relay workflow end to end for the
-current candidate.
+path assertions hold for the prior revision pair. A fresh current-pin run is
+required.
 
 Older schema 1 direct and relay runs passed with the unpublished local
 remediation and seam. They are historical functional evidence only and cannot

--- a/docs/verification-evidence.md
+++ b/docs/verification-evidence.md
@@ -3,10 +3,10 @@ type: "Status Report"
 title: "Verification evidence"
 description: "Revision-bound verification ledger and evidence-recording contract for the v0.6.0 candidate."
 tags: ["evidence", "networking", "release", "testing", "verification"]
-timestamp: "2026-07-16T21:00:00Z"
+timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
 implementation_status: "implemented"
-verification_status: "verified"
+verification_status: "partial"
 release_status: "unreleased"
 audience: ["contributors", "maintainers", "operators", "release-engineers"]
 ---
@@ -17,12 +17,11 @@ This ledger separates a functional test result from release-qualifying
 evidence. A result is transferable to a release candidate only when it binds
 the exact public Jeliya commit, public immutable dependency revisions,
 environment, timestamps, assertions, retained sanitized manifest, and detached
-signature. Both the direct and the forced-relay schema 2 runs now meet that
-bar: each binds the published network-qualified Jeliya commit and the published,
-remediated iroh-rooms revision, is retained as a sanitized manifest, and carries
-a detached Ed25519 signature verified against the pinned release-evidence key.
-Both set `certifiable: true` and `source.releaseable: true`; the evidence
-authorizes the v0.6.0 daemon prerelease.
+signature. The retained direct and forced-relay schema 2 runs meet that bar for
+the earlier Jeliya `55024a4...` + Iroh Rooms `71fbb500...` snapshot. The current
+source candidate repins Iroh Rooms to `a5d98b70...`; those signed manifests do
+not transfer to the new dependency revision and do not authorize a `v0.6.0`
+release from the current tree.
 
 ## Candidate identity
 
@@ -30,23 +29,27 @@ authorizes the v0.6.0 daemon prerelease.
 |---|---|
 | Milestone | `v0.6.0 — Capability-Gated Join Candidate`, not yet published |
 | Baseline commit | `045d85cb1d066f16d564b6051363b9328063ee01` — the published `v0.5.0` tag |
-| Network-qualified commit | `55024a46b3e112796ba2acf1dc408dab26dbba2e` |
-| Current public `iroh-rooms` pin | `71fbb5007bef4ce83631c94762ec68c2beef3d79` — join-after-conversation deadlock fixed and the join bootstrap gated on the invite capability proof (iroh-room tag v0.1.0-rc.3) |
-| Candidate upstream remediation revision | `71fbb5007bef4ce83631c94762ec68c2beef3d79` |
-| Retained evidence signatures | present — detached Ed25519 over `direct.json` and `relay.json`, verified against the pinned public SPKI |
-| Release evidence gate | READY |
-| Evidence window | 2026-07-16 UTC |
+| Current source candidate | `42614709c03277acdb001b1a855952c6d5427625` |
+| Network-qualified commit | `pending — fresh signed direct and relay runs required` |
+| Current public `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first upstream `main` merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the connection-generation follow-ups |
+| Candidate upstream remediation revision | `a5d98b70d717f35d3ce60953a88e12e646f2e871` |
+| Last network-qualified snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` + Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
+| Retained evidence signatures | present and valid for the last network-qualified snapshot; not transferable to the current pin |
+| Release evidence gate | BLOCKED |
+| Evidence window | local exact-revision qualification on 2026-07-19 UTC; current network evidence pending |
 
-Both certifying schema 2 runs resolve the published iroh-rooms revision
-`71fbb500` (iroh-room tag `v0.1.0-rc.3`), which carries the reviewed cross-room
-event-lookup isolation fix and the compile-time relay-only test seam already
-certified for `v0.5.0`, and adds the join-bootstrap capability gate. The direct
-run verifies the hardened public-RPC boundary and stable direct paths; the
-forced-relay run attests a relay-only source build and proves the same behavior
-over relay. Both bind the published network-qualified commit `55024a4`, run over
-three peers spanning two BGP origin ASNs (AS11426 + AS24940) with three distinct
-observed egresses, pass every recorded assertion, and set `certifiable: true`
-and `source.releaseable: true`.
+The current pin is the first upstream `main` merge containing both required
+fixes. The two commits after it change only `iroh-rooms-cli`, which Jeliya does
+not consume, so pinning later would expand the reviewed surface without changing
+the SDK behavior. The newest tag remains `v0.1.0-rc.3` at `71fbb500...` and
+predates both fixes.
+
+The retained signed direct and forced-relay runs remain valid evidence for
+`55024a4...` + `71fbb500...`: they covered three peers across two BGP origin
+ASNs, passed every recorded assertion, and set `certifiable: true`. They are
+historical for the current source candidate. Fresh manifests must bind
+`4261470...` and `a5d98b70...` before the release
+evidence gate can return to `READY`.
 
 The `v0.5.0`-certified pin remains `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb`.
 That revision is still publicly fetchable by commit SHA, but it is no longer
@@ -66,24 +69,26 @@ manifests are the certifying set.
 
 | Gate | Current evidence | Status |
 |---|---|---|
-| Public read-RPC authorization | centralized guard and local negative suite cover foreign timelines, members, agents, files, pipes, local-file HTTP, and aggregate projections; the current schema 2 direct run denied all 17 room-scoped RPCs and filtered local-file and aggregate reads | certifying PASS at `55024a4…`; the direct run denied all room-scoped RPCs and filtered local-file and aggregate reads over the public network |
+| Public read-RPC authorization | centralized guard and local negative suite cover foreign timelines, members, agents, files, pipes, local-file HTTP, and aggregate projections; the retained schema 2 runs denied all 17 room-scoped RPCs and filtered local-file and aggregate reads | certifying PASS at the superseded `55024a4…` + `71fbb500…` snapshot; current-pin network rerun required |
 | Accepted-room provenance | create/join failure injection proves provenance is accepted before irreversible event publication; 24 concurrent mutations retain every room; direct reads reuse the authorized snapshot cache; Unix mode is pinned to `0600`; exact `atomicwrites 0.4.4` uses synchronized Unix directory replacement and Windows write-through replacement | local PASS; Windows semantics source-reviewed but not behaviorally executed on `windows-latest` |
 | Pre-identity protocol contract | `room.list` returns the successful empty onboarding result `{ rooms: [] }` consistently across the core engine, TypeScript mock, Dart daemon, Dart FFI, Dart mock, and golden-corpus oracles | local PASS |
-| Upstream synchronization isolation | malicious `WantEvents`, foreign-parent, and administrative-tip tests pass against the published upstream `71fbb5007bef4ce83631c94762ec68c2beef3d79` (iroh-room tag v0.1.0-rc.3), which carries forward the isolation remediation first published at `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | local PASS at the pinned revision; upstream remediation published and Jeliya repinned. NOT network-certified: both certifying manifests set `synchronization_isolation_claimed: false`, so neither run exercises `WantEvents`, foreign-parent, or administrative-tip traversal over the network |
+| Upstream synchronization isolation | malicious `WantEvents`, foreign-parent, and administrative-tip checks pass at `a5d98b70d717f35d3ce60953a88e12e646f2e871`, which carries forward the isolation remediation first published at `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | local exact-revision PASS. NOT network-certified: the retained manifests set `synchronization_isolation_claimed: false` and do not exercise these internals |
+| Unproven provisional-peer fanout and teardown | live-fanout denial plus the superseded-link and deauthorization-state generation regressions pass at `a5d98b70...`; Jeliya's 67-assertion loopback suite covers capability-proven join integration | local exact-revision PASS; current-pin direct and relay evidence pending |
+| Store insert recovery and degradation | five deterministic upstream tests cover retry recovery, local hole healing under descendants, exhausted-budget durable critical `store_degraded`, queue overflow, and exactly-once peer re-serve | local exact-revision PASS at `a5d98b70...`; disk failure remains possible and must surface operationally |
 | Android backup exclusion | `allowBackup=false`, explicit cloud/device-transfer exclusion rules, and engine state under `noBackupFilesDir`; repository gate and six secret-storage tests pass | local PASS; this is app-private no-backup storage, not Android Keystore wrapping |
 | Agent secret location | platform data directory outside the checkout, deny-all state-directory Git guard, repository ignore rules, and commit-prevention validation | local PASS |
 | Rust dependency audit | zero vulnerability advisories; three unmaintained-crate warnings and one yanked-version warning remain in the register below | PASS for vulnerability threshold |
 | npm dependency audit | zero vulnerabilities | PASS |
-| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | the six pre-existing required jobs pass on hosted `main` runs; the new `linux-flutter` job has no hosted execution yet |
-| Repeatability | two complete hosted CI executions from clean environments | satisfied by `release.yml`, which runs the complete CI gate twice on the network-qualified commit before any release build |
-| Direct different-network P2P | schema 2 run `1ca39cfa`: three peers, three distinct observed egresses, two ASNs (AS11426 + AS24940), stable direct paths on roles A/B/C, all assertions pass | certifying PASS; signed and retained as `direct.json` |
-| Deliberately forced relay | schema 2 run `cf28bc63`: the relay-only source build compiles against the published seam and self-attests on the operator host and both remote hosts, then proves forced-relay paths on roles A/B/C with all assertions passing | certifying PASS; signed and retained as `relay.json` |
-| Join, reconnect, and resynchronization | current direct run covered targeted joins, three-peer convergence, closed-session message, reopen, resynchronization, and settled direct reconnect | certifying PASS; direct and forced-relay both certified |
-| Messages, files, and pipes | current direct run covered bidirectional and three-peer messages, byte-identical engine-verified BLAKE3 file fetch, authorized pipe, and zero-target-connection unauthorized pipe | certifying PASS; direct and forced-relay both certified |
+| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | all jobs, including `linux-flutter` and Windows installer integrity, passed on public `main` run `29688515781` at `a24f223...`; current-candidate rerun pending |
+| Repeatability | two complete hosted CI executions from clean environments | configured in `release.yml`; not executed for the current candidate |
+| Direct different-network P2P | retained schema 2 run `1ca39cfa`: three peers, three distinct observed egresses, two ASNs (AS11426 + AS24940), stable direct paths on roles A/B/C, all assertions pass | certifying PASS for `55024a4…` + `71fbb500…`; current-pin rerun required |
+| Deliberately forced relay | retained schema 2 run `cf28bc63`: the relay-only source build self-attests on all three hosts and proves relay paths on roles A/B/C | certifying PASS for `55024a4…` + `71fbb500…`; current-pin rerun required |
+| Join, reconnect, and resynchronization | the current two-daemon loopback run passes 67/67 assertions; retained network runs cover the same integration boundary at the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
+| Messages, files, and pipes | current loopback covers messages, byte-identical BLAKE3-verified file fetch, authorized pipe, and unauthorized denial; retained network runs cover the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
 | Installer integrity | Unix behavioral tests verify checksum-before-extraction; Windows jobs execute checksum/tamper behavior, simulate reparse rejection, and smoke the native daemon | Unix PASS; hosted `windows-latest` job passes on `main` |
 | Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | executed end to end for `v0.5.0`, which built, verified, and published the five-archive set with sidecars; the same path executes for `v0.6.0` on release dispatch and has not yet run at this candidate. GitHub tag and release operations remain non-transactional |
-| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.0` | PASS locally at `55024a4`; the public `v0.6.0` tag does not exist yet, so tag and artifact-name agreement is asserted by `release.yml` on dispatch, not here |
-| Documentation | required OKF pages distinguish current schema 2 direct evidence, the failed-closed current relay attempt, and historical schema 1 local-remediation evidence | rerun the local docs gate on the final documentation-only commit |
+| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.0` | PASS locally at `4261470`; the public `v0.6.0` tag does not exist yet |
+| Documentation | required OKF pages distinguish the current locally qualified candidate, the prior signed schema 2 snapshot, and historical schema 1 local-remediation evidence | local docs and release-contract gates pass on this documentation diff |
 
 ## Dependency-risk exception register
 
@@ -138,14 +143,14 @@ non-certifying unless it binds public immutable Jeliya and Iroh Rooms
 revisions, a clean source tree, qualifying topology, successful cleanup, and a
 valid detached signature from the pre-authorized evidence key.
 
-## Local upstream remediation qualification
+## Upstream isolation-remediation lineage
 
-The reviewed Iroh Rooms remediation — the room-scoped event-lookup fix and the
-compile-time relay-only test seam — was first published as
-`d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` and certified for `v0.5.0`; it is
-carried forward unchanged in this candidate's pin
-`71fbb5007bef4ce83631c94762ec68c2beef3d79` (iroh-room tag `v0.1.0-rc.3`). Its
-tests demonstrate that:
+The reviewed Iroh Rooms room-scoped event-lookup remediation and compile-time
+relay-only test seam were first published as
+`d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` and certified for `v0.5.0`. They
+were carried through the prior `71fbb500...` snapshot and remain in the current
+pin `a5d98b70d717f35d3ce60953a88e12e646f2e871`. Exact-revision tests demonstrate
+that:
 
 - `WantEvents` cannot serve a known event ID from another room;
 - a foreign row remains unavailable when cited as a local causal parent;
@@ -154,9 +159,10 @@ tests demonstrate that:
 - the relay-only feature is compile-time, propagated through Jeliya and the
   dependency, and attested before a forced-relay run starts.
 
-This remediation is now pinned through Jeliya's public `Cargo.toml` and
-`Cargo.lock` at the network-qualified commit, and the network suite was repeated
-against it — see the certifying evidence below.
+The current `Cargo.toml` and `Cargo.lock` resolve `a5d98b70...`, and the local
+isolation regression was repeated there. The certifying network evidence below
+binds the prior `55024a4...` + `71fbb500...` snapshot; it has not been repeated
+at the current pin.
 
 ## Certifying network evidence
 
@@ -291,29 +297,105 @@ real-network evidence.
 
 ## Exact release blockers
 
-The evidence gate is **READY** for `v0.6.0`. Each prior blocker has been
-cleared:
+The evidence gate is **BLOCKED** for the current `v0.6.0` source candidate.
+Completed work:
 
-1. the upstream remediation is reviewed and published as iroh-rooms
-   `71fbb5007bef4ce83631c94762ec68c2beef3d79` (iroh-room tag `v0.1.0-rc.3`);
-2. Jeliya's public `Cargo.toml` and `Cargo.lock` are repinned to that immutable
-   public revision, and the exact candidate commit
-   `55024a46b3e112796ba2acf1dc408dab26dbba2e` is published on `main`;
-3. out-of-band Ed25519 private-key custody is established and only the canonical
-   public SPKI is committed;
-4. the direct and forced-relay runs were repeated from that public commit and
-   dependency, retained as the exact sanitized `direct.json`/`relay.json`
-   manifests, and carry valid detached signatures; and
-5. the remaining gates — two clean hosted CI runs, the Windows installer
-   integrity gate, the five-archive daemon artifact set, version/tag/name
-   consistency, and the draft-until-verified publication — are executed by
-   `release.yml` on release dispatch under explicit release authority.
+1. upstream fixes for `kortiene/iroh-room#121`, `kortiene/iroh-room#126`, and
+   `kortiene/iroh-room#119` are public
+   and present at immutable revision
+   `a5d98b70d717f35d3ce60953a88e12e646f2e871`;
+2. public Jeliya source candidate
+   `42614709c03277acdb001b1a855952c6d5427625` resolves that exact revision in
+   `Cargo.toml` and `Cargo.lock`; and
+3. the targeted fanout, isolation, and store-degradation regressions, the full
+   upstream core/net suite, the Jeliya workspace suite, and the loopback E2E
+   suite pass at source candidate
+   `42614709c03277acdb001b1a855952c6d5427625`.
 
-`v0.5.0` published through that same path on 2026-07-14 with the complete
-five-archive set and sidecars. `v0.6.0` has not been dispatched yet; the gates
-in item 5 remain unexecuted at this candidate.
+Remaining work before `READY`:
 
-## Candidate provenance: repin to iroh-room v0.1.0-rc.3 (2026-07-16)
+1. run direct and forced-relay qualification from that clean public commit,
+   retaining new sanitized manifests bound to `a5d98b70...`;
+2. sign the exact manifest bytes with the approved out-of-band Ed25519 key;
+3. pass the evidence signature, source ancestry, and docs-only-after-
+   qualification checks; and
+4. complete the hosted double CI run and remaining release gates under explicit
+   release authority.
+
+`v0.5.0` remains released and certified at its own revision pair. The retained
+`v0.6.0` manifests remain valid for the older `55024a4...` + `71fbb500...`
+snapshot but cannot clear the current candidate's gate.
+
+## Candidate provenance: untagged upstream fixes (2026-07-19)
+
+Jeliya source candidate `42614709c03277acdb001b1a855952c6d5427625`
+repins the SDK crates to upstream merge
+`a5d98b70d717f35d3ce60953a88e12e646f2e871`. This is the first `main` commit
+that contains:
+
+- the provisional-peer fanout and deferred-handshake fix from
+  `kortiene/iroh-room#121` (merge `58aca4ba...`);
+- the connection-generation guard and deauthorization follow-up for
+  `kortiene/iroh-room#126`; and
+- store-insert retry, local hole healing, and durable fail-loud degradation for
+  `kortiene/iroh-room#119` (merge `a5d98b70...`).
+
+The newest tag, `v0.1.0-rc.3` at `71fbb500...`, predates all three. The two
+commits after `a5d98b70...` modify only `iroh-rooms-cli/src/audit.rs`, a crate
+Jeliya does not consume. The untagged minimum therefore carries the required
+library fixes without adding unrelated code to the reviewed dependency surface.
+
+Local qualification used a clean detached upstream checkout on Linux aarch64
+with Rust/Cargo 1.97.1:
+
+```sh
+# Upstream checkout at a5d98b70d717f35d3ce60953a88e12e646f2e871
+cargo test --locked -p iroh-rooms-net --all-features --test join_e2e \
+  uninvited_provisional_dialer_receives_no_live_fanout -- --exact
+cargo test --locked -p iroh-rooms-core --all-features --test sync_smoke \
+  want_events_cannot_serve_an_id_from_another_room_in_the_shared_store -- --exact
+cargo test --locked -p iroh-rooms-core --all-features --lib \
+  sync::engine_tests::
+cargo test --locked -p iroh-rooms-net --all-features --lib \
+  transport::tests::superseded_provisional_link_teardown_preserves_the_successors_gate \
+  -- --exact
+cargo test --locked -p iroh-rooms-net --all-features --lib \
+  transport::tests::invalidate_link_makes_a_late_teardown_a_noop_preserving_deauthorized \
+  -- --exact
+cargo test --locked -p iroh-rooms-core -p iroh-rooms-net \
+  --all-targets --all-features
+scripts/verify.sh
+
+# Jeliya checkout at 42614709c03277acdb001b1a855952c6d5427625
+DART_SDK_INCLUDE="$HOME/flutter/bin/cache/dart-sdk/include" \
+  cargo test --locked --workspace
+DART_SDK_INCLUDE="$HOME/flutter/bin/cache/dart-sdk/include" \
+  node scripts/e2e.mjs --mode loopback
+cargo run --locked -p jeliyad --features relay-only-test -- \
+  --verification-relay-only-build
+! cargo run --locked -p jeliyad -- --verification-relay-only-build
+```
+
+- the exact `kortiene/iroh-room#121` live-fanout regression passed (1/1);
+- the malicious `WantEvents` isolation regression passed (1/1), including its
+  foreign-parent and administrative-tip oracles;
+- both targeted connection-generation teardown regressions passed (2/2),
+  covering a superseded provisional link and a late deauthorization teardown;
+- all five deterministic store retry/degradation tests passed (5/5);
+- `iroh-rooms-core` and `iroh-rooms-net` passed 806 tests across all targets and
+  all features, with two intentional ignores;
+- upstream's canonical `scripts/verify.sh` passed formatting, clippy, workspace
+  tests, doctests, and example builds (1,780 tests passed, 20 ignored);
+- Jeliya's locked workspace suite passed 77 tests with one intentional
+  performance ignore; and
+- the two-daemon loopback suite passed all 67 assertions; and
+- the relay-only build emitted `jeliya-relay-only-test-build-v1`, while the
+  normal build rejected the hidden attestation flag with exit status 2.
+
+This is exact-revision local evidence. It does not replace the signed
+three-egress direct and forced-relay runs required above.
+
+## Superseded candidate provenance: iroh-room v0.1.0-rc.3 (2026-07-16)
 
 After the `v0.5.0` release, `main` repinned `iroh-rooms` from certified
 `d0ceb0b…` to the published `v0.1.0-rc.3` tag
@@ -345,14 +427,12 @@ workstation, clean checkouts of the exact tag commit):
   data dir; the default build rejects the hidden flag.
 
 The certified `v0.5.0` evidence binds `c5f740e` + `d0ceb0b` and does not
-transfer to this pin. The fresh signed direct and forced-relay runs it required
-were executed on 2026-07-16 from the public commit `55024a4` carrying the rc.3
-pin, and are the certifying set recorded above; the local qualification in this
-section is corroborating evidence, not the release qualification. Upstream
-residuals at rc.3 are recorded in the
-[threat model](security-threat-model.md): live event fan-out to a
-still-connected unproven provisional dialer while joins are being accepted
-(issue #121) and store holes from swallowed insert errors (issue #119).
+transfer to this pin. Signed direct and forced-relay runs were executed on
+2026-07-16 from public commit `55024a4` carrying the rc.3 pin. Those manifests
+remain certifying evidence for that exact snapshot, not for the current
+`a5d98b70...` dependency candidate. The rc.3 residuals were live event fanout
+to an unproven provisional dialer and store holes from swallowed insert errors;
+both are addressed by the 2026-07-19 repin described above.
 Mixed-fleet caution: a `v0.5.0`-era joiner cannot bootstrap from an rc.3
 admin (it sends no capability proof), and an rc.3 joiner hard-stalls
 bootstrapping from a `v0.5.0`-era responder once it holds more than ~1k


### PR DESCRIPTION
## Summary

- repin `iroh-rooms` from tagged `v0.1.0-rc.3` (`71fbb500...`) to public upstream merge `a5d98b70d717f35d3ce60953a88e12e646f2e871`
- record why this deliberately untagged revision is the minimum reviewed target carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119`, plus the `kortiene/iroh-room#126` follow-ups
- add the repin and exact-revision qualification to the Phase 0 deliverables and go/no-go gate
- reconcile release, platform, threat-model, runbook, and evidence pages without rewriting the retained signed manifests

The runtime candidate is `42614709c03277acdb001b1a855952c6d5427625`, published at `qualification/114-iroh-rooms-a5d98b70`. The PR tip is a docs-only descendant so future signed evidence can bind the runtime SHA without violating the docs-only-after-qualification rule.

Refs #114

## Why this revision

`a5d98b70...` is the first upstream `main` merge containing both required fixes. The newest tag still points to the old pin, while the two later upstream commits change only `iroh-rooms-cli/src/audit.rs`, which Jeliya does not consume.

## Qualification

At the exact upstream revision on Linux aarch64 with Rust/Cargo 1.97.1:

- provisional-peer live-fanout regression: 1 passed
- malicious `WantEvents` isolation regression: 1 passed
- connection-generation teardown regressions: 2 passed
- store retry/degradation regressions: 5 passed
- full `iroh-rooms-core` + `iroh-rooms-net` all-target/all-feature suite: 806 passed, 2 ignored
- upstream `scripts/verify.sh`: 1,780 passed, 20 ignored; fmt, Clippy, doctests, and examples passed

At Jeliya candidate `4261470...`:

- locked workspace: 77 passed, 1 intentional performance ignore
- two-daemon loopback E2E: 67/67 assertions
- relay-only build emitted the exact attestation marker; the normal build rejected the hidden flag
- locked workspace Clippy with `-D warnings` and `cargo fmt --all --check` passed
- docs, release-source, secret-storage, and 37 evidence-contract tests passed

## Remaining release qualification

The release evidence gate intentionally remains **BLOCKED**. Before this candidate can become release-qualified:

1. run fresh signed direct and forced-relay qualification from the public runtime SHA on the required x86_64 macOS operator;
2. replace and sign both `v0.6.0` manifests so they bind `4261470...` + `a5d98b70...`; and
3. complete the hosted double CI run and remaining release gates under explicit release authority.

The existing signed manifests remain valid only for `55024a4...` + `71fbb500...`.