### PR TITLE
docs: designate a1af1cdc as v0.6.1 candidate

### DIFF
--- a/docs/capability-status.md
+++ b/docs/capability-status.md
@@ -1,9 +1,9 @@
 ---
 type: "Status Report"
 title: "Capability status"
-description: "Evidence-aware capability matrix for the released v0.6.0 preview and the v0.6.1 preparation line."
+description: "Evidence-aware capability matrix for the released v0.6.0 preview and the designated v0.6.1 candidate."
 tags: ["capabilities", "release", "status", "verification"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -16,24 +16,25 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 This page separates implementation, verification, and public availability.
 `v0.6.0` shipped on 2026-07-16 as a daemon-only prerelease at tag
 `2283a441...`. Its signed direct and forced-relay evidence binds source commit
-`55024a4...` and Iroh Rooms `71fbb500...`. The `v0.6.1` preparation line keeps
+`55024a4...` and Iroh Rooms `71fbb500...`. The `v0.6.1` candidate keeps
 the corrective repin to untagged upstream revision `a5d98b70...`, the first
 `main` merge carrying the provisional-peer and store-degradation fixes. The
-exact `v0.6.1` candidate will be designated only after this version PR merges;
-no current v0.6.0 evidence transfers to it.
+exact `v0.6.1` source candidate is
+`a1af1cdc974bc307317779afa0765c3988cb871f`; no current v0.6.0 evidence
+transfers to it.
 
 ## Snapshot boundary
 
 | Field | Value |
 |---|---|
 | Released milestone | `v0.6.0 — Capability-Gated Join Technical Preview`, published 2026-07-16 at `2283a441220031485a7a212dc585772231d0f428` as a prerelease: five daemon+embedded-UI archives with `.sha256` sidecars |
-| Current source candidate | pending — designate the exact public `v0.6.1` SHA after the version PR merges; the version PR itself is not qualified |
+| Current source candidate | Jeliya `a1af1cdc974bc307317779afa0765c3988cb871f` with Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`; designated but not network-qualified |
 | Released `v0.6.0` qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` with Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`) |
 | Retained certified evidence | signed schema 2 direct (`1ca39cfa`) and forced-relay (`cf28bc63`) runs of 2026-07-16; valid for released `v0.6.0` only |
 | Candidate `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first merge carrying the `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus `kortiene/iroh-room#126` follow-ups; later `main` changes only an unconsumed CLI crate |
-| Candidate verification | the pre-version baseline at `105744b…` passed exact-revision upstream, workspace, and 67-assertion loopback suites; the post-merge `v0.6.1` SHA still requires qualification refs plus fresh signed direct and forced-relay evidence |
+| Candidate verification | all eight hosted jobs passed on the version PR's identical tree (run `29703977510`) and on public `main` at exact candidate `a1af1cdc…` (run `29704754961`); qualification refs plus fresh signed direct and forced-relay evidence are still required |
 | Historical network verification | schema 1 runs at Jeliya `fe870c7…` with local upstream `3702e8c…`, and the schema 2 preview run at `0f6769a…` with pre-remediation pin `3cb9bfd…`; functional evidence only |
-| Status captured | 2026-07-19 15:15 UTC |
+| Status captured | 2026-07-19 21:49 UTC |
 
 See [Release versus main](release-vs-main.md) for the revision boundaries and
 [Verification evidence](verification-evidence.md) for the complete ledger.
@@ -49,18 +50,18 @@ especially its admin, must move together.
 | Capability | Implementation | Verification | Public release | Honest current claim |
 |---|---|---|---|---|
 | `jeliyad` with embedded React UI | implemented | certified for `v0.6.0` | released in `v0.6.0` (prerelease) | The complete five-target daemon+embedded-UI archive set with `.sha256` sidecars is published. Signed schema 2 direct and forced-relay runs certified the released source revision pair. |
-| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.6.0`; the v0.6.1 pin passes local integration at the pre-version baseline | released in `v0.6.0` | Released `v0.6.0` fixes the v0.5.0 join-after-chat limitation. Fresh v0.6.1 current-pin network runs remain required. |
+| Identity, room create/join/open, membership, and messages | implemented | certified direct and relay pass for `v0.6.0`; the v0.6.1 pin passes local integration at exact candidate `a1af1cdc…` | released in `v0.6.0` | Released `v0.6.0` fixes the v0.5.0 join-after-chat limitation. Fresh v0.6.1 current-pin network runs remain required. |
 | Files and BLAKE3 fetch verification | implemented | certified direct and relay pass for `v0.6.0` | released in `v0.6.0` | Cross-network transfer, byte equality, and hash verification passed in both certifying runs. |
 | Pipes | implemented | certified direct and relay pass for `v0.6.0` | released in `v0.6.0` | Authorized transfer, closure, and zero target bytes from the unauthorized third peer passed in both certifying runs. |
-| Direct cross-network P2P | implemented | certified for released `v0.6.0`; v0.6.1 candidate pending | released in `v0.6.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) certifies `55024a4…` + `71fbb500…`; it does not transfer to the future v0.6.1 SHA + `a5d98b70…`. |
+| Direct cross-network P2P | implemented | certified for released `v0.6.0`; v0.6.1 candidate pending | released in `v0.6.0` | [Signed schema 2 direct run `1ca39cfa`](evidence/v0.6.0/direct.json) certifies `55024a4…` + `71fbb500…`; it does not transfer to `a1af1cdc…` + `a5d98b70…`. |
 | Deliberately forced relay | published seam pinned; verifier chain forwards through jeliya-core | certified for released `v0.6.0`; v0.6.1 candidate pending | released in `v0.6.0` | [Signed schema 2 relay run `cf28bc63`](evidence/v0.6.0/relay.json) certifies `55024a4…` + `71fbb500…`; a new relay-only source build and signed run are required. |
 | Public room-scoped RPC isolation | implemented | verified locally and in both certifying runs | released in `v0.5.0` | A centralized guard covers the public room-scoped surface. Seventeen negative RPC checks, local-file denial, and aggregate filtering passed over the public network in the certifying runs. |
 | Upstream synchronization and provisional-peer isolation | remediated at current pin `a5d98b70…` | targeted isolation, provisional-fanout, and store-degradation regressions pass; core/net all-targets suite passes 806 tests with two ignores | released baseline in `v0.5.0`; new fixes unreleased | Local exact-revision evidence covers the upstream internals. Fresh signed network evidence is still required for Jeliya integration at the new pin. |
 | Agent runner and fleet | implemented | local pass | released as source through `v0.6.0` | Agent E2E passes; the earlier fleet stability run passed 5/5. Linux orphan/zombie process-group cleanup was verified on `demo1` under UID `65534`. |
-| Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland lifecycle remain pending | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
+| Linux Flutter desktop app | implemented for host-native source builds | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` run `29704754961` at `a1af1cdc…`; Wayland lifecycle remains pending | unreleased | The GTK app and path-relocatable sidecar bundle are source-supported. The local ARM64 daemon requires GLIBC 2.39, and the tarball lacks a complete Rust dependency license inventory. Linux enables the real network path, but direct, relay, NAT, and cross-network behavior remain unverified. No native Linux app artifact is public. |
 | Android in-process FFI engine | implemented | local device smoke only | unreleased | App-private identity state is excluded from cloud backup and device transfer. It is not Android Keystore-backed, and Android direct, relay, NAT, and cross-network behavior remain unverified. |
 | Dependency security | gates implemented | Cargo and npm report zero vulnerabilities | release gates passed for `v0.6.0` | Four unmaintained/yanked dependency warnings have documented owners, mitigations, and expiry; no reachable unresolved high/critical vulnerability is accepted. |
-| CI matrix | implemented | all jobs passed on public `main` run `29699530741` at `105744b…`; post-version candidate run pending | exercised for `v0.6.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. The hosted run includes Windows installer integrity and the `linux-flutter` release-build, Xvfb, dependency, archive, and checksum checks. |
+| CI matrix | implemented | all jobs passed on public `main` run `29704754961` at exact candidate `a1af1cdc…`; PR run `29703977510` passed on the identical tree | exercised for `v0.6.0` | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and security jobs are defined. The hosted run includes Windows installer integrity and the `linux-flutter` release-build, Xvfb, dependency, archive, and checksum checks. |
 | Unix installer integrity | implemented | behavioral checks pass | released in `v0.6.0` | Unix installers fetch and verify the matching sidecar before extraction; `v0.6.0` installs via the version-pinned installer path. |
 | Windows installer integrity | implemented | hosted `windows-latest` job passes on `main` | released in `v0.6.0` | The Windows job executes checksum/tamper behavior, simulates reparse-point rejection, and runs native `jeliyad.exe --version`; a `v0.6.0` Windows zip and sidecar are published. |
 | Complete asset-set visibility and version consistency | implemented | executed for `v0.6.0` | released in `v0.6.0` | The publication workflow validated, sealed, smoked, and receipt-verified the complete five-archive set; the evidence key is provisioned and the signed evidence passed the release gate before publication. |
@@ -77,7 +78,8 @@ gates are satisfied.
 
 No row becomes `verified` because code exists, and no row becomes `released`
 because it is on a branch. For the next release the same bar applies to the
-future v0.6.1 candidate: fresh signed network evidence at `a5d98b70...`, passing
+designated v0.6.1 candidate: fresh signed network evidence at `a1af1cdc...` +
+`a5d98b70...`, passing
 hosted gates (including the new `linux-flutter` job), a matching tag, a complete
 verified artifact set, and explicit release authority. See
 [Known gaps and roadmap](known-gaps-roadmap.md).

--- a/docs/evidence/v0.6.1/index.md
+++ b/docs/evidence/v0.6.1/index.md
@@ -3,12 +3,13 @@
 This directory is reserved for fresh `v0.6.1` qualification evidence. It does
 not inherit, copy, or modify the signed `v0.6.0` manifests.
 
-The version-preparation pull request does not qualify a candidate. After that
-pull request merges, maintainers must designate the exact public Jeliya commit
-and the exact Iroh Rooms revision, create the dedicated qualification refs only
-with explicit authorization, and run direct followed by forced-relay
-qualification from that public source. Only the resulting sanitized
-`direct.json`, `relay.json`, and their detached signatures belong here.
+The exact designated source pair is Jeliya
+`a1af1cdc974bc307317779afa0765c3988cb871f` plus Iroh Rooms
+`a5d98b70d717f35d3ce60953a88e12e646f2e871`. This designation does not qualify
+the pair. Maintainers must create the dedicated qualification refs only with
+explicit authorization, then run direct followed by forced-relay qualification
+from that public source. Only the resulting sanitized `direct.json`,
+`relay.json`, and their detached signatures belong here.
 
 Until those four files are reviewed and committed in a documentation-only pull
 request, the `v0.6.1` evidence gate remains blocked.

--- a/docs/known-gaps-roadmap.md
+++ b/docs/known-gaps-roadmap.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Known gaps and roadmap"
 description: "Release blockers, deferred risks, owners, and next actions after the v0.6.0 evidence-backed technical preview."
 tags: ["gaps", "release", "risks", "roadmap"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -16,9 +16,9 @@ audience: ["contributors", "maintainers", "product", "release-engineers"]
 `v0.6.0` shipped on 2026-07-16 at `2283a441...`: the release conditions were
 met for source `55024a4...` + `71fbb500...` (signed certifying direct and relay
 evidence, hosted gates, and a complete verified artifact set). The table below
-records the gaps that carry forward to v0.6.1, whose preparation line repins
-`iroh-rooms` to `a5d98b70...`. The exact Jeliya candidate must be designated
-after the version PR merges and then earn fresh signed evidence at that pair.
+records the gaps that carry forward to v0.6.1, whose candidate pins
+`iroh-rooms` to `a5d98b70...`. Exact Jeliya candidate `a1af1cdc...` is now
+designated and must earn fresh signed evidence at that pair.
 
 ## NOW — closure status
 
@@ -29,17 +29,17 @@ after the version PR merges and then earn fresh signed evidence at that pair.
 | Upstream synchronization, provisional-peer, and store integrity | certified baseline for `v0.5.0` at `d0ceb0b…`; current `a5d98b70…` pin passes targeted fanout, isolation, and store-degradation regressions plus 806 core/net tests and the full Jeliya suites locally | rerun signed direct and relay qualification at `a5d98b70…` before the next release | upstream and core maintainer | current pin locally requalified; network qualification pending |
 | Android and agent secrets | Android cloud/device-transfer exclusions, app-private no-backup identity storage, external agent data default, ignore and tracked-secret gates pass | keep controls; Keystore wrapping is defense-in-depth, not a current claim | mobile and agent maintainers | closed |
 | Dependency security | Cargo and npm report zero vulnerabilities; four unmaintained/yanked warnings have owner, mitigation, and expiry records | rerun against the next candidate's lockfiles | dependency owner | closed |
-| CI completeness | all eight required matrix jobs, including `linux-flutter`, pass on public `main` run `29699530741` at pre-version baseline `105744b…`; the PR matrix passed on the identical tree after rerunning an unrelated transient Playwright offset failure; manual dispatch does not publish; Gradle is checksum-verified | run two clean full matrices on the designated post-merge v0.6.1 commit | CI maintainer | baseline clean; candidate pending |
+| CI completeness | all eight required matrix jobs, including `linux-flutter`, pass on public `main` run `29704754961` at exact candidate `a1af1cdc…`; PR run `29703977510` passed on the identical tree; manual dispatch does not publish; Gradle is checksum-verified | preserve the two clean source-tree matrices through qualification and run the release gates after evidence lands | CI maintainer | candidate source tree clean twice |
 | Agent/fleet reliability | agent E2E passes; fleet stability passed 5/5; Linux orphan/zombie cleanup verified on `demo1` under UID `65534` | repeat in the next candidate's hosted gates | agent maintainer | closed |
-| Linux Flutter source app | Ubuntu 24.04 ARM64 local qualification and the hosted x86_64 `linux-flutter` job pass; the hosted result binds public `main` at `a24f223…` | rerun at the current candidate; obtain a Wayland result; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
-| Direct network behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…` | rerun at the post-merge v0.6.1 SHA + `a5d98b70…` | verification owner | v0.6.1 candidate pending |
-| Forced relay behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…`; the relay-only verifier still builds locally | rerun the source-built relay qualification at the designated v0.6.1 pair | verification owner | v0.6.1 candidate pending |
+| Linux Flutter source app | Ubuntu 24.04 ARM64 local qualification and the hosted x86_64 `linux-flutter` job pass; the hosted result binds public `main` at exact candidate `a1af1cdc…` | obtain a Wayland result; define a compatibility baseline and distribution format; bundle a complete Rust dependency license inventory; establish signing before publication | desktop maintainer | source-supported; unpublished |
+| Direct network behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…` | rerun at `a1af1cdc…` + `a5d98b70…` after both qualification refs exist | verification owner | designated; network run pending |
+| Forced relay behavior | signed run certifies released `v0.6.0` source `55024a4…` + `71fbb500…`; the relay-only verifier still builds locally | rerun the source-built relay qualification at `a1af1cdc…` + `a5d98b70…` after the direct run | verification owner | designated; network run pending |
 | Evidence authenticity | detached Ed25519 signatures over both v0.6.0 manifests verify against the committed public SPKI; the private key is absent from the checkout, repository history, and audited release archives | confirm approved out-of-band custody and key availability without importing it into the checkout; sign the v0.6.1 runs there | release authority | checkout clean; custody confirmation required |
 | Unix installer integrity | behavioral checksum-before-extraction tests pass; `v0.6.0` installs via the version-pinned installer path | rerun against the next artifacts | release maintainer | closed |
 | Windows installer integrity | hosted `windows-latest` behavioral job passes on `main`; a `v0.6.0` Windows zip and sidecar are published | rerun against the next artifacts | release maintainer | closed |
 | Complete asset-set visibility | the publication workflow executed for `v0.6.0`: validation, sealing, isolated smoke, receipt verification, and draft-until-complete publication | re-execute for v0.6.1 under explicit authority | release authority | executed for `v0.6.0` |
 | Complete artifact set | `v0.6.0` published all five daemon-plus-embedded-UI archives with sidecars | build and verify the v0.6.1 set together | release maintainer | closed for `v0.6.0` |
-| Documentation alignment | status pages distinguish released `v0.6.0`, its immutable signed evidence, and the v0.6.1 preparation line | bind fresh signed evidence only under `docs/evidence/v0.6.1/` after the network reruns | documentation owner | current for version preparation |
+| Documentation alignment | status pages distinguish released `v0.6.0`, its immutable signed evidence, and designated v0.6.1 candidate `a1af1cdc…` | bind fresh signed evidence only under `docs/evidence/v0.6.1/` after the network reruns | documentation owner | current for candidate designation |
 
 No reachable high or critical advisory is currently unresolved. The four
 maintenance/yank warnings are tracked with mitigation and an expiry of

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Platform matrix"
 description: "Implementation, verification, packaging, and release status for every Jeliya runtime and target platform."
 tags: ["packaging", "platforms", "release", "verification"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -14,10 +14,10 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 # Platform matrix
 
 The latest public release is `v0.6.0` (2026-07-16, daemon-only prerelease at
-`2283a441...` with certified network evidence). The v0.6.1 preparation line
-repins `iroh-rooms` to untagged `a5d98b70...`; local exact-revision and
-loopback qualification passed at the pre-version baseline, but the exact
-post-merge candidate and signed direct/relay reruns are pending. The retained
+`2283a441...` with certified network evidence). Designated v0.6.1 source
+candidate `a1af1cdc...` pins `iroh-rooms` to untagged `a5d98b70...`; local
+exact-revision, loopback, and hosted qualification pass, but signed
+direct/relay reruns are pending. The retained
 2026-07-16 runs certify released v0.6.0 source `55024a4...` + `71fbb500...`
 only. A source build or passing test is not a release.
 
@@ -35,8 +35,8 @@ The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind macOS x86_64 and
 Linux x86_64 musl builds to Jeliya `55024a4…`, published Iroh Rooms pin
 `71fbb500…`, and the verified toolchain; both are signed and set
-`certifiable: true` for released v0.6.0. They do not transfer to the future
-v0.6.1 candidate + `a5d98b70…`. The `v0.5.0` manifests
+`certifiable: true` for released v0.6.0. They do not transfer to
+`a1af1cdc…` + `a5d98b70…`. The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
 bind the released pair `c5f740e…` + `d0ceb0b…` and do not transfer to another
 pin. The earlier unsigned
@@ -55,18 +55,18 @@ local-remediation evidence only. See
 | Surface | Implementation | Verification evidence | Release status | `v0.6.0` decision |
 |---|---|---|---|---|
 | macOS Flutter app | application and DMG pipeline exist | local tests only; current app sidecar is loopback-only; signing/notarization inactive | no DMG published | excluded |
-| Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` at `a24f223…`; current-candidate rerun and Wayland remain pending | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
+| Linux Flutter app | GTK application, XDG storage policy, bundled-sidecar CMake contract, and host-architecture source packaging exist | Ubuntu 24.04 ARM64 local qualification passes; the x86_64 hosted gate passed on public `main` run `29704754961` at `a1af1cdc…`; Wayland remains pending | no native Linux app archive published; the local ARM64 daemon requires GLIBC 2.39 and the tarball lacks a complete Rust dependency license inventory | excluded |
 | Android Flutter app with in-process Rust engine | application and three-ABI build path exist | Android 13 local lifecycle/FFI smoke only; no cross-network, NAT, direct, or relay evidence | no APK/AAB published | excluded |
 | Android identity storage | app-private no-backup storage with cloud and device-transfer exclusions | rules and validation pass | unreleased | included security control; not Keystore-backed |
 | iOS app | no scaffold or engine build | none | none | excluded |
 | Agent runner and fleet launcher | JavaScript scripts exist | agent E2E pass; fleet stability 5/5; Linux orphan/zombie cleanup verified remotely | source only | no separate artifact |
-| Dart protocol package | source package exists | candidate unit, replay, and integration gates are implemented locally; hosted result pending | not published separately | source only |
+| Dart protocol package | source package exists | candidate unit, replay, and integration gates pass locally and on public `main` run `29704754961` | not published separately | source only |
 
 ## Network claims by runtime
 
 | Runtime | Local protocol | Cross-network direct | Forced relay | Reconnect/resync |
 |---|---|---|---|---|
-| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | signed direct pass for released v0.6.0 source `55024a4…` + `71fbb500…`; v0.6.1 candidate pending | signed relay pass with self-attestation for that released pair; v0.6.1 candidate pending | local current-pin loopback passed at the pre-version baseline; signed v0.6.1 reconnect/resync pending |
+| `jeliyad` on macOS x86_64 and Linux x86_64 | implemented | signed direct pass for released v0.6.0 source `55024a4…` + `71fbb500…`; designated v0.6.1 candidate `a1af1cdc…` pending rerun | signed relay pass with self-attestation for that released pair; designated v0.6.1 candidate pending rerun | local current-pin loopback passed at `a1af1cdc…`; signed v0.6.1 reconnect/resync pending |
 | Other daemon targets | implemented | no candidate evidence | no candidate evidence | no candidate evidence |
 | Android in-process engine | local device-smoke evidence | unverified | unverified | local lifecycle only; cross-peer unverified |
 | macOS Flutter sidecar | loopback-only configuration | unsupported by current app configuration | unsupported by current app configuration | local sidecar lifecycle only |

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -3,7 +3,7 @@ type: "Architecture"
 title: "Production deployment architecture"
 description: "Repository-grounded assessment, target architecture, security boundaries, infrastructure plan, and phased gates for deploying Jeliya at app.jeliya.ai."
 tags: ["architecture", "deployment", "production", "security", "pwa", "iroh"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "proposal"
 implementation_status: "planned"
 verification_status: "partial"
@@ -58,16 +58,15 @@ The exact qualification boundary is different:
 - Signed direct and forced-relay evidence binds the earlier Jeliya commit
   `55024a46b3e112796ba2acf1dc408dab26dbba2e` and Iroh Rooms commit
   `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`).
-- The pre-version v0.6.1 baseline is Jeliya
-  `105744b6c27633e5ccc576d86f1a15e3fe443b94` with the deliberately untagged
+- The designated v0.6.1 source candidate is Jeliya
+  `a1af1cdc974bc307317779afa0765c3988cb871f` with the deliberately untagged
   Iroh Rooms revision `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first upstream `main`
   merge carrying the fixes for `kortiene/iroh-room#121` and
   `kortiene/iroh-room#119` plus the intervening connection-generation fixes.
 - Exact-revision upstream regressions, the Jeliya workspace tests, and the
-  two-daemon loopback suite pass at that pair. The `v0.6.0` signed manifests do
-  not transfer: after the version PR merges, the exact v0.6.1 SHA must be
-  designated and fresh signed direct and forced-relay runs must bind it before
-  release qualification.
+  two-daemon loopback suite and all eight hosted jobs pass at that pair. The
+  `v0.6.0` signed manifests do not transfer: fresh signed direct and
+  forced-relay runs must bind the designated pair before release qualification.
 
 Local verification performed during the assessment:
 

--- a/docs/realnet-runbook.md
+++ b/docs/realnet-runbook.md
@@ -3,7 +3,7 @@ type: "Runbook"
 title: "Real-network NAT runbook"
 description: "Operator procedure for collecting revision-bound direct and forced-relay evidence across three distinct public egress paths."
 tags: ["nat", "networking", "operations", "p2p"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -35,11 +35,11 @@ Neither run certifies room-scoped synchronization isolation: both manifests set
 administrative-tip traversal rest on the upstream suite at the recorded
 revision.
 
-The v0.6.1 preparation line uses the deliberately untagged Iroh Rooms pin
-`a5d98b70...`. Local exact-revision qualification passed at pre-version
-baseline `105744b...`, but the retained manifests do not transfer. Do not run
-the procedures below until the version PR is merged, the exact public Jeliya
-SHA is designated, and both dedicated qualification refs exist. Then run both
+Designated v0.6.1 source candidate
+`a1af1cdc974bc307317779afa0765c3988cb871f` uses the deliberately untagged
+Iroh Rooms pin `a5d98b70...`. Local exact-revision qualification and all eight
+hosted jobs pass, but the retained manifests do not transfer. Do not run the
+procedures below until both dedicated qualification refs exist. Then run both
 procedures from that clean public candidate and place/sign only new v0.6.1
 manifests before marking its release evidence gate ready.
 

--- a/docs/release-vs-main.md
+++ b/docs/release-vs-main.md
@@ -1,9 +1,9 @@
 ---
 type: "Status Report"
 title: "Release versus main"
-description: "Exact boundary between released v0.6.0 artifacts, their qualified source, and the v0.6.1 preparation line."
+description: "Exact boundary between released v0.6.0 artifacts, their qualified source, and the designated v0.6.1 candidate."
 tags: ["artifacts", "main", "release", "versions"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "not-applicable"
 verification_status: "partial"
@@ -15,15 +15,16 @@ audience: ["contributors", "maintainers", "operators", "release-engineers"]
 
 Git branches, test revisions, tags, and release assets answer different
 questions. `v0.6.0` shipped on 2026-07-16 as a daemon-only prerelease at
-`2283a441...`. The v0.6.1 version-preparation branch is neither a designated
-candidate nor a release.
+`2283a441...`. Jeliya `a1af1cdc974bc307317779afa0765c3988cb871f`
+is the designated v0.6.1 source candidate; it is not network-qualified or a
+release.
 
 ## Current boundary
 
 | Layer | Exact revision | Dependency state | Artifact/evidence state | Claim allowed |
 |---|---|---|---|---|
 | Latest public release | lightweight tag `v0.6.0` at `2283a441220031485a7a212dc585772231d0f428` (prerelease) | release source pins published `iroh-rooms` `71fbb5007bef4ce83631c94762ec68c2beef3d79` (`v0.1.0-rc.3`) | five published daemon archives and five checksum sidecars; signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind the qualified source commit | behavior in those archives is released; the tag adds only the reviewed evidence documentation to the qualified source |
-| `v0.6.1` preparation line | exact candidate pending designation after the version PR merges | pins untagged public Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first merge carrying `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus the `kortiene/iroh-room#126` follow-ups | exact-revision upstream, workspace, and 67-assertion loopback suites passed at pre-version baseline `105744b…`; fresh signed direct/relay evidence pending | corrective source only; not network-qualified or published |
+| Current `v0.6.1` source candidate | `a1af1cdc974bc307317779afa0765c3988cb871f` | pins untagged public Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871`, the first merge carrying `kortiene/iroh-room#121` and `kortiene/iroh-room#119` fixes plus the `kortiene/iroh-room#126` follow-ups | all eight hosted jobs passed on public `main` run `29704754961`; fresh signed direct/relay evidence pending | corrective source only; designated but not network-qualified or published |
 | Released `v0.6.0` qualification source | `55024a46b3e112796ba2acf1dc408dab26dbba2e` | pins `v0.1.0-rc.3` at `71fbb5007bef4ce83631c94762ec68c2beef3d79` | signed certifying direct (`1ca39cfa`) and relay (`cf28bc63`) manifests bind this exact pair | evidence authorized `v0.6.0`; it does not transfer to v0.6.1 |
 | Superseded `v0.5.0` network-qualified commit | `c5f740e67d043a1153cf285691e3bc5b2b9a7203` | pins `d0ceb0b…` | both `v0.5.0` certifying schema 2 runs bind this commit | the certified evidence speaks for that revision pair only; it does not transfer to the rc.3 pin |
 | Audited baseline | `1285b42037a3713840955fa518f2b81b19f2929f` | pins vulnerable `iroh-rooms` `3cb9bfd…` | no artifact for this commit | baseline source behavior only |
@@ -35,8 +36,8 @@ The certifying [direct](evidence/v0.6.0/direct.json) and
 [relay](evidence/v0.6.0/relay.json) schema 2 manifests bind the
 network-qualified commit `55024a4…` and published pin `71fbb500…`, carry
 detached Ed25519 signatures, and set `certifiable: true` — they qualify that
-released `v0.6.0` source. They do not qualify the future v0.6.1 candidate +
-`a5d98b70…`. The `v0.5.0` manifests
+released `v0.6.0` source. They do not qualify `a1af1cdc…` + `a5d98b70…`.
+The `v0.5.0` manifests
 ([direct](evidence/v0.5.0/direct.json), [relay](evidence/v0.5.0/relay.json))
 bind `c5f740e…` + `d0ceb0b…` and authorized that prerelease; they do not
 transfer to another pin. Neither generation certifies room-scoped
@@ -59,7 +60,8 @@ prerelease only.
 
 ## Candidate changes are not released capabilities
 
-The v0.6.1 preparation line repins `iroh-rooms` to untagged `a5d98b70...`.
+The v0.6.1 candidate `a1af1cdc...` pins `iroh-rooms` to untagged
+`a5d98b70...`.
 Alongside the rc.3 join capability, bounded membership sync, and gap healing,
 this adds provisional-peer fanout/handshake gating, connection-generation
 teardown guards, and bounded store-insert recovery with durable critical
@@ -100,7 +102,7 @@ the ref and release operations requires operator inspection before retry.
 
 This snapshot records the released `v0.6.0` boundary (tag at `2283a441…`,
 certifying signed direct/relay manifests bound to `55024a4…` + `71fbb500…`),
-the v0.6.1 untagged dependency preparation line, the superseded v0.5.0 pair,
+the designated v0.6.1 candidate and its untagged dependency, the superseded v0.5.0 pair,
 and the retained historical
 manifests (the unsigned schema 2 preview run at `0f6769a…` and the schema 1
 local-remediation runs). Neither tickets, tokens, identity material, nor

--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -3,7 +3,7 @@ type: "Architecture"
 title: "Security and threat model"
 description: "Trust boundaries, assets, threats, controls, and residual risks for the v0.6.1 Jeliya candidate."
 tags: ["authorization", "privacy", "security", "threat-model"]
-timestamp: "2026-07-19T15:15:00Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -19,9 +19,9 @@ peers. The `v0.6.1` target is a trustworthy technical preview, not a claim of
 complete security. The current dependency pin carries the room-scoped
 synchronization remediation, provisional-peer gate, store retry/degradation
 controls, and relay-only verification seam. Exact-revision local qualification
-passes. Signed direct and forced-relay evidence still binds the prior dependency
-pin and must be repeated after the exact post-merge source candidate is
-designated.
+passes. Exact source candidate `a1af1cdc...` is designated; signed direct and
+forced-relay evidence still binds the prior dependency pin and must be repeated
+at this candidate.
 
 ## Candidate boundary
 
@@ -30,7 +30,7 @@ Security conclusions must name the source being evaluated:
 | Surface | Revision | Security meaning |
 |---|---|---|
 | Current public Jeliya dependency | Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` (untagged upstream `main`) | first merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the `kortiene/iroh-room#126` connection-generation follow-ups; local fanout, isolation, and store-degradation qualification passes |
-| Current source candidate | pending after the v0.6.1 version PR merges | the version-preparation branch is not a qualification candidate; its pre-version baseline `105744b…` passed the workspace and 67-assertion loopback suites |
+| Current source candidate | Jeliya `a1af1cdc974bc307317779afa0765c3988cb871f` | exact dependency pin in `Cargo.toml` and `Cargo.lock`; all eight hosted jobs pass on public `main` run `29704754961`; network qualification pending |
 | Released `v0.6.0` qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` plus Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79`; release tag `2283a441220031485a7a212dc585772231d0f428` | signed direct and forced-relay schema 2 evidence authorized the released v0.6.0 artifact set and remains valid for this exact pair only |
 | Superseded `v0.5.0` dependency | Iroh Rooms `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb` | carried the isolation remediation and relay-only seam; certified for the published `v0.5.0` at Jeliya `c5f740e67d043a1153cf285691e3bc5b2b9a7203`. Still fetchable by commit SHA, but no longer named by tag `v0.1.0-rc.2`, which was re-created upstream and now resolves elsewhere; the `v0.5.0` evidence binds the SHA, not the tag |
 | Historical local-remediation verification | Jeliya `fe870c7c5b63f2bf52b031dd1bc8e27e83183be5` plus local Iroh Rooms `3702e8cbcd5ac1808791124dd6bc44068be5f822` | schema 1 direct and forced-relay checks passed, but this older unpublished pair does not qualify a release |
@@ -40,8 +40,7 @@ source commit `55024a4…` and published Iroh Rooms pin `71fbb500…`: they
 establish direct and relay network operation and public-RPC non-disclosure. They
 do not establish room-scoped synchronization isolation — both manifests set
 `synchronization_isolation_claimed: false`; that control rests on the upstream
-suite at that revision. They do not transfer to the future v0.6.1 candidate +
-`a5d98b70…`.
+suite at that revision. They do not transfer to `a1af1cdc…` + `a5d98b70…`.
 Fresh source-built direct and relay runs and signatures are security
 requirements, not release administration.
 
@@ -87,7 +86,7 @@ implemented control.
 | Reachable vulnerable dependency | code execution, compromise, or denial of service | automated cargo/npm audits; high/critical findings block; explicit owned/expiring exception only when unavoidable | zero cargo/npm vulnerabilities; three maintenance warnings and one yanked version expire 2026-09-30 |
 | Compromised action or downloaded build tool | release supply-chain compromise | third-party Actions pinned to immutable revisions; Zig and Gradle distributions verified before execution; certifying network builds use the official complete Zig archive and exact tool bindings; least-privilege jobs | workflow and local contract tests pass; only the complete Zig archive is independently verified by schema 2, while other recorded tool digests are execution identities; the hosted double run executed for published `v0.6.0` and must execute again for `v0.6.1` |
 | Partial, mismatched, or post-validation-modified release | incomplete, stale, mislabeled, or candidate-mutated binaries | validate and seal all five private archives in a no-execution job; smoke the immutable artifact separately; verify the receipt without execution before tag/release creation; expose the write token only to the final step | workflow and receipt negative tests pass locally, and the path executed end to end for the published `v0.6.0` five-archive set; it has not yet run for `v0.6.1` |
-| Installer extracts modified bytes | local code execution | fetch the matching published checksum, validate filename/format, verify SHA-256, then extract | Unix behavior passes; Windows checksum, tamper, and simulated-reparse behavior passed on public `main` run `29688515781` at `a24f223…`; current-candidate rerun pending |
+| Installer extracts modified bytes | local code execution | fetch the matching published checksum, validate filename/format, verify SHA-256, then extract | Unix behavior passes; Windows checksum, tamper, and simulated-reparse behavior passed on public `main` run `29704754961` at exact candidate `a1af1cdc…` |
 | Forged or edited verification record | false release confidence | retained exact manifest, canonical public key, detached Ed25519 signature, source/publication/ancestry checks | retained signatures verify for released `v0.6.0`; the v0.6.1 gate is BLOCKED until new manifests bind the new revision pair without modifying v0.6.0 evidence |
 | Secrets copied into logs or evidence | credential or identity disclosure | transient logs confined to run-owned data directories, no address retention, and digest-only retained summaries | retained runs report completed cleanup. Manifests keep only line/byte counts and stream SHA-256 digests and contain no tickets, tokens, seeds, private keys, excerpts, or IP addresses |
 

--- a/docs/verification-evidence.md
+++ b/docs/verification-evidence.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Verification evidence"
 description: "Revision-bound verification ledger and evidence-recording contract for the v0.6.1 candidate."
 tags: ["evidence", "networking", "release", "testing", "verification"]
-timestamp: "2026-07-19T19:05:30Z"
+timestamp: "2026-07-19T21:49:56Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "partial"
@@ -19,9 +19,9 @@ the exact public Jeliya commit, public immutable dependency revisions,
 environment, timestamps, assertions, retained sanitized manifest, and detached
 signature. The retained direct and forced-relay schema 2 runs meet that bar for
 released v0.6.0 source Jeliya `55024a4...` + Iroh Rooms `71fbb500...`; the
-lightweight release tag is `2283a441...`. The v0.6.1 preparation line repins
-Iroh Rooms to `a5d98b70...`. Those signed manifests remain immutable and do not
-transfer to the new dependency revision.
+lightweight release tag is `2283a441...`. The designated v0.6.1 source
+candidate is `a1af1cdc...` and pins Iroh Rooms to `a5d98b70...`. Those signed
+manifests remain immutable and do not transfer to the new revision pair.
 
 ## Candidate identity
 
@@ -29,14 +29,14 @@ transfer to the new dependency revision.
 |---|---|
 | Milestone | `v0.6.1 — corrective technical-preview candidate`, not yet qualified or published |
 | Baseline commit | `2283a441220031485a7a212dc585772231d0f428` — the published `v0.6.0` tag |
-| Current source candidate | `pending — designate the exact public SHA after the version PR merges` |
+| Current source candidate | `a1af1cdc974bc307317779afa0765c3988cb871f` |
 | Network-qualified commit | `pending — fresh signed direct and relay runs required` |
 | Current public `iroh-rooms` pin | `a5d98b70d717f35d3ce60953a88e12e646f2e871` — deliberately untagged first upstream `main` merge carrying the fixes for `kortiene/iroh-room#121` and `kortiene/iroh-room#119` plus the connection-generation follow-ups |
 | Candidate upstream remediation revision | `a5d98b70d717f35d3ce60953a88e12e646f2e871` |
 | Last released qualification source | Jeliya `55024a46b3e112796ba2acf1dc408dab26dbba2e` + Iroh Rooms `71fbb5007bef4ce83631c94762ec68c2beef3d79` (tag `v0.1.0-rc.3`), released as Jeliya `v0.6.0` at `2283a441…` |
 | Retained evidence signatures | present and valid for released v0.6.0; not transferable to the current pin |
 | Release evidence gate | BLOCKED |
-| Evidence window | pre-version local exact-revision qualification on 2026-07-19 UTC; post-merge candidate and network evidence pending |
+| Evidence window | pre-version local exact-revision qualification plus hosted candidate CI on 2026-07-19 UTC; qualification refs and network evidence pending |
 
 The current pin is the first upstream `main` merge containing both required
 fixes. The two commits after it change only `iroh-rooms-cli`, which Jeliya does
@@ -47,8 +47,9 @@ predates both fixes.
 The retained signed direct and forced-relay runs remain valid evidence for released v0.6.0 source
 `55024a4...` + `71fbb500...`: they covered three peers across two BGP origin
 ASNs, passed every recorded assertion, and set `certifiable: true`. They are
-historical for v0.6.1. Fresh manifests must bind the post-merge designated SHA
-and `a5d98b70...` before the v0.6.1 evidence gate can return to `READY`.
+historical for v0.6.1. Fresh manifests must bind
+`a1af1cdc974bc307317779afa0765c3988cb871f` and `a5d98b70...` before the v0.6.1
+evidence gate can return to `READY`.
 
 The pre-version source baseline was recorded as `4261470...` while the repin was in
 review. `main` enforces linear history, so the merge rebased that work and
@@ -68,6 +69,15 @@ All eight hosted checks passed on public `main` run `29699530741` at the exact
 candidate commit, including the network evidence harness qualification step.
 The evidence gate remains `BLOCKED`: neither the prior signed manifests nor
 the local dry runs can qualify this new public commit.
+
+Jeliya `a1af1cdc974bc307317779afa0765c3988cb871f` is the exact post-merge
+v0.6.1 source candidate. Its tree (`675dcd4c...`) matches the reviewed version
+PR head `be6e43b7...`; PR run `29703977510` and public `main` run
+`29704754961` both passed all eight hosted jobs on that source tree. The
+post-merge run includes the 67-assertion loopback harness but is not real-network
+qualification. The evidence gate stays `BLOCKED` until the dedicated
+qualification refs exist and fresh signed direct and forced-relay manifests
+bind this exact candidate and pin.
 
 The `v0.5.0`-certified pin remains `d0ceb0b320f1ff3a576b63d8b24aa1bf76a2d3bb`.
 That revision is still publicly fetchable by commit SHA, but it is no longer
@@ -97,15 +107,15 @@ manifests are the certifying set.
 | Agent secret location | platform data directory outside the checkout, deny-all state-directory Git guard, repository ignore rules, and commit-prevention validation | local PASS |
 | Rust dependency audit | zero vulnerability advisories; three unmaintained-crate warnings and one yanked-version warning remain in the register below | PASS for vulnerability threshold |
 | npm dependency audit | zero vulnerabilities | PASS |
-| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | all jobs, including `linux-flutter` and Windows installer integrity, passed on public `main` run `29688515781` at `a24f223...`; current-candidate rerun pending |
-| Repeatability | two complete hosted CI executions from clean environments | configured in `release.yml`; not executed for the current candidate |
+| Complete CI definition | Rust, MSRV, TypeScript, Dart, Flutter, Linux native packaging, docs, smoke, sidecar, agent, fleet, protocol, and dependency gates are configured with required-tool failures; manual dispatch is non-publishing and Gradle is checksum-verified | all eight jobs, including `linux-flutter` and Windows installer integrity, passed on public `main` run `29704754961` at exact candidate `a1af1cdc...`; PR run `29703977510` passed on its identical tree |
+| Repeatability | two complete hosted CI executions from clean environments | PR run `29703977510` and public `main` run `29704754961` passed on the identical candidate tree; the post-evidence release workflow has not run |
 | Direct different-network P2P | retained schema 2 run `1ca39cfa`: three peers, three distinct observed egresses, two ASNs (AS11426 + AS24940), stable direct paths on roles A/B/C, all assertions pass | certifying PASS for `55024a4…` + `71fbb500…`; current-pin rerun required |
 | Deliberately forced relay | retained schema 2 run `cf28bc63`: the relay-only source build self-attests on all three hosts and proves relay paths on roles A/B/C | certifying PASS for `55024a4…` + `71fbb500…`; current-pin rerun required |
 | Join, reconnect, and resynchronization | the current two-daemon loopback run passes 67/67 assertions; retained network runs cover the same integration boundary at the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
 | Messages, files, and pipes | current loopback covers messages, byte-identical BLAKE3-verified file fetch, authorized pipe, and unauthorized denial; retained network runs cover the prior dependency pin | local current-pin PASS; current-pin direct and relay evidence pending |
 | Installer integrity | Unix behavioral tests verify checksum-before-extraction; Windows jobs execute checksum/tamper behavior, simulate reparse rejection, and smoke the native daemon | Unix PASS; hosted `windows-latest` job passes on `main` |
 | Complete asset-set visibility | an execution-free read-only job validates and seals the complete set, a separate read-only job performs smoke execution, and the sole writer verifies the receipt without candidate execution before its final token-bearing step; the release stays draft until all uploaded bytes match | executed end to end for `v0.6.0`, which built, verified, and published the five-archive set with sidecars; the same path must execute for `v0.6.1` after qualification. GitHub tag and release operations remain non-transactional |
-| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.1` | PASS on the version-preparation branch; the exact candidate is designated only after merge |
+| Version consistency | local source checks bind daemon/UI/lockfile/changelog naming to `0.6.1` | PASS at exact public candidate `a1af1cdc...` |
 | Documentation | required OKF pages distinguish the current locally qualified candidate, the prior signed schema 2 snapshot, and historical schema 1 local-remediation evidence | local docs and release-contract gates pass on this documentation diff |
 
 ## Dependency-risk exception register
@@ -322,17 +332,18 @@ Completed work:
    `kortiene/iroh-room#119` are public
    and present at immutable revision
    `a5d98b70d717f35d3ce60953a88e12e646f2e871`;
-2. the v0.6.1 preparation line resolves that exact revision in `Cargo.toml`
-   and `Cargo.lock`; and
+2. exact public v0.6.1 source candidate
+   `a1af1cdc974bc307317779afa0765c3988cb871f` resolves that revision in
+   `Cargo.toml` and `Cargo.lock`; and
 3. the targeted fanout, isolation, and store-degradation regressions, the full
    upstream core/net suite, the Jeliya workspace suite, and the loopback E2E
-   suite passed at pre-version baseline
-   `105744b6c27633e5ccc576d86f1a15e3fe443b94`.
+   suite passed at the pre-version baseline; both hosted matrices passed on the
+   candidate's exact source tree.
 
 Remaining work before `READY`:
 
-1. merge the version PR, designate its exact public SHA, and create the Jeliya
-   and Iroh Rooms qualification refs with explicit authorization;
+1. create the dedicated Jeliya and Iroh Rooms qualification refs with explicit
+   authorization, pointing to `a1af1cdc...` and `a5d98b70...` respectively;
 2. run direct and forced-relay qualification from that clean public commit,
    retaining new sanitized manifests under `docs/evidence/v0.6.1/` and bound
    to `a5d98b70...`;


### PR DESCRIPTION
## What changed

- designate Jeliya `a1af1cdc974bc307317779afa0765c3988cb871f` with Iroh Rooms `a5d98b70d717f35d3ce60953a88e12e646f2e871` as the exact v0.6.1 source pair
- record the green version-PR and post-merge `main` CI runs on the identical candidate tree
- keep the v0.6.1 evidence gate blocked until both qualification refs and fresh signed direct/forced-relay evidence exist
- leave `docs/evidence/v0.6.0/` unchanged and keep `docs/evidence/v0.6.1/` empty except for its boundary document

## Why

The version PR is merged and all eight post-merge jobs passed on the exact public commit. The release ledger must name that immutable candidate before the dedicated lightweight qualification refs are created.

## Impact

Documentation only. This PR does not alter the candidate source, dependency pin, release artifacts, or retained v0.6.0 evidence, and it does not run or claim real-network qualification.

## Checks

- `node scripts/check-docs.mjs`
- `node scripts/check-secret-storage.mjs`
- `node scripts/check-release.mjs --source --tag v0.6.1`
- `git diff --quiet v0.6.0 -- docs/evidence/v0.6.0`
- `git diff --check`