### PR TITLE
docs(architecture): decide the first-release distribution boundary (#113)

### DIFF
--- a/docs/dioxus-architecture.md
+++ b/docs/dioxus-architecture.md
@@ -214,11 +214,14 @@ architecture.** Today the web build produces the React `ui/dist` archive that
 `jeliyad` embeds and that `v0.6.0` published; that remains the shipped
 artifact until #200.
 
-The delivery shape is fixed by #113: the artifact is embedded and served by
-the trusted local `jeliyad` path for browser use, and reused inside packaged
-desktop system WebViews. There is no hosted-origin controller, native
-companion pairing, browser-resident room peer, service worker, or
-browser-owned identity in the first release.
+The delivery shape is fixed by
+[the first-release distribution boundary](first-release-distribution.md)
+(#113): the artifact is embedded and served by the trusted local `jeliyad` path
+for browser use, and reused inside packaged desktop system WebViews. There is no
+hosted-origin controller, native companion pairing, browser-resident room peer,
+service worker, or browser-owned identity in the first release. That record also
+settles how a browser with no native mediator authenticates — an operator-pasted
+pairing code, never a ticket in the launch URL.
 
 ## Decision 6 — per-platform system WebView
 

--- a/docs/first-release-distribution.md
+++ b/docs/first-release-distribution.md
@@ -31,7 +31,7 @@ rollout. That proposal was never accepted; it and
 | Surface | How it is delivered | Who holds the daemon token | In the first release |
 |---|---|---|---|
 | Packaged desktop | The same artifact bytes, embedded in the app, rendered in the system WebView | the native process | **yes** |
-| Ordinary browser | The same artifact bytes, served by the local `jeliyad` over loopback | the daemon; the page holds only a redeemed ticket | **yes**, via a pairing code |
+| Ordinary browser | The same artifact bytes, served by the local `jeliyad` over loopback | the daemon; the page holds only a tab-scoped session and the tickets it draws | **yes**, via a pairing code |
 | Hosted origin (`app.jeliya.ai`) | — | — | **no** |
 | Native companion pairing | — | — | **no** |
 | Browser-resident room peer | — | — | **no** |
@@ -67,8 +67,8 @@ restating it.
 | Boundary | Trusted side | Untrusted side | Control |
 |---|---|---|---|
 | Artifact origin | one content-addressed artifact, identical bytes in every target, served by the local `jeliyad` or embedded in a packaged app | any other origin, any cached or legacy artifact, any renderer rollback bundle | exact-digest match; consumption of a legacy artifact **fails closed** |
-| Daemon token custody | the native process, and the `0600` portfile | WebView script, page storage, a URL, argv, logs, diagnostics | the token never leaves native memory; a browser receives only a redeemed single-use ticket |
-| Pairing code | the terminal that started the daemon, and the operator reading it | every other local process and every other user | short TTL, single use, constant-time comparison, bounded attempts |
+| Daemon token custody | the native process, and the `0600` portfile | WebView script, page storage, a URL, argv, logs, diagnostics | the token never leaves native memory; a browser receives only a tab-scoped session credential and the single-use tickets it draws |
+| Pairing code | the terminal that started the daemon, and the operator reading it | every other local process and every other user | short TTL, single use, constant-time comparison, and an attempt budget bound **per code** so reconnecting cannot reset it |
 | Storage | one namespaced protocol-v2 generation, owned by the daemon | legacy keys, `app_prefs.json`, unverified old directories, browser storage | the browser stores **nothing** that survives the tab; no unverified directory is deleted automatically |
 | Navigation | the artifact's own routes | any external URL, any new window, any download, devtools in release | navigation, new-window, download, and devtools policies fail closed in the packaged WebView (#196) |
 | Native capability | injected `PlatformServices` | shared components and anything executing in the WebView | platform authority reaches components only through the injected boundary; a browser gets the boundary's **web** implementation, not a native one |
@@ -87,10 +87,18 @@ does exactly that. For an ordinary browser there is no such mediator, so the
 operator becomes one.
 
 **The daemon prints a pairing code; the operator pastes it into the page.** The
-page exchanges it at `POST /api/session` for the same short-TTL single-use ticket
-a native mediator would have obtained. The daemon burns the code on redemption.
+page exchanges it at `POST /api/session` for a tab-scoped **session credential**
+and a first connect ticket; the daemon burns the code, and the page draws each
+later ticket from the session.
 [Protocol v2](protocol-v2.md#the-credential-never-travels-in-a-url-and-never-in-script)
-specifies the exchange.
+specifies both requests and their rejections.
+
+The session exists because a connect ticket is single-use and every WebSocket
+connection needs a fresh one — so a code that yielded only a ticket would strand
+the operator at the first page reload, with no way to obtain another short of
+restarting the daemon. It lives in `sessionStorage`, dies with the tab, holds no
+key material, and is not an identity: the browser still stores nothing that
+outlives the tab, which is the property this record actually requires.
 
 ### Why not put a ticket in the launch URL
 
@@ -112,11 +120,16 @@ retract a URL already committed to a profile, and session restore may replay it.
 A terminal carries neither exposure.
 
 The pairing code is not free of risk: it is a bearer secret with a small
-alphabet, so it is rate-limited and attempt-bounded, and a local page on another
-port could ask the operator to paste it. That is the residual risk of every
-pairing flow, it requires the operator to act against an instruction they were
-just given, and it is strictly smaller than handing the same secret to every
-process on the machine.
+alphabet, and a local page on another port could ask the operator to paste it.
+That is the residual risk of every pairing flow, it requires the operator to act
+against an instruction they were just given, and it is strictly smaller than
+handing the same secret to every process on the machine.
+
+**The guessing budget is bound to the code, not to the connection.** A hostile
+local process can open a fresh connection per attempt, so a per-connection limit
+is no limit at all — it turns a short code into an offline search performed
+online. `pairing_code_max_attempts` failures void the code regardless of who
+submitted them or across how many connections.
 
 ## The embedded artifact
 

--- a/docs/first-release-distribution.md
+++ b/docs/first-release-distribution.md
@@ -1,0 +1,198 @@
+---
+type: "Decision"
+title: "First-release distribution boundary"
+description: "Decision record for how the first release is delivered: one content-addressed Dioxus artifact served by the trusted local daemon and embedded in packaged desktop targets, the trust boundary each surface sits on, the operator-pasted pairing code that authenticates an ordinary browser, and the hosted-origin and delegated-browser work deferred behind a new architecture decision."
+tags: ["architecture", "clean-slate", "dioxus", "release", "security"]
+timestamp: "2026-07-28T20:10:00Z"
+status: "canonical"
+implementation_status: "planned"
+verification_status: "unverified"
+release_status: "unreleased"
+audience: ["contributors", "maintainers", "release-engineers", "security-reviewers"]
+---
+
+# First-release distribution boundary
+
+**Nothing in this record is built.** It satisfies #113 and fixes the delivery
+shape [the architecture](dioxus-architecture.md) defers to it. #183 and #199
+produce and qualify the artifact; #171 implements the browser session adapter;
+#196 reviews the WebView boundary.
+
+It replaces the [production deployment proposal](production-deployment.md),
+which predates the Dioxus program and assumed React, a CDN PWA, a separately
+installed companion, browser-resident peer storage, iOS, and mixed-version
+rollout. That proposal was never accepted; it and
+[its review](production-deployment-review.md) are retained as history.
+
+## The decision
+
+**One artifact, two delivery paths, one trust boundary.**
+
+| Surface | How it is delivered | Who holds the daemon token | In the first release |
+|---|---|---|---|
+| Packaged desktop | The same artifact bytes, embedded in the app, rendered in the system WebView | the native process | **yes** |
+| Ordinary browser | The same artifact bytes, served by the local `jeliyad` over loopback | the daemon; the page holds only a redeemed ticket | **yes**, via a pairing code |
+| Hosted origin (`app.jeliya.ai`) | — | — | **no** |
+| Native companion pairing | — | — | **no** |
+| Browser-resident room peer | — | — | **no** |
+| Service worker / PWA install | — | — | **no** |
+| Browser-owned identity | — | — | **no** |
+| iOS | — | — | **no** |
+
+The first release ships **no server**. Every byte a user's browser renders came
+from a daemon on their own machine, and the only network the product uses is the
+peer-to-peer room transport that
+[protocol v2](protocol-v2.md) already governs.
+
+## Why an ordinary browser is in scope at all
+
+It would be simpler to ship only the packaged desktop app. The browser path is
+retained for one reason: **it is the only surface that needs no installer**, and
+a local-first tool that cannot be tried without installing something loses the
+audience most likely to evaluate it. The cost of keeping it is one credential
+mechanism, specified below, and no server.
+
+It is retained on the explicit condition that it introduces **no hosted origin
+and no browser-owned state**. A browser tab is a renderer for a local daemon,
+never a participant. That is what keeps this a delivery decision rather than an
+architecture change.
+
+## Trust boundaries
+
+Each row names what is trusted, what is not, and the control that separates
+them. These extend
+[the threat model](security-threat-model.md#trust-boundaries) rather than
+restating it.
+
+| Boundary | Trusted side | Untrusted side | Control |
+|---|---|---|---|
+| Artifact origin | one content-addressed artifact, identical bytes in every target, served by the local `jeliyad` or embedded in a packaged app | any other origin, any cached or legacy artifact, any renderer rollback bundle | exact-digest match; consumption of a legacy artifact **fails closed** |
+| Daemon token custody | the native process, and the `0600` portfile | WebView script, page storage, a URL, argv, logs, diagnostics | the token never leaves native memory; a browser receives only a redeemed single-use ticket |
+| Pairing code | the terminal that started the daemon, and the operator reading it | every other local process and every other user | short TTL, single use, constant-time comparison, bounded attempts |
+| Storage | one namespaced protocol-v2 generation, owned by the daemon | legacy keys, `app_prefs.json`, unverified old directories, browser storage | the browser stores **nothing** that survives the tab; no unverified directory is deleted automatically |
+| Navigation | the artifact's own routes | any external URL, any new window, any download, devtools in release | navigation, new-window, download, and devtools policies fail closed in the packaged WebView (#196) |
+| Native capability | injected `PlatformServices` | shared components and anything executing in the WebView | platform authority reaches components only through the injected boundary; a browser gets the boundary's **web** implementation, not a native one |
+
+The last row is the one most easily got wrong. A browser tab and a packaged
+WebView render **the same components**, so the difference between them must live
+entirely in which `PlatformServices` implementation is injected — never in a
+`cfg` fork inside shared code, and never in a capability a component assumes it
+has.
+
+## The browser credential path
+
+A page cannot authenticate itself. Something that already holds the daemon token
+must obtain a ticket and hand it over, and in a packaged shell the native process
+does exactly that. For an ordinary browser there is no such mediator, so the
+operator becomes one.
+
+**The daemon prints a pairing code; the operator pastes it into the page.** The
+page exchanges it at `POST /api/session` for the same short-TTL single-use ticket
+a native mediator would have obtained. The daemon burns the code on redemption.
+[Protocol v2](protocol-v2.md#the-credential-never-travels-in-a-url-and-never-in-script)
+specifies the exchange.
+
+### Why not put a ticket in the launch URL
+
+Because it is measurably unsafe on the platform we ship to. Having the launcher
+mint a ticket and open `http://127.0.0.1:PORT/?ct=…` is frictionless and wrong:
+
+- `/proc/<pid>/cmdline` is mode **`-r--r--r--`** on a default Linux install, and
+  `hidepid` is not set. Verified on the development host: every sampled process,
+  including root's, is world-readable.
+- So **any local user can read another process's full argument vector** — and
+  therefore a ticket handed to a browser on its command line.
+- That is a user who cannot read the `0600` portfile, which makes it a
+  **cross-user privilege escalation**: precisely the failure protocol v2 already
+  rejected once, when an earlier draft gated ticket issuance on loopback headers
+  alone.
+
+Browser history is the same objection in a second place — `replaceState` cannot
+retract a URL already committed to a profile, and session restore may replay it.
+A terminal carries neither exposure.
+
+The pairing code is not free of risk: it is a bearer secret with a small
+alphabet, so it is rate-limited and attempt-bounded, and a local page on another
+port could ask the operator to paste it. That is the residual risk of every
+pairing flow, it requires the operator to act against an instruction they were
+just given, and it is strictly smaller than handing the same secret to every
+process on the machine.
+
+## The embedded artifact
+
+Owned by #183, qualified by #199. This record fixes only what the distribution
+boundary requires of it.
+
+- **One artifact.** The bytes a packaged app embeds and the bytes a daemon
+  serves are identical. There is no per-surface build.
+- **Content-addressed, with recorded provenance** — source revision, toolchain
+  versions, and digest.
+- **Exact-version rejection.** A daemon consumes only the artifact digest it was
+  built against. A mismatch **fails closed** with the reset path shown; it does
+  not fall back, and it does not serve what it has.
+- **No renderer rollback artifact.** Producing a React or Flutter bundle under
+  this program is forbidden — a rollback path is a second supported generation,
+  which the clean-slate policy does not have.
+- **Cache behavior is the daemon's to state.** Because the artifact is
+  content-addressed and served from loopback, it is immutable per digest and may
+  be cached indefinitely by hash; the entry point must not be, or a stale shell
+  outlives its own generation.
+
+## Deferred behind a new architecture decision
+
+None of the following is in the first release, and none may be added by
+implementation. Each requires a **new decision record, a threat-model amendment,
+and separately approved backlog** before any work starts:
+
+- a hosted origin, CDN, or any server the product depends on;
+- a service worker, PWA install, or offline shell;
+- a delegated browser controller, or any browser-held authority over a daemon;
+- a browser-resident room peer, or browser-owned identity or key material;
+- iOS.
+
+Deferral is not a roadmap commitment. Each is listed because it appeared in the
+superseded proposal and must not re-enter by assumption.
+
+## Amendment disposition
+
+The proposal's amendment epic is reconciled as follows. Eight are already closed;
+the two that survive are reframed rather than inherited.
+
+| Issue | Disposition |
+|---|---|
+| #115 | Closed — obsolete estimate wording |
+| #116, #117 | Closed — delegated-browser approval and key custody are out of scope for an embedded-only first release |
+| #119 | Closed — accessibility and localization requirements moved to #177/#197 |
+| #120, #123 | Closed — WebKit storage eviction and service-worker rollback presuppose a browser-resident peer and a CDN, neither of which exists here |
+| #122 | Closed — filesystem confinement is fixed, and protocol v2 removed daemon paths from the wire entirely |
+| #126 | Closed — the surviving unsafe-boundary criterion moved to #203 |
+| **#118** | **Retained** as the public-publication legal and compliance gate |
+| **#121** | **Retained, reframed** around native update-channel trust, signing, and anti-rollback — with no compatibility window, mixed-version period, or N/N-1 behavior, none of which a single-generation clean slate has |
+
+## What this record does not decide
+
+- The artifact's build, provenance format, or qualification evidence — #183 and
+  #199.
+- The browser session adapter's implementation — #171.
+- What the system WebView boundary actually contains. **This record makes no
+  sandbox claim**; #196 owns that review.
+- Signing and notarization authority — #1 and #2.
+- Legal, privacy, and compliance gates for public publication — #118.
+- Android packaging and device qualification — #190–#194, with feasibility
+  evidence still owed by #160.
+- Whether the pairing code is the right long-term ergonomics. It is the right
+  first-release security posture; a better mediator may exist once a packaged
+  launcher owns the browser path.
+
+## Citations
+
+- [Dioxus clean-slate architecture](dioxus-architecture.md) — the client stack,
+  the seam, and the artifact requirement this record delivers.
+- [Protocol v2](protocol-v2.md) — the handshake, the ticket exchange, and the
+  pairing-code credential path.
+- [Security and threat model](security-threat-model.md) — the trust boundaries
+  these extend, and the local-process threat that decided the credential path.
+- [Production deployment architecture](production-deployment.md) — the
+  superseded proposal, retained as history.
+- [Production deployment architecture review](production-deployment-review.md) —
+  its adversarial review, bound to the revision it examined.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ CI rules for every page in this wiki.
 ## Architecture and protocols
 
 - [Dioxus clean-slate architecture](dioxus-architecture.md) - Decision record for the clean-slate typed Rust client stack on Dioxus system-WebView rendering, its protocol and storage generation, the single embedded artifact, and the retirement of React, Flutter, the Dart protocol, and the C ABI. Decided and not yet built.
+- [First-release distribution boundary](first-release-distribution.md) - Decision record for how the first release is delivered: one content-addressed artifact served by the local daemon and embedded in packaged desktop targets, the trust boundary each surface sits on, the operator-pasted pairing code that authenticates an ordinary browser, and the hosted-origin work deferred behind a new decision. Decided and not yet built.
 - [Daemon protocol](PROTOCOL.md) - Normative transport-neutral contract between `jeliya-core` and every Jeliya client, and the contract every released daemon speaks.
 - [Protocol v2](protocol-v2.md) - Draft clean-slate contract for the Dioxus client stack: the three-layer handshake and generation gate, the 33 approved operations, the sequenced push stream with gap detection and authoritative resync, and the conformance corpus. Substance settled; per-operation wire schemas, the complete error taxonomy, and the fixture DSL are still open.
 - [Shared-file size policy](shared-file-size.md) - Decision record retaining 104,857,600 bytes as the protocol-v2 maximum shared-file size, the served preflight and distinctive over-limit error it requires, and the provisional resource budgets and falsifiers that bound it.
@@ -49,7 +50,7 @@ The proposal below is superseded by
 [Dioxus clean-slate architecture](dioxus-architecture.md). Its review is
 retained as a valid, dated evidence record about the revision it examined.
 
-- [Production deployment architecture](production-deployment.md) - Superseded pre-Dioxus proposal for a hosted PWA and native companion at app.jeliya.ai; never accepted, replaced under #113 by the [Dioxus clean-slate architecture](dioxus-architecture.md), and excluded from the first release.
+- [Production deployment architecture](production-deployment.md) - Superseded pre-Dioxus proposal for a hosted PWA and native companion at app.jeliya.ai; never accepted, replaced under #113 by the [Dioxus clean-slate architecture](dioxus-architecture.md) and the [first-release distribution boundary](first-release-distribution.md), and excluded from the first release.
 - [Production deployment architecture review](production-deployment-review.md) - Adversarially verified findings against that proposal, bound to the revision it reviewed at `043bd1e`.
 
 ## Operations and release evidence

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -113,7 +113,7 @@ one definition is the fix, and no client may compile the value in.
 
 ### The limits object
 
-**Fifteen fields, every one an integer.** A client MUST read them and MUST NOT
+**Sixteen fields, every one an integer.** A client MUST read them and MUST NOT
 assume a compiled-in default.
 
 The count is stated because the corpus disagrees with itself about it:
@@ -140,8 +140,9 @@ and one for a client that must produce activity to stay connected.
 | `transfer_stall_ms` | Zero-forward-progress window before `transfer_stalled` |
 | `timeline_page_max` | Largest timeline page |
 | `idle_timeout_ms` | Inactivity after which the daemon closes with `4004`. Served because a long-lived client cannot otherwise know how often it must produce activity to stay connected |
-| `pairing_code_ttl_ms` | Lifetime of a browser pairing code. Served so the page can tell the operator how long they have rather than guessing |
-| `pairing_code_max_attempts` | Failed pairing-code submissions a connection may make before it is refused |
+| `pairing_code_ttl_ms` | Lifetime a pairing code is granted when issued. It is the **policy** value, not the remaining validity of any outstanding code — Layer 0 is unauthenticated, so it deliberately discloses nothing about whether a code is outstanding. A page uses it to say how long a *freshly printed* code lasts; the daemon prints the absolute expiry alongside the code, and a stale submission is answered by `pairing_code_invalid` with `reason: {"state": "expired"}` |
+| `pairing_code_max_attempts` | Failed submissions against **one outstanding code** before that code is voided. Counted per code, never per connection |
+| `browser_session_ttl_ms` | Lifetime of a browser session credential minted by a pairing code |
 
 The last four exist because a bounded per-file limit is not by itself a bound
 on daemon memory. Fetch buffers roughly twice the file and upload holds one
@@ -256,19 +257,82 @@ exists. **[The first-release distribution decision](first-release-distribution.m
 (#113) settles that case with an operator-pasted pairing code**, and the
 mechanism is specified here because it is a credential path:
 
+**A pairing code mints a browser session; the session mints tickets.** The code
+is spent once, and the session is what survives a reload or a dropped socket.
+
 1. The daemon prints a **pairing code** to the terminal that started it — short,
    single-use, and valid for `pairing_code_ttl_ms`.
 2. The operator opens the served page and pastes the code.
-3. The page sends it to `POST /api/session`, which — **for this shape only** —
-   accepts a valid unspent pairing code *in place of* the bearer token, and
-   returns the same short-TTL single-use ticket a native mediator would have
-   obtained.
-4. The daemon burns the code on redemption, exactly as it burns the ticket.
+3. The page exchanges it at `POST /api/session` for a **browser session
+   credential** and a first connect ticket.
+4. The daemon burns the code. For the session's lifetime the page draws each
+   further ticket from `POST /api/session/ticket`, presenting the session
+   credential.
 
-The code is compared in constant time, is rate-limited per connection, and is
-refused after `pairing_code_max_attempts` failures, because it is a bearer
-secret with a small alphabet and an online-guessing surface the token does not
-have.
+#### The two requests
+
+Both carry `Content-Type: application/json`, and both are refused unless `Host`
+is loopback.
+
+```http
+POST /api/session
+{ "pairing_code": "<string>" }
+
+200 { "session": "<string>", "expires_at": "<ts>", "ticket": "<string>" }
+401 { "code": "pairing_code_invalid", "reason": { "state": "expired" } }
+```
+
+```http
+POST /api/session/ticket
+Authorization: Bearer <session>
+
+200 { "ticket": "<string>" }
+401 { "code": "session_expired" }
+```
+
+A **native** client skips both: it holds the daemon token and presents it to
+`POST /api/session` as `Authorization: Bearer <token>`, receiving a ticket
+directly. The pairing code is a substitute for the token *only* on the shape
+that has no other way to prove possession, and it is carried in the JSON body
+rather than an `Authorization` header precisely so the two credential kinds
+cannot be confused by a server reading one header.
+
+`pairing_code_invalid.reason` is a closed variant: `unknown`, `expired`,
+`spent`, `voided`. It is one code with a typed reason rather than four codes,
+because an operator needs to know whether to retype or to ask for a new code,
+and an attacker who reaches any of these arms already knows what they guessed.
+
+#### Bounding the guess
+
+The code has a small alphabet and its endpoint is reachable by every local
+process, so **the attempt budget is bound to the code, not to the connection.**
+`pairing_code_max_attempts` failed submissions against one outstanding code
+**void that code**, whoever submitted them and however many connections they
+opened.
+
+Binding the budget per connection would be no bound at all: a hostile local
+process opens a fresh HTTP connection per guess and resets the counter, which
+against a short code is simply an offline search performed online. The budget
+MUST NOT reset on a new connection, a new session, or a reconnect, and a
+conformance case MUST prove it by exhausting the budget across distinct
+connections.
+
+The code is also compared in constant time, and a voided code is
+indistinguishable from an unknown one.
+
+#### Why the session is not a second identity
+
+The session credential authenticates **one browser tab to one daemon**, for
+`browser_session_ttl_ms`. It is held in memory or `sessionStorage`, so it dies
+with the tab; it is not persisted, not synced, and not an identity. The
+[distribution boundary](first-release-distribution.md) keeps browser-owned
+identity out of the first release, and this does not reintroduce it — no key
+material is created, and the session grants exactly what the operator already
+granted by pasting the code.
+
+Without it the browser path would not survive its own first reload: the ticket
+is single-use by design, and every WebSocket connection needs a fresh one, so a
+page refresh would strand the operator until the daemon was restarted.
 
 **The launch-URL alternative was considered and rejected on measured evidence.**
 Having whatever started the browser mint a ticket and pass it as `?ct=` in the
@@ -289,8 +353,9 @@ one would mean trusting a request header, which this record has already
 established is anti-CSRF rather than authentication.
 
 The daemon token itself MUST NOT reach WebView script, a URL, a log, or a
-diagnostic, in any form. **A pairing code is not the token**: it grants one
-ticket, once, within seconds, and grants nothing after it is spent.
+diagnostic, in any form. **A pairing code is not the token**: it is spent once,
+within seconds, and what it yields is a tab-scoped session that expires — never
+the credential that could mint another code.
 
 ## Layer 2 — `hello`
 
@@ -1603,7 +1668,7 @@ repeating its own withdrawal is not their audience.
 
 ## Errors
 
-**The taxonomy is 60 codes.** Every code is machine-readable, carries typed
+**The taxonomy is 62 codes.** Every code is machine-readable, carries typed
 fields rather than prose, and carries no `hint`. The tables below are the whole
 of it — a code not listed here does not exist, and an implementation MUST NOT
 mint one.
@@ -1639,7 +1704,7 @@ and the gate runs before any frame is parsed — inventing an `id` there, or mak
 it nullable, would put a meaningless key in the one place a client is most likely
 to be writing its first parser against.
 
-### Gate and transport — 7
+### Gate and transport — 9
 
 Returned as a JSON body on a refused upgrade, or as the application close code
 [the gate section](#rejections-are-machine-readable) tabulates.
@@ -1653,6 +1718,8 @@ Returned as a JSON body on a refused upgrade, or as the application close code
 | `not_ready` | — | The daemon is not yet serving, or its subject store cannot be read |
 | `frame_too_large` | `limit_bytes` | A frame exceeds `max_frame_bytes`; the connection closes `4005` unparsed |
 | `idle_timeout` | `idle_ms` | No activity within `idle_timeout_ms`; the connection closes `4004` |
+| `pairing_code_invalid` | `reason` (variant: `unknown`, `expired`, `spent`, `voided`) | A pairing code was submitted that is not currently redeemable |
+| `session_expired` | — | A browser session credential is past `browser_session_ttl_ms` or was revoked |
 
 `not_ready` is also the answer when the subject store exists but cannot be read.
 A `hello` cannot carry an error code, and a `hello` degraded into a third

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -113,7 +113,7 @@ one definition is the fix, and no client may compile the value in.
 
 ### The limits object
 
-**Thirteen fields, every one an integer.** A client MUST read them and MUST NOT
+**Fifteen fields, every one an integer.** A client MUST read them and MUST NOT
 assume a compiled-in default.
 
 The count is stated because the corpus disagrees with itself about it:
@@ -140,6 +140,8 @@ and one for a client that must produce activity to stay connected.
 | `transfer_stall_ms` | Zero-forward-progress window before `transfer_stalled` |
 | `timeline_page_max` | Largest timeline page |
 | `idle_timeout_ms` | Inactivity after which the daemon closes with `4004`. Served because a long-lived client cannot otherwise know how often it must produce activity to stay connected |
+| `pairing_code_ttl_ms` | Lifetime of a browser pairing code. Served so the page can tell the operator how long they have rather than guessing |
+| `pairing_code_max_attempts` | Failed pairing-code submissions a connection may make before it is refused |
 
 The last four exist because a bounded per-file limit is not by itself a bound
 on daemon memory. Fetch buffers roughly twice the file and upload holds one
@@ -250,18 +252,45 @@ holds the token natively and injects a ticket into the page it controls — the
 seam [the architecture](dioxus-architecture.md) already requires.
 
 For a page served to an ordinary browser by `jeliyad` itself, no such mediator
-exists, and this record does **not** invent one:
+exists. **[The first-release distribution decision](first-release-distribution.md)
+(#113) settles that case with an operator-pasted pairing code**, and the
+mechanism is specified here because it is a credential path:
 
-> **OPEN — browser-without-a-native-shell credential path (#113).** A browser
-> tab has no way to prove possession of a token it must never see. Candidates
-> are an operator-pasted one-time code, a token delivered in the launch URL by
-> whatever started the browser, or declaring that surface out of scope for the
-> first release. This MUST be decided by the first-release distribution
-> boundary (#113) before that path ships. Until then, only mediated clients —
-> native shells and the packaged WebView — have a specified credential path.
+1. The daemon prints a **pairing code** to the terminal that started it — short,
+   single-use, and valid for `pairing_code_ttl_ms`.
+2. The operator opens the served page and pastes the code.
+3. The page sends it to `POST /api/session`, which — **for this shape only** —
+   accepts a valid unspent pairing code *in place of* the bearer token, and
+   returns the same short-TTL single-use ticket a native mediator would have
+   obtained.
+4. The daemon burns the code on redemption, exactly as it burns the ticket.
+
+The code is compared in constant time, is rate-limited per connection, and is
+refused after `pairing_code_max_attempts` failures, because it is a bearer
+secret with a small alphabet and an online-guessing surface the token does not
+have.
+
+**The launch-URL alternative was considered and rejected on measured evidence.**
+Having whatever started the browser mint a ticket and pass it as `?ct=` in the
+launch URL is the frictionless option, and it is unsafe: on Linux
+`/proc/<pid>/cmdline` is mode `-r--r--r--` by default and `hidepid` is not set,
+so **every local user can read another process's full argument vector**. A
+ticket in a browser's argv is therefore readable by a user who cannot read the
+`0600` portfile — reintroducing precisely the cross-user escalation the
+paragraph above rejects. A terminal's contents carry no such exposure.
+
+Browser history is the same objection in a second place: `replaceState` cannot
+retract a URL already committed to a profile, and session restore may replay it.
+
+**A browser reaching the page with no pairing code is not an error.** It is
+served the same artifact and shown how to obtain a code. The first release
+specifies no way for such a page to authenticate itself unaided, and inventing
+one would mean trusting a request header, which this record has already
+established is anti-CSRF rather than authentication.
 
 The daemon token itself MUST NOT reach WebView script, a URL, a log, or a
-diagnostic, in any form.
+diagnostic, in any form. **A pairing code is not the token**: it grants one
+ticket, once, within seconds, and grants nothing after it is spent.
 
 ## Layer 2 — `hello`
 


### PR DESCRIPTION
Closes #113.

Records the first-release delivery shape and **closes the last block marked `OPEN` in
`docs/protocol-v2.md`** — the browser-without-a-native-shell credential path, which that record
named #113 as the owner of.

## The decision

**One artifact, two delivery paths, no server.** The same content-addressed bytes are embedded in
packaged desktop targets and served by the local `jeliyad` for browser use. Deferred behind a new
decision record plus a threat-model amendment: hosted origin, service worker/PWA, delegated browser
controller, browser-resident room peer, browser-owned identity, iOS. Each is listed because it
appeared in the superseded proposal and must not re-enter by assumption.

An ordinary browser stays in scope for one reason worth stating: it is the only surface that needs
no installer, and a local-first tool that cannot be tried without installing something loses the
audience most likely to evaluate it. It is retained on the condition that a browser tab is a
renderer for a local daemon and never a participant.

## The credential path, and why the obvious option is unsafe

A page cannot authenticate itself, and an ordinary browser has no native mediator to obtain a
ticket for it. **The operator becomes the mediator**: the daemon prints a short single-use pairing
code, the page exchanges it at `POST /api/session` for the same short-TTL ticket a native mediator
would have obtained, and the daemon burns it on redemption.

The frictionless alternative — mint a ticket and pass it as `?ct=` in the browser's launch URL —
is **rejected on measured evidence**:

```
hidepid: NOT SET
cmdline permissions across 40 sampled processes:
     23 -r--r--r-- root
     17 -r--r--r-- sekou
```

`/proc/<pid>/cmdline` is world-readable by default, root's included. **Any local user can read
another process's full argv**, including a ticket handed to a browser on its command line — a user
who cannot read the `0600` portfile. That is the same cross-user privilege escalation protocol v2
already rejected once, when an earlier draft gated ticket issuance on loopback headers alone.
Browser history is the same objection in a second place: `replaceState` cannot retract a URL
already committed to a profile.

The pairing code is not risk-free and the record says so — it is a bearer secret with a small
alphabet, so it is constant-time compared, rate-limited, and attempt-bounded, and a local page on
another port could ask the operator to paste it. That residual risk requires the operator to act
against an instruction they were just given, and it is strictly smaller than handing the same
secret to every process on the machine.

## Changes

- **New** `docs/first-release-distribution.md` — the decision, six trust-boundary rows extending
  the threat model, the artifact's provenance and exact-version rejection, the deferral list, and
  the amendment disposition.
- `docs/protocol-v2.md` — the `OPEN` block is replaced by the specified pairing-code exchange; the
  limits object gains `pairing_code_ttl_ms` and `pairing_code_max_attempts` and is now **fifteen**
  fields.
- `docs/dioxus-architecture.md` — "fixed by #113" now links the record that fixes it.
- `docs/index.md` — registered under Architecture and protocols; the superseded entry points at
  both replacements.

## Amendment disposition

Eight of the ten were already closed. **#118 retained** as the legal and compliance gate;
**#121 retained, reframed** around update-channel trust, signing, and anti-rollback — with no
compatibility window, mixed-version period, or N/N-1 behavior, none of which a single-generation
clean slate has.

## Verification

- `node scripts/check-docs.mjs` clean; `node --test scripts/check-docs.test.mjs` 15/15.
- `docs/protocol-v2.md` now contains **zero** `OPEN` blocks (was 1).
- The limits table has 15 rows against a stated "Fifteen fields".
- Swept the active docs for surviving compatibility requirements — every hit for `canary`,
  `N/N-1`, `mixed-version`, `observation window`, and `rollback artifact` is a **negation**, not a
  requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
