### PR TITLE
chore: prepare v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-19
+
 ### Changed
 
 - Repinned `iroh-rooms` from tag `v0.1.0-rc.3` (`71fbb500…`) to the
@@ -10,7 +12,11 @@
   guards, and bounded store-insert recovery with durable critical degradation
   reporting. Exact-revision upstream, workspace, and loopback qualification
   passes. Signed direct and forced-relay evidence at the prior pin remains
-  valid for that snapshot but does not transfer to the new candidate.
+  valid for released `v0.6.0` but does not transfer to the new candidate.
+- Reserved a separate `docs/evidence/v0.6.1/` boundary for fresh qualification
+  records. The `v0.6.0` manifests and signatures remain immutable, and the
+  secret-storage gate now rejects private evidence-signing material even when
+  it is gitignored inside the checkout.
 
 ## [0.6.0] - 2026-07-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jeliya-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "jeliyad"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "dirs",

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ Note: these builds are unsigned, so macOS/Windows will show a security warning
 on first run (see [Troubleshooting](#troubleshooting)) — the `brew`/`curl`/
 PowerShell installs above don't trigger this.
 
-Release `v0.4.3` publishes SHA-256 sidecars, but its installer implementation
-does not automatically verify them before extraction. Automatic installer
-verification is a `v0.5.0` release gate; until that release is published,
-verify a manually downloaded archive against its matching `.sha256` file. See
-the exact [release-versus-main matrix](docs/release-vs-main.md).
+Release `v0.4.3` publishes SHA-256 sidecars, but the installer stored at that
+tag does not automatically verify them before extraction. The fail-closed
+installer shipped in `v0.5.0` and is retained by released `v0.6.0`; the current
+`main` installer also verifies a selected archive against its matching
+`.sha256` file before extraction. Because `v0.6.0` is a prerelease, pin
+`JELIYA_VERSION=v0.6.0` to install that preview explicitly. See the exact
+[release-versus-main matrix](docs/release-vs-main.md).
 
 ### 2. Run it
 

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliya-core"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jeliyad"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/docs/capability-status.md
+++ b/docs/capability-status.md
@@ -1,7 +1,7 @@
 ---
 type: "Status Report"
 title: "Capability status"
-description: "Evidence-aware capability matrix for the v0.5.0 technical-preview candidate and the latest public release."
+description: "Evidence-aware capability matrix for the released v0.6.0 preview and the v0.6.1 preparation line."
 tags: ["capabilities", "release", "status", "verification"]
 timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
@@ -14,33 +14,33 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Capability status
 
 This page separates implementation, verification, and public availability.
-`v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease backed by signed,
-certifying direct and forced-relay evidence. The current `v0.6.0` source
-candidate repins `iroh-rooms` to untagged upstream revision `a5d98b70...`, the
-first `main` merge carrying the provisional-peer and store-degradation fixes.
-It is locally qualified but not network-qualified or published. Signed runs at
-the earlier `55024a4...` + `71fbb500...` snapshot remain valid for that exact
-pair and do not transfer to the current dependency.
+`v0.6.0` shipped on 2026-07-16 as a daemon-only prerelease at tag
+`2283a441...`. Its signed direct and forced-relay evidence binds source commit
+`55024a4...` and Iroh Rooms `71fbb500...`. The `v0.6.1` preparation line keeps
+the corrective repin to untagged upstream revision `a5d98b70...`, the first
+`main` merge carrying the provisional-peer and store-degradation fixes. The
+exact `v0.6.1` candidate will be designated only after this version PR merges;
+no current v0.6.0 evidence transfers to it.
 
 ## Snapshot boundary
 
 | Field | Value |
 |---|---|
-| Released milestone | `v0.5.0 — Evidence-Backed Technical Preview`, published 2026-07-14 as a prerelease: five daemon+embedded-UI archives with `.sha256` sidecars |
-| Current source candidate | `105744b6c27633e5ccc576d86f1a15e3fe443b94` with Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` |
-| Last network-qualified `v0.6.0` snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` with Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
-| Retained certified evidence | signed schema 2 direct (`1ca39cfa`) and forced-relay (`cf28bc63`) runs of 2026-07-16; valid for the last network-qualified snapshot only |
+| Released milestone | `v0.6.0 — Capability-Gated Join Technical Preview`, published 2026-07-16 at `2283a441220031485a7a212dc585772231d0f428` as a prerelease: five daemon+embedded-UI archives with `.sha256` sidecars |
+| Current source candidate | pending — designate the exact public `v0.6.1` SHA after the version PR merges; the version PR itself is not qualified |
+| Released `v0.6.0` qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` with Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
+| Retained certified evidence | signed schema 2 direct (`1ca39cfa`) and forced-relay (`cf28bc63`) runs of 2026-07-16; valid for released `v0.6.0` only |
 | Candidate `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first merge carrying the `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus `kortiene/iroh-room#126` follow-ups; later `main` changes only an unconsumed CLI crate |
-| Candidate verification | exact-revision upstream fanout, isolation, and store-degradation tests pass; full Jeliya workspace and 67-assertion loopback suites pass. Fresh signed direct and forced-relay evidence is required |
+| Candidate verification | the pre-version baseline at `105744b…` passed exact-revision upstream, workspace, and 67-assertion loopback suites; the post-merge `v0.6.1` SHA still requires qualification refs plus fresh signed direct and forced-relay evidence |
 | Historical network verification | schema 1 runs at Jeliya `fe870c7…` with local upstream `3702e8c…`, and the schema 2 preview run at `0f6769a…` with pre-remediation pin `3cb9bfd…`; functional evidence only |
 | Status captured | 2026-07-19 15:15 UTC |
 
 See [Release versus main](release-vs-main.md) for the revision boundaries and
 [Verification evidence](verification-evidence.md) for the complete ledger.
-The released `v0.5.0` pins `d0ceb0b…`, which predates upstream's
+The superseded `v0.5.0` pins `d0ceb0b…`, which predates upstream's
 join-after-conversation fix: an invite minted after any non-admin chat cannot
-complete `room.join` on `v0.5.0` — the current repin carries that fix plus the
-later provisional-peer and store-degradation fixes. Mixed `v0.5.0`/candidate
+complete `room.join` on `v0.5.0` — released `v0.6.0` carries that join fix,
+while the v0.6.1 repin adds the later provisional-peer and store-degradation fixes. Mixed `v0.5.0`/newer
 rooms cannot complete joins in either direction, so a room's members,
 especially its admin, must move together.
 
@@ -48,28 +48,28 @@ especially its admin, must move together.
 
 | Capability | Implementation | Verification | Public release | Honest current claim |
 |---|---|---|---|---|
-| `jeliyad` with embedded React UI | implemented | certified for `v0.5.0` | released in `v0.5.0` (prerelease) | The complete five-target daemon+embedded-UI archive set with `.sha256` sidecars is published. Signed schema 2 direct and forced-relay runs certified the released revision pair. |
-| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.5.0`; current pin passes local integration | released in `v0.5.0` | Known `v0.5.0` limitation: an invite minted after non-admin chat cannot complete `room.join`. The current candidate fixes this and passes all 67 loopback assertions; fresh current-pin network runs remain required. |
-| Files and BLAKE3 fetch verification | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Cross-network transfer, byte equality, and hash verification passed in both certifying runs. |
-| Pipes | implemented | certified direct and relay pass for `v0.5.0` | released in `v0.5.0` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in both certifying runs. |
-| Direct cross-network P2P | implemented | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending | released in `v0.5.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) certifies `55024a4…` + `71fbb500…`; it does not transfer to `105744b…` + `a5d98b70…`. |
-| Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending | released in `v0.5.0` | [Signed schema 2 relay run `cf28bc63`](evidence/v0.6.0/relay.json) certifies `55024a4…` + `71fbb500…`; a new relay-only source build and signed run are required. |
+| `jeliyad` with embedded React UI | implemented | certified for `v0.6.0` | released in `v0.6.0` (prerelease) | The complete five-target daemon+embedded-UI archive set with `.sha256` sidecars is published. Signed schema 2 direct and forced-relay runs certified the released source revision pair. |
+| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.6.0`; the v0.6.1 pin passes local integration at the pre-version baseline | released in `v0.6.0` | Released `v0.6.0` fixes the v0.5.0 join-after-chat limitation. Fresh v0.6.1 current-pin network runs remain required. |
+| Files and BLAKE3 fetch verification | implemented | certified direct and relay pass for `v0.6.0` | released in `v0.6.0` | Cross-network transfer, byte equality, and hash verification passed in both certifying runs. |
+| Pipes | implemented | certified direct and relay pass for `v0.6.0` | released in `v0.6.0` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in both certifying runs. |
+| Direct cross-network P2P | implemented | certified for released `v0.6.0`; v0.6.1 candidate pending | released in `v0.6.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) certifies `55024a4…` + `71fbb500…`; it does not transfer to the future v0.6.1 SHA + `a5d98b70…`. |
+| Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for released `v0.6.0`; v0.6.1 candidate pending | released in `v0.6.0` | [Signed schema 2 relay run `cf28bc63`](evidence/v0.6.0/relay.json) certifies `55024a4…` + `71fbb500…`; a new relay-only source build and signed run are required. |
 | Public room-scoped RPC isolation | implemented | verified locally and in both certifying runs | released in `v0.5.0` | A centralized guard covers the public room-scoped surface. Seventeen negative RPC checks, local-file denial, and aggregate filtering passed over the public network in the certifying runs. |
 | Upstream synchronization and provisional-peer isolation | remediated at current pin `a5d98b70…` | targeted isolation, provisional-fanout, and store-degradation regressions pass; core/net all-targets suite passes 806 tests with two ignores | released baseline in `v0.5.0`; new fixes unreleased | Local exact-revision evidence covers the upstream internals. Fresh signed network evidence is still required for Jeliya integration at the new pin. |
-| Agent runner and fleet | implemented | local pass | released as source through `v0.5.0` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
+| Agent runner and fleet | implemented | local pass | released as source through `v0.6.0` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
 | Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland lifecycle remain pending | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
 | Android in-process FFI engine | implemented | local device smoke only | unreleased | App-private identity state is excluded from cloud backup and device transfer. It is not Android Keystore-backed, and Android direct, relay, NAT, and cross-network behavior remain unverified. |
-| Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | release gates passed for `v0.5.0` | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
-| CI matrix | implemented | all jobs passed on public `main` run `29688515781` at `a24f223…`; current-candidate run pending | exercised for `v0.5.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. The hosted run includes Windows installer integrity and the `linux-flutter` release-build, Xvfb, dependency, archive, and checksum checks. |
-| Unix installer integrity | implemented | behavioral checks pass | released in `v0.5.0` | Unix installers fetch and verify the matching sidecar before extraction; `v0.5.0` installs via the version-pinned installer path. |
-| Windows installer integrity | implemented | hosted `windows-latest` job passes on `main` | released in `v0.5.0` | The Windows job executes checksum/tamper behavior, simulates reparse-point rejection, and runs native `jeliyad.exe --version`; a `v0.5.0` Windows zip and sidecar are published. |
-| Complete asset-set visibility and version consistency | implemented | executed for `v0.5.0` | released in `v0.5.0` | The publication workflow validated, sealed, smoked, and receipt-verified the complete five-archive set; the evidence key is provisioned and the signed evidence passed the release gate before publication. |
-| WCAG 2.1 AA | partial | automated gate on every pull request; manual checklist per release | partial | Enforced, not certified. CI rejects any critical or serious axe violation across every destination at 1440x900, 920x800, 390x844 and 320x568, and fails on clipped layout at 100/200/320% text in English and French; `docs/accessibility-checklist.md` covers the screen-reader and keyboard behaviours automation cannot decide. Not a conformance claim: the web client is English-only until localization lands, and `ui-e2e` is not yet a required status check, so the gate runs on every pull request without blocking merge. |
+| Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | release gates passed for `v0.6.0` | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
+| CI matrix | implemented | all jobs passed on public `main` run `29699530741` at `105744b…`; post-version candidate run pending | exercised for `v0.6.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. The hosted run includes Windows installer integrity and the `linux-flutter` release-build, Xvfb, dependency, archive, and checksum checks. |
+| Unix installer integrity | implemented | behavioral checks pass | released in `v0.6.0` | Unix installers fetch and verify the matching sidecar before extraction; `v0.6.0` installs via the version-pinned installer path. |
+| Windows installer integrity | implemented | hosted `windows-latest` job passes on `main` | released in `v0.6.0` | The Windows job executes checksum/tamper behavior, simulates reparse-point rejection, and runs native `jeliyad.exe --version`; a `v0.6.0` Windows zip and sidecar are published. |
+| Complete asset-set visibility and version consistency | implemented | executed for `v0.6.0` | released in `v0.6.0` | The publication workflow validated, sealed, smoked, and receipt-verified the complete five-archive set; the evidence key is provisioned and the signed evidence passed the release gate before publication. |
+| WCAG 2.1 AA | partial | automated gate on every pull request; manual checklist per release | partial | Enforced, not certified. CI rejects any critical or serious axe violation across every destination at 1440x900, 920x800, 390x844 and 320x568, and fails on clipped layout at 100/200/320% text in English and French; `docs/accessibility-checklist.md` covers the screen-reader and keyboard behaviours automation cannot decide. The English/French automation is not a conformance claim, and required-check policy remains an external repository setting. |
 | OKF-compatible documentation | implemented | locally checked; reconciled to the released `v0.5.0`, prior signed snapshot, and current untagged candidate | released posture documented | The profile separates lifecycle, implementation, verification, and release status. |
 
 ## Preview publication rule
 
-`v0.5.0` published only `jeliyad` with its embedded web UI, after all required
+`v0.6.0` published only `jeliyad` with its embedded web UI, after all required
 daemon target gates passed — the rule held. Native Flutter applications, DMG,
 Linux app tarballs, APK/AAB, Homebrew app cask, iOS artifacts, and a
 separately packaged agent runner remain out of scope until their own platform
@@ -77,7 +77,7 @@ gates are satisfied.
 
 No row becomes `verified` because code exists, and no row becomes `released`
 because it is on a branch. For the next release the same bar applies to the
-current candidate: fresh signed network evidence at `a5d98b70...`, passing
+future v0.6.1 candidate: fresh signed network evidence at `a5d98b70...`, passing
 hosted gates (including the new `linux-flutter` job), a matching tag, a complete
 verified artifact set, and explicit release authority. See
 [Known gaps and roadmap](known-gaps-roadmap.md).

--- a/docs/evidence/v0.6.1/index.md
+++ b/docs/evidence/v0.6.1/index.md
@@ -1,0 +1,14 @@
+# v0.6.1 evidence boundary
+
+This directory is reserved for fresh `v0.6.1` qualification evidence. It does
+not inherit, copy, or modify the signed `v0.6.0` manifests.
+
+The version-preparation pull request does not qualify a candidate. After that
+pull request merges, maintainers must designate the exact public Jeliya commit
+and the exact Iroh Rooms revision, create the dedicated qualification refs only
+with explicit authorization, and run direct followed by forced-relay
+qualification from that public source. Only the resulting sanitized
+`direct.json`, `relay.json`, and their detached signatures belong here.
+
+Until those four files are reviewed and committed in a documentation-only pull
+request, the `v0.6.1` evidence gate remains blocked.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ CI rules for every page in this wiki.
 
 ## Current status and evidence
 
-- [Capability status](capability-status.md) - What is implemented, verified, and publicly released as of v0.5.0 and the post-release candidate.
+- [Capability status](capability-status.md) - What is implemented, verified, and publicly released as of v0.6.0 and the v0.6.1 preparation line.
 - [Platform matrix](platform-matrix.md) - Runtime, packaging, verification, and release status by operating system and artifact.
-- [Release versus main](release-vs-main.md) - Exact boundary between released v0.5.0, its certified evidence, and the post-release candidate on main.
+- [Release versus main](release-vs-main.md) - Exact boundary between released v0.6.0, its certified evidence, and the v0.6.1 preparation line on main.
 - [Verification evidence](verification-evidence.md) - Revision-bound milestone ledger, remote-test record, and evidence-sanitization contract.
 - [Known gaps and roadmap](known-gaps-roadmap.md) - Release blockers, deferred risks, owners, and the NOW/NEXT/LATER boundary.
 
@@ -46,6 +46,7 @@ CI rules for every page in this wiki.
 
 - [Accessibility release checklist](accessibility-checklist.md) - The screen-reader and keyboard behaviours automated checks cannot prove, verified by hand before a release.
 - [Real-network NAT runbook](realnet-runbook.md) - Procedure for proving direct or relayed connectivity across two networks.
+- [v0.6.1 evidence boundary](evidence/v0.6.1/index.md) - Empty qualification boundary reserved for fresh, signed v0.6.1 manifests after candidate designation.
 - [Historical Gate A result](gate-a-result.md) - Older direct-connectivity evidence that does not certify the v0.5.0 candidate.
 - [Signing and notarization](signing-notarization.md) - Release-security plan for macOS and Windows artifacts.
 

--- a/docs/known-gaps-roadmap.md
+++ b/docs/known-gaps-roadmap.md
@@ -1,7 +1,7 @@
 ---
 type: "Status Report"
 title: "Known gaps and roadmap"
-description: "Release blockers, deferred risks, owners, and next actions for the v0.5.0 evidence-backed technical preview."
+description: "Release blockers, deferred risks, owners, and next actions after the v0.6.0 evidence-backed technical preview."
 tags: ["gaps", "release", "risks", "roadmap"]
 timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
@@ -13,33 +13,33 @@ audience: ["contributors", "maintainers", "product", "release-engineers"]
 
 # Known gaps and roadmap
 
-`v0.5.0` shipped on 2026-07-14: the release conditions the `NOW` phase tracked
-were met (published safe pin, signed certifying direct and relay evidence,
-hosted gates, complete verified artifact set). The table below records that
-closure and the gaps that carry forward to the current post-release source
-candidate, which repins `iroh-rooms` to the untagged upstream revision
-`a5d98b70...` and must earn fresh signed network evidence at that exact pin.
+`v0.6.0` shipped on 2026-07-16 at `2283a441...`: the release conditions were
+met for source `55024a4...` + `71fbb500...` (signed certifying direct and relay
+evidence, hosted gates, and a complete verified artifact set). The table below
+records the gaps that carry forward to v0.6.1, whose preparation line repins
+`iroh-rooms` to `a5d98b70...`. The exact Jeliya candidate must be designated
+after the version PR merges and then earn fresh signed evidence at that pair.
 
 ## NOW — closure status
 
 | Area | Evidence now available | Remaining condition for the next release | Owner | Status |
 |---|---|---|---|---|
-| Public room-scoped authorization | centralized guard; 17 negative RPCs, local-file denial, and aggregate filtering passed locally and in both certifying network runs | preserve gates on the next candidate | core maintainer | closed for `v0.5.0` |
+| Public room-scoped authorization | centralized guard; 17 negative RPCs, local-file denial, and aggregate filtering passed locally and in both certifying network runs | preserve gates on the next candidate | core maintainer | closed for `v0.6.0` |
 | Accepted-room provenance | failure-injected create/join ordering, serialized concurrent updates, cached reads, owner-only Unix state, and durable replacement semantics pass; hosted Windows job passes on `main` | preserve on the next candidate | core maintainer | closed |
 | Upstream synchronization, provisional-peer, and store integrity | certified baseline for `v0.5.0` at `d0ceb0b…`; current `a5d98b70…` pin passes targeted fanout, isolation, and store-degradation regressions plus 806 core/net tests and the full Jeliya suites locally | rerun signed direct and relay qualification at `a5d98b70…` before the next release | upstream and core maintainer | current pin locally requalified; network qualification pending |
 | Android and agent secrets | Android cloud/device-transfer exclusions, app-private no-backup identity storage, external agent data default, ignore and tracked-secret gates pass | keep controls; Keystore wrapping is defense-in-depth, not a current claim | mobile and agent maintainers | closed |
 | Dependency security | Cargo and npm report zero vulnerabilities; four unmaintained/yanked warnings have owner, mitigation, and expiry records | rerun against the next candidate's lockfiles | dependency owner | closed |
-| CI completeness | all eight required matrix jobs, including `linux-flutter`, pass on public `main` run `29699530741` at `105744b…`; the PR matrix passed on the identical tree after rerunning an unrelated transient Playwright offset failure; manual dispatch does not publish; Gradle is checksum-verified | complete a second clean full run on the final commit | CI maintainer | one clean candidate run; second pending |
+| CI completeness | all eight required matrix jobs, including `linux-flutter`, pass on public `main` run `29699530741` at pre-version baseline `105744b…`; the PR matrix passed on the identical tree after rerunning an unrelated transient Playwright offset failure; manual dispatch does not publish; Gradle is checksum-verified | run two clean full matrices on the designated post-merge v0.6.1 commit | CI maintainer | baseline clean; candidate pending |
 | Agent/fleet reliability | agent E2E passes; fleet stability passed 5/5; Linux orphan/zombie cleanup verified on `demo1` under UID `65534` | repeat in the next candidate's hosted gates | agent maintainer | closed |
 | Linux Flutter source app | Ubuntu 24.04 ARM64 local qualification and the hosted x86_64 `linux-flutter` job pass; the hosted result binds public `main` at `a24f223…` | rerun at the current candidate; obtain a Wayland result; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
-| Direct network behavior | signed runs certify released `v0.5.0` and the prior `55024a4…` + `71fbb500…` snapshot | rerun at `105744b…` + `a5d98b70…` | verification owner | current candidate pending |
-| Forced relay behavior | signed runs certify released `v0.5.0` and the prior `55024a4…` + `71fbb500…` snapshot; the relay-only verifier still builds locally | rerun the source-built relay qualification at the current revision pair | verification owner | current candidate pending |
-| Evidence authenticity | detached Ed25519 signatures over both certifying manifests verify against the committed public SPKI; private-key custody is out of band | keep custody; sign the next candidate's runs | release authority | closed |
-| Unix installer integrity | behavioral checksum-before-extraction tests pass; `v0.5.0` installs via the version-pinned installer path | rerun against the next artifacts | release maintainer | closed |
-| Windows installer integrity | hosted `windows-latest` behavioral job passes on `main`; a `v0.5.0` Windows zip and sidecar are published | rerun against the next artifacts | release maintainer | closed |
-| Complete asset-set visibility | the publication workflow executed for `v0.5.0`: validation, sealing, isolated smoke, receipt verification, and draft-until-complete publication | re-execute for the next release under explicit authority | release authority | executed for `v0.5.0` |
-| Complete artifact set | `v0.5.0` published all five daemon-plus-embedded-UI archives with sidecars | build and verify the next candidate's set together | release maintainer | closed for `v0.5.0` |
-| Documentation alignment | status pages distinguish released `v0.5.0`, the prior signed `v0.6.0` snapshot, and the current untagged dependency candidate | bind fresh signed evidence after the network reruns | documentation owner | current for this snapshot |
+| Direct network behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…` | rerun at the post-merge v0.6.1 SHA + `a5d98b70…` | verification owner | v0.6.1 candidate pending |
+| Forced relay behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…`; the relay-only verifier still builds locally | rerun the source-built relay qualification at the designated v0.6.1 pair | verification owner | v0.6.1 candidate pending |
+| Evidence authenticity | detached Ed25519 signatures over both v0.6.0 manifests verify against the committed public SPKI; the private key is absent from the checkout, repository history, and audited release archives | confirm approved out-of-band custody and key availability without importing it into the checkout; sign the v0.6.1 runs there | release authority | checkout clean; custody confirmation required |
+| Unix installer integrity | behavioral checksum-before-extraction tests pass; `v0.6.0` installs via the version-pinned installer path | rerun against the next artifacts | release maintainer | closed |
+| Windows installer integrity | hosted `windows-latest` behavioral job passes on `main`; a `v0.6.0` Windows zip and sidecar are published | rerun against the next artifacts | release maintainer | closed |
+| Complete asset-set visibility | the publication workflow executed for `v0.6.0`: validation, sealing, isolated smoke, receipt verification, and draft-until-complete publication | re-execute for v0.6.1 under explicit authority | release authority | executed for `v0.6.0` |
+| Complete artifact set | `v0.6.0` published all five daemon-plus-embedded-UI archives with sidecars | build and verify the v0.6.1 set together | release maintainer | closed for `v0.6.0` |
+| Documentation alignment | status pages distinguish released `v0.6.0`, its immutable signed evidence, and the v0.6.1 preparation line | bind fresh signed evidence only under `docs/evidence/v0.6.1/` after the network reruns | documentation owner | current for version preparation |
 
 No reachable high or critical advisory is currently unresolved. The four
 maintenance/yank warnings are tracked with mitigation and an expiry of

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -13,29 +13,30 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 
 # Platform matrix
 
-The latest public release is `v0.5.0` (2026-07-14, daemon-only prerelease
-with certified network evidence). The current `v0.6.0` source candidate repins
-`iroh-rooms` to untagged `a5d98b70...`; local exact-revision and loopback
-qualification passes, but signed direct and relay reruns are pending. The
-retained 2026-07-16 runs certify only the prior `55024a4...` + `71fbb500...`
-snapshot. A source build or passing test is not a release.
+The latest public release is `v0.6.0` (2026-07-16, daemon-only prerelease at
+`2283a441...` with certified network evidence). The v0.6.1 preparation line
+repins `iroh-rooms` to untagged `a5d98b70...`; local exact-revision and
+loopback qualification passed at the pre-version baseline, but the exact
+post-merge candidate and signed direct/relay reruns are pending. The retained
+2026-07-16 runs certify released v0.6.0 source `55024a4...` + `71fbb500...`
+only. A source build or passing test is not a release.
 
 ## Daemon and embedded web UI
 
-| Target | Implementation | `v0.5.0` evidence | Latest public artifact | Preview status |
+| Target | Implementation | Network/release evidence | Latest public artifact | Preview status |
 |---|---|---|---|---|
-| macOS arm64 (`aarch64-apple-darwin`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
-| macOS x86_64 (`x86_64-apple-darwin`) | implemented | certifying signed schema 2 direct and relay runs pass (operator role); installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending |
-| Linux arm64 musl (`aarch64-unknown-linux-musl`) | implemented | archive built and verified by the release workflow; no platform-specific network run | `v0.5.0` archive and sidecar | released; platform network run still absent |
-| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | certifying signed schema 2 direct and relay runs pass on Ubuntu x86_64 under UID `65534`; installer behavior passes | `v0.5.0` archive and sidecar | certified for `v0.5.0` and the prior `v0.6.0` snapshot; current candidate pending |
-| Windows x86_64 MSVC (`x86_64-pc-windows-msvc`) | implemented | hosted behavioral installer/checksum/tamper, simulated reparse, and native daemon smoke jobs pass on `main` | `v0.5.0` archive and sidecar | released; no platform network run |
+| macOS arm64 (`aarch64-apple-darwin`) | implemented | archive built and verified by the v0.6.0 release workflow; no platform-specific network run | `v0.6.0` archive and sidecar | released; platform network run still absent |
+| macOS x86_64 (`x86_64-apple-darwin`) | implemented | certifying signed schema 2 direct and relay runs pass (operator role); installer behavior passes | `v0.6.0` archive and sidecar | certified and released for `v0.6.0`; v0.6.1 candidate pending |
+| Linux arm64 musl (`aarch64-unknown-linux-musl`) | implemented | archive built and verified by the v0.6.0 release workflow; no platform-specific network run | `v0.6.0` archive and sidecar | released; platform network run still absent |
+| Linux x86_64 musl (`x86_64-unknown-linux-musl`) | implemented | certifying signed schema 2 direct and relay runs pass on Ubuntu x86_64 under UID `65534`; installer behavior passes | `v0.6.0` archive and sidecar | certified and released for `v0.6.0`; v0.6.1 candidate pending |
+| Windows x86_64 MSVC (`x86_64-pc-windows-msvc`) | implemented | hosted behavioral installer/checksum/tamper, simulated reparse, and native daemon smoke jobs pass on `main` | `v0.6.0` archive and sidecar | released; no platform network run |
 
 The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind macOS x86_64 and
 Linux x86_64 musl builds to Jeliya `55024a4…`, published Iroh Rooms pin
 `71fbb500…`, and the verified toolchain; both are signed and set
-`certifiable: true` for that prior snapshot. They do not transfer to the
-current `105744b…` + `a5d98b70…` candidate. The `v0.5.0` manifests
+`certifiable: true` for released v0.6.0. They do not transfer to the future
+v0.6.1 candidate + `a5d98b70…`. The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
 bind the released pair `c5f740e…` + `d0ceb0b…` and do not transfer to another
 pin. The earlier unsigned
@@ -51,7 +52,7 @@ local-remediation evidence only. See
 
 ## Native applications and source-only tools
 
-| Surface | Implementation | Verification evidence | Release status | `v0.5.0` decision |
+| Surface | Implementation | Verification evidence | Release status | `v0.6.0` decision |
 |---|---|---|---|---|
 | macOS Flutter app | application and DMG pipeline exist | local tests only; current app sidecar is loopback-only; signing/notarization inactive | no DMG published | excluded |
 | Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland remain pending | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
@@ -65,7 +66,7 @@ local-remediation evidence only. See
 
 | Runtime | Local protocol | Cross-network direct | Forced relay | Reconnect/resync |
 |---|---|---|---|---|
-| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | signed direct pass at prior `55024a4…` + `71fbb500…` and released `c5f740e…` + `d0ceb0b…`; current candidate pending | signed relay pass with self-attestation at those same prior pairs; current candidate pending | local current-pin loopback passes; signed current-pin reconnect/resync pending |
+| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | signed direct pass for released v0.6.0 source `55024a4…` + `71fbb500…`; v0.6.1 candidate pending | signed relay pass with self-attestation for that released pair; v0.6.1 candidate pending | local current-pin loopback passed at the pre-version baseline; signed v0.6.1 reconnect/resync pending |
 | Other daemon targets | implemented | no candidate evidence | no candidate evidence | no candidate evidence |
 | Android in-process engine | local device-smoke evidence | unverified | unverified | local lifecycle only; cross-peer unverified |
 | macOS Flutter sidecar | loopback-only configuration | unsupported by current app configuration | unsupported by current app configuration | local sidecar lifecycle only |
@@ -77,7 +78,7 @@ on Android means only `loopback: false`; it is not evidence of a peer path.
 
 ## Packaging trust status
 
-`v0.5.0` contains five daemon archives and a SHA-256 sidecar for each. Its
+`v0.6.0` contains five daemon archives and a SHA-256 sidecar for each. Its
 Unix installers pass behavioral fail-closed tests for sidecar verification
 before extraction, and the hosted Windows job exercises the PowerShell
 installer, tamper rejection, a simulated reparse-point payload, and native
@@ -88,5 +89,5 @@ keeps build jobs read-only, validates and seals the complete set without
 executing it, and runs smoke execution in a separate read-only job. The sole
 writer verifies the sealed receipt without executing candidate bytes and
 exposes its token only to the final publishing step. It executed exactly this
-way to publish `v0.5.0`'s five-target set.
+way to publish `v0.6.0`'s five-target set.
 See [Release versus main](release-vs-main.md).

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -58,15 +58,16 @@ The exact qualification boundary is different:
 - Signed direct and forced-relay evidence binds the earlier Jeliya commit
   `55024a46b3e112796ba2acf1dc408dab26dbba2e` and Iroh Rooms commit
   `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`).
-- The current dependency candidate is Jeliya
+- The pre-version v0.6.1 baseline is Jeliya
   `105744b6c27633e5ccc576d86f1a15e3fe443b94` with the deliberately untagged
   Iroh Rooms revision `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first upstream `main`
   merge carrying the fixes for `kortiene/iroh-room#121` and
   `kortiene/iroh-room#119` plus the intervening connection-generation fixes.
 - Exact-revision upstream regressions, the Jeliya workspace tests, and the
-  two-daemon loopback suite pass at the new pair. The older signed manifests do
-  not transfer: fresh signed direct and forced-relay runs must bind the new
-  public Jeliya commit and dependency revision before release qualification.
+  two-daemon loopback suite pass at that pair. The `v0.6.0` signed manifests do
+  not transfer: after the version PR merges, the exact v0.6.1 SHA must be
+  designated and fresh signed direct and forced-relay runs must bind it before
+  release qualification.
 
 Local verification performed during the assessment:
 

--- a/docs/realnet-runbook.md
+++ b/docs/realnet-runbook.md
@@ -13,17 +13,17 @@ audience: ["contributors", "maintainers", "operators"]
 
 # Real-network NAT runbook
 
-This is the canonical `v0.6.0` network-evidence procedure. It drives one local
+This is the canonical `v0.6.1` network-evidence procedure. It drives one local
 operator process and two supervised remote daemons through
 `scripts/realnet-evidence.mjs`. The older `gate-a.mjs` flow is retained only as
 a diagnostic and historical reference; it cannot qualify a release.
 
 ## Current evidence status
 
-The retained certifying `v0.6.0` runs bind published Jeliya commit
+The retained certifying `v0.6.0` runs bind released Jeliya source commit
 `55024a46b3e112796ba2acf1dc408dab26dbba2e` and Iroh Rooms pin `71fbb500…`
 (tag `v0.1.0-rc.3`); both are signed and set `certifiable: true` for that exact
-prior snapshot:
+release:
 
 | Path | Run | Evidence status |
 |---|---|---|
@@ -35,11 +35,13 @@ Neither run certifies room-scoped synchronization isolation: both manifests set
 administrative-tip traversal rest on the upstream suite at the recorded
 revision.
 
-The current source candidate is Jeliya `105744b...` with the deliberately
-untagged Iroh Rooms pin `a5d98b70...`. Its local exact-revision qualification
-passes, but the retained manifests do not transfer. Run both procedures below
-from the clean public candidate and replace/sign the manifests together before
-marking the current release evidence gate ready.
+The v0.6.1 preparation line uses the deliberately untagged Iroh Rooms pin
+`a5d98b70...`. Local exact-revision qualification passed at pre-version
+baseline `105744b...`, but the retained manifests do not transfer. Do not run
+the procedures below until the version PR is merged, the exact public Jeliya
+SHA is designated, and both dedicated qualification refs exist. Then run both
+procedures from that clean public candidate and place/sign only new v0.6.1
+manifests before marking its release evidence gate ready.
 
 The superseded `v0.5.0` runs (direct `3b86ac67`,
 [manifest](evidence/v0.5.0/direct.json); forced relay `a3c76859`,
@@ -276,7 +278,7 @@ lockfile.
 ## Interpret and retain the result
 
 The harness writes its initial sanitized record to
-`.jeliya-gatea/v0.6.0/<run-id>.json`. This local directory is gitignored. A
+`.jeliya-gatea/v0.6.1/<run-id>.json`. This local directory is gitignored. A
 successful functional result still fails release qualification when any source
 or dependency revision is local/unpublished, topology is insufficient, the
 working tree is dirty, or the build is not source-bound.
@@ -297,8 +299,8 @@ For a release candidate:
 2. review the structured record for secrets and remove all log excerpts while
    retaining per-role line count, byte count, and stream SHA-256 records;
 3. copy the final exact JSON bytes to
-   `docs/evidence/v0.6.0/direct.json` or
-   `docs/evidence/v0.6.0/relay.json` (the release gate derives this
+   `docs/evidence/v0.6.1/direct.json` or
+   `docs/evidence/v0.6.1/relay.json` (the release gate derives this
    directory from the daemon crate version);
 4. sign those final bytes with the approved out-of-band Ed25519 private key and
    retain the canonical base64 detached signature as the adjacent `.sig` file;
@@ -314,10 +316,11 @@ and only documentation paths may change after network qualification.
 
 The retained `v0.6.0` manifests have valid adjacent signatures verified against
 `release/evidence-ed25519-public.pem`; they remain certifying for
-`55024a4...` + `71fbb500...`. Do not relabel or edit them to match the current
-candidate. Replace each manifest only with fresh source-bound output, then sign
-the final exact bytes. Historical schema 1 and preview records remain
-non-certifying and cannot be promoted by adding signatures.
+`55024a4...` + `71fbb500...`. Never relabel, edit, replace, or copy them for
+v0.6.1. Add fresh source-bound output only under `docs/evidence/v0.6.1/`, then
+sign the final exact bytes from approved out-of-band custody. Historical schema
+1 and preview records remain non-certifying and cannot be promoted by adding
+signatures.
 
 ## Evidence and log hygiene
 

--- a/docs/release-vs-main.md
+++ b/docs/release-vs-main.md
@@ -1,7 +1,7 @@
 ---
 type: "Status Report"
 title: "Release versus main"
-description: "Exact boundary between the latest published Jeliya artifacts, the audited baseline, and the v0.5.0 candidate."
+description: "Exact boundary between released v0.6.0 artifacts, their qualified source, and the v0.6.1 preparation line."
 tags: ["artifacts", "main", "release", "versions"]
 timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
@@ -14,17 +14,17 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Release versus main
 
 Git branches, test revisions, tags, and release assets answer different
-questions. `v0.5.0` shipped on 2026-07-14 as a daemon-only prerelease. The
-post-release source line and the current branch candidate must not be described
-as released.
+questions. `v0.6.0` shipped on 2026-07-16 as a daemon-only prerelease at
+`2283a441...`. The v0.6.1 version-preparation branch is neither a designated
+candidate nor a release.
 
 ## Current boundary
 
 | Layer | Exact revision | Dependency state | Artifact/evidence state | Claim allowed |
 |---|---|---|---|---|
-| Latest public release | tag `v0.5.0` at `045d85cb1d066f16d564b6051363b9328063ee01` (prerelease) | pins published `iroh-rooms` `d0ceb0b…` (rc.2-era remediation) | five published daemon archives and five checksum sidecars; signed certifying direct (`3b86ac67`) and relay (`a3c76859`) manifests | behavior in those archives is released; known limitation: joins from invites minted after non-admin chat fail at this pin |
-| Current `v0.6.0` source candidate | `105744b6c27633e5ccc576d86f1a15e3fe443b94` | pins untagged public Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first merge carrying `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus the `kortiene/iroh-room#126` follow-ups | exact-revision upstream, workspace, and 67-assertion loopback suites pass; fresh signed direct/relay evidence pending | locally qualified; not network-qualified or published |
-| Prior `v0.6.0` network-qualified snapshot | `55024a46b3e112796ba2acf1dc408dab26dbba2e` | pins `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind this exact pair | evidence remains valid for the snapshot but does not transfer to the current candidate |
+| Latest public release | lightweight tag `v0.6.0` at `2283a441220031485a7a212dc585772231d0f428` (prerelease) | release source pins published `iroh-rooms` `71fbb5007bef4ce83631c94762ec68c2beef3d79` (`v0.1.0-rc.3`) | five published daemon archives and five checksum sidecars; signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind the qualified source commit | behavior in those archives is released; the tag adds only the reviewed evidence documentation to the qualified source |
+| `v0.6.1` preparation line | exact candidate pending designation after the version PR merges | pins untagged public Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first merge carrying `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus the `kortiene/iroh-room#126` follow-ups | exact-revision upstream, workspace, and 67-assertion loopback suites passed at pre-version baseline `105744b…`; fresh signed direct/relay evidence pending | corrective source only; not network-qualified or published |
+| Released `v0.6.0` qualification source | `55024a46b3e112796ba2acf1dc408dab26dbba2e` | pins `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind this exact pair | evidence authorized `v0.6.0`; it does not transfer to v0.6.1 |
 | Superseded `v0.5.0` network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` | pins `d0ceb0b…` | both `v0.5.0` certifying schema 2 runs bind this commit | the certified evidence speaks for that revision pair only; it does not transfer to the rc.3 pin |
 | Audited baseline | `1285b42037a3713840955fa518f2b81b19f2929f` | pins vulnerable `iroh-rooms` `3cb9bfd…` | no artifact for this commit | baseline source behavior only |
 | Initial hardening checkpoint | `4d0807a42ad79f7eb1b44edab48a62bf8813dd9c` | pinned `3cb9bfd…` at that checkpoint | historical checkpoint before provenance, cache, and protocol-contract follow-ups | historical only |
@@ -35,8 +35,8 @@ The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind the
 network-qualified commit `55024a4…` and published pin `71fbb500…`, carry
 detached Ed25519 signatures, and set `certifiable: true` — they qualify that
-prior `v0.6.0` snapshot. They do not qualify the current `105744b…` +
-`a5d98b70…` source candidate. The `v0.5.0` manifests
+released `v0.6.0` source. They do not qualify the future v0.6.1 candidate +
+`a5d98b70…`. The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
 bind `c5f740e…` + `d0ceb0b…` and authorized that prerelease; they do not
 transfer to another pin. Neither generation certifies room-scoped
@@ -44,22 +44,22 @@ synchronization isolation — every manifest sets
 `synchronization_isolation_claimed: false`, so that control rests on the
 upstream suite at the pinned revision, not on network evidence.
 
-## Published `v0.5.0` artifact set
+## Published `v0.6.0` artifact set
 
-- `jeliyad-v0.5.0-aarch64-apple-darwin.tar.gz`
-- `jeliyad-v0.5.0-x86_64-apple-darwin.tar.gz`
-- `jeliyad-v0.5.0-aarch64-unknown-linux-musl.tar.gz`
-- `jeliyad-v0.5.0-x86_64-unknown-linux-musl.tar.gz`
-- `jeliyad-v0.5.0-x86_64-pc-windows-msvc.zip`
+- `jeliyad-v0.6.0-aarch64-apple-darwin.tar.gz`
+- `jeliyad-v0.6.0-x86_64-apple-darwin.tar.gz`
+- `jeliyad-v0.6.0-aarch64-unknown-linux-musl.tar.gz`
+- `jeliyad-v0.6.0-x86_64-unknown-linux-musl.tar.gz`
+- `jeliyad-v0.6.0-x86_64-pc-windows-msvc.zip`
 - one `.sha256` sidecar for each archive
 
 No DMG, Linux native-app tarball, APK/AAB, iOS application, or separately
-packaged agent runner is in `v0.5.0`; it is a daemon-plus-embedded-UI
+packaged agent runner is in `v0.6.0`; it is a daemon-plus-embedded-UI
 prerelease only.
 
 ## Candidate changes are not released capabilities
 
-The post-release candidate repins `iroh-rooms` to untagged `a5d98b70...`.
+The v0.6.1 preparation line repins `iroh-rooms` to untagged `a5d98b70...`.
 Alongside the rc.3 join capability, bounded membership sync, and gap healing,
 this adds provisional-peer fanout/handshake gating, connection-generation
 teardown guards, and bounded store-insert recovery with durable critical
@@ -67,12 +67,12 @@ degradation reporting. It also adds a source-supported Linux
 Flutter app with its packaging gate and `linux-flutter` CI job. The Linux app
 is an unsigned, unpublished developer package; it adds no released feature.
 Local tests and upstream regressions demonstrate implementation progress;
-they do not alter the release boundary — `v0.5.0` behavior is exactly what
-its archives contain, including its known join-after-chat limitation.
+they do not alter the release boundary — `v0.6.0` behavior is exactly what
+its archives contain.
 
 ## Publication gate
 
-`v0.5.0` met this gate and published. Before the next release tag can be
+`v0.6.0` met this gate and published. Before the v0.6.1 release tag can be
 published, the same public immutable commit must prove all of the following:
 
 1. the reviewed upstream pin (`a5d98b70…` or a reviewed tagged successor
@@ -80,7 +80,7 @@ published, the same public immutable commit must prove all of the following:
 2. the approved evidence Ed25519 public key predates the qualifying network
    runs, and both retained manifests have valid detached signatures;
 3. direct and relay evidence is certifiable against the candidate's published
-   revisions (the `v0.5.0` evidence binds `c5f740e` + `d0ceb0b` and does not
+   revisions (the `v0.6.0` evidence binds `55024a4` + `71fbb500` and does not
    transfer);
 4. all required hosted CI gates — now including `linux-flutter` — pass twice
    from clean environments;
@@ -98,9 +98,9 @@ the ref and release operations requires operator inspection before retry.
 
 ## Evidence provenance
 
-This snapshot records the released `v0.5.0` boundary (tag at `045d85c…`,
-certifying signed direct/relay manifests bound to `c5f740e…` + `d0ceb0b…`),
-the post-release untagged dependency candidate, the prior signed rc.3 snapshot,
+This snapshot records the released `v0.6.0` boundary (tag at `2283a441…`,
+certifying signed direct/relay manifests bound to `55024a4…` + `71fbb500…`),
+the v0.6.1 untagged dependency preparation line, the superseded v0.5.0 pair,
 and the retained historical
 manifests (the unsigned schema 2 preview run at `0f6769a…` and the schema 1
 local-remediation runs). Neither tickets, tokens, identity material, nor

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -1,7 +1,7 @@
 ---
 type: "Architecture"
 title: "Security and threat model"
-description: "Trust boundaries, assets, threats, controls, and residual risks for the v0.6.0 Jeliya candidate."
+description: "Trust boundaries, assets, threats, controls, and residual risks for the v0.6.1 Jeliya candidate."
 tags: ["authorization", "privacy", "security", "threat-model"]
 timestamp: "2026-07-19T15:15:00Z"
 status: "canonical"
@@ -15,13 +15,13 @@ audience: ["contributors", "maintainers", "operators", "security-reviewers"]
 
 Jeliya is a local daemon or in-process mobile engine that stores identity keys,
 room state, files, and agent events while communicating with untrusted network
-peers. The `v0.6.0` target is a trustworthy technical preview, not a claim of
+peers. The `v0.6.1` target is a trustworthy technical preview, not a claim of
 complete security. The current dependency pin carries the room-scoped
 synchronization remediation, provisional-peer gate, store retry/degradation
 controls, and relay-only verification seam. Exact-revision local qualification
 passes. Signed direct and forced-relay evidence still binds the prior dependency
-pin and must be repeated before the current source candidate is network-
-qualified.
+pin and must be repeated after the exact post-merge source candidate is
+designated.
 
 ## Candidate boundary
 
@@ -30,17 +30,18 @@ Security conclusions must name the source being evaluated:
 | Surface | Revision | Security meaning |
 |---|---|---|
 | Current public Jeliya dependency | Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` (untagged upstream `main`) | first merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the `kortiene/iroh-room#126` connection-generation follow-ups; local fanout, isolation, and store-degradation qualification passes |
-| Current source candidate | Jeliya `105744b6c27633e5ccc576d86f1a15e3fe443b94` | exact dependency pin in `Cargo.toml` and `Cargo.lock`; workspace and 67-assertion loopback suites pass; network qualification pending |
-| Last network-qualified snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` plus Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed direct and forced-relay schema 2 evidence remains valid for this exact prior pair only |
+| Current source candidate | pending after the v0.6.1 version PR merges | the version-preparation branch is not a qualification candidate; its pre-version baseline `105744b…` passed the workspace and 67-assertion loopback suites |
+| Released `v0.6.0` qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` plus Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79`; release tag `2283a441220031485a7a212dc585772231d0f428` | signed direct and forced-relay schema 2 evidence authorized the released v0.6.0 artifact set and remains valid for this exact pair only |
 | Superseded `v0.5.0` dependency | Iroh Rooms `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | carried the isolation remediation and relay-only seam; certified for the published `v0.5.0` at Jeliya `c5f740e67d043a1153cf285691e3bc5b2b9a7203`. Still fetchable by commit SHA, but no longer named by tag `v0.1.0-rc.2`, which was re-created upstream and now resolves elsewhere; the `v0.5.0` evidence binds the SHA, not the tag |
 | Historical local-remediation verification | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` plus local Iroh Rooms `3702e8cbcd5ac1808791124dd6bc44068be5f822` | schema 1 direct and forced-relay checks passed, but this older unpublished pair does not qualify a release |
 
 The retained certifying direct and forced-relay runs bind published Jeliya
-commit `55024a4…` and published Iroh Rooms pin `71fbb500…`: they
+source commit `55024a4…` and published Iroh Rooms pin `71fbb500…`: they
 establish direct and relay network operation and public-RPC non-disclosure. They
 do not establish room-scoped synchronization isolation — both manifests set
 `synchronization_isolation_claimed: false`; that control rests on the upstream
-suite at that revision. They do not transfer to `105744b…` + `a5d98b70…`.
+suite at that revision. They do not transfer to the future v0.6.1 candidate +
+`a5d98b70…`.
 Fresh source-built direct and relay runs and signatures are security
 requirements, not release administration.
 
@@ -84,10 +85,10 @@ implemented control.
 | Android identity copied through backup or device transfer | long-lived identity disclosure outside the device | `allowBackup=false`, explicit backup/data-extraction exclusions, `noBackupFilesDir`, fail-closed migration | repository validation passes; no Keystore protection and no claim against a rooted or compromised device |
 | Agent identity or state committed from a checkout | public secret disclosure and identity reuse | platform data directory outside the checkout, per-directory deny-all `.gitignore`, repository ignore rules, tracked-secret gate | six secret-storage tests plus repository validation pass locally |
 | Reachable vulnerable dependency | code execution, compromise, or denial of service | automated cargo/npm audits; high/critical findings block; explicit owned/expiring exception only when unavoidable | zero cargo/npm vulnerabilities; three maintenance warnings and one yanked version expire 2026-09-30 |
-| Compromised action or downloaded build tool | release supply-chain compromise | third-party Actions pinned to immutable revisions; Zig and Gradle distributions verified before execution; certifying network builds use the official complete Zig archive and exact tool bindings; least-privilege jobs | workflow and local contract tests pass; only the complete Zig archive is independently verified by schema 2, while other recorded tool digests are execution identities; the hosted double run executed for the published `v0.5.0` and executes again for `v0.6.0` on dispatch |
-| Partial, mismatched, or post-validation-modified release | incomplete, stale, mislabeled, or candidate-mutated binaries | validate and seal all five private archives in a no-execution job; smoke the immutable artifact separately; verify the receipt without execution before tag/release creation; expose the write token only to the final step | workflow and receipt negative tests pass locally, and the path executed end to end for the published `v0.5.0` five-archive set; it has not yet run for `v0.6.0` |
+| Compromised action or downloaded build tool | release supply-chain compromise | third-party Actions pinned to immutable revisions; Zig and Gradle distributions verified before execution; certifying network builds use the official complete Zig archive and exact tool bindings; least-privilege jobs | workflow and local contract tests pass; only the complete Zig archive is independently verified by schema 2, while other recorded tool digests are execution identities; the hosted double run executed for published `v0.6.0` and must execute again for `v0.6.1` |
+| Partial, mismatched, or post-validation-modified release | incomplete, stale, mislabeled, or candidate-mutated binaries | validate and seal all five private archives in a no-execution job; smoke the immutable artifact separately; verify the receipt without execution before tag/release creation; expose the write token only to the final step | workflow and receipt negative tests pass locally, and the path executed end to end for the published `v0.6.0` five-archive set; it has not yet run for `v0.6.1` |
 | Installer extracts modified bytes | local code execution | fetch the matching published checksum, validate filename/format, verify SHA-256, then extract | Unix behavior passes; Windows checksum, tamper, and simulated-reparse behavior passed on public `main` run `29688515781` at `a24f223…`; current-candidate rerun pending |
-| Forged or edited verification record | false release confidence | retained exact manifest, canonical public key, detached Ed25519 signature, source/publication/ancestry checks | retained signatures verify for the prior snapshot; the current release gate is BLOCKED until replacement manifests bind the new revision pair |
+| Forged or edited verification record | false release confidence | retained exact manifest, canonical public key, detached Ed25519 signature, source/publication/ancestry checks | retained signatures verify for released `v0.6.0`; the v0.6.1 gate is BLOCKED until new manifests bind the new revision pair without modifying v0.6.0 evidence |
 | Secrets copied into logs or evidence | credential or identity disclosure | transient logs confined to run-owned data directories, no address retention, and digest-only retained summaries | retained runs report completed cleanup. Manifests keep only line/byte counts and stream SHA-256 digests and contain no tickets, tokens, seeds, private keys, excerpts, or IP addresses |
 
 ## Authorization invariant

--- a/docs/verification-evidence.md
+++ b/docs/verification-evidence.md
@@ -1,7 +1,7 @@
 ---
 type: "Status Report"
 title: "Verification evidence"
-description: "Revision-bound verification ledger and evidence-recording contract for the v0.6.0 candidate."
+description: "Revision-bound verification ledger and evidence-recording contract for the v0.6.1 candidate."
 tags: ["evidence", "networking", "release", "testing", "verification"]
 timestamp: "2026-07-19T19:05:30Z"
 status: "canonical"
@@ -18,25 +18,25 @@ evidence. A result is transferable to a release candidate only when it binds
 the exact public Jeliya commit, public immutable dependency revisions,
 environment, timestamps, assertions, retained sanitized manifest, and detached
 signature. The retained direct and forced-relay schema 2 runs meet that bar for
-the earlier Jeliya `55024a4...` + Iroh Rooms `71fbb500...` snapshot. The current
-source candidate repins Iroh Rooms to `a5d98b70...`; those signed manifests do
-not transfer to the new dependency revision and do not authorize a `v0.6.0`
-release from the current tree.
+released v0.6.0 source Jeliya `55024a4...` + Iroh Rooms `71fbb500...`; the
+lightweight release tag is `2283a441...`. The v0.6.1 preparation line repins
+Iroh Rooms to `a5d98b70...`. Those signed manifests remain immutable and do not
+transfer to the new dependency revision.
 
 ## Candidate identity
 
 | Field | Value |
 |---|---|
-| Milestone | `v0.6.0 — Capability-Gated Join Candidate`, not yet published |
-| Baseline commit | `045d85cb1d066f16d564b6051363b9328063ee01` — the published `v0.5.0` tag |
-| Current source candidate | `105744b6c27633e5ccc576d86f1a15e3fe443b94` |
+| Milestone | `v0.6.1 — corrective technical-preview candidate`, not yet qualified or published |
+| Baseline commit | `2283a441220031485a7a212dc585772231d0f428` — the published `v0.6.0` tag |
+| Current source candidate | `pending — designate the exact public SHA after the version PR merges` |
 | Network-qualified commit | `pending — fresh signed direct and relay runs required` |
 | Current public `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first upstream `main` merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the connection-generation follow-ups |
 | Candidate upstream remediation revision | `a5d98b70d717f35d3ce60953a88e12e646f2e871` |
-| Last network-qualified snapshot | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` + Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
-| Retained evidence signatures | present and valid for the last network-qualified snapshot; not transferable to the current pin |
+| Last released qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` + Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`), released as Jeliya `v0.6.0` at `2283a441…` |
+| Retained evidence signatures | present and valid for released v0.6.0; not transferable to the current pin |
 | Release evidence gate | BLOCKED |
-| Evidence window | local exact-revision qualification on 2026-07-19 UTC; current network evidence pending |
+| Evidence window | pre-version local exact-revision qualification on 2026-07-19 UTC; post-merge candidate and network evidence pending |
 
 The current pin is the first upstream `main` merge containing both required
 fixes. The two commits after it change only `iroh-rooms-cli`, which Jeliya does
@@ -44,14 +44,13 @@ not consume, so pinning later would expand the reviewed surface without changing
 the SDK behavior. The newest tag remains `v0.1.0-rc.3` at `71fbb500...` and
 predates both fixes.
 
-The retained signed direct and forced-relay runs remain valid evidence for
+The retained signed direct and forced-relay runs remain valid evidence for released v0.6.0 source
 `55024a4...` + `71fbb500...`: they covered three peers across two BGP origin
 ASNs, passed every recorded assertion, and set `certifiable: true`. They are
-historical for the current source candidate. Fresh manifests must bind
-`105744b...` and `a5d98b70...` before the release
-evidence gate can return to `READY`.
+historical for v0.6.1. Fresh manifests must bind the post-merge designated SHA
+and `a5d98b70...` before the v0.6.1 evidence gate can return to `READY`.
 
-The current source candidate was recorded as `4261470...` while the repin was in
+The pre-version source baseline was recorded as `4261470...` while the repin was in
 review. `main` enforces linear history, so the merge rebased that work and
 rewrote its commit SHA to `9c71fac...`. The rebased commit has the identical
 tree (`53e5ce2c...`) and the identical parent (`a24f2238...`), so it is the same
@@ -61,8 +60,8 @@ must not be used in reproduction steps. This restatement does not alter the
 `Network-qualified commit` row, which stays `pending` until fresh signed direct
 and forced-relay runs are performed.
 
-Jeliya `105744b6c27633e5ccc576d86f1a15e3fe443b94` advances the source
-candidate to include the bounded concurrent path-settlement observer and
+Jeliya `105744b6c27633e5ccc576d86f1a15e3fe443b94` is the pre-version source
+baseline that includes the bounded concurrent path-settlement observer and
 sanitized timeout diagnostics from `kortiene/jeliya#133`. Its tree
 (`4aeed8ce...`) and parent (`05b5f4e...`) match the reviewed PR head exactly.
 All eight hosted checks passed on public `main` run `29699530741` at the exact
@@ -88,7 +87,7 @@ manifests are the certifying set.
 
 | Gate | Current evidence | Status |
 |---|---|---|
-| Public read-RPC authorization | centralized guard and local negative suite cover foreign timelines, members, agents, files, pipes, local-file HTTP, and aggregate projections; the retained schema 2 runs denied all 17 room-scoped RPCs and filtered local-file and aggregate reads | certifying PASS at the superseded `55024a4…` + `71fbb500…` snapshot; current-pin network rerun required |
+| Public read-RPC authorization | centralized guard and local negative suite cover foreign timelines, members, agents, files, pipes, local-file HTTP, and aggregate projections; the retained schema 2 runs denied all 17 room-scoped RPCs and filtered local-file and aggregate reads | certifying PASS for released v0.6.0 source `55024a4…` + `71fbb500…`; v0.6.1 network rerun required |
 | Accepted-room provenance | create/join failure injection proves provenance is accepted before irreversible event publication; 24 concurrent mutations retain every room; direct reads reuse the authorized snapshot cache; Unix mode is pinned to `0600`; exact `atomicwrites 0.4.4` uses synchronized Unix directory replacement and Windows write-through replacement | local PASS; Windows semantics source-reviewed but not behaviorally executed on `windows-latest` |
 | Pre-identity protocol contract | `room.list` returns the successful empty onboarding result `{ rooms: [] }` consistently across the core engine, TypeScript mock, Dart daemon, Dart FFI, Dart mock, and golden-corpus oracles | local PASS |
 | Upstream synchronization isolation | malicious `WantEvents`, foreign-parent, and administrative-tip checks pass at `a5d98b70d717f35d3ce60953a88e12e646f2e871`, which carries forward the isolation remediation first published at `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | local exact-revision PASS. NOT network-certified: the retained manifests set `synchronization_isolation_claimed: false` and do not exercise these internals |
@@ -105,8 +104,8 @@ manifests are the certifying set.
 | Join, reconnect, and resynchronization | the current two-daemon loopback run passes 67/67 assertions; retained network runs cover the same integration boundary at the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
 | Messages, files, and pipes | current loopback covers messages, byte-identical BLAKE3-verified file fetch, authorized pipe, and unauthorized denial; retained network runs cover the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
 | Installer integrity | Unix behavioral tests verify checksum-before-extraction; Windows jobs execute checksum/tamper behavior, simulate reparse rejection, and smoke the native daemon | Unix PASS; hosted `windows-latest` job passes on `main` |
-| Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | executed end to end for `v0.5.0`, which built, verified, and published the five-archive set with sidecars; the same path executes for `v0.6.0` on release dispatch and has not yet run at this candidate. GitHub tag and release operations remain non-transactional |
-| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.0` | PASS locally at `105744b`; the public `v0.6.0` tag does not exist yet |
+| Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | executed end to end for `v0.6.0`, which built, verified, and published the five-archive set with sidecars; the same path must execute for `v0.6.1` after qualification. GitHub tag and release operations remain non-transactional |
+| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.1` | PASS on the version-preparation branch; the exact candidate is designated only after merge |
 | Documentation | required OKF pages distinguish the current locally qualified candidate, the prior signed schema 2 snapshot, and historical schema 1 local-remediation evidence | local docs and release-contract gates pass on this documentation diff |
 
 ## Dependency-risk exception register
@@ -316,38 +315,40 @@ real-network evidence.
 
 ## Exact release blockers
 
-The evidence gate is **BLOCKED** for the current `v0.6.0` source candidate.
+The evidence gate is **BLOCKED** for `v0.6.1`.
 Completed work:
 
 1. upstream fixes for `kortiene/iroh-room#121`, `kortiene/iroh-room#126`, and
    `kortiene/iroh-room#119` are public
    and present at immutable revision
    `a5d98b70d717f35d3ce60953a88e12e646f2e871`;
-2. public Jeliya source candidate
-   `105744b6c27633e5ccc576d86f1a15e3fe443b94` resolves that exact revision in
-   `Cargo.toml` and `Cargo.lock`; and
+2. the v0.6.1 preparation line resolves that exact revision in `Cargo.toml`
+   and `Cargo.lock`; and
 3. the targeted fanout, isolation, and store-degradation regressions, the full
    upstream core/net suite, the Jeliya workspace suite, and the loopback E2E
-   suite pass at source candidate
+   suite passed at pre-version baseline
    `105744b6c27633e5ccc576d86f1a15e3fe443b94`.
 
 Remaining work before `READY`:
 
-1. run direct and forced-relay qualification from that clean public commit,
-   retaining new sanitized manifests bound to `a5d98b70...`;
-2. sign the exact manifest bytes with the approved out-of-band Ed25519 key;
-3. pass the evidence signature, source ancestry, and docs-only-after-
+1. merge the version PR, designate its exact public SHA, and create the Jeliya
+   and Iroh Rooms qualification refs with explicit authorization;
+2. run direct and forced-relay qualification from that clean public commit,
+   retaining new sanitized manifests under `docs/evidence/v0.6.1/` and bound
+   to `a5d98b70...`;
+3. sign the exact manifest bytes with the approved out-of-band Ed25519 key;
+4. pass the evidence signature, source ancestry, and docs-only-after-
    qualification checks; and
-4. complete the hosted double CI run and remaining release gates under explicit
+5. complete the hosted double CI run and remaining release gates under explicit
    release authority.
 
-`v0.5.0` remains released and certified at its own revision pair. The retained
-`v0.6.0` manifests remain valid for the older `55024a4...` + `71fbb500...`
-snapshot but cannot clear the current candidate's gate.
+`v0.6.0` remains released and certified at its own revision pair. Its retained
+manifests remain valid for `55024a4...` + `71fbb500...` but cannot clear the
+v0.6.1 gate and must not be modified or copied.
 
-## Candidate provenance: untagged upstream fixes (2026-07-19)
+## v0.6.1 dependency provenance: untagged upstream fixes (2026-07-19)
 
-Jeliya source candidate `105744b6c27633e5ccc576d86f1a15e3fe443b94`
+The pre-version Jeliya baseline `105744b6c27633e5ccc576d86f1a15e3fe443b94`
 repins the SDK crates to upstream merge
 `a5d98b70d717f35d3ce60953a88e12e646f2e871`. This is the first `main` commit
 that contains:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -8,35 +8,36 @@ refreshed from each release's sidecars. Native-app packaging helpers also
 exist in `../scripts`, but their outputs are source-built developer artifacts,
 not public downloads.
 
-**`v0.5.0` publishes exactly five `jeliyad` archives with the embedded web UI,
+**`v0.6.0` publishes exactly five `jeliyad` archives with the embedded web UI,
 plus one checksum sidecar per archive.** It does not publish the macOS Flutter
 app or DMG, the Linux Flutter app or its tarball, Android APK/AAB files, an iOS
 app, or the Homebrew app cask. Native build instructions below remain
-development references, not `v0.5.0` release scope.
+development references, not `v0.6.0` release scope.
 
 ## Files
 
 | File | What it is |
 | --- | --- |
-| `../.github/workflows/release.yml` | Manual GitHub Actions promotion workflow. For `v0.5.0`, it runs the complete CI workflow twice on the exact `main` revision, builds `jeliyad` plus its embedded UI for five targets, validates the private archive/checksum set, and then exposes one complete release from the sole write-enabled job. It publishes no native app artifact. |
+| `../.github/workflows/release.yml` | Manual GitHub Actions promotion workflow. For `v0.6.0`, it ran the complete CI workflow twice on the exact release revision, built `jeliyad` plus its embedded UI for five targets, validated the private archive/checksum set, and then exposed one complete release from the sole write-enabled job. It publishes no native app artifact. |
 | `install.sh` | POSIX-sh one-liner installer for macOS + Linux (`curl \| sh`). Detects OS/arch, downloads the matching archive and checksum, verifies SHA-256 before extraction, then installs `jeliyad` to `/usr/local/bin` (or `~/.local/bin`). |
 | `install.ps1` | Windows PowerShell equivalent. Downloads the archive and checksum, verifies SHA-256 before extraction, installs to `%LOCALAPPDATA%\Programs\Jeliya`, and adds it to the user PATH. |
 | `jeliya.rb` | Homebrew formula template. Belongs in a tap (`kortiene/homebrew-jeliya`), not homebrew-core. |
-| `jeliya-app.rb` | Unpublished Homebrew cask template for a future desktop-app release. It is not completed, uploaded, or updated by the `v0.5.0` release. |
+| `jeliya-app.rb` | Unpublished Homebrew cask template for a future desktop-app release. It is not completed, uploaded, or updated by the `v0.6.0` release. |
 | `../scripts/package-linux.mjs` | Source-only Linux Flutter packager. Builds the host-native app and `jeliyad`, installs the adjacent sidecar and freedesktop metadata, exercises the bundle, then emits a tarball and SHA-256 sidecar under `dist/`. CI checks but does not publish them. |
 
 ## How they fit together
 
-1. An authorized release operator dispatches `release.yml` from the current
-   `main` tip with the exact `v0.5.0` input. No release tag exists yet.
+1. An authorized release operator dispatches `release.yml` from the exact
+   qualified `main` tip with the intended `vX.Y.Z` input. The workflow refuses
+   to proceed if that tag or release already exists.
 2. Two independent clean executions of the required CI workflow must pass on
    that exact commit.
 3. Read-only jobs build and validate the complete private set:
-   - `jeliyad-v0.5.0-aarch64-apple-darwin.tar.gz`
-   - `jeliyad-v0.5.0-x86_64-apple-darwin.tar.gz`
-   - `jeliyad-v0.5.0-x86_64-unknown-linux-musl.tar.gz`
-   - `jeliyad-v0.5.0-aarch64-unknown-linux-musl.tar.gz`
-   - `jeliyad-v0.5.0-x86_64-pc-windows-msvc.zip`
+   - `jeliyad-vX.Y.Z-aarch64-apple-darwin.tar.gz`
+   - `jeliyad-vX.Y.Z-x86_64-apple-darwin.tar.gz`
+   - `jeliyad-vX.Y.Z-x86_64-unknown-linux-musl.tar.gz`
+   - `jeliyad-vX.Y.Z-aarch64-unknown-linux-musl.tar.gz`
+   - `jeliyad-vX.Y.Z-x86_64-pc-windows-msvc.zip`
    - plus a `<asset>.sha256` next to each one.
 4. The sole write-enabled job revalidates the commit and complete set, refuses
    any existing tag or release, creates a run-owned tag plus private draft,
@@ -55,25 +56,24 @@ before the write boundary and that the release stays draft until remote bytes
 match. Its scoped failure cleanup minimizes orphan-tag risk, but an interrupted
 GitHub API cleanup must still be inspected before retrying.
 
-`v0.5.0` is intentionally a prerelease technical preview, so GitHub's
+`v0.6.0` is intentionally a prerelease technical preview, so GitHub's
 `/releases/latest` endpoint and an unpinned installer continue to select the
 latest non-prerelease version (`v0.4.3` at this snapshot). Preview operators
 must pin it explicitly:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/kortiene/jeliya/v0.5.0/packaging/install.sh \
-  | JELIYA_VERSION=v0.5.0 sh
+curl -fsSL https://raw.githubusercontent.com/kortiene/jeliya/v0.6.0/packaging/install.sh \
+  | JELIYA_VERSION=v0.6.0 sh
 ```
 
 ```powershell
-$env:JELIYA_VERSION = 'v0.5.0'
-irm https://raw.githubusercontent.com/kortiene/jeliya/v0.5.0/packaging/install.ps1 | iex
+$env:JELIYA_VERSION = 'v0.6.0'
+irm https://raw.githubusercontent.com/kortiene/jeliya/v0.6.0/packaging/install.ps1 | iex
 ```
 
 Installer code at the `v0.4.3` tag did not perform this automatic sidecar
-verification. The fail-closed implementation is part of the unreleased
-`v0.5.0` hardening candidate and must pass its adversarial tests before the
-release claim changes.
+verification. The fail-closed implementation shipped in `v0.5.0`, was reused
+for `v0.6.0`, and remains covered by adversarial installer tests.
 
 ## Mandatory build ordering (UI before cargo)
 
@@ -123,10 +123,10 @@ shipped:
 
 ## Per-release follow-up
 
-After the five `v0.5.0` daemon archives are published and independently
-verified, update `version` and checksums in `jeliya.rb` in a separate reviewed
-tap change. Do not update or publish `jeliya-app.rb`: no DMG belongs to this
-release.
+Prerelease daemon archives do not automatically advance the stable Homebrew
+formula. For a stable release, update `version` and checksums in `jeliya.rb` in
+a separate reviewed tap change. Do not update or publish `jeliya-app.rb`: no
+DMG belongs to the current v0.6.x release scope.
 
 `release.yml` needs no slug edit — it always builds the repo it runs in.
 
@@ -136,7 +136,7 @@ The daemon archives are **unsigned**. A *browser* download of an unsigned
 binary trips Gatekeeper (macOS) and SmartScreen (Windows). The `curl | sh` and
 Homebrew install paths do **not** set the quarantine bit, so they install
 cleanly. The repository contains a Developer ID and notarization design for a
-future macOS app release, but `v0.5.0` must not execute a DMG publishing job or
+future macOS app release, but v0.6.x must not execute a DMG publishing job or
 attach a DMG to its release. Every release to date carries only unsigned daemon
 archives. Signing the bare daemon archives (issue #1) and Windows Authenticode
 (issue #2) are tracked in
@@ -201,7 +201,7 @@ distribution.
 
 ## Android release builds
 
-These commands are development and future-release references. `v0.5.0` does
+These commands are development and future-release references. v0.6.x does
 not build or publish an APK or AAB, and its release workflow must not receive or
 upload one.
 

--- a/scripts/check-secret-storage.mjs
+++ b/scripts/check-secret-storage.mjs
@@ -1,13 +1,27 @@
 #!/usr/bin/env node
 // Static release gate for secret-bearing local state. No npm dependencies.
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const failures = [];
+
+const forbiddenCheckoutSecrets = [
+  "release/evidence-ed25519-private.pem",
+  "release/evidence-operator.key",
+  "docs/evidence/v0.5.0/direct.private.pem",
+  "docs/evidence/v0.6.0/direct.private.pem",
+  "docs/evidence/v0.6.1/direct.private.pem",
+];
+
+for (const candidate of forbiddenCheckoutSecrets) {
+  if (existsSync(join(repoRoot, candidate))) {
+    failures.push(`${candidate}: private signing material must remain in out-of-band custody, not the checkout`);
+  }
+}
 
 function read(path) {
   return readFileSync(join(repoRoot, path), "utf8");
@@ -141,6 +155,7 @@ for (const candidate of [
   "release/evidence-operator.key",
   "docs/evidence/v0.5.0/direct.private.pem",
   "docs/evidence/v0.6.0/direct.private.pem",
+  "docs/evidence/v0.6.1/direct.private.pem",
 ]) {
   const ignored = spawnSync("git", ["check-ignore", "--no-index", "--quiet", candidate], {
     cwd: repoRoot,
@@ -154,4 +169,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log("secret-storage: PASS — Android backup/transfer and local identity guards are explicit");
+console.log("secret-storage: PASS — private signing material is absent and local identity guards are explicit");

--- a/scripts/realnet-evidence.mjs
+++ b/scripts/realnet-evidence.mjs
@@ -68,7 +68,7 @@ const DEFAULT_LOCAL_BIN = join(REPO_ROOT, "target", "release", "jeliyad");
 const DEFAULT_DEBUG_BIN = join(REPO_ROOT, "target", "debug", "jeliyad");
 const EVIDENCE_ROOT = process.env.JELIYA_EVIDENCE_ROOT
   ? resolve(process.env.JELIYA_EVIDENCE_ROOT)
-  : join(REPO_ROOT, ".jeliya-gatea", "v0.6.0");
+  : join(REPO_ROOT, ".jeliya-gatea", "v0.6.1");
 const WAIT_MS = 120_000;
 const LINUX_TARGET = "x86_64-unknown-linux-musl";
 const REQUIRED_RUST_TOOLCHAIN = "1.91.0";
@@ -2321,7 +2321,7 @@ async function runFlow({ peers, expectedPath, runId, resources, record }) {
   }
 
   const room = await record("A: room created", () => a.client.call("room.create", {
-    name: `v0.6.0 network evidence ${runId}`,
+    name: `v0.6.1 network evidence ${runId}`,
   }));
   const roomId = room.room_id;
   const openedA = await record("A: room opened", async () => {
@@ -2408,7 +2408,7 @@ async function runFlow({ peers, expectedPath, runId, resources, record }) {
   }
 
   const payload = Buffer.concat([
-    Buffer.from(`jeliya-v0.6.0-${runId}\n`),
+    Buffer.from(`jeliya-v0.6.1-${runId}\n`),
     randomBytes(256 * 1024),
   ]);
   const payloadPath = join(a.dataDir, `payload-${runId}.bin`);
@@ -2864,7 +2864,7 @@ export function parseCli(argv) {
     withThird: localDryrun ? Boolean(args["with-third"]) : true,
     allowDirty: Boolean(args["allow-dirty"] || localDryrun),
     allowSharedEgress: Boolean(args["allow-shared-egress"] || args["allow-same-network"] || localDryrun),
-    expectedVersion: String(args["expected-version"] ?? "0.6.0"),
+    expectedVersion: String(args["expected-version"] ?? "0.6.1"),
     localBin: String(args["local-bin"] ?? (localDryrun ? DEFAULT_DEBUG_BIN : DEFAULT_LOCAL_BIN)),
     linuxBin: args["linux-bin"] ? String(args["linux-bin"]) : null,
     linuxSha256: args["linux-sha256"] ? String(args["linux-sha256"]) : null,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jeliya-ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jeliya-ui",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jeliya-ui",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What changed

- bumps the daemon, core, UI, lockfiles, changelog, and real-network harness defaults to 0.6.1
- records v0.6.0 at `2283a441220031485a7a212dc585772231d0f428` as the latest release and keeps its qualification source/evidence boundary explicit
- reserves `docs/evidence/v0.6.1/` without copying or modifying any v0.6.0 proof
- makes the secret-storage gate fail when private evidence-signing material exists in the checkout, even if gitignored
- corrects stale release, packaging, platform, threat-model, and evidence assertions

## Why

v0.6.0 and its signed evidence must remain immutable. The corrective repin and follow-up release work need a separate v0.6.1 source/evidence boundary before an exact post-merge candidate is designated.

The named private key was already absent from the checkout. Audits found no matching path or private-PEM marker in Git history, the local distribution archive, or any of the five published v0.6.0 archives. Out-of-band custody still needs confirmation by the release authority before signing.

## Impact

This PR does not create qualification tags, run network qualification, add evidence manifests, or authorize release publication. The v0.6.1 publish gate remains blocked until a post-merge SHA is designated and fresh signed direct and forced-relay evidence is committed in a docs-only PR.

## Validation

- `node scripts/check-docs.mjs`
- `node scripts/check-secret-storage.mjs`
- `node scripts/check-release.mjs --source --tag v0.6.1`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo build --locked -p jeliyad`
- `node --test scripts/check-secret-storage.test.mjs scripts/check-release.test.mjs` (17 passed)
- `env -u LD_LIBRARY_PATH node --test scripts/realnet-evidence.test.mjs` (39 passed)
- confirmed `node scripts/check-release.mjs --source --publish --tag v0.6.1` fails closed because evidence is not verified
- confirmed `docs/evidence/v0.6.0/` is unchanged from tag `v0.6.0`