### PR TITLE
docs(protocol): specify the v2 wire schemas, error taxonomy, and fixture DSL (#212)

### DIFF
--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -123,7 +123,7 @@ breaking change it would catch is not worth running.
 
 ## Steps
 
-A step has **exactly one verb**. The verb set is closed at eight.
+A step has **exactly one verb**. The verb set is closed at seven.
 
 | Verb | Value | Meaning |
 |---|---|---|
@@ -132,8 +132,7 @@ A step has **exactly one verb**. The verb set is closed at eight.
 | `upgrade` | `{query, headers}` | A Layer 1 `/ws` upgrade attempt |
 | `send` | raw frame value | Write bytes that may not be a valid frame |
 | `await` | `{push}`, `{frame}`, or `{reply}` | Wait for a specific frame, by type or by correlating `id` |
-| `control` | `{…}` | Drive the harness, not the daemon |
-| `save` | `{var: path}` | Capture values into variables |
+| `control` | `{do, …}` | Drive the harness, not the daemon |
 | `assert` | array of assertions | Everything else |
 
 Any step may additionally carry:
@@ -144,10 +143,46 @@ Any step may additionally carry:
 | `op_id` | the envelope `op_id`, for `call` — **never inside `in`** |
 | `on` | which session this step runs on |
 | `expect` | the reply matcher |
+| `save` | capture values from this step's result into variables |
 | `note` | prose for a human; a harness ignores it |
+
+`save` is an **auxiliary key, not a verb**. It always captures from the step it
+sits on, so making it a verb would force every capture into a second step with
+nothing to capture from.
 
 `note` is the only annotation key. The committed corpus also uses `why`,
 `comment`, `intent_note`, and `meaning` for the same thing.
+
+### `control` — driving the harness
+
+`control` is discriminated by `do`, closed at nine. It is the one verb that does
+not touch the daemon's protocol surface, so leaving it as an open object would
+have let every harness invent its own dialect — which is what the committed
+corpus already did, spelling this idea four ways (`harness`, `control`, `fault`,
+`trigger`) split cleanly by authoring file.
+
+| `do` | Keys | Effect |
+|---|---|---|
+| `advance_clock` | `ms` | Move the harness clock forward |
+| `idle` | `ms` | Wait without producing activity |
+| `disconnect` | `on` | Drop a session's transport without a close frame |
+| `reconnect` | `on` | Re-establish it, same principal |
+| `inject_fault` | `fault` | Force a named fault condition |
+| `set_limit` | `limit`, `value` | Override a served limit for this case |
+| `stop_daemon` | `daemon` | Terminate a daemon process |
+| `start_transfers` | `count` | Begin N concurrent transfers |
+| `pause_link` | `between` | Suspend transport between two daemons |
+
+`inject_fault`'s `fault` is a **taxonomy code**, so a fault a case wants that
+names no code is a signal the taxonomy is incomplete — that is how
+`room_index_unreadable` and its four siblings were found. Two conditions are
+deliberately not codes and are named directly: `backpressure` and
+`subscription_lapse`, which are the two `gap.reason` arms a harness must be able
+to force in order to test gap detection at all.
+
+`set_limit` exists because several boundary cases need a limit small enough to
+reach — `max_connections` and `max_subscriptions_per_connection` cannot be
+exercised against production values in a test.
 
 ### `on` — which session
 
@@ -325,8 +360,9 @@ asserts only the code proves half the property.
 { "call": "room.timeline", "in": { "room_id": "$r", "…": "…" } }
 ```
 
-`save` maps variable names to paths. A `$name` reference resolves to the captured
-value anywhere a literal is legal. Variables are scoped to the case.
+`save` maps variable names to paths and rides on the step that produces them. A
+`$name` reference resolves to the captured value anywhere a literal is legal.
+Variables are scoped to the case.
 
 This replaces `save`, `save_out`, and `save_error`, which differed only in which
 root they read from — now expressed as the path's root.

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -131,7 +131,7 @@ A step has **exactly one verb**. The verb set is closed at eight.
 | `http` | `{method, path, headers, body}` | A Layer 0 or `/api/session` request |
 | `upgrade` | `{query, headers}` | A Layer 1 `/ws` upgrade attempt |
 | `send` | raw frame value | Write bytes that may not be a valid frame |
-| `await` | `{frame}` or `{push}` | Wait for a server-initiated frame |
+| `await` | `{push}`, `{frame}`, or `{reply}` | Wait for a specific frame, by type or by correlating `id` |
 | `control` | `{…}` | Drive the harness, not the daemon |
 | `save` | `{var: path}` | Capture values into variables |
 | `assert` | array of assertions | Everything else |
@@ -198,11 +198,21 @@ To pin a key set exactly, use the `exact_keys` assertion. To require a key be
 "asserted absent" — the distinction is load-bearing, and conflating the two is
 how a fixture starts passing against an implementation that leaks a field.
 
-An `expect` on a `call` step replaces all thirteen of the corpus's `expect_*`
-verbs: `expect_error`, `expect_subset`, `expect_frame`, `expect_status`,
-`expect_body`, `expect_hello`, `expect_upgrade`, `expect_absent`,
-`expect_one_of`, `expect_identical_to`, `expect_no_null`, `expect_all`, and
-`expect_each_subset`.
+`expect` replaces **all 42 `expect_*` verbs** the corpus currently uses. They
+divide three ways, and the division is the point — a flat list of replacements
+would hide that a third of them are not reply matchers at all:
+
+| Corpus verbs | Become |
+|---|---|
+| `expect_error`, `expect_subset`, `expect_ok`, `expect_envelope`, `expect_body`, `expect_body_shape`, `expect_final_body`, `expect_hello`, `expect_hello_subset`, `expect_status`, `expect_content_type`, `expect_upgrade`, `expect_upgrade_error` | `expect`, directly |
+| `expect_absent`, `expect_no_null`, `expect_identical_to`, `expect_one_of`, `expect_any_of`, `expect_all`, `expect_each_subset`, `expect_every_element`, `expect_across`, `expect_at_least_one_error`, `expect_all_replies`, `expect_hello_assert`, `expect_rendering` | an `assert` predicate — they are assertions wearing an `expect_` prefix |
+| `expect_frame`, `expect_push`, `expect_no_push`, `expect_frame_order`, `expect_each_frame`, `expect_close`, `expect_no_further_frames_of_type`, `expect_transport`, `expect_process`, `expect_connect_failure`, `expect_timing_indistinguishable`, `expect_reply_for_id`, `expect_reply_for_id_2`, `expect_error_for_id`, `expect_no_reply_for_id` | `await` or an `observe` assertion — they are about frames and processes, not about one reply |
+
+`expect_reply_for_id` and its three siblings deserve their own note: they exist
+because **replies may arrive out of order**, which the record makes normative.
+A harness that could only match replies in request order would silently pass an
+implementation that violated it. `await {reply: "$id"}` is how a case names the
+reply it means.
 
 ## `assert` — one assertion form, two families
 

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -5,14 +5,6 @@ Hand-authored, language-neutral fixtures for
 independent harness against every adapter: the codec, the typed daemon, the
 Rust adapters, and the agent cutover.
 
-**Not yet replayable.** The specification is `draft` and does not state
-per-operation wire schemas, so these fixtures encode a contract the document
-does not yet contain. They also use several dialects for the same concepts —
-`assert` appears as an array, as an object, and as a predicate string with
-sibling operands — so a harness cannot interpret them consistently. Both are
-tracked as **#212**. Treat the corpus as **recorded intent**, precise
-about behaviour and not yet precise about shape.
-
 This directory is data. It contains no TypeScript, no Rust, and no test runner,
 because a corpus that only one language can replay is not a conformance corpus.
 
@@ -29,41 +21,40 @@ conformance corpus is for. #161 states it as an acceptance criterion.
 
 The v1 surface was consulted **only** to know what to avoid transcribing.
 
-## Status
+## Status — not yet replayable
 
-`manifest.json` is the machine-checkable answer, and today it says:
+The specification is now complete: it states every request and reply shape, the
+whole 60-code taxonomy, and the DSL below. **The fixtures have not yet been
+normalized to that DSL**, and until they are, this corpus cannot be replayed and
+must not be cited as evidence for any adapter.
 
 | | |
 |---|---|
-| Cases | 332 |
-| Operations satisfying the required kinds | **33 of 33** |
-| Quarantined | 0 |
+| Cases | 335 |
+| Cases conforming to the DSL below | **0** |
+| Distinct step verbs in use | 178, against a closed set of 8 |
+| Cases carrying at least one off-DSL step | 332 of 335 |
+| Cases asserting a field or code the specification does not define | 51 |
 | Blocked on upstream | 10 |
 
-Every operation has a success case and an error case using **its own most
-specific code**. A shared code does not satisfy the rule, because
-`subject_absent` asserted against `room.list` and against `fleet.list` is the
-same assertion twice.
+Normalization is tracked as **#213**. It is deliberately a separate change from
+the specification work (#212): deciding whether a fixture is wrong requires the
+schema it is wrong against, so the schemas had to land first.
 
 **Ten cases are blocked on upstream work** (U1, U2, U3 in the spec). They
 **fail**; they do not skip. A skipped case reads as coverage and quietly
 becomes permanent. A failing case reads as work.
 
-### How the quarantine was cleared
+### What normalization must not do
 
-An earlier round quarantined eleven cases for asserting payload contracts the
-specification did not state — they had fallen back on v1 shapes (`points`,
-`rooms_total`, a nullable `progress`). That was a finding about the
-*specification*: an operation described only as "read the agent fleet
-projection" cannot be conformance-tested, and cannot be implemented either.
+The corpus's value rests entirely on the independence rule, and the fastest way
+to normalize 335 fixtures would destroy it. A fixture rewritten by pattern
+substitution is no longer a transcription of something independently known to be
+right — it is a transcription of whatever the substitution produced.
 
-The fix was to write the missing contracts, not to bless the v1 shapes. Twelve
-superseded cases were **deleted** rather than un-quarantined, and replacements
-were authored against the new contracts.
-
-One decision remains open and is recorded in the specification: whether typed
-status severity lives on the signed event or in the daemon projection. It is a
-wire change, and the corpus must not freeze before it is settled.
+Each case is therefore re-derived from the specification by hand, and a case
+whose intent no longer names a breaking change it would catch is **deleted**
+rather than mechanically translated.
 
 ## Layout
 
@@ -78,27 +69,249 @@ files.json           sharing, fetching, the size limit and its enforcement point
 pipes.json           publish / connect / release / revoke, reachability as fact
 ```
 
-## Case shape
+One flat file per domain. Case `name` is a **corpus-wide unique identifier**,
+not unique-per-file: a harness indexes by it, so a collision silently drops a
+case.
+
+---
+
+# The fixture DSL
+
+Normative. A harness implements exactly this, and a fixture that uses anything
+not defined here is invalid rather than interestingly extended.
+
+The design constraint is that it must lose no assertion the corpus currently
+expresses while replacing 178 ad-hoc verbs and three `assert` dialects — string,
+object, and array — with one language. Every construct below exists because some
+committed fixture needs it.
+
+## The case object
 
 ```json
 {
-  "name": "snake_case_unique",
-  "kind": "success|error|malformed|boundary|push|ordering|authorization|handshake",
-  "operation": "room.create",
-  "intent": "what this proves, and what breaking change it would catch",
-  "requires": ["subject", "live_room"],
-  "steps": [{ "call": "room.create", "in": {}, "expect": {} }],
-  "blocked_on_upstream": null,
-  "quarantined": null
+  "name": "room_list_reports_standing_and_capabilities_from_local_evidence",
+  "kind": "success",
+  "operation": "room.list",
+  "intent": "Proves room.list answers from local evidence with zero network activity, catching any change that makes the room list depend on liveness.",
+  "requires": ["subject", "room:live", "observe:network"],
+  "steps": [ … ],
+  "blocked_on_upstream": "U1"
 }
 ```
 
-Dynamic values are asserted as type tags (`<hex64>`, `<room_id>`, `<ts>`,
-`<uint>`), never as literals, so a fixture pins a shape without pinning a clock
-or a random identifier. This convention is inherited from the v1 corpus.
+| Key | Required | Value |
+|---|---|---|
+| `name` | yes | `snake_case`, corpus-wide unique |
+| `kind` | yes | one of the eight below |
+| `operation` | yes | one of the 33 operation names, or `null` |
+| `intent` | yes | prose naming the breaking change this case would catch |
+| `requires` | yes | array of preconditions, closed vocabulary below |
+| `steps` | yes | non-empty array |
+| `blocked_on_upstream` | no | `"U1"`, `"U2"`, or `"U3"` |
+
+`kind` is closed: `success`, `error`, `malformed`, `boundary`, `authorization`,
+`handshake`, `push`, `ordering`.
+
+**`operation: null` is legal and means the case is not about one operation** —
+gate behaviour, envelope framing, cross-room ordering. 103 of the 335 committed
+cases are in this class, and the manifest's coverage table counts only the
+attributed ones, which is why its rows sum to 232 rather than 335. A case may
+not use `null` merely because attributing it is inconvenient.
 
 `intent` is required and is not decoration: a case whose intent cannot name the
 breaking change it would catch is not worth running.
+
+## Steps
+
+A step has **exactly one verb**. The verb set is closed at eight.
+
+| Verb | Value | Meaning |
+|---|---|---|
+| `call` | operation name | Invoke an operation on the current session |
+| `http` | `{method, path}` | An unauthenticated Layer 0 request |
+| `upgrade` | `{query, headers}` | A Layer 1 `/ws` upgrade attempt |
+| `send` | raw frame value | Write bytes that may not be a valid frame |
+| `await` | `{frame}` or `{push}` | Wait for a server-initiated frame |
+| `control` | `{…}` | Drive the harness, not the daemon |
+| `save` | `{var: path}` | Capture values into variables |
+| `assert` | array of assertions | Everything else |
+
+Any step may additionally carry:
+
+| Key | Meaning |
+|---|---|
+| `in` | the request body, for `call` |
+| `op_id` | the envelope `op_id`, for `call` — **never inside `in`** |
+| `expect` | the reply matcher |
+| `note` | prose for a human; a harness ignores it |
+
+`note` is the only annotation key. The committed corpus also uses `why`,
+`comment`, `intent_note`, and `meaning` for the same thing.
+
+## `expect` — one reply matcher
+
+`expect` is a single form discriminated by `ok`, exactly as the wire is:
+
+```json
+{ "expect": { "ok": true,  "out": { "room_id": "<room_id>", "live": true } } }
+{ "expect": { "ok": false, "err": { "code": "room_not_available" } } }
+```
+
+**Matching is a subset match by default.** Keys named in `out` or `err` must be
+present and equal; keys not named are not constrained. This is what makes a
+fixture robust against fields added later without making it vacuous.
+
+To pin a key set exactly, use the `exact_keys` assertion. To require a key be
+**absent**, use `absent`. Silence in `expect` means "not asserted", never
+"asserted absent" — the distinction is load-bearing, and conflating the two is
+how a fixture starts passing against an implementation that leaks a field.
+
+An `expect` on a `call` step replaces all thirteen of the corpus's `expect_*`
+verbs: `expect_error`, `expect_subset`, `expect_frame`, `expect_status`,
+`expect_body`, `expect_hello`, `expect_upgrade`, `expect_absent`,
+`expect_one_of`, `expect_identical_to`, `expect_no_null`, `expect_all`, and
+`expect_each_subset`.
+
+## `assert` — one assertion form, two families
+
+`assert` is **always an array of objects**. It is never a bare string and never a
+single object; the committed corpus uses all three, which is the single largest
+source of the dialect problem.
+
+### Value assertions
+
+```json
+{ "path": "out.rooms[*].role", "op": "member_of", "value": ["authority", "member"] }
+```
+
+`path` is a dotted path rooted at `out`, `err`, `frame`, or a `$variable`.
+`[*]` is a wildcard over an array: the assertion must hold for **every** element.
+This is what lets one predicate replace the corpus's `every_row_has_fields`,
+`every_row_has_non_null`, `every_push_has_non_null`, `all_eq`, `every_has_key`,
+and `every_row_has_value`.
+
+`op` is closed at fourteen:
+
+| `op` | `value` | Holds when |
+|---|---|---|
+| `eq` | any | Deep equality. `value` may be `"$var"` |
+| `ne` | any | Deep inequality |
+| `lt` `lte` `gt` `gte` | number | Numeric comparison |
+| `member_of` | array | The value is one of these |
+| `type` | type tag | The value inhabits that domain |
+| `present` | — | The path resolves |
+| `absent` | — | The path does not resolve |
+| `exact_keys` | array | The object's key set is exactly this |
+| `len` | `{op, value}` | The array/string length satisfies a nested comparison |
+| `unique` | — | All values at a wildcard path are distinct |
+| `increasing` | — | Strictly increasing |
+| `contiguous` | — | Strictly increasing by exactly 1 |
+| `no_nulls` | — | No JSON `null` anywhere in the subtree |
+
+`no_nulls` deserves its own predicate rather than being a convention because
+[the specification's no-null rule](../../docs/protocol-v2.md#bounded-parsing) is
+normative for every frame, and a corpus that cannot assert it cannot test it.
+
+These fourteen replace the corpus's `eq`, `equals`, `equal_modulo`, `all_eq`,
+`same_value_as`, `codes_equal`, `identical_to`, `errors_identical`, `ne`, `neq`,
+`not_equal`, `not_equals`, `distinct_from`, `len`, `len_eq`, `array_len`,
+`byte_len`, `len_lte`, `len_gte`, `no_null`, `no_nulls_deep`, `no_null_values`,
+`absent_key`, `no_keys`, `present_key`, `greater_than`, `strictly_increasing`,
+`monotonic_non_decreasing`, `pos_strictly_increasing`, and
+`contiguous_increasing`.
+
+### Observation assertions
+
+Some cases assert facts about the daemon's *behaviour*, not about a value in a
+reply. Those are a separate family, because no path names them:
+
+```json
+{ "observe": "no_network_activity", "scope": "step" }
+```
+
+`observe` is closed at nine:
+
+| `observe` | Holds when |
+|---|---|
+| `no_network_activity` | No packet left the host during `scope` |
+| `no_durable_mutation` | No byte of the data dir changed during `scope` |
+| `no_event_authored` | No room event was written during `scope` |
+| `bytes_streamed` | Bytes sent satisfies a nested comparison |
+| `connection_open` | The session is still open |
+| `close_code` | The connection closed with a given code |
+| `push_count` | Pushes received satisfies a nested comparison |
+| `no_push` | No push arrived for a named room |
+| `timing_indistinguishable` | Two named steps are not separable by latency |
+
+`scope` is `step`, `case`, or a named step range. It is required on the first
+three and forbidden on the rest.
+
+`timing_indistinguishable` exists because
+[the non-oracle property](../../docs/protocol-v2.md#the-non-oracle-property)
+requires indistinguishable *timing*, not merely an identical code. A corpus that
+asserts only the code proves half the property.
+
+## Variables
+
+```json
+{ "call": "room.create", "in": { "name": "Build" }, "save": { "r": "out.room_id" } }
+{ "call": "room.timeline", "in": { "room_id": "$r", "…": "…" } }
+```
+
+`save` maps variable names to paths. A `$name` reference resolves to the captured
+value anywhere a literal is legal. Variables are scoped to the case.
+
+This replaces `save`, `save_out`, and `save_error`, which differed only in which
+root they read from — now expressed as the path's root.
+
+## Type tags
+
+A dynamic value is asserted as a **type tag** rather than a literal, so a fixture
+pins a shape without pinning a clock or a random identifier.
+
+**A tag names a value domain, not an encoding.**
+
+`<room_id>` `<subject_id>` `<device_id>` `<event_id>` `<invite_id>` `<file_id>`
+`<pipe_id>` `<op_id>` `<ts>` `<uint>` `<bool>` `<string>`
+
+- **`<hex64>` is not a tag.** It names an encoding shared by four distinct
+  domains, so asserting it where `<device_id>` belongs would pass against a
+  subject id. The corpus uses it 
+  in exactly that ambiguous way today.
+- `<u64>`, `<number>`, and `<int>` all collapse into `<uint>`.
+- **`<variant>` and `<array>` are not tags.** `{"state": "<variant>"}` asserts
+  that a discriminant exists without asserting which arms are legal — it asserts
+  nothing at all. Every such site becomes an explicit token set via `member_of`.
+- A new tag is minted only when a value's domain is not already named, and it
+  must be added to this table in the same change.
+
+## `requires`
+
+A closed vocabulary of preconditions the harness must establish. The committed
+corpus uses **133 flat tokens**, many of them synonyms (`daemon`,
+`authority_daemon`, `member_daemon`, `fresh_daemon`, `disposable_daemon`), which
+no harness can implement as a closed set.
+
+The replacement is a `namespace:argument` form. Namespaces are closed at nine:
+
+| Namespace | Arguments | Establishes |
+|---|---|---|
+| `subject` | `self`, `none`, `second`, `outsider` | Local cryptographic subjects |
+| `daemon` | `self`, `second`, `fresh`, `restartable` | Daemon processes |
+| `room` | `plain`, `live`, `quiescent`, `left`, `removed`, `foreign`, `with_history` | A room in a named state |
+| `member` | `b`, `c`, `agent`, `non_agent` | Additional members of the current room |
+| `link` | `up`, `down`, `relay`, `slow` | Transport conditions between daemons |
+| `resource` | `tcp_service`, `large_file`, `shared_file`, `fetched_file` | Fixtures the case operates on |
+| `observe` | `network`, `store`, `frames`, `timing`, `process` | Observation capabilities |
+| `control` | `clock`, `limits`, `reconnect`, `concurrency` | Harness controls |
+| `fault` | a taxonomy code, e.g. `room_index_unreadable` | Fault injection |
+
+A bare `subject` is shorthand for `subject:self`; a bare `daemon` for
+`daemon:self`. Nothing else may be bare.
+
+`fault:` takes **a code from the taxonomy**, so a fault a fixture wants to inject
+that names no code is a signal the taxonomy is incomplete — which is how
+`room_index_unreadable` and its four siblings were found in the first place.
 
 ## Adding a case
 
@@ -108,3 +321,5 @@ breaking change it would catch is not worth running.
 3. Prefer a case that would fail against a plausible wrong implementation. The
    repository's own precedent is to verify this by deliberately breaking the
    implementation and confirming the case goes red.
+4. Give it an `intent` that names the breaking change. If you cannot, the case is
+   not worth running.

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -128,7 +128,7 @@ A step has **exactly one verb**. The verb set is closed at eight.
 | Verb | Value | Meaning |
 |---|---|---|
 | `call` | operation name | Invoke an operation on the current session |
-| `http` | `{method, path}` | An unauthenticated Layer 0 request |
+| `http` | `{method, path, headers, body}` | A Layer 0 or `/api/session` request |
 | `upgrade` | `{query, headers}` | A Layer 1 `/ws` upgrade attempt |
 | `send` | raw frame value | Write bytes that may not be a valid frame |
 | `await` | `{frame}` or `{push}` | Wait for a server-initiated frame |
@@ -142,11 +142,32 @@ Any step may additionally carry:
 |---|---|
 | `in` | the request body, for `call` |
 | `op_id` | the envelope `op_id`, for `call` — **never inside `in`** |
+| `on` | which session this step runs on |
 | `expect` | the reply matcher |
 | `note` | prose for a human; a harness ignores it |
 
 `note` is the only annotation key. The committed corpus also uses `why`,
 `comment`, `intent_note`, and `meaning` for the same thing.
+
+### `on` — which session
+
+`on` names a session established by `requires`, defaulting to `subject:self`'s
+primary connection when omitted:
+
+```json
+{ "call": "room.create", "on": "subject:self",   "in": { "name": "Build" } }
+{ "call": "room.timeline", "on": "subject:second", "in": { "…": "…" } }
+{ "call": "room.list",   "on": "subject:self#2", "in": {} }
+```
+
+**Nothing else selects an actor**, and without this key roughly a third of the
+corpus is inexpressible. The committed fixtures spell the same idea four ways —
+`as` (504 uses, 25 distinct actor labels), `conn`, `session`, and `client` — and
+the cases that need it are not marginal: the non-oracle property needs a
+non-member, `op_ids_do_not_collide_across_session_principals` needs two
+principals on one daemon, and every reconnect case needs two connections for one
+subject. `#2` names a second connection for the same principal, which is what
+distinguishes a per-connection scope from a per-principal one.
 
 ## `expect` — one reply matcher
 
@@ -156,6 +177,17 @@ Any step may additionally carry:
 { "expect": { "ok": true,  "out": { "room_id": "<room_id>", "live": true } } }
 { "expect": { "ok": false, "err": { "code": "room_not_available" } } }
 ```
+
+For `http` and `upgrade` steps the matcher instead carries `status`, `headers`,
+and `body`:
+
+```json
+{ "expect": { "status": 426, "body": { "code": "protocol_unsupported" } } }
+```
+
+The record makes the refusal statuses normative — `426`, `401`, `403` — and
+requires that `POST /api/session` prove possession of the daemon token. Neither
+is assertable without a status and a header slot, so both exist.
 
 **Matching is a subset match by default.** Keys named in `out` or `err` must be
 present and equal; keys not named are not constrained. This is what makes a
@@ -190,7 +222,7 @@ This is what lets one predicate replace the corpus's `every_row_has_fields`,
 `every_row_has_non_null`, `every_push_has_non_null`, `all_eq`, `every_has_key`,
 and `every_row_has_value`.
 
-`op` is closed at fourteen:
+`op` is closed at nineteen:
 
 | `op` | `value` | Holds when |
 |---|---|---|
@@ -205,8 +237,25 @@ and `every_row_has_value`.
 | `len` | `{op, value}` | The array/string length satisfies a nested comparison |
 | `unique` | — | All values at a wildcard path are distinct |
 | `increasing` | — | Strictly increasing |
+| `non_decreasing` | — | Increasing or equal — **not** the same as `increasing` |
 | `contiguous` | — | Strictly increasing by exactly 1 |
 | `no_nulls` | — | No JSON `null` anywhere in the subtree |
+| `byte_len` | `{op, value}` | Length **in bytes**, for the size-boundary cases |
+| `eq_except` | `{path, keys}` | Deep equality with another path, ignoring named keys |
+
+`eq_except` exists for **the non-oracle property**, which is the corpus's
+flagship assertion and which `eq` alone cannot express: two refusals must be
+identical *except* for the envelope `id` that correlates them. Without it, every
+non-oracle case degrades into asserting the codes match, which proves half the
+property.
+
+`byte_len` is separate from `len` because the size limits are byte limits and
+`max_message_body_bytes` is not a character count. Collapsing them would make
+every multi-byte boundary case silently wrong.
+
+`non_decreasing` is separate from `increasing` because `transferred_bytes` on
+successive progress frames may legitimately repeat, and asserting strict
+increase there would fail a correct implementation.
 
 `no_nulls` deserves its own predicate rather than being a convention because
 [the specification's no-null rule](../../docs/protocol-v2.md#bounded-parsing) is
@@ -227,24 +276,32 @@ reply. Those are a separate family, because no path names them:
 
 ```json
 { "observe": "no_network_activity", "scope": "step" }
+{ "observe": "close_code",  "value": 4004 }
+{ "observe": "push_count",  "value": { "op": "eq", "value": 3 }, "room_id": "$r" }
+{ "observe": "timing_indistinguishable", "between": ["step:3", "step:5"] }
 ```
 
-`observe` is closed at nine:
+`observe` is closed at ten. Each row states the keys it takes, because an
+observation with no slot for its argument cannot be written down:
 
-| `observe` | Holds when |
-|---|---|
-| `no_network_activity` | No packet left the host during `scope` |
-| `no_durable_mutation` | No byte of the data dir changed during `scope` |
-| `no_event_authored` | No room event was written during `scope` |
-| `bytes_streamed` | Bytes sent satisfies a nested comparison |
-| `connection_open` | The session is still open |
-| `close_code` | The connection closed with a given code |
-| `push_count` | Pushes received satisfies a nested comparison |
-| `no_push` | No push arrived for a named room |
-| `timing_indistinguishable` | Two named steps are not separable by latency |
+| `observe` | Additional keys | Holds when |
+|---|---|---|
+| `no_network_activity` | `scope` | No packet left the host during `scope` |
+| `no_durable_mutation` | `scope` | No byte of the data dir changed during `scope` |
+| `no_event_authored` | `scope` | No room event was written during `scope` |
+| `bytes_streamed` | `value` | Bytes sent satisfies a nested comparison |
+| `connection_open` | `on` | That session is still open |
+| `close_code` | `value`, `on` | That connection closed with this code |
+| `push_count` | `value`, `room_id` | Pushes received for a room satisfies a comparison |
+| `no_push` | `room_id`, `scope` | No push arrived for that room |
+| `timing_indistinguishable` | `between` | Two named steps are not separable by latency |
+| `process_exited` | `value` | The daemon process exited with this status |
 
-`scope` is `step`, `case`, or a named step range. It is required on the first
-three and forbidden on the rest.
+`scope` is `step`, `case`, or `step:<n>..step:<m>`.
+
+Steps are addressable as `step:<n>`, one-indexed within the case. That is what
+makes `timing_indistinguishable` writable at all — it is a claim about a *pair*
+of steps, and the non-oracle property is not provable without it.
 
 `timing_indistinguishable` exists because
 [the non-oracle property](../../docs/protocol-v2.md#the-non-oracle-property)
@@ -263,6 +320,29 @@ value anywhere a literal is legal. Variables are scoped to the case.
 
 This replaces `save`, `save_out`, and `save_error`, which differed only in which
 root they read from — now expressed as the path's root.
+
+### Computed values
+
+A boundary case must say "exactly the served limit" and "one past it" without
+compiling either number in — that is the whole point of serving limits. So a
+value may also be a single-key computed node:
+
+| Node | Meaning |
+|---|---|
+| `{"$add": ["$max", 1]}` | Arithmetic on captured values |
+| `{"$sub": ["$max", 1]}` | |
+| `{"$bytes_of_len": "$max"}` | A string of exactly that many bytes |
+| `{"$concat": ["a", "$b"]}` | Concatenation |
+| `{"$unknown": "<room_id>"}` | A well-formed value of that domain naming nothing that exists |
+
+Without these, **every case that probes a served limit would have to hard-code
+the limit**, which is precisely the failure the record's served-limits object
+exists to prevent — and the corpus already embeds thirteen ad-hoc operators to
+avoid it.
+
+`{"$unknown": …}` is separate from a literal because the non-oracle cases need a
+value that is syntactically valid and semantically absent, and a fixture cannot
+know a real identifier that does not exist.
 
 ## Type tags
 

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -1,11 +1,15 @@
 {
   "corpus": "jeliya protocol v2",
   "spec": "../../docs/protocol-v2.md",
+  "dsl": "./README.md",
   "authored": "by hand, from the specification. NOT generated from any implementation.",
+  "replayable": false,
+  "why_not_replayable": "The 335 committed fixtures predate the fixture DSL and are not yet normalized to it: they use 178 step verbs against a closed set of 8, and 51 assert a field or code the specification deliberately does not define. Normalization is #213. Until it lands, no coverage claim in this file is verifiable and satisfies_required_kinds is false everywhere.",
   "rules": {
     "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
     "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
-    "quarantine": "a quarantined case asserts a payload contract the spec does not state. It does not run, and it does not count as coverage. Each names the operation whose contract must be written first."
+    "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
+    "counts_are_computed": "every count in this file is derived from the committed fixtures, not asserted alongside them. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
   },
   "blocked_on_upstream": {
     "U1": "ConnEvent must carry the connection generation and a typed offline reason",
@@ -14,243 +18,303 @@
   },
   "totals": {
     "cases": 335,
+    "attributed_to_an_operation": 232,
+    "not_operation_scoped": 103,
+    "conforming_to_the_dsl": 0,
     "quarantined": 0,
     "blocked_on_upstream": 10
   },
+  "exemptions": {
+    "room.deactivate": {
+      "from": "required_per_operation",
+      "reason": "Every way room.deactivate can fail is already a cross-cutting refusal: no subject, no such room, or membership ended. Deactivating a room the caller may act in always succeeds, because it withdraws local participation and asks nothing of the network. A code that no reachable state produces would buy a green cell in this table and nothing else.",
+      "reviewed_in": "#212"
+    }
+  },
+  "codes_without_a_case": {
+    "note": "real codes in the taxonomy that no fixture yet exercises. A gap in the corpus, not in the specification. Authoring them is #213.",
+    "codes": [
+      "authority_cannot_be_removed",
+      "capability_redeemed",
+      "cursor_unknown",
+      "declared_size_mismatch",
+      "idle_timeout",
+      "malformed_frame",
+      "pipe_index_unreadable",
+      "pipe_not_publisher",
+      "room_still_active",
+      "subject_store_unwritable",
+      "transport_unavailable"
+    ]
+  },
   "coverage": {
-    "subject.ensure": {
-      "cases": 12,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
     "daemon.stop": {
       "cases": 4,
       "success": true,
-      "distinctive_error": true,
       "distinctive_code": "shutdown_in_progress",
-      "satisfies_required_kinds": true
-    },
-    "room.create": {
-      "cases": 10,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "room_name_invalid",
-      "satisfies_required_kinds": true
-    },
-    "room.list": {
-      "cases": 6,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "room_index_unreadable",
-      "satisfies_required_kinds": true
-    },
-    "room.activate": {
-      "cases": 4,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "room.deactivate": {
-      "cases": 3,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "room.leave": {
-      "cases": 4,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "room.timeline": {
-      "cases": 9,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "room.members": {
-      "cases": 5,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "membership_unresolved",
-      "satisfies_required_kinds": true
-    },
-    "room.archive": {
-      "cases": 4,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "room.peers": {
-      "cases": 6,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "member.remove": {
-      "cases": 9,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "invite.mint": {
-      "cases": 11,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "invitee_already_member",
-      "satisfies_required_kinds": true
-    },
-    "invite.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "invite_index_unreadable",
-      "satisfies_required_kinds": true
-    },
-    "invite.revoke": {
-      "cases": 6,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "invite.redeem": {
-      "cases": 11,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "message.send": {
-      "cases": 11,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "message_too_large",
-      "satisfies_required_kinds": true
-    },
-    "status.post": {
-      "cases": 9,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "status_label_unknown",
-      "satisfies_required_kinds": true
-    },
-    "status.history": {
-      "cases": 7,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "status_subject_unknown",
-      "satisfies_required_kinds": true
-    },
-    "fleet.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "fleet_projection_unavailable",
-      "satisfies_required_kinds": true
-    },
-    "file.share": {
-      "cases": 15,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
-    },
-    "file.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "file_index_unreadable",
-      "satisfies_required_kinds": true
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "file.fetch": {
       "cases": 13,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "provider_unreachable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "file.list": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "file_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "file.read": {
       "cases": 3,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "file_not_fetched",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
-    "transfer.cancel": {
+    "file.share": {
+      "cases": 15,
+      "success": true,
+      "distinctive_code": "declared_size_mismatch",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "fleet.list": {
       "cases": 5,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "transfer_unknown",
-      "satisfies_required_kinds": true
+      "distinctive_code": "fleet_projection_unavailable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
-    "pipe.publish": {
-      "cases": 16,
+    "invite.list": {
+      "cases": 5,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "pipe_target_refused",
-      "satisfies_required_kinds": true
+      "distinctive_code": "invite_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
-    "pipe.list": {
+    "invite.mint": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "invitee_already_member",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "invite.redeem": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "capability_invalid",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "invite.revoke": {
       "cases": 6,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "capability_redeemed",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "member.remove": {
+      "cases": 9,
+      "success": true,
+      "distinctive_code": "authority_cannot_be_removed",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "message.send": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "message_too_large",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "pipe.connect": {
       "cases": 7,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "pipe_unreachable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "pipe.list": {
+      "cases": 6,
+      "success": true,
+      "distinctive_code": "pipe_index_unreadable",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "pipe.publish": {
+      "cases": 16,
+      "success": true,
+      "distinctive_code": "pipe_target_refused",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "pipe.release": {
       "cases": 3,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "connection_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "pipe.revoke": {
       "cases": 3,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "pipe_not_publisher",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
     },
-    "stream.subscribe": {
+    "room.activate": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "transport_unavailable",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "room.archive": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "room_still_active",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "room.create": {
+      "cases": 10,
+      "success": true,
+      "distinctive_code": "room_name_invalid",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "room.deactivate": {
+      "cases": 3,
+      "success": true,
+      "distinctive_code": null,
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "room.leave": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "sole_authority_cannot_leave",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "room.list": {
+      "cases": 6,
+      "success": true,
+      "distinctive_code": "room_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "room.members": {
       "cases": 5,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "subscription_limit_reached",
-      "satisfies_required_kinds": true
+      "distinctive_code": "membership_unresolved",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
-    "stream.unsubscribe": {
-      "cases": 2,
+    "room.peers": {
+      "cases": 6,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": "subscription_unknown",
-      "satisfies_required_kinds": true
+      "distinctive_code": "room_not_live",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "room.timeline": {
+      "cases": 9,
+      "success": true,
+      "distinctive_code": "cursor_unknown",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "status.history": {
+      "cases": 8,
+      "success": true,
+      "distinctive_code": "status_subject_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "status.post": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "status_label_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     },
     "stream.resync": {
       "cases": 5,
       "success": true,
-      "distinctive_error": true,
-      "distinctive_code": null,
-      "satisfies_required_kinds": true
+      "distinctive_code": "resync_required",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "stream.subscribe": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "subscription_limit_reached",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "stream.unsubscribe": {
+      "cases": 2,
+      "success": true,
+      "distinctive_code": "subscription_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
+    },
+    "subject.ensure": {
+      "cases": 12,
+      "success": true,
+      "distinctive_code": "subject_store_unwritable",
+      "distinctive_code_has_a_case": false,
+      "satisfies_required_kinds": false
+    },
+    "transfer.cancel": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "transfer_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": false
     }
   },
-  "operations_not_yet_satisfying_required_kinds": [],
+  "operations_not_yet_satisfying_required_kinds": [
+    "daemon.stop",
+    "file.fetch",
+    "file.list",
+    "file.read",
+    "file.share",
+    "fleet.list",
+    "invite.list",
+    "invite.mint",
+    "invite.redeem",
+    "invite.revoke",
+    "member.remove",
+    "message.send",
+    "pipe.connect",
+    "pipe.list",
+    "pipe.publish",
+    "pipe.release",
+    "pipe.revoke",
+    "room.activate",
+    "room.archive",
+    "room.create",
+    "room.deactivate",
+    "room.leave",
+    "room.list",
+    "room.members",
+    "room.peers",
+    "room.timeline",
+    "status.history",
+    "status.post",
+    "stream.resync",
+    "stream.subscribe",
+    "stream.unsubscribe",
+    "subject.ensure",
+    "transfer.cancel"
+  ],
   "severity_derivation": {
     "note": "severity is derived from the closed label set and SERVED; no signed severity field exists",
     "map": {

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -32,13 +32,12 @@
     }
   },
   "codes_without_a_case": {
-    "note": "real codes in the taxonomy that no fixture yet exercises. A gap in the corpus, not in the specification. Authoring them is #213.",
+    "note": "real codes in the taxonomy that no fixture yet exercises. A gap in the corpus, not in the specification. Authoring them is #213. idle_timeout is deliberately absent from this list: close_code_4004_is_emitted_on_idle_timeout already covers it via close code 4004, the protocol's transport representation of that code, so listing it would send #213 to duplicate a test rather than retranscribe one.",
     "codes": [
       "authority_cannot_be_removed",
       "capability_redeemed",
       "cursor_unknown",
       "declared_size_mismatch",
-      "idle_timeout",
       "malformed_frame",
       "pipe_index_unreadable",
       "pipe_not_publisher",

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -167,6 +167,16 @@ Checks run in this fixed order:
 4. `sg` MUST be present and MUST equal the daemon's storage generation, else
    `storage_generation_mismatch`. **Absence is refusal.**
 5. Credential, else `unauthenticated`, compared in constant time.
+6. Connection capacity, else `resource_exhausted` with `resource:
+   "max_connections"`, returned as `503`.
+
+Capacity is checked **last, after the credential**, and the ordering is a
+security decision rather than an implementation detail. Checking it earlier
+would let an unauthenticated caller learn how many connections the daemon is
+holding, turning a capacity limit into a cheap occupancy oracle — and a caller
+that cannot authenticate has no business learning anything about load. It is
+also the only gate refusal that is a transient condition rather than a verdict
+about the caller, which is why it takes `503` rather than a `4xx`.
 
 Step 3's absence rule is load-bearing: a v1 client sends no `v` at all, so a
 missing generation that defaulted to current would admit every legacy client
@@ -179,10 +189,11 @@ generation is refused before it can write.
 
 ### Rejections are machine-readable
 
-A refused upgrade returns the v2 error envelope as a JSON body with a matching
-status: `426` for `protocol_unsupported` and `storage_generation_mismatch`,
-`401` for `unauthenticated`, `403` for `forbidden_origin`. v1's plain-text
-bodies are removed; one error format, everywhere.
+A refused upgrade returns [the bare `err` object](#the-error-object) as a JSON
+body with a matching status: `426` for `protocol_unsupported` and
+`storage_generation_mismatch`, `401` for `unauthenticated`, `403` for
+`forbidden_origin`, and `503` for `resource_exhausted`. v1's plain-text bodies
+are removed; one error format, everywhere.
 
 A rejection after the upgrade closes with a defined application close code:
 
@@ -379,6 +390,28 @@ bound is easier to reason about than six.
 
 Every operation validates in this order, and the order is normative because two
 of its steps are security properties rather than conveniences.
+
+**A stage runs only where its precondition is meaningful**, and which stages
+those are is decidable from the operation's own schema rather than by
+convention:
+
+| Stage | Runs for |
+|---|---|
+| 1 structural decode | every operation |
+| 2 subject | every operation **except `subject.ensure`**, which exists to create one |
+| 3 dedup | the operations in the `op_id` deduplicated row of [Idempotency](#idempotency-and-retry) |
+| 4 room index | every operation whose `in` carries `room_id` |
+| 5 standing | as step 4, minus `room.archive` and `room.list` |
+| 6 role | the four operations that [require `authority`](#room-and-membership--8) |
+| 7 semantics | every operation |
+
+Two consequences are worth stating rather than deriving. `subject.ensure` skips
+step 2, or it could never succeed on a fresh daemon. **`invite.redeem` skips
+steps 4, 5, and 6** — its `in` carries no `room_id`, because it is the only
+operation a non-member can reach and an identifier there would be exactly the
+probe [the non-oracle property](#the-non-oracle-property) forbids. It resolves
+its room from the capability inside step 7, and every capability failure is one
+of the four fieldless redemption-side codes.
 
 1. **Structural decode** — does the frame decode into this operation's request
    type, with every required key present, correctly typed, correctly formatted,
@@ -923,7 +956,7 @@ whose standing is `left` or `removed` gets `membership_ended` and uses
 |---|---|
 | `in` | `{ "room_id": "<room_id>" }` |
 | `out` | `{ "room_id": "<room_id>", "members": [ { "subject_id": "<subject_id>", "role": "member", "standing": "active", "joined_at": "<ts>" } ] }` |
-| Errors | `membership_unresolved`, `member_unknown` |
+| Errors | `membership_unresolved` |
 
 The authoritative signed answer to who belongs, in what capacity and standing.
 Carries **no** presence and **no** reachability — those are `room.peers`, and
@@ -1017,7 +1050,7 @@ The capability itself is **never** returned by `invite.list` — only
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "invite_id": "<invite_id>" }` |
-| `out` | `{ "invite_id": "<invite_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
+| `out` | `{ "room_id": "<room_id>", "invite_id": "<invite_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
 | Errors | `capability_redeemed`, `invite_unknown` |
 
 **Re-revoking an already-revoked capability succeeds**, returning the original
@@ -1186,7 +1219,7 @@ fact, one place. Requires liveness.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "file_id": "<file_id>" }` |
-| `out` | `{ "file_id": "<file_id>", "bytes": "<uint>", "declared_content_type": "<string>" }`, then the bytes streamed |
+| `out` | `{ "room_id": "<room_id>", "file_id": "<file_id>", "bytes": "<uint>", "declared_content_type": "<string>" }`, then the bytes streamed |
 | Errors | `file_not_fetched`, `file_unknown` |
 
 Streams bytes rather than serving them over HTTP. v1's never-render-inline
@@ -1289,7 +1322,7 @@ the same type `room.peers` and `file.list` use.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
-| `out` | `{ "pipe_id": "<pipe_id>", "connection_id": "<string>", "local": <target> }` |
+| `out` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>", "connection_id": "<string>", "local": <target> }` |
 | Errors | `pipe_unreachable`, `pipe_unknown`, `pipe_revoked`, `room_not_live` |
 
 A caller outside the pipe's audience answers `pipe_unknown`, indistinguishable
@@ -1311,7 +1344,7 @@ pipe.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
-| `out` | `{ "pipe_id": "<pipe_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
+| `out` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
 | Errors | `pipe_not_publisher`, `pipe_unknown` |
 
 Withdraws a published pipe as a signed fact. Re-revoking succeeds and returns
@@ -1564,6 +1597,19 @@ is counted, and the group subtotals sum to the total.
 `code` is always present. Every other key is fixed by the code, per the tables
 below — an error carries exactly the fields its row names, no more and no fewer.
 
+**A refused upgrade has no `id` to correlate**, so it carries the `err` object
+alone, as the whole HTTP body:
+
+```json
+{ "code": "storage_generation_mismatch", "daemon": 2, "client": { "state": "declared", "sg": 1 } }
+```
+
+The two shapes are deliberately different rather than one shape with an optional
+`id`. An `id` is meaningful only for a frame that answers a request carrying one,
+and the gate runs before any frame is parsed — inventing an `id` there, or making
+it nullable, would put a meaningless key in the one place a client is most likely
+to be writing its first parser against.
+
 ### Gate and transport — 7
 
 Returned as a JSON body on a refused upgrade, or as the application close code
@@ -1742,6 +1788,14 @@ non-member can reach, so it is the one place a membership oracle could be built.
 | `transfer_unknown` | `transfer_op_id` | No such in-flight transfer for this principal |
 | `transfer_stalled` | `transferred_bytes`, `total` (`<byte_total>`) | No forward progress within the stall window |
 
+`provider_unreachable.providers` is an array of **the provider rows that were
+attempted**, each identical in shape to a `file.list` row's provider —
+`{ subject_id, device_id, link }`. It is the attempted set rather than the
+candidate set, and it carries the same `link` type as everywhere else, so a
+client can say *why* each one failed instead of only that the fetch did. An
+error whose typed field has no stated element shape is prose wearing a
+schema's clothes.
+
 `file_too_large.enforced_at` names one of the **five daemon-side** enforcement
 points of the six in [the shared-file size policy](shared-file-size.md):
 `stage_declared`, `stage_stream`, `authoring`, `fetch_preflight`,
@@ -1834,13 +1888,19 @@ it.
 | `cursor_invalid` | → `cursor_unknown` for a pruned position, or `invalid_argument` with `reason: {"state": "format"}` for a malformed one. The single corpus code conflated the two |
 | `<the case's code>` | Not a code at all — an unsubstituted placeholder left in a fixture |
 
-Eleven codes in the tables above have no corpus case yet:
+Ten codes in the tables above have no corpus case yet:
 `authority_cannot_be_removed`, `capability_redeemed`, `cursor_unknown`,
-`declared_size_mismatch`, `idle_timeout`, `malformed_frame`,
-`pipe_index_unreadable`, `pipe_not_publisher`, `room_still_active`,
-`subject_store_unwritable`, and `transport_unavailable`. They are real codes
-with no coverage, which is a corpus gap rather than a specification gap, and
-they are named in the manifest so the gap cannot read as coverage.
+`declared_size_mismatch`, `malformed_frame`, `pipe_index_unreadable`,
+`pipe_not_publisher`, `room_still_active`, `subject_store_unwritable`, and
+`transport_unavailable`. They are real codes with no coverage, which is a corpus
+gap rather than a specification gap, and they are named in the manifest so the
+gap cannot read as coverage.
+
+`idle_timeout` is deliberately **not** on that list, though it has no fixture
+naming it directly. `close_code_4004_is_emitted_on_idle_timeout` already covers
+it through close code `4004`, which is that code's transport representation —
+and a coverage list that ignored the transport form would send the corpus work
+to duplicate an existing case rather than retranscribe it.
 
 ### The non-oracle property
 

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -113,8 +113,17 @@ one definition is the fix, and no client may compile the value in.
 
 ### The limits object
 
-Every field is an integer. A client MUST read them and MUST NOT assume a
-compiled-in default.
+**Thirteen fields, every one an integer.** A client MUST read them and MUST NOT
+assume a compiled-in default.
+
+The count is stated because the corpus disagrees with itself about it:
+`health_limits_object_carries_all_eleven_named_integer_fields` asserts an exact
+key set of eleven, omitting `max_subscriptions_per_connection` and
+`idle_timeout_ms` — while `close_code_4004_is_emitted_on_idle_timeout` reads
+`idle_timeout_ms` out of the very object the other case says cannot contain it.
+Both cases cannot be right. The record is right and both fixtures are wrong: the
+two omitted fields are each load-bearing, one for `subscription_limit_reached`
+and one for a client that must produce activity to stay connected.
 
 | Field | Meaning |
 |---|---|
@@ -408,6 +417,8 @@ belongs to exactly one operation.
 | `resume` | variant: `fresh`, `resumed {from_pos}` — `hello` only |
 | `gap.to` | variant: `bounded {pos}`, `open` |
 | `gap.reason` | bare enum: `backpressure`, `retention`, `subscription_lapse` |
+| `target` | `{ host, port }` — one object, never two sibling fields |
+| `audience` | variant: `room`, `subjects {subject_ids}` |
 
 Every variant in this record appears in this table. A variant whose arms are not
 enumerated here does not exist — an arm set stated only by example is how an
@@ -941,7 +952,7 @@ different fact and not a terminal one this operation authored.
 | | |
 |---|---|
 | `in` | `{ "capability": "<string>" }` |
-| `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "standing": "active", "event_id": "<event_id>", "pos": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "standing": "active", "event_id": "<event_id>", "pos": "<uint>", "joined": "<bool>" }` |
 | Errors | `capability_invalid`, `capability_expired`, `capability_revoked`, `capability_redeemed` |
 
 **The only operation reachable by a non-member.** Its authorization object is
@@ -950,7 +961,11 @@ the key-bound capability itself, never an identifier — so `in` carries no
 could probe with.
 
 Naturally idempotent: re-redeeming from the same subject reports existing
-membership.
+membership, and **`joined` is how it reports it** — `true` when this call
+authored the membership, `false` when it already existed. Without that field the
+two outcomes are byte-identical, so a client could not tell a fresh join from a
+replay, which is the same defect this record removes from `subject.ensure` by
+serving `created`.
 
 ### `message.send`
 
@@ -1019,7 +1034,7 @@ contributes nothing, and its absence is indistinguishable from it not existing.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "name": "<string>", "declared_bytes": "<uint>", "content_type": "<string>" }` |
+| `in` | `{ "room_id": "<room_id>", "name": "<string>", "declared_bytes": "<uint>", "declared_content_type": "<string>" }` |
 | `out` | `{ "room_id": "<room_id>", "file_id": "<file_id>", "event_id": "<event_id>", "pos": "<uint>", "bytes": "<uint>", "digest": "<string>" }` |
 | Errors | `declared_size_mismatch`, `file_too_large` |
 
@@ -1035,7 +1050,11 @@ accepted (`enforced_at: "stage_declared"`) and against the streamed total after
 corruption for a size disagreement is the false accusation
 [the size policy](shared-file-size.md) forbids.
 
-`content_type` is peer-declared and **untrusted**; see `file.read`.
+The field is `declared_content_type` on **every** operation that carries it —
+`file.share`, `file.list`, and `file.read` alike. It is peer-declared and
+untrusted at each of them, and a value that is untrusted in one place and named
+`content_type` in another is a value a client will eventually trust by accident.
+See `file.read`.
 
 ### `file.list`
 
@@ -1047,6 +1066,7 @@ corruption for a size disagreement is the false accusation
 
 ```json
 { "file_id": "<file_id>", "name": "<string>", "bytes": 4096,
+  "digest": "<string>",
   "declared_content_type": "<string>",
   "shared_by": "<subject_id>", "shared_at": "<ts>",
   "providers": [ { "subject_id": "<subject_id>", "device_id": "<device_id>", "link": { "state": "direct", "since": "<ts>" } } ],
@@ -1062,6 +1082,11 @@ removed with the rest of the filesystem paths; whether bytes are held locally is
 
 Each provider's `link` is the same per-device type `room.peers` uses. There is
 no separate per-provider reachability vocabulary.
+
+`digest` is served here, not only by `file.share`, because a client that fetches
+a file it did not share has no other way to learn the digest it must verify
+against — and `digest_mismatch` is meaningless to a client that never held an
+expected value.
 
 ### `file.fetch`
 
@@ -1098,7 +1123,7 @@ the strength of it.**
 | | |
 |---|---|
 | `in` | `{ "transfer_op_id": "<op_id>" }` |
-| `out` | `{ "transfer_op_id": "<op_id>", "cancelled": true, "transferred_bytes": "<uint>" }` |
+| `out` | `{ "transfer_op_id": "<op_id>", "cancelled": true, "transferred_bytes": "<uint>", "total": { "state": "known", "bytes": "<uint>" } }` |
 | Errors | `transfer_unknown` |
 
 **The request field is `transfer_op_id`, not `op_id`.** It names the transfer
@@ -1107,6 +1132,11 @@ survives the reconnect that would make a cancel-request identifier meaningless.
 Giving it a distinct name is what keeps one wire spelling from meaning two
 things; the envelope `op_id` on this operation is ignored like any other
 naturally-idempotent operation.
+
+`total` is the same `known {bytes}` / `unknown` variant `transfer_stalled`
+carries. A cancel that reports "4 MiB transferred" without a total reports a
+number the user cannot interpret, and the `unknown` arm exists because a
+provider that never declared a size genuinely leaves it unknown.
 
 Authorized by `(session principal, transfer_op_id)`. Cancelling a transfer
 belonging to a different principal returns `transfer_unknown`, indistinguishable
@@ -1117,15 +1147,35 @@ clients' activity.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "host": "127.0.0.1", "port": 8080 }` |
-| `out` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>", "host": "<string>", "port": "<uint>", "event_id": "<event_id>", "pos": "<uint>" }` |
+| `in` | `{ "room_id": "<room_id>", "target": <target>, "audience": <audience> }` |
+| `out` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>", "target": <target>, "audience": <audience>, "event_id": "<event_id>", "pos": "<uint>" }` |
 | Errors | `pipe_target_refused`, `policy_refused` |
 
-The target MUST be loopback — IPv4 in `127.0.0.0/8` or IPv6 `::1` — and `port`
-MUST be in `1..=65535`. Anything else is `pipe_target_refused` carrying the
-rejected `target`, **not** the generic `policy_refused`, because "your target is
-not allowed" and "you may not publish in this room" are refusals a user responds
-to differently.
+`target` is one object, `{ "host": "<string>", "port": "<uint>" }`, rather than
+two sibling fields. It is one value — a client sends it, the reply echoes it, and
+`pipe_target_refused` returns it verbatim — and splitting it across two fields
+would mean the error either echoes a partial target or invents a spelling the
+request never used.
+
+`audience` is a variant naming who may connect:
+
+```json
+{ "state": "room" }
+{ "state": "subjects", "subject_ids": ["<subject_id>"] }
+```
+
+It is **required**, like every request field. A pipe is a peer-reachable tunnel,
+so who may open it is not a value to leave to a default — `room` has to be said
+out loud rather than fallen into. A caller outside the audience answers
+`pipe_unknown`, indistinguishable from no such pipe, which is what makes a
+separate audience-refusal code unnecessary and a separate `pipe_audience`
+capability actively harmful.
+
+The target MUST be loopback — IPv4 in `127.0.0.0/8` or IPv6 `::1` — and
+`target.port` MUST be in `1..=65535`. Anything else is `pipe_target_refused`
+carrying the rejected `target`, **not** the generic `policy_refused`, because
+"your target is not allowed" and "you may not publish in this room" are refusals
+a user responds to differently.
 
 A private-range address such as `192.168.1.10` is **refused**: being unroutable
 from the internet is not the same as being local, and the policy is loopback,
@@ -1155,7 +1205,7 @@ the same type `room.peers` and `file.list` use.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
-| `out` | `{ "pipe_id": "<pipe_id>", "connection_id": "<string>", "local_port": "<uint>" }` |
+| `out` | `{ "pipe_id": "<pipe_id>", "connection_id": "<string>", "local": <target> }` |
 | Errors | `pipe_unreachable`, `pipe_unknown`, `pipe_revoked` |
 
 A caller outside the pipe's audience answers `pipe_unknown`, indistinguishable
@@ -1545,7 +1595,7 @@ bytes are sent.
 
 | Code | Fields | Raised when |
 |---|---|---|
-| `pipe_target_refused` | `target` | The target is not loopback, or the port is out of range |
+| `pipe_target_refused` | `target` | `target.host` is not loopback, or `target.port` is outside `1..=65535` |
 | `pipe_index_unreadable` | — | The room's pipe index cannot be read |
 | `pipe_unknown` | `pipe_id` | No such pipe, **or** the caller is outside its audience |
 | `pipe_unreachable` | `pipe_id`, `link` | The pipe's publisher device could not be reached |

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -13,7 +13,8 @@ audience: ["client-authors", "contributors", "maintainers"]
 
 # Jeliya protocol v2
 
-**Status: DRAFT 2026-07-28. Incomplete — see [What this does not yet
+**Status: DRAFT 2026-07-28. The contract is complete; its corpus is not yet
+normalized to it — see [What this does not yet
 specify](#what-this-does-not-yet-specify). Nothing in this record is
 built.** Protocol v2
 is the wire contract for the clean-slate client stack in the
@@ -34,27 +35,38 @@ null convention, event shape, or storage shape for its own sake.
 
 ## What this does not yet specify
 
-This record is `draft`, not `canonical`, and the reason is specific: **it states
-what each operation is for, not the shape of its request and reply.** Three gaps
-must close before it is a contract an independent adapter can implement.
+The three gaps that made this record `draft` are closed. It now states
+[the shape of every request and reply](#operation-schemas), the
+[complete 60-code taxonomy](#errors), and — in
+[the corpus's own README](../conformance/v2/README.md) — one normative fixture
+DSL. An independent adapter can implement from this document alone.
+
+**One gap remains, and it is the corpus, not the contract.**
 
 | Gap | Consequence while it is open |
 |---|---|
-| **Per-operation wire schemas** — every field, its type, requiredness, and bounds | Two adapters can each satisfy every sentence here and still be mutually incompatible. The corpus, written against the gap, is selecting an undocumented contract rather than this one |
-| **The complete error taxonomy** — every code with its typed fields and trigger | The [Errors](#errors) table is a selected subset. The corpus already relies on codes this document never names |
-| **One fixture DSL** — a normative schema for the corpus's own language | The committed fixtures use several dialects for the same concepts, so an independent harness cannot interpret them consistently — which defeats cross-adapter replay, the corpus's whole purpose |
+| **The 335 committed fixtures are not yet normalized to the DSL** | They were authored against the specification's earlier silence, so they use 178 step verbs where the DSL defines a closed set, and 51 of them assert a field or code this record deliberately does not define. Until they are retranscribed, the corpus is not replayable and cannot be cited as evidence for any adapter |
 
-All three were found in review of the first draft, and all three are correct.
-They are tracked as **#212**, a single follow-up, because they interlock: an attempt to
-write them as five parallel sections produced **22 mutually contradictory
-definitions** — three incompatible shapes for one error, the role enum closed
-twice with different contents, three vocabularies for one `truncated` field. A
-wire contract has to be authored once, by one hand, in one vocabulary.
+That work is tracked as **#213**. This record stays `draft` until it lands, for
+one reason: a `canonical` contract whose own bundled corpus contradicts it in
+fifty-one places is a contract that overclaims. The distinction matters more
+than the label — everything an implementer needs is here, and #163 and #164 are
+unblocked by the content rather than by the status field.
 
-Everything below this section is settled in substance — the operation set, the
-handshake and its gate, the removals, the push and resync model, the severity
-derivation, and the credential rules. What is missing is the field-level
-precision that turns settled substance into an implementable contract.
+Where this record and a fixture disagree, **this record is right and the fixture
+is a bug**, unless the disagreement is named as a specification defect below.
+Each class of fixture bug is named at the point the relevant rule is stated,
+rather than gathered into a list that would rot separately from the rules.
+
+Everything is settled in substance — the operation set, the handshake and its
+gate, the removals, the push and resync model, the severity derivation, and the
+credential rules were decided in #161 and are not reopened here. #212 added
+field-level precision to that substance and resolved the twenty-seven
+contradictions an earlier five-section parallel drafting attempt produced. That
+attempt is why this document was authored by one hand in one vocabulary: five
+authors writing five sections of one wire contract produced three incompatible
+shapes for one error, the role enum closed twice with different contents, and
+three vocabularies for one `truncated` field.
 
 ## What must be true before this can be implemented
 
@@ -173,6 +185,11 @@ A rejection after the upgrade closes with a defined application close code:
 | `4004` | `idle_timeout` |
 | `4005` | `frame_too_large` |
 | `4006` | `storage_generation_mismatch` |
+| `4007` | `malformed_frame` |
+
+`4007` closes only when a frame's `id` cannot be recovered. A frame that decodes
+far enough to correlate always gets an error reply instead — closing a
+connection over one bad request would punish the other requests in flight on it.
 
 A client can therefore distinguish "you speak the wrong generation" from "the
 daemon died", and present the reset path instead of retrying forever.
@@ -248,13 +265,16 @@ adoption check that needs pid and port is Layer 0.
 ## The envelope
 
 ```json
-{ "id": 42, "op": "room.create", "in": { "name": "Build" } }
+{ "id": 42, "op": "room.create", "op_id": "<op_id>", "in": { "name": "Build" } }
 { "id": 42, "ok": true,  "out": { "...": "..." } }
 { "id": 42, "ok": false, "err": { "code": "insufficient_standing", "…": "…" } }
 ```
 
 - `id` correlates a reply to its request and is unique per connection while
   outstanding.
+- `op_id` is the **only** envelope field that is optional, and it deduplicates
+  the request rather than parameterising the operation. See
+  [`op_id` is an envelope field](#request-deduplication-lives-in-the-envelope).
 - Replies MAY arrive out of order. A client MUST correlate by `id` and MUST NOT
   assume completion order. v1's socket dispatched strictly serially, forwarding
   no pushes while a call was in flight; v2 explicitly does not.
@@ -275,6 +295,140 @@ unbounded allocation.
 tagged variant. This applies to the protocol's own frames, not only to
 operation payloads: a `null` that means "unbounded" or "unknown" is exactly the
 v1 compatibility-nullability this generation exists to shed.
+
+## Wire conventions
+
+Every schema below is written in this vocabulary. It is stated once, here, so
+that no operation section may define a shape a second way.
+
+### Three discriminants, each with one domain
+
+| Key | Domain |
+|---|---|
+| `t` | the type of a push frame |
+| `kind` | the type of a committed event |
+| `state` | a **condition variant** — what the situation is with respect to one thing |
+
+Nothing else discriminates. `type`, `variant`, and `status` are never
+discriminant keys, and a discriminant is never spelled two ways.
+
+**Enum or variant, never both.** A closed set whose arms all carry no payload is
+a **bare string enum**. A closed set where any arm carries a payload is a
+**tagged variant**: an object whose `state` names the arm, with that arm's
+payload as siblings. A variant never carries an arm-independent sibling — a
+field that is meaningful in one arm and meaningless in another belongs inside
+the arm, which is what makes the meaningless case unrepresentable rather than
+merely discouraged.
+
+### Request deduplication lives in the envelope
+
+```json
+{ "id": 42, "op": "message.send", "op_id": "<op_id>",
+  "in": { "room_id": "<room_id>", "body": "…" } }
+```
+
+`op_id` deduplicates a **request**; it is not an argument to an operation, and
+v1's habit of mixing the two is why the rule below needed an exception.
+
+Because it sits in the envelope, **`op_id` is accepted on every operation and
+ignored by those that do not deduplicate** — including all three `stream.*`
+operations. It is never `unrecognised_field`.
+
+`transfer.cancel` is the one operation that needs to *name* an `op_id` rather
+than carry one. Its request field is therefore `transfer_op_id`, and the
+envelope `op_id` on a `transfer.cancel` is ignored like any other
+naturally-idempotent operation. One wire name never means two things.
+
+### There are no optional request fields
+
+Every field of every `in` object is required. A missing key is
+`invalid_argument` with `reason: {"state": "missing"}`, and an undefined key is
+`invalid_argument` with `reason: {"state": "unrecognised_field"}`.
+
+This is why `cursor`, `direction`, and `limit` are required on every paging
+operation. `{"state": "start"}` and `"forward"` are the caller's explicit
+choice, not a daemon default — a default is a second place the contract can
+disagree with itself, and a client that did not choose a page size cannot
+reason about the page it got.
+
+### Validation order
+
+Every operation validates in this order, and the order is normative because two
+of its steps are security properties rather than conveniences.
+
+1. **Structural decode** — does the frame decode into this operation's request
+   type, with every required key present, correctly typed, correctly formatted,
+   and within bounds? → `invalid_argument`
+2. **Subject precondition** → `subject_absent`
+3. **Dedup ledger** — a replayed `op_id` returns the original result, and no
+   later step runs
+4. **Room index** → `room_not_available`
+5. **Lifecycle** → `membership_ended`
+6. **Role** → `insufficient_standing`
+7. **Operation semantics** → the operation's own codes
+
+Structure comes first because no rule can be applied to a value that has not
+been decoded. Putting format and bounds in step 1 does **not** weaken
+[the non-oracle property](#the-non-oracle-property): step 1 discloses only the
+value formats this record publishes, never any daemon state. The property that
+must hold is that steps 4 and later are indistinguishable to a non-member, and
+they are — a caller who is not a member cannot reach step 5 at all.
+
+### Shared value types
+
+Every operation draws from these. A type defined here is never redefined in an
+operation section.
+
+| Type | Form |
+|---|---|
+| `<room_id>` `<subject_id>` `<device_id>` `<event_id>` `<invite_id>` `<file_id>` `<pipe_id>` `<op_id>` | opaque strings, each a distinct domain |
+| `<ts>` | RFC 3339 UTC instant with a `Z` offset |
+| `<uint>` | JSON number, integral, `>= 0` |
+| `role` | bare enum: `authority`, `member` |
+| `standing` | bare enum: `active`, `left`, `removed` |
+| `severity` | bare enum: `ok`, `failed`, `review` — **derived, never sent** |
+| `liveness` | bare enum: `online-idle`, `working`, `offline`, `stale` — **derived** |
+| `reachability` | bare enum: `connecting`, `connected`, `alone`, `offline` — **one room** |
+| `link` | variant: `direct {since}`, `relay {since}`, `not_connected {reason}` — **one device** |
+| `link.reason` | bare enum: `never_dialed`, `dial_failed`, `no_route`, `closed` |
+| `cursor` | variant: `start`, `at {pos}` |
+| `truncated` | variant: `complete`, `more {cursor}` |
+| `progress` | variant: `absent`, `reported {percent}` where `percent` is `0..=100` |
+| `author` | variant: `resolved {subject_id, role, standing}`, `unresolved` |
+
+`role` is closed on exactly two tokens. **`agent` is not a role** — this record
+already states that member and agent are a classification, not a permission, and
+agent-ness is derived: a member that has authored at least one `status.post`
+event is an agent, which is what `fleet.list` projects. `owner` is v1's spelling
+and is removed.
+
+**`standing` is the only vocabulary for a subject's relationship to a room.** It
+is what `room.list` reports about the caller, what `room.members` reports about
+each member, and what `author.standing` carries on a committed event. There is
+no separate room `lifecycle`: this record settles that a room can never be wound
+down, so no room state exists that is not somebody's standing. `live` remains a
+distinct `<bool>`, because liveness is a fact about this device and standing is a
+fact about the room.
+
+**`reachability` and `link` are two types, not one.** `reachability` answers for
+a whole room; `link` answers for one device, and every per-device answer uses it
+— `room.peers`, the provider rows of `file.list`, and `pipe.list`. A single
+per-device type is what keeps `reason` one closed set instead of four.
+
+### The committed event
+
+```json
+{ "pos": 58, "event_id": "<event_id>", "at": "<ts>",
+  "kind": "message", "content": { "body": "…" },
+  "author": { "state": "resolved", "subject_id": "<subject_id>",
+              "role": "authority", "standing": "active" } }
+```
+
+`author` is a variant because this record removes **the fabricated default
+role** — v1 returned `member` for a sender the membership fold could not
+resolve. A flat `sender_role` cannot express an unresolvable author without a
+null or an invention, and both are forbidden, so the unresolvable case gets an
+arm of its own and carries no attribution at all.
 
 ## The 33 operations
 
@@ -297,7 +451,7 @@ success as failure.
 | Operation | | Purpose |
 |---|---|---|
 | `room.create` | M | Bring a room into existence with the caller as its authority; works with no network |
-| `room.list` | | What rooms are mine, in what lifecycle state, what may I do in each — from local evidence, no network |
+| `room.list` | | What rooms are mine, in what standing, what may I do in each — from local evidence, no network |
 | `room.activate` | M | Make a room live on this device. Returns reachability and capabilities, **not history** |
 | `room.deactivate` | M | Stop live participation without changing membership |
 | `room.leave` | M | Author a signed departure every member converges on |
@@ -522,6 +676,533 @@ network round trip and reveals nothing to peers.
 These replace v1's single global broadcast, in which a client received whatever
 the daemon chose to send for whatever rooms it had open.
 
+## Operation schemas
+
+One request and one reply shape per operation, in the vocabulary
+[Wire conventions](#wire-conventions) fixes. Types named there are not redefined
+here.
+
+Reading the tables: **every `in` field listed is required** — there are no
+optional request fields, so the column is omitted rather than filled with "yes"
+thirty-three times. `op_id` never appears in an `in` table because it is an
+envelope field. The **Errors** row names only the codes specific to that
+operation; every operation can additionally answer any cross-cutting code its
+[validation order](#validation-order) step reaches.
+
+### `subject.ensure`
+
+| | |
+|---|---|
+| `in` | `{}` |
+| `out` | `{ "subject_id": "<subject_id>", "device_id": "<device_id>", "created": "<bool>" }` |
+| Errors | `subject_store_unwritable` |
+
+Naturally idempotent. A second call returns the same subject with
+`created: false`, and that is a success — this record removes v1's
+`identity_exists` precisely because reporting it as a failure was a lie. No
+secret is returned in any form.
+
+### `daemon.stop`
+
+| | |
+|---|---|
+| `in` | `{}` |
+| `out` | `{ "stopping": true }` |
+| Errors | `shutdown_in_progress` |
+
+Terminal and single-effect. The reply is flushed before teardown begins; a
+second call answers `shutdown_in_progress` rather than a comfortable `true`.
+
+### `room.create`
+
+| | |
+|---|---|
+| `in` | `{ "name": "<string>" }` |
+| `out` | `{ "room_id": "<room_id>", "name": "<string>", "role": "authority", "standing": "active", "created_at": "<ts>" }` |
+| Errors | `room_name_invalid` |
+
+Works with no network. The caller is the room's authority, so `role` is
+constant — it is served rather than assumed because a client that infers it is
+a client that will get it wrong for a room it did not create.
+
+### `room.list`
+
+| | |
+|---|---|
+| `in` | `{}` |
+| `out` | `{ "rooms": [ <room_row> ] }` |
+| Errors | `room_index_unreadable` |
+
+```json
+{ "room_id": "<room_id>",
+  "name": "<string>",
+  "standing": "active",
+  "live": false,
+  "role": "member",
+  "member_count": 3,
+  "last_event": { "state": "present", "at": "<ts>", "kind": "message" },
+  "capabilities": ["room.timeline", "message.send"] }
+```
+
+Answered from local evidence with **zero network activity**, whether or not any
+room is live.
+
+`last_event` is a variant because a room with no events must be able to say so.
+A flat `last_event_ts` could express that only with a null or a sentinel, and
+both are forbidden — which is why this record removes v1's nullable
+`last_event_ts` and `last_event_kind` rather than renaming them. One variant
+un-nulls both and makes a kind without an instant unrepresentable.
+
+`standing` is the caller's own. It is not called `lifecycle`: that was the same
+value under a second name, and there is no room state that is not somebody's
+standing.
+
+`capabilities` holds **operation-name tokens** — a capability token *is* the
+name of the operation it authorises, so the mapping is total and no second
+vocabulary exists. A token is present **iff** the operation would not be refused
+on membership, standing, lifecycle, **or liveness** grounds at the instant the
+reply was composed. Liveness is in that list deliberately: an advertised
+capability that is refused right now for want of a transport is exactly the
+drift this array exists to prevent. The three operations that require liveness
+are `file.fetch`, `pipe.connect`, and `room.peers`; a non-live room's array
+omits them.
+
+### `room.activate`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "live": true, "reachability": "connecting", "capabilities": ["…"] }` |
+| Errors | `transport_unavailable` |
+
+Returns reachability and capabilities, **not history**. Naturally idempotent.
+
+### `room.deactivate`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "live": false }` |
+| Errors | none — [exempt](#one-distinctive-code-per-operation) |
+
+Stops live participation without changing membership. Naturally idempotent.
+
+### `room.leave`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "event_id": "<event_id>", "pos": "<uint>", "standing": "left" }` |
+| Errors | `sole_authority_cannot_leave` |
+
+Authors a signed departure every member converges on, so it returns the event it
+wrote rather than a bare acknowledgement.
+
+### `room.timeline`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "events": [ <event> ], "next_pos": "<uint>", "truncated": <truncated> }` |
+| Errors | `cursor_unknown` |
+
+`direction` is a bare enum: `forward`, `backward`. `limit` is `1..=timeline_page_max`;
+outside that it is `invalid_argument` with `reason: {"state": "bound"}`, refused
+rather than clamped.
+
+**`next_pos` is the position of the last event returned, or `from_pos` when
+`events` is empty.** Positions are exclusive on the low side, so a client
+resends `next_pos` to get what follows. An earlier worked example showed a
+single event at position 58 with `next_pos: 59`, which under an exclusive cursor
+skips exactly one event at every page boundary — the example was wrong, not the
+rule.
+
+Reads committed history identically whether or not the room is live. A caller
+whose standing is `left` or `removed` gets `membership_ended` and uses
+`room.archive`.
+
+### `room.members`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "members": [ { "subject_id": "<subject_id>", "role": "member", "standing": "active", "joined_at": "<ts>" } ] }` |
+| Errors | `membership_unresolved`, `member_unknown` |
+
+The authoritative signed answer to who belongs, in what capacity and standing.
+Carries **no** presence and **no** reachability — those are `room.peers`, and
+conflating them is the confusion (#50/#94) this generation exists to end.
+
+### `room.archive`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "standing": "left", "events": [ <event> ], "next_pos": "<uint>", "truncated": <truncated> }` |
+| Errors | `room_still_active` |
+
+Normatively **zero network activity and zero durable mutation**. Defined only
+over a room the caller has left or been removed from; on an active room it
+answers `room_still_active`.
+
+### `room.peers`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "reachability": "connected", "peers": [ { "subject_id": "<subject_id>", "device_id": "<device_id>", "link": <link> } ] }` |
+| Errors | `room_not_live` |
+
+Observed transport facts for one live room: which devices this daemon holds a
+link to, by what path, and why not when not. Requires liveness, so a non-live
+room answers `room_not_live` and `room.peers` is absent from that room's
+`capabilities`.
+
+### `member.remove`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "event_id": "<event_id>", "pos": "<uint>", "standing": "removed" }` |
+| Errors | `authority_cannot_be_removed`, `member_unknown` |
+
+Requires `role: "authority"`; a member calling it gets
+`insufficient_standing { required: "authority", held: "member" }`.
+
+**Re-removing an already-removed member succeeds**, returning the original
+removal's `event_id`, `pos`, and `standing`, and authoring no second event. See
+[Idempotency](#idempotency-and-retry) for why this and `invite.revoke` answer
+alike.
+
+### `invite.mint`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>" }` |
+| `out` | `{ "invite_id": "<invite_id>", "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "capability": "<string>", "redeemable": "<bool>" }` |
+| Errors | `invitee_already_member`, `role_not_grantable` |
+
+Mints one **key-bound** capability exactly one named identity can redeem;
+`subject_id` is that identity and is required.
+
+`role` accepts **`member` only** today. `authority` answers
+`role_not_grantable`, because this record settles that the creator is
+permanently the sole authority. The field is kept rather than dropped because
+that limitation is recorded as a *product gap, not a design intent* — a required
+field with one legal value makes widening it a non-breaking change.
+
+A replayed `op_id` MUST return **the original capability**, never a second
+grant.
+
+### `invite.list`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "invites": [ { "invite_id": "<invite_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "state": "outstanding" } ], "truncated": <truncated> }` |
+| Errors | `invite_index_unreadable` |
+
+An invite row's `state` is a bare enum: `outstanding`, `expired`, `revoked`,
+`redeemed`. The capability itself is **never** returned by `invite.list` — only
+`invite.mint` ever serves it, and only once.
+
+### `invite.revoke`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "invite_id": "<invite_id>" }` |
+| `out` | `{ "invite_id": "<invite_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
+| Errors | `capability_redeemed`, `invite_unknown` |
+
+**Re-revoking an already-revoked capability succeeds**, returning the original
+withdrawal, exactly as `member.remove` does. It answers `capability_redeemed`
+only when the capability was already converted into membership, which is a
+different fact and not a terminal one this operation authored.
+
+### `invite.redeem`
+
+| | |
+|---|---|
+| `in` | `{ "capability": "<string>" }` |
+| `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "standing": "active", "event_id": "<event_id>", "pos": "<uint>" }` |
+| Errors | `capability_invalid`, `capability_expired`, `capability_revoked`, `capability_redeemed` |
+
+**The only operation reachable by a non-member.** Its authorization object is
+the key-bound capability itself, never an identifier — so `in` carries no
+`room_id` and no `invite_id`, both of which would be identifiers a non-member
+could probe with.
+
+Naturally idempotent: re-redeeming from the same subject reports existing
+membership.
+
+### `message.send`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "body": "<string>" }` |
+| `out` | `{ "room_id": "<room_id>", "event_id": "<event_id>", "pos": "<uint>", "at": "<ts>" }` |
+| Errors | `message_too_large` |
+
+The returned `pos` is in the **same position space** as the room's push stream,
+which is what makes a client able to tell that the push it just received is its
+own write.
+
+### `status.post`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "label": "working", "progress": <progress> }` |
+| `out` | `{ "room_id": "<room_id>", "event_id": "<event_id>", "pos": "<uint>", "at": "<ts>", "severity": "ok" }` |
+| Errors | `status_label_unknown` |
+
+`label` is drawn from [the closed vocabulary](#the-label-vocabulary-is-closed-and-severity-is-derived-from-it).
+`severity` is served on the reply as the derived value; it is **never sent**, and
+a client MUST NOT re-derive it.
+
+**There is no free-text field.** A `message` key — or any other undefined key —
+is `invalid_argument` with `field: "in.message"` and
+`reason: {"state": "unrecognised_field"}`. Open to any active member: member and
+agent are a classification, not a permission.
+
+### `status.history`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "entries": [ { "at": "<ts>", "label": "working", "severity": "ok", "progress": <progress> } ], "truncated": <truncated> }` |
+| Errors | `status_subject_unknown` |
+
+**Entries carry no `pos` and no `event_id`.** This is a projection read;
+positions are read from `room.timeline`, which is the one position space.
+
+One entry per real posted event, in chronological order. The daemon MUST NOT
+interpolate, smooth, or fabricate a point — a chart drawn from this plots actual
+events or it plots a lie.
+
+### `fleet.list`
+
+| | |
+|---|---|
+| `in` | `{}` |
+| `out` | `{ "agents": [ { "subject_id": "<subject_id>", "room_id": "<room_id>", "liveness": "working", "latest_status": { "state": "present", "label": "working", "at": "<ts>" }, "last_seen": { "state": "present", "at": "<ts>" } } ] }` |
+| Errors | `fleet_projection_unavailable` |
+
+**No tallies.** v1 served `active`, `working`, `total`, `rooms_total`, and
+`rooms_covered` alongside the list; all are derivable from it, and a served
+tally is a second thing that can disagree with the facts it summarises.
+
+An **agent** is a member that has authored at least one `status.post` event.
+Agent-ness is derived here, not declared: it is a classification, not a
+permission, so it is not a `role` and appears in no membership row.
+
+Scope is the caller's authorized room set. A room the caller cannot see
+contributes nothing, and its absence is indistinguishable from it not existing.
+
+### `file.share`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "name": "<string>", "declared_bytes": "<uint>", "content_type": "<string>" }` |
+| `out` | `{ "room_id": "<room_id>", "file_id": "<file_id>", "event_id": "<event_id>", "pos": "<uint>", "bytes": "<uint>", "digest": "<string>" }` |
+| Errors | `declared_size_mismatch`, `file_too_large` |
+
+Bytes are **streamed**, combining v1's RPC and its separate HTTP upload edge.
+**No filesystem path appears in the request**: v1's `path` is removed, because a
+protocol that takes a daemon path cannot serve a browser or an Android
+`content://` consumer. `PlatformServices` owns paths.
+
+`declared_bytes` is checked against `max_shared_file_bytes` before any byte is
+accepted (`enforced_at: "stage_declared"`) and against the streamed total after
+(`enforced_at: "stage_stream"`). A stream that does not match its declaration is
+`declared_size_mismatch`, never `digest_mismatch` — accusing an honest peer of
+corruption for a size disagreement is the false accusation
+[the size policy](shared-file-size.md) forbids.
+
+`content_type` is peer-declared and **untrusted**; see `file.read`.
+
+### `file.list`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "files": [ <file_row> ], "truncated": <truncated> }` |
+| Errors | `file_index_unreadable` |
+
+```json
+{ "file_id": "<file_id>", "name": "<string>", "bytes": 4096,
+  "declared_content_type": "<string>",
+  "shared_by": "<subject_id>", "shared_at": "<ts>",
+  "providers": [ { "subject_id": "<subject_id>", "device_id": "<device_id>", "link": { "state": "direct", "since": "<ts>" } } ],
+  "fetchable": true,
+  "self_hosted": false }
+```
+
+v1's `available` boolean and `providers` **count** become named provider devices
+carrying evidence: **provider availability is a protocol fact, not an inference
+from membership display state** (#50/#94). `local_path` and `local_bytes` are
+removed with the rest of the filesystem paths; whether bytes are held locally is
+`self_hosted`.
+
+Each provider's `link` is the same per-device type `room.peers` uses. There is
+no separate per-provider reachability vocabulary.
+
+### `file.fetch`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "file_id": "<file_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "file_id": "<file_id>", "bytes": "<uint>", "digest": "<string>", "provider": { "subject_id": "<subject_id>", "device_id": "<device_id>" } }` |
+| Errors | `provider_unreachable`, `file_unknown`, `file_too_large`, `digest_mismatch`, `transfer_stalled` |
+
+**No `save_dir`.** v1's destination path is removed; the daemon holds the bytes
+and `file.read` streams them out.
+
+The reply does **not** report local hold state. Whether bytes are held is
+answered by `file.read` succeeding or by a `file.list` row's `self_hosted` — one
+fact, one place. Requires liveness.
+
+### `file.read`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "file_id": "<file_id>" }` |
+| `out` | `{ "file_id": "<file_id>", "bytes": "<uint>", "declared_content_type": "<string>" }`, then the bytes streamed |
+| Errors | `file_not_fetched`, `file_unknown` |
+
+Streams bytes rather than serving them over HTTP. v1's never-render-inline
+protections were all HTTP *response headers*, and headers do not exist here, so
+they become **data**: the peer-declared type is carried in an explicitly
+untrusted, distinctly named field — `declared_content_type`, never
+`content_type` — and **a client MUST NOT render peer-supplied bytes inline on
+the strength of it.**
+
+### `transfer.cancel`
+
+| | |
+|---|---|
+| `in` | `{ "transfer_op_id": "<op_id>" }` |
+| `out` | `{ "transfer_op_id": "<op_id>", "cancelled": true, "transferred_bytes": "<uint>" }` |
+| Errors | `transfer_unknown` |
+
+**The request field is `transfer_op_id`, not `op_id`.** It names the transfer
+being cancelled — which the caller knows because it chose it — so a cancel
+survives the reconnect that would make a cancel-request identifier meaningless.
+Giving it a distinct name is what keeps one wire spelling from meaning two
+things; the envelope `op_id` on this operation is ignored like any other
+naturally-idempotent operation.
+
+Authorized by `(session principal, transfer_op_id)`. Cancelling a transfer
+belonging to a different principal returns `transfer_unknown`, indistinguishable
+from one that never existed, so the operation is not an oracle for other
+clients' activity.
+
+### `pipe.publish`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "host": "127.0.0.1", "port": 8080 }` |
+| `out` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>", "host": "<string>", "port": "<uint>", "event_id": "<event_id>", "pos": "<uint>" }` |
+| Errors | `pipe_target_refused`, `policy_refused` |
+
+The target MUST be loopback — IPv4 in `127.0.0.0/8` or IPv6 `::1` — and `port`
+MUST be in `1..=65535`. Anything else is `pipe_target_refused` carrying the
+rejected `target`, **not** the generic `policy_refused`, because "your target is
+not allowed" and "you may not publish in this room" are refusals a user responds
+to differently.
+
+A private-range address such as `192.168.1.10` is **refused**: being unroutable
+from the internet is not the same as being local, and the policy is loopback,
+not "probably safe". The refusal is a local decision made before publication, so
+it costs no round trip and reveals nothing to peers.
+
+v1's hardcoded `label` (always `"pipe"`) and `kind` (always `"tcp"`) are
+removed.
+
+### `pipe.list`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "pipes": [ { "pipe_id": "<pipe_id>", "published_by": "<subject_id>", "device_id": "<device_id>", "published_at": "<ts>", "link": <link>, "connected": "<bool>" } ], "truncated": <truncated> }` |
+| Errors | `pipe_index_unreadable` |
+
+v1's single `connected` boolean is **split into two separately named facts**: it
+was named as if it were reachability while being a purely local runtime fact.
+`link` is whether the publisher's device can be reached — **pipe reachability is
+a protocol fact** (#50/#94/#79) — and `connected` is whether this daemon
+currently holds a local connection. Both are per-device answers, so `link` is
+the same type `room.peers` and `file.list` use.
+
+### `pipe.connect`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
+| `out` | `{ "pipe_id": "<pipe_id>", "connection_id": "<string>", "local_port": "<uint>" }` |
+| Errors | `pipe_unreachable`, `pipe_unknown`, `pipe_revoked` |
+
+A caller outside the pipe's audience answers `pipe_unknown`, indistinguishable
+from no such pipe. Requires liveness.
+
+### `pipe.release`
+
+| | |
+|---|---|
+| `in` | `{ "connection_id": "<string>" }` |
+| `out` | `{ "connection_id": "<string>", "released": true }` |
+| Errors | `connection_unknown` |
+
+Releases a **local** connection, so it names the connection rather than the
+pipe.
+
+### `pipe.revoke`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
+| `out` | `{ "pipe_id": "<pipe_id>", "event_id": "<event_id>", "pos": "<uint>", "revoked_at": "<ts>" }` |
+| Errors | `pipe_not_publisher`, `pipe_unknown` |
+
+Withdraws a published pipe as a signed fact. Re-revoking succeeds and returns
+the original withdrawal, like every other terminal withdrawal in this record.
+
+### `stream.subscribe`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "from": <cursor> }` |
+| `out` | `{ "room_id": "<room_id>", "from_pos": "<uint>" }` |
+| Errors | `subscription_limit_reached` |
+
+**Naturally idempotent** — subscribing twice does not duplicate delivery and is
+not an error. Scoped to the connection that holds it. Exceeding
+`max_subscriptions_per_connection` is `subscription_limit_reached`, never a
+silent drop.
+
+### `stream.unsubscribe`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>" }` |
+| `out` | `{ "room_id": "<room_id>", "unsubscribed": true }` |
+| Errors | `subscription_unknown` |
+
+### `stream.resync`
+
+| | |
+|---|---|
+| `in` | `{ "room_id": "<room_id>", "from_pos": "<uint>" }` |
+| `out` | `{ "room_id": "<room_id>", "events": [ <event> ], "next_pos": "<uint>", "truncated": <truncated> }` |
+| Errors | `resync_required` |
+
+The **authoritative** recovery. The client names the last position it holds and
+the daemon returns either the events since it, or `resync_required` naming a
+position to discard back to and re-read from. Resync is not best-effort and is
+not "call `room.activate` again", which is what v1 clients did.
+
+`next_pos` follows the same rule as `room.timeline`: the position of the last
+event returned, or `from_pos` when `events` is empty.
+
 ## Pushes, ordering, gap detection, and resync
 
 **Every push carries a per-room monotonic position.** v1 had no sequence number
@@ -538,11 +1219,16 @@ The `gap` frame states a bounded or open range as a tagged variant, never a
 null:
 
 ```json
-{ "t": "gap", "room": "<id>",
+{ "t": "gap", "room_id": "<room_id>",
   "from_pos": 41,
   "to": { "state": "bounded", "pos": 57 },
   "reason": "backpressure" }
 ```
+
+**Every room-scoped request names the room `room_id`, and every reply and frame
+about one room echoes `room_id`.** One spelling, everywhere — an earlier draft
+of this example said `room`, which is v1's spelling and is the sort of drift
+that costs an adapter author an afternoon.
 
 `stream.resync` is the **authoritative** recovery: the client names the last
 position it holds, and the daemon returns either the events since, or a
@@ -603,24 +1289,32 @@ reply lost to a dropped connection.
 | Naturally idempotent | `subject.ensure`, `room.activate`, `room.deactivate`, `invite.redeem` (re-redeeming from the same subject reports existing membership) |
 | Terminal, single-effect | `daemon.stop` — the first call succeeds, a second returns `shutdown_in_progress`. This is deliberately **not** natural idempotence: once teardown is sequenced there is no state in which a caller can be told "done" truthfully, and reporting success for an operation that will not run again is the kind of comfortable lie this generation exists to remove |
 | `op_id` deduplicated | `room.create`, `room.leave`, `member.remove`, `invite.mint`, `invite.revoke`, `message.send`, `status.post`, `file.share`, `file.fetch`, `pipe.publish`, `pipe.connect`, `pipe.release`, `pipe.revoke` |
-| Scoped to one connection, no `op_id` | `stream.subscribe`, `stream.unsubscribe`, `stream.resync` — subscription state belongs to the connection that holds it, so a retry after a lost reply is a retry on a **new** connection with no prior subscription. Re-issuing is always safe and always correct |
-| Scoped to the principal, `op_id` names the TARGET | `transfer.cancel` — see below |
+| Scoped to one connection, `op_id` ignored | `stream.subscribe`, `stream.unsubscribe`, `stream.resync` — subscription state belongs to the connection that holds it, so a retry after a lost reply is a retry on a **new** connection with no prior subscription. Re-issuing is always safe and always correct |
+| Scoped to the principal, names its target | `transfer.cancel` — see below |
 
-`transfer.cancel`'s `op_id` field names **the transfer being cancelled**, not
-the cancel request. That is the whole point: the caller knows the transfer's
-`op_id` because it chose it, and can therefore cancel across a reconnect on
-which a cancel-request identifier would be meaningless. Cancel is naturally
-idempotent — cancelling an already-cancelled transfer reports the existing
-cancellation — so it needs no identifier of its own.
+Because `op_id` lives in [the envelope](#request-deduplication-lives-in-the-envelope), an
+operation that does not deduplicate **accepts it and ignores it**. It is never
+`unrecognised_field`. The three `stream.*` operations are the case that matters:
+refusing an `op_id` there would make a client's uniform envelope-builder an
+error, to enforce a rule that only ever existed because `op_id` had been
+misfiled as an argument.
+
+`transfer.cancel` names **the transfer being cancelled** in a request field
+called `transfer_op_id`. The caller knows that value because it chose it, and
+can therefore cancel across a reconnect on which a cancel-request identifier
+would be meaningless. Cancel is naturally idempotent — cancelling an
+already-cancelled transfer reports the existing cancellation — so it needs no
+identifier of its own, and the envelope `op_id` on it is ignored.
 
 Every operation marked `M` appears in exactly one row above.
 
 A replayed `op_id` returns the **original** result and performs no second
 effect. `invite.mint` in particular MUST return the original capability, never
-a second grant.
+a second grant. An `op_id` replayed with a *different* request body is
+`op_id_conflict`, not a silent second effect.
 
-`transfer.cancel` is authorized by **`(session principal, op_id)`** — the same
-key as the ledger, not `(subject, op_id)` and not the connection.
+`transfer.cancel` is authorized by **`(session principal, transfer_op_id)`** —
+the same key as the ledger, not `(subject, …)` and not the connection.
 
 The connection is wrong because a transfer whose originating connection has
 dropped could then never be cancelled, which is precisely the case cancellation
@@ -628,27 +1322,200 @@ exists for. The bare subject is wrong because a daemon has one subject, so any
 local client could cancel any other's transfer. The principal is the only scope
 that survives a reconnect without becoming daemon-global.
 
-Cancelling an `op_id` belonging to a different principal returns
-`transfer_unknown` — indistinguishable from an `op_id` that never existed, so
-the operation is not an oracle for other clients' activity.
+Cancelling a `transfer_op_id` belonging to a different principal returns
+`transfer_unknown` — indistinguishable from one that never existed, so the
+operation is not an oracle for other clients' activity.
+
+### Repeating a withdrawal
+
+**`member.remove` and `invite.revoke` answer alike: repeating either against an
+already-terminal fact succeeds**, returns the original withdrawal's `event_id`,
+`pos`, and resulting state, and authors no second event.
+
+They are stated together because an earlier draft made them differ — remove
+succeeding, revoke refusing `capability_revoked` — with no reason that
+distinguished them. There is none to find: both are re-assertions of a terminal
+fact by the party that authored it, and both change nothing. Two operations with
+identical shape must not have opposite answers.
+
+`capability_revoked` and `capability_expired` are **redemption-side** codes.
+They answer the redeemer, telling them why they cannot join. An authority
+repeating its own withdrawal is not their audience.
 
 ## Errors
 
-The taxonomy is 55 codes. Every code is machine-readable, carries typed fields
-rather than prose, and carries no `hint`.
+**The taxonomy is 60 codes.** Every code is machine-readable, carries typed
+fields rather than prose, and carries no `hint`. The tables below are the whole
+of it — a code not listed here does not exist, and an implementation MUST NOT
+mint one.
 
-Selected codes whose shape is normative:
+An earlier draft of this record said 55 without listing them, and the count was
+unverifiable in both directions: the same draft introduced its distinctive codes
+under a sentence saying "nine operations" above a table of fifteen rows. A
+stated count that no table supports is how a taxonomy drifts. Every code below
+is counted, and the group subtotals sum to the total.
 
-| Code | Fields | Meaning |
+### The error object
+
+```json
+{ "id": 42, "ok": false,
+  "err": { "code": "invalid_argument",
+           "field": "in.limit",
+           "reason": { "state": "bound", "min": 1, "max": 500 } } }
+```
+
+`code` is always present. Every other key is fixed by the code, per the tables
+below — an error carries exactly the fields its row names, no more and no fewer.
+
+### Gate and transport — 7
+
+Returned as a JSON body on a refused upgrade, or as the application close code
+[the gate section](#rejections-are-machine-readable) tabulates.
+
+| Code | Fields | Raised when |
 |---|---|---|
-| `protocol_unsupported` | `supported`, `client` as a tagged declared/absent variant | The generation gate refused |
-| `storage_generation_mismatch` | `daemon`, `client` | The storage gate refused |
+| `forbidden_origin` | — | `Host`, or a present `Origin`, is not loopback |
+| `protocol_unsupported` | `supported`, `client` (variant: `declared {v}` / `absent`) | `v` is absent or names an unsupported generation |
+| `storage_generation_mismatch` | `daemon`, `client` (variant: `declared {sg}` / `absent`) | `sg` is absent or does not equal the daemon's |
+| `unauthenticated` | — | The credential is absent, wrong, or a spent ticket |
+| `not_ready` | — | The daemon is not yet serving, or its subject store cannot be read |
+| `frame_too_large` | `limit_bytes` | A frame exceeds `max_frame_bytes`; the connection closes `4005` unparsed |
+| `idle_timeout` | `idle_ms` | No activity within `idle_timeout_ms`; the connection closes `4004` |
+
+`not_ready` is also the answer when the subject store exists but cannot be read.
+A `hello` cannot carry an error code, and a `hello` degraded into a third
+`subject.state` arm forces every client to branch on a condition it can do
+nothing about. Failing the connection closed is both simpler and more honest.
+
+### Envelope and structure — 3
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `malformed_frame` | — | The frame is not JSON, or decodes to no envelope with a usable `id`. Closes `4007` |
+| `unknown_operation` | `op` | `op` names no operation in this generation |
+| `invalid_argument` | `field`, `reason` | Step 1 of [validation order](#validation-order) refused |
+
+**`invalid_argument` carries exactly two fields.** `field` is a dotted path into
+the frame — `in.progress.percent`, not `percent` — so a nested violation is
+nameable without a second convention. `reason` is a closed variant:
+
+| Arm | Payload | Meaning |
+|---|---|---|
+| `missing` | — | A required key is absent |
+| `unrecognised_field` | — | A key the operation does not define |
+| `type` | `expected` | Wrong JSON type |
+| `format` | — | Right type, unparseable as its domain |
+| `bound` | `min`, `max` | A numeric or length bound was violated |
+
+Bound information lives **inside the `bound` arm**, never as a top-level `max`.
+This is why an over-maximum `limit` is `invalid_argument` and never
+`resource_exhausted`: `resource_exhausted` means a served limit was reached *by
+consumption*, whereas asking for a page larger than the served maximum is a
+malformed argument. It is refused, never silently clamped.
+
+A frame with a usable `id` always gets a correlated error reply. Only a frame
+whose `id` cannot be recovered closes the connection, because there is nothing
+to correlate a reply to. `4007` is added to the close-code table for it.
+
+### Subject — 2
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `subject_absent` | — | The operation needs a local subject and none exists |
+| `subject_store_unwritable` | — | `subject.ensure` cannot persist the subject it created |
+
+### Room and membership — 8
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `room_not_available` | `room_id` | No such room, **or** the room exists and the caller is not a member |
+| `membership_ended` | `room_id`, `standing` | The caller's standing is `left` or `removed` |
+| `insufficient_standing` | `room_id`, `required`, `held` | The caller is an active member whose `role` is below what the operation needs |
+| `room_not_live` | `room_id` | The operation requires an active transport and the room is not live |
+| `room_still_active` | `room_id` | `room.archive` was called on a room the caller has not left |
+| `room_index_unreadable` | — | The accepted-room index cannot be read |
+| `membership_unresolved` | `room_id`, `subject_id` | The fold cannot resolve a member's standing |
+| `member_unknown` | `room_id`, `subject_id` | The named subject is not a member of this room |
+
+**`insufficient_standing`'s `required` and `held` are `role` tokens**, not
+capability tokens. The error is only reachable by an active member — a
+non-member gets `room_not_available` and a former member gets `membership_ended`
+— so the only thing that can be lacking is role. That makes the field set total
+without a second vocabulary and without disclosing a capability set.
+
+`room_not_available` **echoes the `room_id` the caller sent**. The non-oracle
+guarantee is equality of the response across both causes, not fieldlessness; a
+value the caller supplied one frame earlier discloses nothing back to it.
+
+### Idempotency and capacity — 3
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `op_id_conflict` | `op_id` | The `op_id` was seen before with a different request body |
+| `resource_exhausted` | `resource`, `limit` | A served limit was reached by consumption |
+| `shutdown_in_progress` | — | A `daemon.stop` is already sequenced |
+
+### Rooms — 5
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `room_name_invalid` | `reason` (the `invalid_argument` variant) | The name fails the stated bounds |
+| `sole_authority_cannot_leave` | `room_id` | The caller is the room's only authority |
+| `cursor_unknown` | `cursor` | A well-formed cursor names a position the store can no longer serve |
+| `transport_unavailable` | `room_id` | `room.activate` cannot bring the room live |
+| `authority_cannot_be_removed` | `room_id`, `subject_id` | `member.remove` names an authority |
+
+`cursor_unknown` is deliberately not `invalid_argument`: a cursor that is
+structurally valid but names a pruned position is a fact about the store, not a
+defect in the request, and a client responds to it by resyncing rather than by
+fixing its code.
+
+### Invitations — 8
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `invite_index_unreadable` | — | The invite index cannot be read |
+| `invite_unknown` | `invite_id` | No such invite for this authority |
+| `invitee_already_member` | `room_id`, `subject_id` | The named identity already holds membership |
+| `capability_invalid` | — | The presented capability does not verify |
+| `capability_expired` | `expired_at` | The capability's absolute expiry has passed |
+| `capability_revoked` | `revoked_at` | The capability was withdrawn before expiry |
+| `capability_redeemed` | `redeemed_at` | The capability has already been converted into membership |
+| `role_not_grantable` | `requested` | `invite.mint` named a role this record does not permit minting |
+
+**`capability_invalid`, `capability_expired`, `capability_revoked`, and
+`capability_redeemed` are redemption-side codes.** They answer the *redeemer*,
+telling them why they cannot join. An authority repeating its own withdrawal is
+not their audience — see [Idempotency](#idempotency-and-retry).
+
+`capability_invalid` carries no fields on purpose. It is the answer for a forged
+capability, a capability for a room that does not exist, and a capability naming
+a different identity, and those must be indistinguishable for the same reason
+`room_not_available` is one code: `invite.redeem` is the only operation a
+non-member can reach, so it is the one place a membership oracle could be built.
+
+### Timeline — 4
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `message_too_large` | `declared_bytes`, `limit_bytes` | The body exceeds `max_message_body_bytes` |
+| `status_label_unknown` | `label` | The label is outside the closed vocabulary |
+| `status_subject_unknown` | `room_id`, `subject_id` | The named agent has no status history |
+| `fleet_projection_unavailable` | — | The projection cannot be built |
+
+### Files and transfers — 9
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `file_index_unreadable` | — | The room's file index cannot be read |
+| `file_unknown` | `file_id` | No such file in this room |
+| `file_not_fetched` | `file_id` | `file.read` named a file whose bytes are not held locally |
 | `file_too_large` | `declared_bytes`, `limit_bytes`, `enforced_at` | Over-limit, naming which enforcement point fired |
 | `digest_mismatch` | `expected`, `observed` | Content did not verify. **Never returned for a size refusal** |
-| `resource_exhausted` | `resource`, `limit` | A served limit was reached |
-| `transfer_stalled` | `transferred_bytes`, `total` as a tagged variant | No forward progress within the stall window |
-| `capability_expired` | `expired_at` | Invite expired — distinct from invalid and from revoked |
-| `capability_revoked` | `revoked_at` | Withdrawn before expiry |
+| `declared_size_mismatch` | `declared_bytes`, `observed_bytes` | `file.share`'s streamed bytes did not match its declared size |
+| `provider_unreachable` | `file_id`, `providers` | No provider holding the file could be reached |
+| `transfer_unknown` | `transfer_op_id` | No such in-flight transfer for this principal |
+| `transfer_stalled` | `transferred_bytes`, `total` (variant: `known {bytes}` / `unknown`) | No forward progress within the stall window |
 
 `file_too_large.enforced_at` names one of the **five daemon-side** enforcement
 points of the six in [the shared-file size policy](shared-file-size.md):
@@ -657,48 +1524,120 @@ points of the six in [the shared-file size policy](shared-file-size.md):
 never reaches the daemon and is proven by a client-side case asserting zero
 bytes are sent.
 
-**Every operation has at least one error code specific to it.** A conformance
-corpus that can only assert a shared code proves nothing about the operation it
-is supposed to cover: `subject_absent` returned by `room.list` and by
-`fleet.list` are the same assertion twice.
+### Pipes — 8
 
-Authoring the corpus found nine operations still resting entirely on
-cross-cutting codes. Each therefore gains one:
-
-| Operation | Distinctive code | Raised when |
+| Code | Fields | Raised when |
 |---|---|---|
-| `daemon.stop` | `shutdown_in_progress` | A stop is already sequenced |
-| `stream.unsubscribe` | `subscription_unknown` | No such subscription on this connection |
-| `room.list` | `room_index_unreadable` | The accepted-room index cannot be read |
-| `room.create` | `room_name_invalid` | The name fails the stated bounds |
-| `room.members` | `membership_unresolved` | The fold cannot resolve a member's standing |
-| `invite.mint` | `invitee_already_member` | The named identity already holds membership |
-| `invite.list` | `invite_index_unreadable` | The invite index cannot be read |
-| `status.history` | `status_subject_unknown` | The named agent has no status history |
-| `fleet.list` | `fleet_projection_unavailable` | The projection cannot be built |
-| `file.list` | `file_index_unreadable` | The room's file index cannot be read |
-| `transfer.cancel` | `transfer_unknown` | No such in-flight transfer for this principal |
-| `message.send` | `message_too_large` | The body exceeds `max_message_body_bytes`, carrying `declared_bytes` and `limit_bytes` |
-| `status.post` | `status_label_unknown` | The label is outside the closed vocabulary |
-| `pipe.publish` | `pipe_target_refused` | The target is not loopback, or the port is out of range, carrying the rejected target |
-| `stream.subscribe` | `subscription_limit_reached` | This connection holds the maximum number of subscriptions |
+| `pipe_target_refused` | `target` | The target is not loopback, or the port is out of range |
+| `pipe_index_unreadable` | — | The room's pipe index cannot be read |
+| `pipe_unknown` | `pipe_id` | No such pipe, **or** the caller is outside its audience |
+| `pipe_unreachable` | `pipe_id`, `link` | The pipe's publisher device could not be reached |
+| `pipe_revoked` | `pipe_id`, `revoked_at` | The pipe was withdrawn |
+| `pipe_not_publisher` | `pipe_id` | `pipe.revoke` named a pipe this subject did not publish |
+| `connection_unknown` | `connection_id` | `pipe.release` named no local connection |
+| `policy_refused` | `room_id` | Publishing is not permitted in this room |
 
-These are the taxonomy's last additions; the total is 55 codes, not the 40 the
-mined design projected.
+`pipe_unknown` covers the out-of-audience case for the same reason
+`room_not_available` covers non-membership: a caller MUST NOT be able to
+distinguish a pipe it is not entitled to from one that does not exist. This is
+what makes a separate `pipe_audience` capability unnecessary, and a separate
+audience refusal code actively harmful.
 
 `pipe_target_refused` replaces the generic `policy_refused` for the
 publish-target case specifically, so a client can tell "your target is not
 allowed" from "you are not permitted to publish here" — two refusals a user
 must respond to differently.
 
+### Stream — 3
+
+| Code | Fields | Raised when |
+|---|---|---|
+| `subscription_limit_reached` | `limit` | This connection holds `max_subscriptions_per_connection` |
+| `subscription_unknown` | `room_id` | No such subscription on this connection |
+| `resync_required` | `room_id`, `from_pos` | The named position can no longer be served; discard and re-read from `from_pos` |
+
+### One distinctive code per operation
+
+**Every operation has at least one error code specific to it.** A conformance
+corpus that can only assert a shared code proves nothing about the operation it
+is supposed to cover: `subject_absent` returned by `room.list` and by
+`fleet.list` are the same assertion twice.
+
+| Operation | Distinctive code | Operation | Distinctive code |
+|---|---|---|---|
+| `subject.ensure` | `subject_store_unwritable` | `status.post` | `status_label_unknown` |
+| `daemon.stop` | `shutdown_in_progress` | `status.history` | `status_subject_unknown` |
+| `room.create` | `room_name_invalid` | `fleet.list` | `fleet_projection_unavailable` |
+| `room.list` | `room_index_unreadable` | `file.share` | `declared_size_mismatch` |
+| `room.activate` | `transport_unavailable` | `file.list` | `file_index_unreadable` |
+| `room.deactivate` | **exempt — see below** | `file.fetch` | `provider_unreachable` |
+| `room.leave` | `sole_authority_cannot_leave` | `file.read` | `file_not_fetched` |
+| `room.timeline` | `cursor_unknown` | `transfer.cancel` | `transfer_unknown` |
+| `room.members` | `membership_unresolved` | `pipe.publish` | `pipe_target_refused` |
+| `room.archive` | `room_still_active` | `pipe.list` | `pipe_index_unreadable` |
+| `room.peers` | `room_not_live` | `pipe.connect` | `pipe_unreachable` |
+| `member.remove` | `authority_cannot_be_removed` | `pipe.release` | `connection_unknown` |
+| `invite.mint` | `invitee_already_member` | `pipe.revoke` | `pipe_not_publisher` |
+| `invite.list` | `invite_index_unreadable` | `stream.subscribe` | `subscription_limit_reached` |
+| `invite.revoke` | `capability_redeemed` | `stream.unsubscribe` | `subscription_unknown` |
+| `invite.redeem` | `capability_invalid` | `stream.resync` | `resync_required` |
+| `message.send` | `message_too_large` | | |
+
+**`room.deactivate` is exempt, and the exemption is recorded rather than
+papered over.** Every way it can fail is already a cross-cutting refusal —
+no subject, no such room, membership ended. Deactivating a room the caller may
+act in always succeeds, because it withdraws local participation and asks
+nothing of the network. Minting a code that no reachable state produces would
+buy a green cell in a coverage table and nothing else. The manifest carries this
+as a named exemption with this reason.
+
+### Codes this record refuses to define
+
+The corpus currently asserts fourteen codes that v2 does not have. Each is a
+fixture bug, not a taxonomy gap, and each is listed with the code that replaces
+it.
+
+| Corpus code | Verdict |
+|---|---|
+| `room_unknown` | **A defect, not a synonym.** A distinct code for "no such room" is exactly the membership oracle `room_not_available` exists to prevent. Every use becomes `room_not_available` |
+| `not_found`, `forbidden`, `conflict`, `already_exists` | v1's generic HTTP-shaped codes. Each becomes the specific code for its operation |
+| `invalid_params` | → `invalid_argument` |
+| `hash_mismatch` | → `digest_mismatch` |
+| `identity_missing`, `subject_missing` | → `subject_absent` |
+| `identity_exists`, `subject_exists` | Removed outright. `subject.ensure` is naturally idempotent, so an existing subject is **success with `created: false`**, and this record already removes `identity_exists` for reporting success as failure |
+| `subject_unreadable` | → `not_ready`, which closes the connection rather than answering an operation |
+| `cursor_invalid` | → `cursor_unknown` for a pruned position, or `invalid_argument` with `reason: {"state": "format"}` for a malformed one. The single corpus code conflated the two |
+| `<the case's code>` | Not a code at all — an unsubstituted placeholder left in a fixture |
+
+Eleven codes in the tables above have no corpus case yet:
+`authority_cannot_be_removed`, `capability_redeemed`, `cursor_unknown`,
+`declared_size_mismatch`, `idle_timeout`, `malformed_frame`,
+`pipe_index_unreadable`, `pipe_not_publisher`, `room_still_active`,
+`subject_store_unwritable`, and `transport_unavailable`. They are real codes
+with no coverage, which is a corpus gap rather than a specification gap, and
+they are named in the manifest so the gap cannot read as coverage.
+
 ### The non-oracle property
 
 A caller that is not a member of a room MUST NOT be able to distinguish "no
 such room" from "that room exists and you are not a member". Both answer
-`room_not_available`, with identical fields and indistinguishable timing.
+`room_not_available`, echoing the `room_id` the caller supplied, with identical
+fields and indistinguishable timing.
 
 This is normative, it applies to every room-scoped operation and to the push
 stream, and it is the reason `room_not_available` is one code rather than two.
+
+The property generalises to two other places, and both are stated as
+consequences rather than left to be re-derived:
+
+- **`invite.redeem`** is the only operation a non-member can reach, so it is the
+  one place a non-member could probe. `capability_invalid` is fieldless and
+  covers forgery, an unknown room, and a mismatched identity alike.
+- **`pipe_unknown`** covers both "no such pipe" and "you are outside its
+  audience", for the same reason.
+
+Timing is part of the guarantee in all three cases. A refusal that is
+constant-time in its code but not in its latency is still an oracle.
 
 ## What v2 removes
 

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -361,6 +361,20 @@ choice, not a daemon default — a default is a second place the contract can
 disagree with itself, and a client that did not choose a page size cannot
 reason about the page it got.
 
+**The six paging operations are `room.timeline`, `room.archive`,
+`status.history`, `invite.list`, `file.list`, and `pipe.list`.** All six take the
+same three fields with the same meanings and bounds: `cursor` is
+[`<cursor>`](#shared-value-types), `direction` is a bare enum of `forward` and
+`backward`, and `limit` is an integer in `1..=timeline_page_max`. A `limit`
+outside that range is `invalid_argument` with `reason: {"state": "bound"}` —
+**refused, never silently clamped**, and never `resource_exhausted`.
+
+Stating the bound once, here, is deliberate. An earlier draft stated it under
+two operations and left the other four to inherit it by implication, which is
+the same drift as stating a rule and then writing schemas that violate it.
+`timeline_page_max` governs all six despite its name, because one served page
+bound is easier to reason about than six.
+
 ### Validation order
 
 Every operation validates in this order, and the order is normative because two
@@ -471,6 +485,29 @@ role** — v1 returned `member` for a sender the membership fold could not
 resolve. A flat `sender_role` cannot express an unresolvable author without a
 null or an invention, and both are forbidden, so the unresolvable case gets an
 arm of its own and carries no attribution at all.
+
+**`kind` is closed at ten, and each arm fixes its `content`.** An event whose
+`kind` a client does not recognise is not rendered and not counted; it is never
+guessed at.
+
+| `kind` | `content` | Authored by |
+|---|---|---|
+| `room_created` | `{ name }` | `room.create` |
+| `message` | `{ body }` | `message.send` |
+| `agent_status` | `{ label, progress }` | `status.post` |
+| `member_joined` | `{ subject_id, role }` | `invite.redeem` |
+| `member_left` | `{ subject_id }` | `room.leave` |
+| `member_removed` | `{ subject_id, by }` | `member.remove` |
+| `invite_revoked` | `{ invite_id }` | `invite.revoke` |
+| `file_shared` | `{ file_id, name, bytes, digest }` | `file.share` |
+| `pipe_published` | `{ pipe_id, target, audience }` | `pipe.publish` |
+| `pipe_revoked` | `{ pipe_id }` | `pipe.revoke` |
+
+Every operation that returns an `event_id` appears in the right-hand column, and
+every kind is authored by exactly one operation. `agent_status.content` carries
+**no `severity`**: severity is derived and served on the projection, never
+written into signed content, which is what makes a new label a value change
+rather than an `iroh-rooms` schema change.
 
 ## The 33 operations
 
@@ -760,12 +797,24 @@ second call answers `shutdown_in_progress` rather than a comfortable `true`.
 | | |
 |---|---|
 | `in` | `{ "name": "<string>" }` |
-| `out` | `{ "room_id": "<room_id>", "name": "<string>", "role": "authority", "standing": "active", "created_at": "<ts>" }` |
+| `out` | `{ "room_id": "<room_id>", "name": "<string>", "role": "authority", "standing": "active", "event_id": "<event_id>", "pos": "<uint>", "created_at": "<ts>" }` |
 | Errors | `room_name_invalid` |
 
 Works with no network. The caller is the room's authority, so `role` is
 constant — it is served rather than assumed because a client that infers it is
 a client that will get it wrong for a room it did not create.
+
+`name` is `1..=128` bytes after trimming surrounding whitespace, and must
+contain at least one non-whitespace character. Outside that it is
+`room_name_invalid`, whose `reason` is the same closed variant
+`invalid_argument` uses — a `bound` arm for length, a `format` arm for a name
+that is only whitespace. The bounds are stated here because a code defined
+against unstated bounds is a code no two implementations agree on.
+
+It returns `event_id` and `pos` like every other event-authoring operation.
+Room creation is a committed `room_created` event, and `pos` is what anchors the
+room's position space at its origin — a client that could not learn it would
+have to guess where the timeline starts.
 
 ### `room.list`
 
@@ -848,9 +897,8 @@ wrote rather than a bare acknowledgement.
 | `out` | `{ "room_id": "<room_id>", "events": [ <event> ], "truncated": <truncated> }` |
 | Errors | `cursor_unknown` |
 
-`direction` is a bare enum: `forward`, `backward`. `limit` is `1..=timeline_page_max`;
-outside that it is `invalid_argument` with `reason: {"state": "bound"}`, refused
-rather than clamped.
+`cursor`, `direction`, and `limit` behave as
+[stated for all six paging operations](#there-are-no-optional-request-fields).
 
 **Continuation is `truncated`, and only `truncated`.** When the reply is
 `{"state": "more", "cursor": …}` the caller resends that cursor; when it is
@@ -1405,6 +1453,15 @@ upgrade** — a stable, client-generated opaque identifier it reuses across
 reconnects and persists for as long as it wants its own `op_id` scope. The
 principal is `(credential, client_id)`.
 
+It travels as a query parameter on the upgrade, `GET
+/ws?v=2&sg=<storage-generation>&cid=<client_id>`, for the same reason `v` and
+`sg` do: a browser `WebSocket` constructor controls only the URL and the
+subprotocol list. It is bounded by the codec like any other string, and unlike
+`v` and `sg` its **absence is not refusal** — an omitted `cid` yields a fresh
+ephemeral principal, which is the documented choice a short-lived CLI makes.
+`cid` is not a credential and is never compared in constant time; putting it in
+the URL is safe precisely because it grants nothing.
+
 - A client that omits `client_id` gets a fresh ephemeral principal per
   connection and therefore no cross-reconnect replay. That is a legitimate
   choice for a short-lived CLI invocation, and it is refusal of a capability
@@ -1582,6 +1639,26 @@ capability tokens. The error is only reachable by an active member — a
 non-member gets `room_not_available` and a former member gets `membership_ended`
 — so the only thing that can be lacking is role. That makes the field set total
 without a second vocabulary and without disclosing a capability set.
+
+**Four operations require `role: "authority"`. Every other operation is open to
+any active member.**
+
+| Requires `authority` | Why |
+|---|---|
+| `member.remove` | Ending someone else's membership is the room's decision, not a peer's |
+| `invite.mint` | Admitting a new member is the same decision taken in advance |
+| `invite.revoke` | Withdrawing a grant belongs to whoever could make it |
+| `invite.list` | The invite index is the authority's own record of what it issued; enumerating it to any member would disclose who has been invited and not yet joined |
+
+Stating this as one list rather than per-operation is deliberate. Step 6 of
+[validation order](#validation-order) is normative for all 33 operations, so a
+reader who found the rule stated only under `member.remove` would reasonably
+conclude the other 32 never raise it — which is how a permission gets
+implemented as open by accident.
+
+`pipe.revoke` is **not** on this list. It is restricted to the pipe's publisher,
+which is a narrower relation than role and answers `pipe_not_publisher`; an
+authority who did not publish a pipe cannot revoke it either.
 
 `room_not_available` **echoes the `room_id` the caller sent**. The non-oracle
 guarantee is equality of the response across both causes, not fieldlessness; a

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -373,9 +373,17 @@ of its steps are security properties rather than conveniences.
 3. **Dedup ledger** — a replayed `op_id` returns the original result, and no
    later step runs
 4. **Room index** → `room_not_available`
-5. **Lifecycle** → `membership_ended`
+5. **Standing** → `membership_ended`, unless the operation is defined over a
+   former membership. Exactly two are: `room.archive` and `room.list`
 6. **Role** → `insufficient_standing`
 7. **Operation semantics** → the operation's own codes
+
+The step 5 exception is not a convenience. `room.archive` exists *to* open a
+room the caller has left, so a pipeline that refused it on standing would make
+the operation unreachable in every state it is defined for, and `room.list`
+must enumerate left rooms or a client could never find one to archive. Stating
+the exception in the pipeline rather than only in the operation's own section is
+the difference between a rule with a carve-out and a rule that is quietly false.
 
 Structure comes first because no rule can be applied to a value that has not
 been decoded. Putting format and bounds in step 1 does **not** weaken
@@ -837,19 +845,25 @@ wrote rather than a bare acknowledgement.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
-| `out` | `{ "room_id": "<room_id>", "events": [ <event> ], "next_pos": "<uint>", "truncated": <truncated> }` |
+| `out` | `{ "room_id": "<room_id>", "events": [ <event> ], "truncated": <truncated> }` |
 | Errors | `cursor_unknown` |
 
 `direction` is a bare enum: `forward`, `backward`. `limit` is `1..=timeline_page_max`;
 outside that it is `invalid_argument` with `reason: {"state": "bound"}`, refused
 rather than clamped.
 
-**`next_pos` is the position of the last event returned, or `from_pos` when
-`events` is empty.** Positions are exclusive on the low side, so a client
-resends `next_pos` to get what follows. An earlier worked example showed a
-single event at position 58 with `next_pos: 59`, which under an exclusive cursor
-skips exactly one event at every page boundary — the example was wrong, not the
-rule.
+**Continuation is `truncated`, and only `truncated`.** When the reply is
+`{"state": "more", "cursor": …}` the caller resends that cursor; when it is
+`{"state": "complete"}` there is nothing further and no cursor exists to
+misuse.
+
+An earlier draft returned a sibling `next_pos` alongside `truncated`, and the
+two disagreed: the worked example paired a single event at position 58 with
+`next_pos: 59`, which under an exclusive cursor skips exactly one event at every
+page boundary. The off-by-one was the symptom; **two continuation mechanisms in
+one reply was the defect**, because a client may follow either and they need not
+agree. `stream.resync` keeps an explicit position because recovery is defined
+over positions rather than pages, and it is the only place one appears.
 
 Reads committed history identically whether or not the room is live. A caller
 whose standing is `left` or `removed` gets `membership_ended` and uses
@@ -872,7 +886,7 @@ conflating them is the confusion (#50/#94) this generation exists to end.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
-| `out` | `{ "room_id": "<room_id>", "standing": "left", "events": [ <event> ], "next_pos": "<uint>", "truncated": <truncated> }` |
+| `out` | `{ "room_id": "<room_id>", "standing": "left", "events": [ <event> ], "truncated": <truncated> }` |
 | Errors | `room_still_active` |
 
 Normatively **zero network activity and zero durable mutation**. Defined only
@@ -932,7 +946,7 @@ grant.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
 | `out` | `{ "room_id": "<room_id>", "invites": [ { "invite_id": "<invite_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "redeemability": "outstanding" } ], "truncated": <truncated> }` |
 | Errors | `invite_index_unreadable` |
 
@@ -1016,7 +1030,7 @@ agent are a classification, not a permission.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
 | `out` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "entries": [ { "at": "<ts>", "label": "working", "severity": "ok", "progress": <progress> } ], "truncated": <truncated> }` |
 | Errors | `status_subject_unknown` |
 
@@ -1076,7 +1090,7 @@ See `file.read`.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
 | `out` | `{ "room_id": "<room_id>", "files": [ <file_row> ], "truncated": <truncated> }` |
 | Errors | `file_index_unreadable` |
 
@@ -1110,7 +1124,7 @@ expected value.
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "file_id": "<file_id>" }` |
 | `out` | `{ "room_id": "<room_id>", "file_id": "<file_id>", "bytes": "<uint>", "digest": "<string>", "provider": { "subject_id": "<subject_id>", "device_id": "<device_id>" } }` |
-| Errors | `provider_unreachable`, `file_unknown`, `file_too_large`, `digest_mismatch`, `transfer_stalled` |
+| Errors | `provider_unreachable`, `file_unknown`, `file_too_large`, `digest_mismatch`, `transfer_stalled`, `room_not_live` |
 
 **No `save_dir`.** v1's destination path is removed; the daemon holds the bytes
 and `file.read` streams them out.
@@ -1211,7 +1225,7 @@ removed.
 
 | | |
 |---|---|
-| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
+| `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "direction": "forward", "limit": "<uint>" }` |
 | `out` | `{ "room_id": "<room_id>", "pipes": [ { "pipe_id": "<pipe_id>", "published_by": "<subject_id>", "device_id": "<device_id>", "published_at": "<ts>", "link": <link>, "connected": "<bool>" } ], "truncated": <truncated> }` |
 | Errors | `pipe_index_unreadable` |
 
@@ -1228,7 +1242,7 @@ the same type `room.peers` and `file.list` use.
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "pipe_id": "<pipe_id>" }` |
 | `out` | `{ "pipe_id": "<pipe_id>", "connection_id": "<string>", "local": <target> }` |
-| Errors | `pipe_unreachable`, `pipe_unknown`, `pipe_revoked` |
+| Errors | `pipe_unreachable`, `pipe_unknown`, `pipe_revoked`, `room_not_live` |
 
 A caller outside the pipe's audience answers `pipe_unknown`, indistinguishable
 from no such pipe. Requires liveness.
@@ -1268,6 +1282,14 @@ not an error. Scoped to the connection that holds it. Exceeding
 `max_subscriptions_per_connection` is `subscription_limit_reached`, never a
 silent drop.
 
+`from` and `from_pos` are deliberately different types and are not two spellings
+of one thing. `from` is a **cursor** — what the caller asks for, including
+`{"state": "start"}`, which names no position because the caller does not yet
+know one. `from_pos` is the concrete position that cursor **resolved to**, which
+the caller needs in order to detect the first gap. A reply that merely echoed
+the cursor would leave a client that sent `start` still unable to say where its
+stream begins.
+
 ### `stream.unsubscribe`
 
 | | |
@@ -1289,8 +1311,12 @@ the daemon returns either the events since it, or `resync_required` naming a
 position to discard back to and re-read from. Resync is not best-effort and is
 not "call `room.activate` again", which is what v1 clients did.
 
-`next_pos` follows the same rule as `room.timeline`: the position of the last
-event returned, or `from_pos` when `events` is empty.
+`from_pos` is a position rather than a cursor because recovery is defined over
+positions: the client already holds one and is naming it. `next_pos` is the
+position of the last event returned, or `from_pos` itself when `events` is
+empty. Positions are exclusive on the low side, so the client resends `next_pos`
+to get what follows — and because this reply has exactly one continuation
+mechanism, there is no second value it can disagree with.
 
 ## Pushes, ordering, gap detection, and resync
 
@@ -1597,10 +1623,18 @@ fixing its code.
 | `capability_redeemed` | `redeemed_at` | The capability has already been converted into membership |
 | `role_not_grantable` | `requested` | `invite.mint` named a role this record does not permit minting |
 
-**`capability_invalid`, `capability_expired`, `capability_revoked`, and
-`capability_redeemed` are redemption-side codes.** They answer the *redeemer*,
-telling them why they cannot join. An authority repeating its own withdrawal is
-not their audience — see [Idempotency](#idempotency-and-retry).
+**`capability_invalid`, `capability_expired`, and `capability_revoked` are
+redemption-side codes.** They answer the *redeemer*, telling them why they cannot
+join. An authority repeating its own withdrawal is not their audience — see
+[Idempotency](#idempotency-and-retry).
+
+`capability_redeemed` is the exception, and it faces **both** ways. To a
+redeemer it means "you already used this". To an authority calling
+`invite.revoke` it means "there is nothing left to withdraw — this became a
+membership, and `member.remove` is the operation that ends one". Those are the
+same fact answered to two audiences, not two codes sharing a name, which is why
+it is `invite.revoke`'s distinctive code without contradicting the paragraph
+above.
 
 `capability_invalid` carries no fields on purpose. It is the answer for a forged
 capability, a capability for a room that does not exist, and a capability naming

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -419,6 +419,12 @@ belongs to exactly one operation.
 | `gap.reason` | bare enum: `backpressure`, `retention`, `subscription_lapse` |
 | `target` | `{ host, port }` — one object, never two sibling fields |
 | `audience` | variant: `room`, `subjects {subject_ids}` |
+| `redeemability` | bare enum: `outstanding`, `expired`, `revoked`, `redeemed` |
+| `last_event` | variant: `present {at, kind}`, `absent` |
+| `last_seen` | variant: `present {at}`, `absent` |
+| `latest_status` | variant: `present {label, at}`, `absent` |
+| `byte_total` | variant: `known {bytes}`, `unknown` |
+| `outcome` | variant: `cancelled`, `already_cancelled` — `transfer.cancel` only |
 
 Every variant in this record appears in this table. A variant whose arms are not
 enumerated here does not exist — an arm set stated only by example is how an
@@ -907,7 +913,7 @@ alike.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>" }` |
-| `out` | `{ "invite_id": "<invite_id>", "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "capability": "<string>", "redeemable": "<bool>" }` |
+| `out` | `{ "invite_id": "<invite_id>", "room_id": "<room_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "capability": "<string>", "redeemability": "outstanding" }` |
 | Errors | `invitee_already_member`, `role_not_grantable` |
 
 Mints one **key-bound** capability exactly one named identity can redeem;
@@ -927,11 +933,21 @@ grant.
 | | |
 |---|---|
 | `in` | `{ "room_id": "<room_id>", "cursor": <cursor>, "limit": "<uint>" }` |
-| `out` | `{ "room_id": "<room_id>", "invites": [ { "invite_id": "<invite_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "state": "outstanding" } ], "truncated": <truncated> }` |
+| `out` | `{ "room_id": "<room_id>", "invites": [ { "invite_id": "<invite_id>", "subject_id": "<subject_id>", "role": "member", "expires_at": "<ts>", "redeemability": "outstanding" } ], "truncated": <truncated> }` |
 | Errors | `invite_index_unreadable` |
 
-An invite row's `state` is a bare enum: `outstanding`, `expired`, `revoked`,
-`redeemed`. The capability itself is **never** returned by `invite.list` — only
+`redeemability` is the **same** bare enum `invite.mint` returns:
+`outstanding`, `expired`, `revoked`, `redeemed`. One vocabulary answers "can
+this be redeemed, and if not why not" in both places, which a boolean cannot —
+a `redeemable: false` that will not say whether the capability expired, was
+withdrawn, or was already used forces the client to guess between three
+different things to tell the user.
+
+It is **not** called `state`. `state` is the discriminant *inside* a tagged
+variant, and using it as an ordinary field name is how a reader stops being able
+to tell a variant from a record at a glance.
+
+The capability itself is **never** returned by `invite.list` — only
 `invite.mint` ever serves it, and only once.
 
 ### `invite.revoke`
@@ -1123,7 +1139,7 @@ the strength of it.**
 | | |
 |---|---|
 | `in` | `{ "transfer_op_id": "<op_id>" }` |
-| `out` | `{ "transfer_op_id": "<op_id>", "cancelled": true, "transferred_bytes": "<uint>", "total": { "state": "known", "bytes": "<uint>" } }` |
+| `out` | `{ "transfer_op_id": "<op_id>", "outcome": { "state": "cancelled" }, "transferred_bytes": "<uint>", "total": { "state": "known", "bytes": "<uint>" } }` |
 | Errors | `transfer_unknown` |
 
 **The request field is `transfer_op_id`, not `op_id`.** It names the transfer
@@ -1133,10 +1149,16 @@ Giving it a distinct name is what keeps one wire spelling from meaning two
 things; the envelope `op_id` on this operation is ignored like any other
 naturally-idempotent operation.
 
-`total` is the same `known {bytes}` / `unknown` variant `transfer_stalled`
-carries. A cancel that reports "4 MiB transferred" without a total reports a
-number the user cannot interpret, and the `unknown` arm exists because a
-provider that never declared a size genuinely leaves it unknown.
+`outcome` is a variant closed on `cancelled` and `already_cancelled`, not a
+`cancelled: true` boolean. Cancel is naturally idempotent, and an operation
+whose idempotence a caller cannot observe reports a replay as a fresh effect —
+the same reason `subject.ensure` serves `created` and `invite.redeem` serves
+`joined`.
+
+`total` is `<byte_total>`, the same variant `transfer_stalled` carries. A cancel
+that reports "4 MiB transferred" without a total reports a number the user
+cannot interpret, and the `unknown` arm exists because a provider that never
+declared a size genuinely leaves it unknown.
 
 Authorized by `(session principal, transfer_op_id)`. Cancelling a transfer
 belonging to a different principal returns `transfer_unknown`, indistinguishable
@@ -1271,6 +1293,31 @@ not "call `room.activate` again", which is what v1 clients did.
 event returned, or `from_pos` when `events` is empty.
 
 ## Pushes, ordering, gap detection, and resync
+
+### The push frames
+
+`t` is closed at four. A frame type not listed here does not exist — the same
+rule the [shared value types](#shared-value-types) apply to every variant, and
+for the same reason: the committed corpus contains two mutually incompatible
+spellings of the event push, `t: "event"` and `t: "room.event"`, because neither
+was ever written down.
+
+| `t` | Payload | Emitted when |
+|---|---|---|
+| `event` | `room_id`, and the [committed event](#the-committed-event) inline | A room event commits |
+| `gap` | `room_id`, `from_pos`, `to`, `reason` | A position discontinuity is detected or forced |
+| `peer` | `room_id`, `subject_id`, `device_id`, `link`, `generation` | A peer's link changes. **Depends on U1** |
+| `transfer` | `transfer_op_id`, `transferred_bytes`, `total` | A transfer makes progress. **Depends on U2** |
+
+A push carries `t` and never `id`; a reply carries `id` and never `t`. That is
+the whole of how the two are told apart, so a frame carrying both, or neither, is
+`malformed_frame`.
+
+`peer.generation` is the connection generation U1 must supply, and it is what
+makes a stale teardown discardable from the frame alone rather than by
+inference. `transfer` frames go **only to the principal that started the
+transfer** — a progress frame is otherwise an oracle for another client's
+activity, exactly as `transfer.cancel` would be without its principal guard.
 
 **Every push carries a per-room monotonic position.** v1 had no sequence number
 and no cursor — only wall-clock timestamps — so a client could not tell that it
@@ -1582,7 +1629,7 @@ non-member can reach, so it is the one place a membership oracle could be built.
 | `declared_size_mismatch` | `declared_bytes`, `observed_bytes` | `file.share`'s streamed bytes did not match its declared size |
 | `provider_unreachable` | `file_id`, `providers` | No provider holding the file could be reached |
 | `transfer_unknown` | `transfer_op_id` | No such in-flight transfer for this principal |
-| `transfer_stalled` | `transferred_bytes`, `total` (variant: `known {bytes}` / `unknown`) | No forward progress within the stall window |
+| `transfer_stalled` | `transferred_bytes`, `total` (`<byte_total>`) | No forward progress within the stall window |
 
 `file_too_large.enforced_at` names one of the **five daemon-side** enforcement
 points of the six in [the shared-file size policy](shared-file-size.md):

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -252,7 +252,7 @@ The daemon's first frame after upgrade is exactly one `hello`:
   "protocol": 2,
   "storage_generation": 1,
   "limits": { "...": "as above" },
-  "subject": { "state": "present", "subject_id": "<64-hex>", "device_id": "<64-hex>" },
+  "subject": { "state": "present", "subject_id": "<subject_id>", "device_id": "<device_id>" },
   "resume": { "state": "fresh" } }
 ```
 
@@ -327,8 +327,9 @@ merely discouraged.
   "in": { "room_id": "<room_id>", "body": "…" } }
 ```
 
-`op_id` deduplicates a **request**; it is not an argument to an operation, and
-v1's habit of mixing the two is why the rule below needed an exception.
+`op_id` deduplicates a **request**; it is not an argument to an operation.
+Keeping it out of `in` is what lets the next rule — no optional request fields —
+hold without a single exception.
 
 Because it sits in the envelope, **`op_id` is accepted on every operation and
 ignored by those that do not deduplicate** — including all three `stream.*`
@@ -379,11 +380,19 @@ they are — a caller who is not a member cannot reach step 5 at all.
 Every operation draws from these. A type defined here is never redefined in an
 operation section.
 
+**Notation.** `<name>` in any schema below means "a value of the type `name`",
+whether that type is a scalar domain or a composite. The three row types —
+`<room_row>`, `<file_row>`, and `<event>` — are defined by the JSON block that
+immediately follows their first use rather than in this table, because each
+belongs to exactly one operation.
+
 | Type | Form |
 |---|---|
 | `<room_id>` `<subject_id>` `<device_id>` `<event_id>` `<invite_id>` `<file_id>` `<pipe_id>` `<op_id>` | opaque strings, each a distinct domain |
 | `<ts>` | RFC 3339 UTC instant with a `Z` offset |
 | `<uint>` | JSON number, integral, `>= 0` |
+| `<bool>` | JSON `true` or `false` |
+| `<string>` | JSON string, bounded by the codec |
 | `role` | bare enum: `authority`, `member` |
 | `standing` | bare enum: `active`, `left`, `removed` |
 | `severity` | bare enum: `ok`, `failed`, `review` — **derived, never sent** |
@@ -395,6 +404,14 @@ operation section.
 | `truncated` | variant: `complete`, `more {cursor}` |
 | `progress` | variant: `absent`, `reported {percent}` where `percent` is `0..=100` |
 | `author` | variant: `resolved {subject_id, role, standing}`, `unresolved` |
+| `subject` | variant: `present {subject_id, device_id}`, `absent` — `hello` only |
+| `resume` | variant: `fresh`, `resumed {from_pos}` — `hello` only |
+| `gap.to` | variant: `bounded {pos}`, `open` |
+| `gap.reason` | bare enum: `backpressure`, `retention`, `subscription_lapse` |
+
+Every variant in this record appears in this table. A variant whose arms are not
+enumerated here does not exist — an arm set stated only by example is how an
+adapter author guesses, and two adapters guess differently.
 
 `role` is closed on exactly two tokens. **`agent` is not a role** — this record
 already states that member and agent are a classification, not a permission, and
@@ -590,7 +607,7 @@ than inferred from a full page.
 tallies**:
 
 ```json
-{ "agents": [ { "subject_id": "<64-hex>", "room_id": "<room_id>",
+{ "agents": [ { "subject_id": "<subject_id>", "room_id": "<room_id>",
                 "liveness": "working",
                 "latest_status": { "state": "present", "label": "working", "at": "<ts>" },
                 "last_seen": { "state": "present", "at": "<ts>" } } ] }


### PR DESCRIPTION
Closes #212. Follow-up filed as #213.

Turns protocol v2 from a settled design into an implementable contract: every request and reply
shape, the complete error taxonomy, and one normative fixture DSL. Authored as **one pass in one
vocabulary** — the previous five-section parallel attempt is what produced the mutually
contradictory definitions #212 exists to resolve.

## Scope call, made early

**#212 as filed was too large for one change, and this lands the half that must be authored by
one hand.** The normalization surface was measured, not estimated:

| Measure | Value |
|---|---|
| Fixtures / steps / lines | 335 / 1,674 / 26,687 (830 KB) |
| Distinct step verbs in use | **178**, against a closed set of 7 |
| Steps carrying ≥1 off-DSL verb | 1,458 / 1,674 = **87%** |
| Cases carrying ≥1 such step | 332 / 335 = **99%** |
| Verbs covering 90% of occurrences | 56 — with a tail of **96 verbs used ≤2×** |
| Distinct assertion predicate names | **168** across three `assert` dialects |

The 96-verb tail is not scriptable: each is a one-off needing a decision about whether it folds
into the closed predicate set or the assertion is dropped. And normalization is strictly
*downstream* of the schemas — deciding whether a fixture is wrong requires the schema it is wrong
against. So the authoring pass lands here and the corpus rewrite is **#213**.

## The 27 forks, each resolved once

- **`op_id` moves to the envelope.** It deduplicates a *request*, not an *operation*. This makes
  "no optional request fields" absolute with no exception, and settles the ~55 `stream.*` steps
  that send one — accepted and ignored. Here **the corpus was right and the draft was wrong**.
  `transfer.cancel`'s target becomes `transfer_op_id` so one wire name never means two things.
- **`role` closes on `{authority, member}`**; `agent` is derived (a member that has authored a
  `status.post`), `owner` is removed. **`standing` replaces `lifecycle`** — one value space under
  two names.
- **`last_event` and `author` become variants**, *forced* by already-settled rules: a flat
  `last_event_ts` cannot express a room with no events, and a flat `sender_role` cannot express an
  unresolvable author, without a null or an invention.
- **`reachability` and `link` are two types, not three** — one per room, one per device,
  collapsing four competing `reason` vocabularies into one.
- **Validation order is one normative pipeline**, with each stage naming the operations it runs
  for. That precision matters: applied to "every operation" it made `room.archive` unreachable and
  killed `subject.ensure` on a fresh daemon.

## The taxonomy is enumerated at 60

Every code with typed fields and trigger, in eleven groups whose subtotals sum to the total.

The earlier "55" was unverifiable in both directions — the same draft introduced its distinctive
codes under a sentence saying **"nine operations"** above a table of **fifteen** rows, while the
manifest recorded **eighteen** operations with no distinctive code and asserted
`satisfies_required_kinds: true` for every one.

`room.deactivate` is exempt **with a stated reason** rather than an unexplained null.

**Fourteen codes the corpus asserts are refused.** `room_unknown` is called out as a defect rather
than a synonym: a distinct code for "no such room" is precisely the membership oracle
`room_not_available` exists to prevent.

## The fixture DSL

7 step verbs, one `expect` matcher discriminated by `ok`, one `assert` form in two families
(19 value ops with `[*]` wildcards, 10 observation predicates), 12 domain-naming type tags, a
9-command `control` schema, and a `namespace:argument` `requires` vocabulary — replacing 178 verbs,
three `assert` dialects, 168 predicate names, and 133 flat `requires` tokens.

Two calls worth review: **`<hex64>` is retired** (it names an encoding shared by four domains, so
it would pass a subject id where a device id belongs), and **`{"state": "<variant>"}` asserts
nothing** — a discriminant exists but no arm is constrained.

## Manifest counts are computed, not asserted

`totals.cases` said 335 against a coverage table summing to **232**; `status.history` 7 vs **8**;
`status.post` 9 vs **11**; the README said **332**. All derived from the fixtures now, and
`satisfies_required_kinds` is honestly `false` everywhere until #213 makes it true per operation.

## Stays `status: draft`, deliberately

The contract is complete — an independent adapter can implement from it alone, which is #212's own
promotion bar. But 51 committed fixtures still contradict it, and a `canonical` record whose own
bundled corpus disagrees with it in fifty-one places overclaims. #213 flips it. #163/#164 are
unblocked by the content, not the status field.

## Review

Three passes ran against this branch, and all three found real defects in text I had just written:

- **A read-only corpus evidence pass** (7 per-file inventories + 8 cross-cutting) closed seven
  schema gaps — most seriously, `pipe_unknown`'s non-oracle guarantee was justified by reference
  to "the pipe's audience" while **no operation defined an audience**.
- **A six-lens adversarial pass** raised 79 findings; **65 were refuted**. Two refutations
  corrected *me*: the missing byte-transport for `file.share`/`file.read` is #164's job under a
  #161 carve-out this PR doesn't touch, and `pipe.release` needs no principal guard because
  `connection_id` is daemon-issued and unique by construction.
- **Codex** raised 16 threads; 7 were already closed by intervening commits and **8 were correct
  and are fixed** — including the validation-order scoping, four room-scoped replies not echoing
  `room_id`, and `control` left as an open object.

## Verification

- `node scripts/check-docs.mjs` clean; `node --test scripts/check-docs.test.mjs` 15/15.
- A scripted sweep checks every count the documents claim **about themselves**: all 11 taxonomy
  subtotals against their headings, 60 distinct codes with no cross-group duplicates, 33 schemas
  each with `in`/`out`/`Errors`, 4 push frames, 10 event kinds, 7 DSL verbs, 9 control commands,
  10 observations, 19 value ops, 9 requires namespaces, and manifest 232 + 103 = 335.
- Mechanically verified that no operation whose `in` carries `room_id` omits it from `out`, and
  that every code cited in an `Errors` row exists in the taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
