### PR TITLE
fix(deps): bump postcss past the sourceMappingURL path-traversal advisory

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2368,9 +2368,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2501,9 +2501,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2521,7 +2521,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Why

[GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (high) covers `postcss <= 8.5.17`: previous-source-map auto-loading follows `sourceMappingURL` without confining the path, allowing a crafted stylesheet to disclose arbitrary `.map` files.

The advisory was published **after** main last ran CI (2026-07-19, `8f0cc2a`, green). The required `dependency-security` job now fails on **every** branch, not just new work — it is blocking #150 and will block anything else opened today.

## What

Lockfile-only, dev-only:

- `postcss` 8.5.16 → 8.5.23
- `nanoid` 3.3.15 → 3.3.16 (postcss's own pinned dependency)

`postcss` is a transitive **dev** dependency of `vite` (`^8.5.6`), so no `package.json` range changes and nothing ships to users.

## Verification

| Gate | Before | After |
|---|---|---|
| `npm audit --audit-level=high` | 1 high | **0 vulnerabilities** |
| `npm ci --ignore-scripts` | — | clean |
| `npm run test:unit` | — | **213 pass** (15 files) |
| `npm run build` | — | clean |
| `node scripts/check-design-tokens.mjs` | — | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)