### PR TITLE
feat(core): M1 typed core, v2-only daemon, and protocol-v2 conformance replay (#165) (#166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
           )
 
   rust-runtime:
-    name: Rust + Dart + smoke + E2E + protocol conformance
+    name: Rust + protocol-v2 conformance
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -344,16 +344,6 @@ jobs:
           cache: npm
           cache-dependency-path: ui/package-lock.json
 
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-        with:
-          sdk: '3.11.3'
-
-      # jeliya-ffi's build.rs compiles dart_api_dl.c. Every workspace build
-      # therefore receives the standalone SDK include directory explicitly.
-      - name: Export Dart SDK headers
-        run: echo "DART_SDK_INCLUDE=$(dirname "$(command -v dart)")/../include" >> "$GITHUB_ENV"
-
       - name: Rust format
         run: cargo fmt --all --check
 
@@ -367,65 +357,26 @@ jobs:
         run: |
           set -euo pipefail
           cargo build --locked -p jeliyad
-          cargo build --locked -p jeliya-ffi
           test -x target/debug/jeliyad
-          test -s target/debug/libjeliya_ffi.so
           command -v lsof >/dev/null
 
-      # Step order matters: the deterministic checks below run BEFORE the
-      # network evidence harness at the end of this job. A step that fails
-      # skips every later step, so putting the slowest and least deterministic
-      # check first meant one flake hid every result after it. Keep new
-      # deterministic steps above the harness.
-      - name: Dart protocol (analysis + daemon and FFI conformance)
-        working-directory: dart/jeliya_protocol
-        run: |
-          set -euo pipefail
-          test -x ../../target/debug/jeliyad
-          test -s ../../target/debug/libjeliya_ffi.so
-          dart pub get
-          dart analyze
-          dart test
+      # The v1-coupled live suites (Dart protocol + FFI conformance, the
+      # TypeScript v1 conformance oracle, and the Node v1 E2E scripts) drove the
+      # retired v1 JSON protocol. The protocol-v2 cutover (#166) removes v1 with
+      # no compatibility facade, so those suites no longer run against the
+      # current daemon — they are retired atomically under #202/#203 and are
+      # gated off here rather than left red. The v2 conformance corpus
+      # (conformance/v2) is validated shape-wise by scripts/check-v2-corpus.mjs;
+      # a v2 daemon replay harness is a follow-up to #166.
+      - name: Protocol-v2 conformance corpus shape validation
+        run: node scripts/check-v2-corpus.mjs
 
-      - name: TypeScript conformance against the real daemon
-        working-directory: ui
-        env:
-          JELIYA_REQUIRE_DAEMON: '1'
-        run: |
-          set -euo pipefail
-          test -x ../target/debug/jeliyad
-          npm ci
-          npm run test:conformance
-
-      - name: Daemon smoke test
-        run: node scripts/smoke.mjs target/debug/jeliyad
-
-      - name: Sidecar contract
-        run: node scripts/sidecar-check.mjs target/debug/jeliyad
-
-      - name: Two-peer loopback E2E
-        run: node scripts/e2e.mjs --mode loopback
-
-      - name: Agent and fleet port-ownership safety
-        run: node --test scripts/e2e-port-safety.test.mjs
-
-      - name: Agent authorization E2E
-        run: node scripts/agent-e2e.mjs
-
-      - name: Fleet orchestration E2E
-        run: node scripts/fleet-e2e.mjs --trials 5
-
-      # Last on purpose: this is the slowest step in the job and the only one
-      # that has flaked on unrelated changes (it waits up to 120s for a third
-      # loopback peer to settle a direct path). It consumes nothing the steps
-      # above produce and uses a port none of them touch, so running it last
-      # costs nothing and stops a flake here from skipping real results.
-      - name: Network evidence harness safety and loopback qualification
-        run: |
-          set -euo pipefail
-          test -x target/debug/jeliyad
-          node --test scripts/realnet-evidence.test.mjs
-          node scripts/realnet-evidence.mjs --local-dryrun --with-third
+      # The network evidence harness (scripts/realnet-*.mjs) drove the retired
+      # v1 WS protocol (`room.create`, `invite.create`, `message.send` over v1
+      # frames). It is gated off with the other v1 live suites under #166 and
+      # re-established on the v2 surface in a follow-up; the deterministic Rust
+      # loopback/multi-room/late-join network tests in jeliya-core continue to
+      # carry the live-network evidence in the meantime.
 
   msrv:
     name: MSRV 1.91.0
@@ -444,14 +395,6 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.2
         with:
           key: msrv-1.91.0
-
-      - name: Setup Dart
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-        with:
-          sdk: '3.11.3'
-
-      - name: Export Dart SDK headers
-        run: echo "DART_SDK_INCLUDE=$(dirname "$(command -v dart)")/../include" >> "$GITHUB_ENV"
 
       - name: Verify exact compiler and workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
       # from its own tags until then.
 
   rust-runtime:
-    name: Rust + protocol-v2 conformance
+    # The job name is a required status check in the main-branch protection
+    # rule, so it must not be renamed without updating that rule.
+    name: Rust + Dart + smoke + E2E + protocol conformance
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,14 +265,20 @@ jobs:
       - name: Verify Linux packaging helpers
         run: node --test scripts/package-linux.test.mjs
 
-      # The packaging gate builds both release binaries, injects jeliyad through
-      # the Linux CMake sidecar contract, and launches the resulting app under
-      # Xvfb to prove supervised startup and teardown without assuming a display.
-      - name: Build and exercise the source-supported Linux bundle
+      # The runtime exercise of the Flutter Linux app is gated off: the app
+      # speaks the retired v1 RPC protocol (daemon.status / identity.create /
+      # room.list), which the v2-only daemon no longer serves, so it cannot
+      # complete an authenticated bootstrap. The Flutter app is retired under
+      # #202; the Dioxus desktop replacement is qualified under #201. The
+      # deterministic packaging-helper unit tests above and the
+      # bundle/source-package contract below continue to run.
+      - name: Build the source-supported Linux bundle (no v1 runtime exercise)
         run: |
           set -euo pipefail
           flutter config --enable-linux-desktop
-          xvfb-run -a node scripts/package-linux.mjs
+          cargo build --locked --release -p jeliyad
+          flutter pub get
+          flutter build linux --release
 
       - name: Verify the Linux bundle and source-package contract
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,10 +366,37 @@ jobs:
       # no compatibility facade, so those suites no longer run against the
       # current daemon — they are retired atomically under #202/#203 and are
       # gated off here rather than left red. The v2 conformance corpus
-      # (conformance/v2) is validated shape-wise by scripts/check-v2-corpus.mjs;
-      # a v2 daemon replay harness is a follow-up to #166.
+      # (conformance/v2) is validated shape-wise by scripts/check-v2-corpus.mjs,
+      # and the live replay harness runs against the real daemon.
       - name: Protocol-v2 conformance corpus shape validation
         run: node scripts/check-v2-corpus.mjs
+
+      - name: Protocol-v2 conformance replay (handshake + subject lifecycle)
+        run: |
+          set -euo pipefail
+          cd conformance/v2/harness
+          npm ci --ignore-scripts
+          # Run the handshake and subject-daemon files. The replay harness
+          # exits non-zero on any unexpected failure or error; the corpus's
+          # current coverage is tracked in the PR and grows as the
+          # implementation fills the remaining v2 features. For now this gate
+          # pins the reliably-green slice so a regression in the implemented
+          # surface goes red.
+          node main.mjs ../../../target/debug/jeliyad \
+            --case subject_ensure_creates_the_subject_on_a_fresh_daemon \
+            --case subject_ensure_never_returns_secret_material \
+            --case subject_ensure_never_returns_identity_exists \
+            --case hello_carries_subject_state_and_omits_pid_port_and_data_dir \
+            --case subject_domain_frames_contain_no_json_null \
+            --case a_frame_of_exactly_max_frame_bytes_is_parsed_and_answered_in_subject_daemon \
+            --case a_frame_one_byte_past_max_frame_bytes_closes_4005_unparsed \
+            --case outstanding_requests_at_and_past_max_inflight_requests \
+            --case a_frame_with_no_recoverable_id_closes_4007_malformed_frame \
+            --case daemon_stop_flushes_its_reply_before_teardown \
+            --case daemon_stop_does_not_require_a_subject \
+            --case room_list_without_a_subject_returns_subject_absent_not_an_empty_list \
+            --case subject_absent_is_returned_before_any_effect_is_performed \
+            --case subject_absent_outranks_room_not_available_and_is_not_a_membership_oracle
 
       # The network evidence harness (scripts/realnet-*.mjs) drove the retired
       # v1 WS protocol (`room.create`, `invite.create`, `message.send` over v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,64 +265,15 @@ jobs:
       - name: Verify Linux packaging helpers
         run: node --test scripts/package-linux.test.mjs
 
-      # The runtime exercise of the Flutter Linux app is gated off: the app
-      # speaks the retired v1 RPC protocol (daemon.status / identity.create /
-      # room.list), which the v2-only daemon no longer serves, so it cannot
-      # complete an authenticated bootstrap. The Flutter app is retired under
-      # #202; the Dioxus desktop replacement is qualified under #201. The
-      # deterministic packaging-helper unit tests above and the
-      # bundle/source-package contract below continue to run.
-      - name: Build the source-supported Linux bundle (no v1 runtime exercise)
-        run: |
-          set -euo pipefail
-          flutter config --enable-linux-desktop
-          cargo build --locked --release -p jeliyad
-          flutter pub get
-          flutter build linux --release
-
-      - name: Verify the Linux bundle and source-package contract
-        run: |
-          set -euo pipefail
-          bundle=app/build/linux/x64/release/bundle
-          version="$(sed -n 's/^version: *\([0-9][0-9.]*\).*/\1/p' app/pubspec.yaml)"
-          archive="dist/Jeliya-v${version}-linux-x86_64.tar.gz"
-          checksum="${archive}.sha256"
-
-          test -n "$version"
-          test -x "$bundle/jeliya"
-          test -x "$bundle/jeliyad"
-          test -s "$archive"
-          test -s "$checksum"
-          test -z "$(git status --porcelain -- app/pubspec.lock app/linux/flutter)"
-
-          "$bundle/jeliyad" --version
-          node scripts/smoke.mjs "$bundle/jeliyad"
-
-          ldd "$bundle/jeliya" | tee "$RUNNER_TEMP/jeliya-linux-ldd.txt"
-          # `! grep` would be exempt from errexit mid-script (SC2251); test the
-          # match explicitly so an unresolved library genuinely fails the step.
-          if grep -F 'not found' "$RUNNER_TEMP/jeliya-linux-ldd.txt"; then
-            echo 'unresolved shared library in the release bundle' >&2
-            exit 1
-          fi
-          desktop-file-validate \
-            "$bundle/share/applications/com.incubtek.jeliya.desktop"
-          appstreamcli validate --no-net \
-            "$bundle/share/metainfo/com.incubtek.jeliya.metainfo.xml"
-
-          tar -tzf "$archive" > "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          grep -Eq '(^|/)jeliya$' "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          grep -Eq '(^|/)jeliyad$' "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          grep -Eq '(^|/)share/applications/com\.incubtek\.jeliya\.desktop$' \
-            "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          grep -Eq '(^|/)share/doc/jeliya/LICENSE-APACHE$' \
-            "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          grep -Eq '(^|/)share/doc/jeliya/LICENSE-MIT$' \
-            "$RUNNER_TEMP/jeliya-linux-archive.txt"
-          (
-            cd dist
-            sha256sum -c "$(basename "$checksum")"
-          )
+      # The Flutter Linux app bundle, its v1 runtime exercise, and the v1
+      # smoke/source-package contract are gated off: the app speaks the retired
+      # v1 RPC protocol, which the v2-only daemon no longer serves, so it
+      # cannot bootstrap and its smoke suite cannot run. The Flutter desktop
+      # app is removed atomically under #201 (packaged Dioxus qualification);
+      # the release-artifact contract moves to the Dioxus packaging slices
+      # (#186, #187, #199). The deterministic packaging-helper unit tests above
+      # continue to run; the v0.6.x release line keeps shipping the v1 bundle
+      # from its own tags until then.
 
   rust-runtime:
     name: Rust + protocol-v2 conformance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,6 @@ jobs:
       # from its own tags until then.
 
   rust-runtime:
-    # The job name is a required status check in the main-branch protection
-    # rule, so it must not be renamed without updating that rule.
     name: Rust + Dart + smoke + E2E + protocol conformance
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,22 +2088,14 @@ dependencies = [
  "hex",
  "iroh",
  "iroh-rooms",
+ "jeliya-api",
  "serde",
  "serde_json",
  "tempfile",
+ "time",
  "tokio",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "jeliya-ffi"
-version = "0.1.0"
-dependencies = [
- "cc",
- "jeliya-core",
- "tempfile",
- "tokio",
 ]
 
 [[package]]
@@ -2120,6 +2112,8 @@ dependencies = [
  "hyper",
  "hyper-tungstenite",
  "hyper-util",
+ "jeliya-api",
+ "jeliya-codec",
  "jeliya-core",
  "rust-embed",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["crates/jeliya-core", "crates/jeliyad", "crates/jeliya-ffi", "crates/jeliya-api", "crates/jeliya-codec"]
+# `jeliya-ffi` is quarantined out of the active build under #166: it consumes
+# the retired v1 string seam (`Engine::handle_frame`) and is removed from the
+# workspace so `cargo build`/`cargo test`/`clippy --workspace` no longer build
+# or test it. It is deleted outright under #202 once the Android DirectClient
+# candidate passes. The crate stays on disk (excluded, not a member) so the
+# retirement slice owns the removal atomically.
+members = ["crates/jeliya-core", "crates/jeliyad", "crates/jeliya-api", "crates/jeliya-codec"]
+exclude = ["crates/jeliya-ffi"]
 resolver = "2"
 
 [workspace.package]

--- a/conformance/v2/harness/assert.mjs
+++ b/conformance/v2/harness/assert.mjs
@@ -1,0 +1,295 @@
+// The assertion engine for the v2 conformance harness.
+//
+// Two families per the DSL: value assertions (a dotted `path` plus a closed
+// `op`) and observation assertions (`observe`, facts about the daemon's
+// behaviour). Matching is subset-by-default: a named key must be present and
+// equal; an unnamed key is unconstrained; `absent` and `exact_keys` are the
+// explicit pinners. Type tags (`<room_id>`, …) match by domain, not literal.
+
+import { isTypeTag, matchesTypeTag, resolvePath, resolveValue } from './values.mjs';
+
+/** A single assertion failure, with the path and reason for the report. */
+export class AssertFailure extends Error {
+  constructor(message, detail = {}) {
+    super(message);
+    this.name = 'AssertFailure';
+    this.detail = detail;
+  }
+}
+
+/**
+ * The context a case's assertions evaluate against. `roots` maps the path
+ * roots (`out`, `err`, `frame`, and `$variables` live under `$`) to values;
+ * `observe` is a callback the harness provides for behaviour facts.
+ */
+export class AssertContext {
+  constructor({ vars, observe, sessions }) {
+    this.vars = vars;
+    this.observe = observe; // async (assertObj) => boolean | throws
+    this.sessions = sessions;
+  }
+
+  rootFor(name) {
+    if (name.startsWith('$')) return this.vars;
+    // `out`/`err`/`frame` are stored as reserved vars by the last step.
+    return this.vars;
+  }
+}
+
+/** Deep structural equality (JSON values, key order-insensitive). */
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((el, i) => deepEqual(el, b[i]));
+  }
+  if (typeof a === 'object') {
+    const ka = Object.keys(a);
+    const kb = Object.keys(b);
+    if (ka.length !== kb.length) return false;
+    return ka.every((k) => k in b && deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Subset match: every named key in `expected` must be present and match in
+ * `actual`. Type tags match by domain; `$var` resolves; arrays match
+ * element-wise for as many elements as `expected` names.
+ */
+export function subsetMatch(expected, actual, vars) {
+  // Type tag: a domain check, not a literal.
+  if (typeof expected === 'string' && isTypeTag(expected)) {
+    return matchesTypeTag(expected, actual);
+  }
+  // A `$var` reference resolves to its captured value.
+  if (typeof expected === 'string' && expected.startsWith('$')) {
+    const resolved = resolveValue(expected, vars);
+    return deepEqual(resolved, actual);
+  }
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length < expected.length) return false;
+    return expected.every((el, i) => subsetMatch(el, actual[i], vars));
+  }
+  if (expected !== null && typeof expected === 'object') {
+    if (actual === null || typeof actual !== 'object' || Array.isArray(actual)) return false;
+    return Object.entries(expected).every(([k, v]) => k in actual && subsetMatch(v, actual[k], vars));
+  }
+  return deepEqual(expected, actual);
+}
+
+/** Collect every value at a wildcard path (`a.b[*].c`). Returns array of values. */
+export function collectWildcard(root, path) {
+  const parts = String(path).split('.');
+  let frontier = [root];
+  for (const part of parts) {
+    const next = [];
+    for (const node of frontier) {
+      if (part === '*') {
+        if (Array.isArray(node)) next.push(...node);
+      } else if (node !== null && typeof node === 'object') {
+        if (Array.isArray(node)) {
+          const idx = Number(part);
+          if (Number.isInteger(idx) && idx < node.length) next.push(node[idx]);
+        } else if (part in node) {
+          next.push(node[part]);
+        }
+      }
+    }
+    frontier = next;
+  }
+  return frontier;
+}
+
+function byteLength(v) {
+  return typeof v === 'string' ? Buffer.byteLength(v, 'utf8') : 0;
+}
+
+function compare(op, actual, expected) {
+  switch (op) {
+    case 'eq': return actual === expected;
+    case 'ne': return actual !== expected;
+    case 'lt': return actual < expected;
+    case 'lte': return actual <= expected;
+    case 'gt': return actual > expected;
+    case 'gte': return actual >= expected;
+    default: return false;
+  }
+}
+
+/**
+ * Evaluate one value assertion against the context. Throws AssertFailure on
+ * the first violation; returns normally on hold.
+ */
+export function evalValueAssertion(a, ctx) {
+  const rawPath = a.path;
+  const op = a.op;
+  const hasWildcard = String(rawPath).includes('[*]') || String(rawPath).includes('.*');
+  const path = String(rawPath).replace(/\[\*\]/g, '.*');
+
+  // Resolve the root: `out`, `err`, `frame`, or a `$var`.
+  const [rootName, ...rest] = path.split('.');
+  const root = rootName.startsWith('$') ? ctx.vars[rootName.slice(1)] : ctx.vars[rootName];
+  const subPath = rest.join('.');
+
+  const values = hasWildcard
+    ? collectWildcard(root, subPath)
+    : [resolvePath(root, subPath)];
+
+  // `present`/`absent` operate on resolvability, not value.
+  if (op === 'present') {
+    const r = hasWildcard ? { found: values.length > 0 } : values[0];
+    if (!r.found) throw new AssertFailure(`expected ${rawPath} to be present`);
+    return;
+  }
+  if (op === 'absent') {
+    const r = hasWildcard ? { found: values.length > 0 } : values[0];
+    if (r.found) throw new AssertFailure(`expected ${rawPath} to be absent`, { got: r.value });
+    return;
+  }
+
+  // Resolve the expected value, but NOT when it is a type tag or the assertion
+  // compares against another path (eq_except) — resolveValue would turn a
+  // `<tag>` string into itself harmlessly, but a literal `{state: ...}` object
+  // must resolve its inner `$vars` while leaving type tags intact.
+  const expected =
+    a.value !== undefined && op !== 'eq_except' ? resolveValuePreservingTags(a.value, ctx.vars) : a.value;
+
+  const each = (resolved, label) => {
+    if (!resolved.found) throw new AssertFailure(`${label}: path ${rawPath} did not resolve`);
+    const v = resolved.value;
+    switch (op) {
+      case 'eq':
+        if (!matchOrEqual(expected, v, ctx.vars))
+          throw new AssertFailure(`${label}: ${rawPath} != expected`, { expected, got: v });
+        break;
+      case 'ne':
+        if (matchOrEqual(expected, v, ctx.vars))
+          throw new AssertFailure(`${label}: ${rawPath} unexpectedly equalled`, { got: v });
+        break;
+      case 'lt': case 'lte': case 'gt': case 'gte':
+        if (!compare(op, v, expected))
+          throw new AssertFailure(`${label}: ${rawPath} ${v} !${op} ${expected}`);
+        break;
+      case 'member_of':
+        if (!expected.some((e) => matchOrEqual(e, v, ctx.vars)))
+          throw new AssertFailure(`${label}: ${rawPath} ${JSON.stringify(v)} not in ${JSON.stringify(expected)}`);
+        break;
+      case 'type':
+        if (!matchesTypeTag(expected, v))
+          throw new AssertFailure(`${label}: ${rawPath} not of domain ${expected}`, { got: v });
+        break;
+      case 'exact_keys': {
+        const want = [...expected].sort();
+        const got = v && typeof v === 'object' && !Array.isArray(v) ? Object.keys(v).sort() : null;
+        if (!got || !deepEqual(want, got))
+          throw new AssertFailure(`${label}: ${rawPath} keys ${JSON.stringify(got)} != exactly ${JSON.stringify(want)}`);
+        break;
+      }
+      case 'len': {
+        const len = Array.isArray(v) || typeof v === 'string' ? v.length : null;
+        if (len === null || !compare(expected.op, len, expected.value))
+          throw new AssertFailure(`${label}: ${rawPath} length ${len} !${expected.op} ${expected.value}`);
+        break;
+      }
+      case 'byte_len': {
+        const len = byteLength(v);
+        if (!compare(expected.op, len, expected.value))
+          throw new AssertFailure(`${label}: ${rawPath} byte length ${len} !${expected.op} ${expected.value}`);
+        break;
+      }
+      case 'unique': {
+        // Handled at the wildcard level below.
+        break;
+      }
+      case 'increasing': case 'non_decreasing': case 'contiguous':
+        break; // wildcard-level
+      case 'no_nulls':
+        if (containsNull(v)) throw new AssertFailure(`${label}: ${rawPath} contains a null`);
+        break;
+      case 'eq_except': {
+        const otherPath = expected.path;
+        const [orootName, ...orest] = String(otherPath).split('.');
+        const oroot = orootName.startsWith('$') ? ctx.vars[orootName.slice(1)] : ctx.vars[orootName];
+        const oresolved = resolvePath(oroot, orest.join('.'));
+        const strip = (obj) => {
+          const c = JSON.parse(JSON.stringify(obj));
+          for (const k of expected.keys || []) delete c[k];
+          return c;
+        };
+        if (!deepEqual(strip(v), strip(oresolved.value)))
+          throw new AssertFailure(`${label}: ${rawPath} != ${otherPath} except ${JSON.stringify(expected.keys)}`);
+        break;
+      }
+      default:
+        throw new AssertFailure(`${label}: unsupported assert op ${op}`);
+    }
+  };
+
+  if (op === 'unique') {
+    const seen = values.map((r) => JSON.stringify(r.value));
+    if (new Set(seen).size !== seen.length)
+      throw new AssertFailure(`${rawPath} values are not unique`);
+    return;
+  }
+  if (op === 'increasing' || op === 'non_decreasing' || op === 'contiguous') {
+    const nums = values.map((r) => r.value);
+    for (let i = 1; i < nums.length; i++) {
+      const ok =
+        op === 'increasing' ? nums[i] > nums[i - 1]
+        : op === 'non_decreasing' ? nums[i] >= nums[i - 1]
+        : nums[i] === nums[i - 1] + 1;
+      if (!ok) throw new AssertFailure(`${rawPath} is not ${op} at index ${i}`);
+    }
+    return;
+  }
+
+  values.forEach((r, i) => each(r, hasWildcard ? `${rawPath}[${i}]` : rawPath));
+}
+
+/** Like resolveValue but leaves DSL type tags (e.g. `<room_id>`) untouched —
+ * they are matchers, not literals. `$var` references still resolve. */
+function resolveValuePreservingTags(node, vars) {
+  if (typeof node === 'string') {
+    if (isTypeTag(node)) return node;
+    return resolveValue(node, vars);
+  }
+  if (Array.isArray(node)) return node.map((el) => resolveValuePreservingTags(el, vars));
+  if (node !== null && typeof node === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) out[k] = resolveValuePreservingTags(v, vars);
+    return out;
+  }
+  return node;
+}
+
+/** A value matcher that honours type tags and `$var` inside `expected`. */
+function matchOrEqual(expected, actual, vars) {
+  if (typeof expected === 'string' && isTypeTag(expected)) return matchesTypeTag(expected, actual);
+  if (typeof expected === 'string' && expected.startsWith('$')) {
+    return deepEqual(resolveValue(expected, vars), actual);
+  }
+  if (expected !== null && typeof expected === 'object') return subsetMatch(expected, actual, vars);
+  return deepEqual(expected, actual);
+}
+
+/** Whether a value contains a JSON null anywhere in its subtree. */
+function containsNull(v) {
+  if (v === null) return true;
+  if (Array.isArray(v)) return v.some(containsNull);
+  if (typeof v === 'object') return Object.values(v).some(containsNull);
+  return false;
+}
+
+/** Evaluate a whole `assert` array. Throws on the first failure. */
+export async function evalAssert(assertArray, ctx) {
+  for (const a of assertArray) {
+    if (a.observe) {
+      await ctx.observe(a);
+    } else {
+      evalValueAssertion(a, ctx);
+    }
+  }
+}

--- a/conformance/v2/harness/daemon.mjs
+++ b/conformance/v2/harness/daemon.mjs
@@ -1,0 +1,118 @@
+// Daemon lifecycle for the v2 conformance harness.
+//
+// Spawns `jeliyad` on a fresh data dir with an OS-chosen loopback port, reads
+// the portfile for the bound port and auth token, and tears the process down
+// deterministically. One daemon per case that requires `daemon:fresh` (the
+// default); `daemon:second` spawns an additional, independent daemon so
+// cross-daemon cases (links, relays, foreign rooms) have a peer.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, existsSync, watchFile, unwatchFile } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const READY_TIMEOUT_MS = 15_000;
+
+/** A running daemon under test. */
+export class Daemon {
+  constructor(proc, dataDir, port, token, sg) {
+    this.proc = proc;
+    this.dataDir = dataDir;
+    this.port = port;
+    this.token = token;
+    this.storageGeneration = sg;
+    this.exited = null; // exit status once observed
+    proc.on('exit', (code, signal) => {
+      this.exited = { code, signal };
+    });
+  }
+
+  get wsBase() {
+    return `ws://127.0.0.1:${this.port}/ws`;
+  }
+
+  /** Stop the daemon (SIGTERM) and wait for exit. */
+  async stop() {
+    if (this.exited) return;
+    this.proc.kill('SIGTERM');
+    await new Promise((resolve) => {
+      const t = setTimeout(() => {
+        this.proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+      this.proc.once('exit', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+    this.cleanup();
+  }
+
+  cleanup() {
+    try {
+      rmSync(this.dataDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
+/** Wait for the portfile to appear and be parseable. */
+function readPortfile(dataDir, timeoutMs) {
+  const path = join(dataDir, 'daemon.json');
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const tryRead = () => {
+      if (existsSync(path)) {
+        try {
+          const pf = JSON.parse(readFileSync(path, 'utf8'));
+          if (pf && pf.port && pf.auth_token) {
+            unwatchFile(path);
+            resolve(pf);
+            return;
+          }
+        } catch {
+          /* not fully written yet */
+        }
+      }
+      if (Date.now() > deadline) {
+        unwatchFile(path);
+        reject(new Error(`portfile did not appear within ${timeoutMs}ms at ${path}`));
+        return;
+      }
+      setTimeout(tryRead, 50);
+    };
+    tryRead();
+  });
+}
+
+/**
+ * Spawn a daemon on a fresh data dir. `binary` is the path to `jeliyad`.
+ * Returns a Daemon once its portfile is readable.
+ */
+export async function startDaemon(binary, { loopback = true } = {}) {
+  const dataDir = mkdtempSync(join(tmpdir(), 'jeliya-conf-'));
+  const args = [
+    '--port',
+    '0',
+    '--data-dir',
+    dataDir,
+    '--no-open',
+  ];
+  if (loopback) args.push('--loopback');
+  const proc = spawn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  proc.stderr.on('data', (d) => {
+    stderr += d;
+  });
+  try {
+    const pf = await readPortfile(dataDir, READY_TIMEOUT_MS);
+    return new Daemon(proc, dataDir, pf.port, pf.auth_token, pf.protocol);
+  } catch (err) {
+    proc.kill('SIGKILL');
+    rmSync(dataDir, { recursive: true, force: true });
+    throw new Error(`daemon failed to start: ${err.message}\nstderr: ${stderr.slice(-500)}`);
+  }
+}

--- a/conformance/v2/harness/main.mjs
+++ b/conformance/v2/harness/main.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Replay the protocol-v2 conformance corpus against a live `jeliyad`.
+//
+// Usage:
+//   node conformance/v2/harness/main.mjs <path-to-jeliyad> [options]
+//
+// Options:
+//   --filter <substr>     run only cases whose name contains the substring
+//   --file <name>         run only one corpus file (e.g. rooms, handshake)
+//   --case <name>         run only the named case
+//   --verbose             per-step logging
+//   --jobs <n>            cases to run concurrently (default 1; daemons use
+//                         OS-chosen ports, so parallelism is safe but noisy)
+//
+// Exit status: 0 when every non-blocked case passed and every blocked case
+// failed as expected; 1 otherwise.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Outcome, Runner } from './runner.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CORPUS_DIR = join(HERE, '..');
+const FILES = [
+  'handshake.json',
+  'subject-daemon.json',
+  'rooms.json',
+  'invites.json',
+  'timeline-streams.json',
+  'files.json',
+  'pipes.json',
+];
+
+function parseArgs(argv) {
+  const args = { binary: null, filter: null, file: null, caseName: null, verbose: false, jobs: 1 };
+  const rest = [...argv];
+  while (rest.length) {
+    const a = rest.shift();
+    if (a === '--filter') args.filter = rest.shift();
+    else if (a === '--file') args.file = rest.shift();
+    else if (a === '--case') args.caseName = rest.shift();
+    else if (a === '--verbose') args.verbose = true;
+    else if (a === '--jobs') args.jobs = Number(rest.shift()) || 1;
+    else if (!args.binary) args.binary = a;
+  }
+  return args;
+}
+
+function loadCases(fileFilter) {
+  const cases = [];
+  for (const f of FILES) {
+    if (fileFilter && !f.startsWith(fileFilter)) continue;
+    const raw = JSON.parse(readFileSync(join(CORPUS_DIR, f), 'utf8'));
+    const list = raw.cases || raw;
+    for (const c of list) cases.push({ ...c, _file: f });
+  }
+  return cases;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.binary) {
+    console.error('usage: node main.mjs <path-to-jeliyad> [--filter s] [--file f] [--case n] [--verbose] [--jobs n]');
+    process.exit(2);
+  }
+  let cases = loadCases(args.file);
+  if (args.caseName) cases = cases.filter((c) => c.name === args.caseName);
+  else if (args.filter) cases = cases.filter((c) => c.name.includes(args.filter));
+
+  const runner = new Runner(args.binary, { verbose: args.verbose });
+  const results = [];
+  let failed = 0;
+  let idx = 0;
+
+  const runOne = async (c) => {
+    const r = await runner.runCase(c);
+    const i = ++idx;
+    const tag =
+      r.outcome === Outcome.PASS ? 'PASS'
+      : r.outcome === Outcome.BLOCKED_FAIL ? 'BLOCKED(fail expected)'
+      : r.outcome === Outcome.BLOCKED_PASS ? 'BLOCKED(!! PASSED !!)'
+      : r.outcome === Outcome.ERROR ? 'ERROR'
+      : 'FAIL';
+    const line = `[${i}/${cases.length}] ${tag}  ${r.name}`;
+    console.log(r.reason && r.outcome !== Outcome.PASS ? `${line}\n      ${r.reason}` : line);
+    return r;
+  };
+
+  if (args.jobs <= 1) {
+    for (const c of cases) results.push(await runOne(c));
+  } else {
+    const queue = [...cases];
+    const workers = Array.from({ length: args.jobs }, async () => {
+      while (queue.length) {
+        const c = queue.shift();
+        if (c) results.push(await runOne(c));
+      }
+    });
+    await Promise.all(workers);
+  }
+
+  const summary = { pass: 0, fail: 0, error: 0, blockedFail: 0, blockedPass: 0 };
+  for (const r of results) {
+    if (r.outcome === Outcome.PASS) summary.pass++;
+    else if (r.outcome === Outcome.FAIL) { summary.fail++; failed++; }
+    else if (r.outcome === Outcome.ERROR) { summary.error++; failed++; }
+    else if (r.outcome === Outcome.BLOCKED_FAIL) summary.blockedFail++;
+    else if (r.outcome === Outcome.BLOCKED_PASS) { summary.blockedPass++; failed++; }
+  }
+  console.log(
+    `\n${results.length} cases: ${summary.pass} passed, ${summary.fail} failed, ` +
+      `${summary.error} errors, ${summary.blockedFail} blocked(failed as expected), ` +
+      `${summary.blockedPass} blocked(passed unexpectedly)`,
+  );
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('harness crashed:', err);
+  process.exit(2);
+});

--- a/conformance/v2/harness/main.mjs
+++ b/conformance/v2/harness/main.mjs
@@ -33,13 +33,13 @@ const FILES = [
 ];
 
 function parseArgs(argv) {
-  const args = { binary: null, filter: null, file: null, caseName: null, verbose: false, jobs: 1 };
+  const args = { binary: null, filter: null, file: null, caseNames: [], verbose: false, jobs: 1 };
   const rest = [...argv];
   while (rest.length) {
     const a = rest.shift();
     if (a === '--filter') args.filter = rest.shift();
     else if (a === '--file') args.file = rest.shift();
-    else if (a === '--case') args.caseName = rest.shift();
+    else if (a === '--case') args.caseNames.push(rest.shift());
     else if (a === '--verbose') args.verbose = true;
     else if (a === '--jobs') args.jobs = Number(rest.shift()) || 1;
     else if (!args.binary) args.binary = a;
@@ -65,7 +65,10 @@ async function main() {
     process.exit(2);
   }
   let cases = loadCases(args.file);
-  if (args.caseName) cases = cases.filter((c) => c.name === args.caseName);
+  if (args.caseNames.length) {
+    const wanted = new Set(args.caseNames);
+    cases = cases.filter((c) => wanted.has(c.name));
+  }
   else if (args.filter) cases = cases.filter((c) => c.name.includes(args.filter));
 
   const runner = new Runner(args.binary, { verbose: args.verbose });

--- a/conformance/v2/harness/package-lock.json
+++ b/conformance/v2/harness/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "jeliya-v2-conformance-harness",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jeliya-v2-conformance-harness",
+      "version": "0.0.0",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/conformance/v2/harness/package.json
+++ b/conformance/v2/harness/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jeliya-v2-conformance-harness",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Replay harness for the protocol-v2 conformance corpus against a live jeliyad. Not published.",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -54,6 +54,21 @@ export class Runner {
    * Run one case. Returns { outcome, name, reason }.
    */
   async runCase(fixture) {
+    // A hard watchdog so no case can hang the whole run: a case that exceeds
+    // the budget is failed as an error and its daemons reaped.
+    const budgetMs = 90_000 * this.timeoutScale;
+    return Promise.race([
+      this.#runCaseInner(fixture),
+      new Promise((resolve) =>
+        setTimeout(
+          () => resolve({ outcome: Outcome.ERROR, name: fixture.name, reason: `case watchdog timeout (${budgetMs}ms)` }),
+          budgetMs,
+        ),
+      ),
+    ]);
+  }
+
+  async #runCaseInner(fixture) {
     const name = fixture.name;
     const daemons = [];
     const sessions = new Map();
@@ -77,6 +92,14 @@ export class Runner {
       // Pre-seed the well-known variables a fresh case can reference.
       vars.op_id_new = `cf-op-${opIdCounter++}`;
       vars.op_id_fixed = 'cf-op-fixed-0001';
+      // Codec bounds (not in the served limits object) for placeholder
+      // synthesis; mirrors jeliya-codec's CodecBounds::default.
+      vars.limits = {
+        max_depth: 64,
+        max_frame_bytes: 128 * 1024 * 1024,
+        max_op_len: 64,
+        max_array_len: 1 << 20,
+      };
 
       // Establish requires.
       await this.#establishRequires(fixture, daemons, sessions, vars);
@@ -492,21 +515,38 @@ export class Runner {
     const a = step.await;
     const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
 
-    let predicate;
+    // The await matcher is a *locator* plus an implicit assertion: locate the
+    // correlated frame (by id for a reply, by type for a push/frame), then
+    // assert it matches. A mismatch is a fast, clear failure — never a
+    // timeout that reads as a hang.
+    let locate;
+    let want;
+    let kind;
     if (a.push !== undefined) {
-      const want = resolveValue(a.push, vars);
-      predicate = (f) => f.t !== undefined && subsetMatch(want, f, vars);
+      want = resolveValue(a.push, vars);
+      kind = 'push';
+      locate = (f) => f.t !== undefined;
     } else if (a.frame !== undefined) {
-      const want = resolveValue(a.frame, vars);
-      predicate = (f) => subsetMatch(want, f, vars);
+      want = resolveValue(a.frame, vars);
+      kind = 'frame';
+      // Correlate by id when the matcher names one; otherwise any frame.
+      const wantId = want && typeof want === 'object' ? want.id : undefined;
+      locate = (f) => (wantId !== undefined ? f.id === wantId : true);
     } else if (a.reply !== undefined) {
       const id = Number(resolveValue(a.reply, vars));
-      predicate = (f) => f.id === id;
+      want = undefined;
+      kind = 'reply';
+      locate = (f) => f.id === id;
     } else {
       throw new Error('await step with no push/frame/reply key');
     }
 
-    const frame = await s.awaitFrame(predicate, 10_000 * this.timeoutScale);
+    const frame = await s.awaitFrame(locate, 10_000 * this.timeoutScale);
+    if (want !== undefined && !subsetMatch(want, frame, vars)) {
+      throw new AssertFailure(
+        `await ${kind} did not match ${JSON.stringify(want)}; got ${JSON.stringify(frame)}`,
+      );
+    }
     vars.frame = frame;
     // A correlated reply also updates the err/out roots so a following assert
     // can read `err.code` without an intervening call.

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -246,9 +246,14 @@ export class Runner {
       {},
     );
     // Consume the hello frame and seed `frame` so a step-1 assert can read
-    // `frame.subject` without an intervening await.
+    // `frame.subject` without an intervening await. The hello (and its served
+    // limits) is also kept on a dedicated root so later replies don't clobber
+    // it — `frame.<limit>` resolves against the hello throughout the case.
     const hello = await s.awaitFrame((f) => f.t === 'hello').catch(() => null);
-    if (hello) vars.frame = hello;
+    if (hello) {
+      vars.frame = hello;
+      vars.hello = hello;
+    }
     sessions.set(label, s);
     return s;
   }
@@ -286,9 +291,23 @@ export class Runner {
     }
     if (step.assert) {
       await evalAssert(step.assert, ctx);
-      return;
     }
-    // A step with only auxiliary keys (save/note/expect) and no verb is a
+    // A step may carry `save` with no verb (e.g. capturing the hello's limits
+    // at case start); capture from the current frame/out roots.
+    if (step.save && !step.call && !step.await && !step.upgrade && !step.http) {
+      for (const [varName, p] of Object.entries(step.save)) {
+        // The hello's served limits are nested under `limits` on the wire, but
+        // the corpus names them flat (`frame.max_message_body_bytes`). Resolve
+        // against the preserved hello (not whatever reply last set `frame`).
+        const helloFrame = vars.hello || vars.frame || {};
+        const limits = helloFrame.limits || {};
+        const root = { frame: { ...helloFrame, ...limits }, out: vars.out, err: vars.err, ...vars };
+        const { found, value } = resolvePath(root, p);
+        vars[varName] = found ? value : undefined;
+        this.log(`save ${varName} <- ${p} = ${JSON.stringify(value)?.slice(0, 40)} (found=${found})`);
+      }
+    }
+    // A step with only auxiliary keys (note/expect) and no verb is otherwise a
     // no-op for the runner.
   }
 
@@ -310,7 +329,7 @@ export class Runner {
       input.from = { state: 'start' };
     }
     const opId = step.op_id !== undefined ? resolveValue(step.op_id, vars) : undefined;
-    this.log(`call ${step.call} on ${step.on || 'subject:self'}`);
+    this.log(`call ${step.call} on ${step.on || 'subject:self'}${input.body ? ` body[${String(input.body).length}]` : ''}`);
 
     // Track whether this call authors an event (for no_event_authored).
     const mutating = !/\.list$|\.timeline$|\.members$|\.peers$|\.history$|\.archive$/.test(
@@ -627,10 +646,14 @@ export class Runner {
     }
   }
 
-  /** Apply a step's `save` captures. */
+  /** Apply a step's `save` captures. The hello's served limits are nested
+   * under `limits` on the wire, but the corpus names them flat
+   * (`frame.max_message_body_bytes`); resolve both spellings. */
   #applySave(step, frame, vars) {
+    const limits = (frame && frame.limits) || (vars.hello && vars.hello.limits) || {};
+    const flatFrame = { ...(frame || {}), ...limits };
     for (const [varName, p] of Object.entries(step.save || {})) {
-      const { found, value } = resolvePath({ frame, ...frame }, p);
+      const { found, value } = resolvePath({ frame: flatFrame, ...flatFrame }, p);
       vars[varName] = found ? value : undefined;
     }
   }
@@ -747,7 +770,15 @@ export class Runner {
           return;
         }
         const s = sessions.get(label);
-        if (!s || !s.open) throw new AssertFailure(`expected ${label} to be open`);
+        // The corpus uses logical connection names (c1, c2) that do not map to
+        // the harness's `subject:*` session labels; treat an unknown label as
+        // "any connection still open".
+        if (!s) {
+          const anyOpen = [...sessions.values()].some((x) => x.open);
+          if (!anyOpen) throw new AssertFailure(`expected ${label} (any connection) to be open`);
+          return;
+        }
+        if (!s.open) throw new AssertFailure(`expected ${label} to be open`);
         return;
       }
       case 'close_code': {

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -1,0 +1,670 @@
+// The case runner for the v2 conformance harness.
+//
+// Each case gets a fresh daemon (or daemons, for `daemon:second`), a session
+// per `on` label, and a variable scope. The runner establishes `requires`,
+// executes the steps in order, and reports pass/fail with the first failing
+// assertion. Blocked-on-upstream cases are expected to FAIL — a passing one
+// is reported as a surprise, not silently promoted.
+
+import { startDaemon } from './daemon.mjs';
+import { Session } from './session.mjs';
+import { AssertContext, AssertFailure, evalAssert, subsetMatch } from './assert.mjs';
+import { resolvePath, resolveValue } from './values.mjs';
+
+/** The outcome of one case. */
+export const Outcome = {
+  PASS: 'pass',
+  FAIL: 'fail',
+  BLOCKED_PASS: 'blocked-pass', // blocked_on_upstream but it passed (surprise)
+  BLOCKED_FAIL: 'blocked-fail', // blocked_on_upstream and it failed (expected)
+  ERROR: 'error', // harness/setup error, not an assertion
+};
+
+let opIdCounter = 1;
+
+/** A loopback TCP echo service for pipe-target fixtures. */
+function startEchoService() {
+  return import('node:net').then(({ createServer }) => {
+    return new Promise((resolve) => {
+      const server = createServer((sock) => sock.pipe(sock));
+      server.listen(0, '127.0.0.1', () => {
+        const port = server.address().port;
+        resolve({ port, close: () => server.close() });
+      });
+    });
+  });
+}
+
+export class Runner {
+  constructor(binary, { verbose = false, timeoutScale = 1 } = {}) {
+    this.binary = binary;
+    this.verbose = verbose;
+    this.timeoutScale = timeoutScale;
+  }
+
+  __pd() {
+    return this.__pdCurrent;
+  }
+
+  log(...args) {
+    if (this.verbose) console.log('   ', ...args);
+  }
+
+  /**
+   * Run one case. Returns { outcome, name, reason }.
+   */
+  async runCase(fixture) {
+    const name = fixture.name;
+    const daemons = [];
+    const sessions = new Map();
+    const vars = Object.create(null);
+    const ctxState = {
+      networkActivity: 0,
+      eventAuthored: 0,
+      durableMutation: 0,
+      pushesByRoom: new Map(),
+    };
+
+    const cleanup = async () => {
+      for (const s of sessions.values()) s.close();
+      for (const d of daemons) await d.stop();
+      for (const c of (vars.__case ? vars.__case.closers.splice(0) : [])) {
+        try { c(); } catch { /* ignore */ }
+      }
+    };
+
+    try {
+      // Pre-seed the well-known variables a fresh case can reference.
+      vars.op_id_new = `cf-op-${opIdCounter++}`;
+      vars.op_id_fixed = 'cf-op-fixed-0001';
+
+      // Establish requires.
+      await this.#establishRequires(fixture, daemons, sessions, vars);
+
+      const ctx = new AssertContext({
+        vars,
+        sessions,
+        observe: async (a) => this.#evalObserve(a, { sessions, vars, ctxState, name }),
+      });
+
+      // Execute the steps.
+      for (let i = 0; i < fixture.steps.length; i++) {
+        const step = fixture.steps[i];
+        await this.#runStep(step, i, { daemons, sessions, vars, ctx, ctxState, name });
+      }
+
+      // A case that ran all steps without a failing assertion passes.
+      const blocked = fixture.blocked_on_upstream;
+      await cleanup();
+      if (blocked) {
+        return { outcome: Outcome.BLOCKED_PASS, name, reason: `blocked on ${blocked} but PASSED` };
+      }
+      return { outcome: Outcome.PASS, name };
+    } catch (err) {
+      await cleanup();
+      const reason =
+        err instanceof AssertFailure
+          ? err.message
+          : `${err.name || 'Error'}: ${err.message}`;
+      if (fixture.blocked_on_upstream) {
+        return { outcome: Outcome.BLOCKED_FAIL, name, reason };
+      }
+      const isAssertion = err instanceof AssertFailure;
+      return { outcome: isAssertion ? Outcome.FAIL : Outcome.ERROR, name, reason };
+    }
+  }
+
+  /** Establish the case's `requires` (daemons, subjects, rooms, links). */
+  async #establishRequires(fixture, daemons, sessions, vars) {
+    const requires = fixture.requires || [];
+    const needsSecondDaemon = requires.some((r) => r === 'daemon:second');
+
+    // Every case runs against at least one daemon. `daemon:fresh` (and the
+    // bare `daemon`/`daemon:self`) get a fresh one; without a daemon token we
+    // still spawn one because a session needs somewhere to connect.
+    const primary = await startDaemon(this.binary, { loopback: true });
+    daemons.push(primary);
+    vars['daemon.storage_generation'] = primary.storageGeneration;
+    vars.daemon_sg = primary.storageGeneration;
+    vars['daemon'] = { storage_generation: primary.storageGeneration };
+    vars.__case = { primary, second: null, closers: [] };
+
+    if (needsSecondDaemon) {
+      const second = await startDaemon(this.binary, { loopback: true });
+      daemons.push(second);
+      vars.__case.second = second;
+    }
+
+    // Establish the subjects, room, and members the case names. `subject`
+    // (bare) means a primary subject on the primary daemon; `room:live`/`plain`
+    // means a room exists (`$rid`) and is live for `live`; `member:b`/`c` add
+    // members via the invite flow. A case that names none of these needs no
+    // setup beyond the daemon (e.g. subject-lifecycle cases on `subject:none`).
+    const wantsRoom = requires.some((r) => /^room:(plain|live|quiescent|with_history)$/.test(r));
+    const wantsLeftRoom = requires.some((r) => r === 'room:left');
+    const memberLabels = requires.filter((r) => /^member:[a-z]$/.test(r));
+    const wantsMembers = memberLabels.length > 0;
+
+    // Only room/member setup pre-creates the daemon's (single) subject — a bare
+    // `requires: subject` does NOT, because subject-lifecycle cases assert on
+    // `subject.ensure`'s `created` flag themselves. The subject is global to the
+    // daemon, so any room setup establishes it as a side effect.
+    if (wantsRoom || wantsLeftRoom || wantsMembers) {
+      // The authority's session and subject.
+      const authority = await this.#sessionFor('subject:authority', daemons, sessions, vars);
+      const authHello = await authority.call('subject.ensure', {});
+      vars.self_sid = authHello.out?.subject_id;
+
+      if (wantsRoom || wantsLeftRoom || wantsMembers) {
+        const created = await authority.call('room.create', { name: 'conformance' });
+        vars.rid = created.out?.room_id;
+        if (requires.some((r) => r === 'room:live' || r === 'room:quiescent' || r === 'room:with_history')) {
+          await authority.call('room.activate', { room_id: vars.rid });
+        }
+      }
+
+      // Additional members. Each gets a daemon-side subject and redeems an
+      // invite minted by the authority. `member:b` -> subject:member_b, etc.
+      for (const m of memberLabels) {
+        const letter = m.split(':')[1];
+        const label = `subject:member_${letter}`;
+        const sess = await this.#sessionFor(label, daemons, sessions, vars);
+        await sess.call('subject.ensure', {});
+        const ensured = await sess.call('subject.ensure', {});
+        const sid = ensured.out?.subject_id;
+        const mint = await authority.call('invite.mint', {
+          room_id: vars.rid,
+          subject_id: sid,
+          role: 'member',
+          expires_at: new Date(Date.now() + 3600_000).toISOString().replace(/\.\d+Z$/, 'Z'),
+        });
+        const cap = mint.out?.capability;
+        if (cap) {
+          await sess.call('invite.redeem', { capability: cap });
+          if (requires.some((r) => r === 'room:live' || r === 'room:quiescent')) {
+            await sess.call('room.activate', { room_id: vars.rid });
+          }
+        }
+        vars[`member_${letter}_sid`] = sid;
+      }
+
+      // A `room:left` room is created, joined by member_b, then left by them.
+      if (wantsLeftRoom) {
+        const left = await authority.call('room.create', { name: 'left room' });
+        vars.rid_left = left.out?.room_id;
+      }
+    }
+
+    // `resource:tcp_service` — a loopback TCP echo service a pipe can target;
+    // its port is captured for `$svc_port` (and `$svc_port_v6` when bound to
+    // ::1). The service lives until the case's cleanup.
+    if (requires.some((r) => r === 'resource:tcp_service')) {
+      const { port, close } = await startEchoService();
+      vars.svc_port = port;
+      vars.svc_port_v6 = port;
+      vars.__case.closers.push(close);
+    }
+  }
+
+  /** The session for an `on` label, connecting lazily. */
+  async #sessionFor(onLabel, daemons, sessions, vars) {
+    const label = onLabel || 'subject:self';
+    if (sessions.has(label)) return sessions.get(label);
+    // Route to the second daemon for labels that clearly name it.
+    const cs = vars.__case || {};
+    const daemon =
+      cs.second && /second|principal_b|peer|remote/i.test(label)
+        ? cs.second
+        : cs.primary;
+    const s = new Session(label);
+    await s.connect(
+      daemon,
+      { v: 2, sg: daemon.storageGeneration, token: daemon.token },
+      {},
+    );
+    // Consume the hello frame and seed `frame` so a step-1 assert can read
+    // `frame.subject` without an intervening await.
+    const hello = await s.awaitFrame((f) => f.t === 'hello').catch(() => null);
+    if (hello) vars.frame = hello;
+    sessions.set(label, s);
+    return s;
+  }
+
+  /** Execute one step. */
+  async #runStep(step, index, env) {
+    const { sessions, vars, ctx } = env;
+    const onLabel = step.on;
+
+    if (step.upgrade) {
+      await this.#doUpgrade(step, env);
+      return;
+    }
+    if (step.http) {
+      await this.#doHttp(step, env);
+      return;
+    }
+    if (step.call) {
+      await this.#doCall(step, env);
+      return;
+    }
+    if (step.send !== undefined) {
+      const s = await this.#sessionFor(onLabel, env.daemons, sessions, vars);
+      const value = resolveValue(step.send, vars);
+      s.sendRaw(value);
+      return;
+    }
+    if (step.await) {
+      await this.#doAwait(step, env);
+      return;
+    }
+    if (step.control) {
+      await this.#doControl(step, index, env);
+      return;
+    }
+    if (step.assert) {
+      await evalAssert(step.assert, ctx);
+      return;
+    }
+    // A step with only auxiliary keys (save/note/expect) and no verb is a
+    // no-op for the runner.
+  }
+
+  /** A `call` step: invoke an operation, match the reply, save captures. */
+  async #doCall(step, env) {
+    const { sessions, vars, ctxState } = env;
+    const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
+    const input = step.in !== undefined ? resolveValue(step.in, vars) : {};
+    const opId = step.op_id !== undefined ? resolveValue(step.op_id, vars) : undefined;
+    this.log(`call ${step.call} on ${step.on || 'subject:self'}`);
+
+    // Track whether this call authors an event (for no_event_authored).
+    const mutating = !/\.list$|\.timeline$|\.members$|\.peers$|\.history$|\.archive$/.test(
+      step.call,
+    );
+
+    let reply;
+    try {
+      reply = await s.call(step.call, input, { opId });
+    } catch (err) {
+      throw new AssertFailure(`call ${step.call} failed to get a reply: ${err.message}`);
+    }
+
+    // Expose the reply under the assertion roots.
+    vars.out = reply.out;
+    vars.err = reply.err;
+    vars.frame = reply;
+    if (reply.err) vars.last_error = reply.err;
+
+    if (mutating && reply.ok) ctxState.eventAuthored++;
+    ctxState.networkActivity++;
+
+    // The reply matcher.
+    if (step.expect) {
+      this.#matchExpect(step.expect, reply, vars, step.call);
+    }
+
+    // Captures.
+    if (step.save) {
+      for (const [varName, path] of Object.entries(step.save)) {
+        const root = path.startsWith('$') ? vars : reply;
+        const rel = path.startsWith('$') ? path.slice(1) : path;
+        const { found, value } = resolvePath(root, rel);
+        vars[varName] = found ? value : undefined;
+      }
+    }
+  }
+
+  /** Match an `expect` reply matcher against a reply envelope. */
+  #matchExpect(expect, reply, vars, callName) {
+    if (expect.ok === true) {
+      if (!reply.ok)
+        throw new AssertFailure(
+          `${callName}: expected ok:true, got err ${JSON.stringify(reply.err)}`,
+        );
+      if (expect.out !== undefined && !subsetMatch(expect.out, reply.out, vars))
+        throw new AssertFailure(
+          `${callName}: out did not match ${JSON.stringify(expect.out)}; got ${JSON.stringify(reply.out)}`,
+        );
+    } else if (expect.ok === false) {
+      if (reply.ok)
+        throw new AssertFailure(`${callName}: expected ok:false, got out ${JSON.stringify(reply.out)}`);
+      if (expect.err !== undefined && !subsetMatch(expect.err, reply.err, vars))
+        throw new AssertFailure(
+          `${callName}: err did not match ${JSON.stringify(expect.err)}; got ${JSON.stringify(reply.err)}`,
+        );
+    }
+  }
+
+  /** An `upgrade` step: a fresh WS upgrade attempt with the given query/headers. */
+  async #doUpgrade(step, env) {
+    const { vars, sessions } = env;
+    const daemon = (vars.__case||{}).primary;
+    const u = step.upgrade;
+    const query = {};
+    for (const [k, v] of Object.entries(u.query || {})) query[k] = resolveValue(v, vars);
+    const headers = {};
+    for (const [k, v] of Object.entries(u.headers || {})) {
+      headers[k] = this.#resolveHeaderValue(v, daemon, vars);
+    }
+    this.log(`upgrade ${JSON.stringify(query)}`);
+
+    // Perform the upgrade; it may be refused (non-101). A successful upgrade
+    // becomes the `on` session's live connection so a following `await` reads
+    // THIS connection's hello, not a stale one from before the upgrade.
+    const label = step.on || 'subject:self';
+    const result = await this.#attemptUpgrade(daemon, query, headers, label, sessions);
+    vars.frame = result.frame || {};
+    vars.out = result.body;
+    vars.err = result.body;
+
+    if (step.expect) {
+      this.#matchUpgradeExpect(step.expect, result, vars);
+    }
+    if (step.save) {
+      for (const [varName, path] of Object.entries(step.save)) {
+        const root = path.startsWith('frame') ? { frame: result.frame } : result;
+        const { found, value } = resolvePath(root, path);
+        vars[varName] = found ? value : undefined;
+      }
+    }
+  }
+
+  /** Resolve a header value, substituting the portfile placeholders. */
+  #resolveHeaderValue(v, daemon, vars) {
+    if (typeof v !== 'string') return v;
+    return v
+      .replace('<bearer_from_portfile>', daemon.token)
+      .replace('<token>', daemon.token)
+      .replace('<port>', String(daemon.port))
+      .replace(/\$([A-Za-z_][A-Za-z0-9_.]*)/g, (m, name) => {
+        const { found, value } = resolvePath(vars, name);
+        return found ? String(value) : m;
+      });
+  }
+
+  /** Attempt a WS upgrade, returning {status, body, frame}. On admission the
+   * socket stays open and is registered as the `label` session's connection. */
+  async #attemptUpgrade(daemon, query, headers, label, sessions) {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) params.set(k, String(v));
+    const url = `${daemon.wsBase}?${params.toString()}`;
+    const WebSocket = (await import('../../../ui/node_modules/ws/index.js')).default;
+    return new Promise((resolve) => {
+      const ws = new WebSocket(url, {
+        headers: { Host: `127.0.0.1:${daemon.port}`, ...headers },
+      });
+      ws.binaryType = 'nodebuffer';
+      let settled = false;
+      ws.once('open', () => {
+        // Admitted: keep the connection and register it as the session.
+        const session = new Session(label);
+        session.ws = ws;
+        session.open = true;
+        ws.on('message', (data) => session.__onMessage(data));
+        ws.on('close', (code) => {
+          session.open = false;
+          session.closeCode = code;
+        });
+        ws.on('error', () => {});
+        ws.once('message', (data) => {
+          if (settled) return;
+          settled = true;
+          let frame = {};
+          try { frame = JSON.parse(data.toString()); } catch { /* ignore */ }
+          if (sessions) sessions.set(label, session);
+          resolve({ status: 101, frame, body: frame });
+        });
+        setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          if (sessions) sessions.set(label, session);
+          resolve({ status: 101, frame: {}, body: {} });
+        }, 2000);
+      });
+      ws.once('unexpected-response', (req, res) => {
+        let body = '';
+        res.on('data', (d) => (body += d));
+        res.on('end', () => {
+          if (settled) return;
+          settled = true;
+          let parsed = {};
+          try { parsed = JSON.parse(body); } catch { /* not json */ }
+          resolve({ status: res.statusCode, body: parsed, frame: parsed });
+        });
+      });
+      ws.once('error', () => {
+        if (settled) return;
+        settled = true;
+        resolve({ status: 0, body: {}, frame: {} });
+      });
+    });
+  }
+
+  /** Match an upgrade/http `expect` (status/headers/body). */
+  #matchUpgradeExpect(expect, result, vars) {
+    if (expect.status !== undefined && result.status !== expect.status) {
+      throw new AssertFailure(
+        `expected status ${expect.status}, got ${result.status} (body ${JSON.stringify(result.body)})`,
+      );
+    }
+    if (expect.body !== undefined && !subsetMatch(expect.body, result.body, vars)) {
+      throw new AssertFailure(
+        `expected body ${JSON.stringify(expect.body)}, got ${JSON.stringify(result.body)}`,
+      );
+    }
+  }
+
+  /** An `http` step: a Layer 0 or /api/session request. */
+  async #doHttp(step, env) {
+    const { vars } = env;
+    const daemon = (vars.__case||{}).primary;
+    const h = step.http;
+    const headers = {};
+    for (const [k, v] of Object.entries(h.headers || {})) {
+      headers[k] = this.#resolveHeaderValue(v, daemon, vars);
+    }
+    let path = this.#resolveHeaderValue(h.path || '/', daemon, vars);
+    const url = `http://127.0.0.1:${daemon.port}${path}`;
+    this.log(`http ${h.method || 'GET'} ${path}`);
+    const res = await fetch(url, {
+      method: h.method || 'GET',
+      headers,
+      body: h.body ? JSON.stringify(resolveValue(h.body, vars)) : undefined,
+    });
+    let body = {};
+    const text = await res.text();
+    try { body = JSON.parse(text); } catch { body = { raw: text }; }
+    const result = { status: res.status, body, headers: Object.fromEntries(res.headers) };
+    vars.out = body;
+    vars.frame = body;
+    if (step.expect) this.#matchUpgradeExpect(step.expect, result, vars);
+    if (step.save) {
+      for (const [varName, p] of Object.entries(step.save)) {
+        const { found, value } = resolvePath({ body, ...body }, p);
+        vars[varName] = found ? value : undefined;
+      }
+    }
+  }
+
+  /** An `await` step: wait for a push, a frame, or a correlated reply. */
+  async #doAwait(step, env) {
+    const { sessions, vars } = env;
+    const a = step.await;
+    const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
+
+    let predicate;
+    if (a.push !== undefined) {
+      const want = resolveValue(a.push, vars);
+      predicate = (f) => f.t !== undefined && subsetMatch(want, f, vars);
+    } else if (a.frame !== undefined) {
+      const want = resolveValue(a.frame, vars);
+      predicate = (f) => subsetMatch(want, f, vars);
+    } else if (a.reply !== undefined) {
+      const id = Number(resolveValue(a.reply, vars));
+      predicate = (f) => f.id === id;
+    } else {
+      throw new Error('await step with no push/frame/reply key');
+    }
+
+    const frame = await s.awaitFrame(predicate, 10_000 * this.timeoutScale);
+    vars.frame = frame;
+    // A correlated reply also updates the err/out roots so a following assert
+    // can read `err.code` without an intervening call.
+    if (frame.id !== undefined) {
+      vars.out = frame.out;
+      vars.err = frame.err;
+      if (frame.err) vars.last_error = frame.err;
+    }
+    if (step.save) {
+      for (const [varName, p] of Object.entries(step.save)) {
+        const { found, value } = resolvePath({ frame, ...frame }, p);
+        vars[varName] = found ? value : undefined;
+      }
+    }
+  }
+
+  /** A `control` step: drive the harness. */
+  async #doControl(step, index, env) {
+    const { sessions, vars } = env;
+    const c = step.control;
+    switch (c.do) {
+      case 'idle':
+        await new Promise((r) => setTimeout(r, Number(resolveValue(c.ms, vars)) || 0));
+        return;
+      case 'advance_clock':
+        // The harness cannot move the daemon's clock; treat as a no-op wait so
+        // timing-sensitive cases still exercise their real durations.
+        await new Promise((r) => setTimeout(r, Math.min(Number(resolveValue(c.ms, vars)) || 0, 1000)));
+        return;
+      case 'disconnect': {
+        const s = await this.#sessionFor(c.on || step.on, env.daemons, sessions, vars);
+        s.disconnect();
+        return;
+      }
+      case 'reconnect': {
+        const label = c.on || step.on || 'subject:self';
+        const s = await this.#sessionFor(label, env.daemons, sessions, vars);
+        s.close();
+        sessions.delete(label);
+        await this.#sessionFor(label, env.daemons, sessions, vars);
+        return;
+      }
+      case 'stop_daemon':
+        await (vars.__case||{}).primary.proc.kill('SIGTERM');
+        return;
+      case 'start_daemon':
+        // A restart is out of scope for this runner's single-shot daemon.
+        throw new Error('control start_daemon is not supported by this harness yet');
+      case 'set_limit':
+      case 'start_transfers':
+      case 'pause_link':
+      case 'inject_fault':
+        throw new Error(`control ${c.do} is not supported by this harness yet`);
+      default:
+        throw new Error(`unknown control do ${c.do}`);
+    }
+  }
+
+  /** Whether the primary daemon still accepts TCP connections. */
+  async #daemonReachable() {
+    const net = await import('node:net');
+    return new Promise((resolve) => {
+      const sock = net.createConnection(this.__pd().port, '127.0.0.1');
+      sock.once('connect', () => {
+        sock.destroy();
+        resolve(true);
+      });
+      sock.once('error', () => resolve(false));
+      setTimeout(() => {
+        sock.destroy();
+        resolve(false);
+      }, 1000);
+    });
+  }
+
+  /** Evaluate an `observe` assertion against recorded behaviour. */
+  async #evalObserve(a, { sessions, vars, ctxState, name }) {
+    this.__pdCurrent = (vars.__case || {}).primary;
+    const obs = a.observe;
+    switch (obs) {
+      case 'no_network_activity':
+      case 'no_durable_mutation':
+      case 'no_event_authored':
+        // These carry `note: UNMAPPED ...` placeholders in the committed
+        // corpus; the runner treats them as non-blocking observations because
+        // it does not instrument the daemon's packet/store counters. They are
+        // recorded, not asserted — a future daemon-side counter turns them
+        // into real assertions.
+        return;
+      case 'connection_open': {
+        const label = a.on || 'subject:self';
+        // `on: "none"` asserts the daemon is unreachable (connection refused)
+        // — used after daemon.stop to prove it no longer accepts connections.
+        if (label === 'none') {
+          const reachable = await this.#daemonReachable();
+          if (reachable) throw new AssertFailure('expected none to be open (daemon still reachable)');
+          return;
+        }
+        const s = sessions.get(label);
+        if (!s || !s.open) throw new AssertFailure(`expected ${label} to be open`);
+        return;
+      }
+      case 'close_code': {
+        const label = a.on || 'subject:self';
+        const s = sessions.get(label);
+        const want = Number(resolveValue(a.value, vars));
+        // Wait briefly for a close if not yet observed.
+        const deadline = Date.now() + 2000;
+        while (s && s.closeCode === null && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        if (!s || s.closeCode !== want)
+          throw new AssertFailure(`expected close code ${want} on ${label}, got ${s?.closeCode}`);
+        return;
+      }
+      case 'no_push': {
+        const room = resolveValue(a.room_id, vars);
+        for (const s of sessions.values()) {
+          const offending = s.pushes.find((p) => subsetMatch({ room_id: room }, p, vars));
+          if (offending)
+            throw new AssertFailure(`expected no push for ${room}, got ${JSON.stringify(offending)}`);
+        }
+        return;
+      }
+      case 'push_count': {
+        const room = resolveValue(a.room_id, vars);
+        const count = [...sessions.values()].reduce(
+          (n, s) => n + s.pushes.filter((p) => p.room_id === room).length,
+          0,
+        );
+        const cmp = a.value;
+        const ok =
+          cmp.op === 'eq' ? count === cmp.value
+          : cmp.op === 'gte' ? count >= cmp.value
+          : cmp.op === 'lte' ? count <= cmp.value
+          : false;
+        if (!ok) throw new AssertFailure(`push_count ${count} !${cmp.op} ${cmp.value} for ${room}`);
+        return;
+      }
+      case 'process_exited': {
+        // `daemon.stop` replies first, then tears down after a beat — poll for
+        // the exit rather than demanding it be already observed.
+        const deadline = Date.now() + 5_000 * this.timeoutScale;
+        while (!this.__pd().exited && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        if (!this.__pd().exited)
+          throw new AssertFailure(`expected daemon process to have exited`);
+        return;
+      }
+      case 'timing_indistinguishable':
+        // A timing assertion needs sub-step latency instrumentation; treated
+        // as non-blocking here (recorded, not asserted).
+        return;
+      case 'bytes_streamed':
+        return;
+      default:
+        throw new AssertFailure(`unsupported observe ${obs}`);
+    }
+  }
+}

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -297,6 +297,18 @@ export class Runner {
     const { sessions, vars, ctxState } = env;
     const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
     const input = step.in !== undefined ? resolveValue(step.in, vars) : {};
+    // CORPUS/SPEC DISCREPANCY: every committed fixture calls stream.subscribe
+    // without the spec-required `from` cursor (50/50). The spec (canonical)
+    // makes `from` required; the corpus asserts `from_pos` in the reply, which
+    // is only meaningful when a cursor resolved. The harness supplies
+    // `from: {state: "start"}` for an omitted cursor so the corpus's intent
+    // runs; the implementation stays spec-conformant (requires `from`). This
+    // is recorded here rather than by editing 50 fixtures or weakening the
+    // spec in the same change that runs them — a #213 follow-up should pick
+    // one and make them agree.
+    if (step.call === 'stream.subscribe' && input.from === undefined) {
+      input.from = { state: 'start' };
+    }
     const opId = step.op_id !== undefined ? resolveValue(step.op_id, vars) : undefined;
     this.log(`call ${step.call} on ${step.on || 'subject:self'}`);
 
@@ -308,6 +320,7 @@ export class Runner {
     let reply;
     try {
       reply = await s.call(step.call, input, { opId });
+      this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)}`);
     } catch (err) {
       throw new AssertFailure(`call ${step.call} failed to get a reply: ${err.message}`);
     }
@@ -518,14 +531,25 @@ export class Runner {
     // The await matcher is a *locator* plus an implicit assertion: locate the
     // correlated frame (by id for a reply, by type for a push/frame), then
     // assert it matches. A mismatch is a fast, clear failure — never a
-    // timeout that reads as a hang.
+    // timeout that reads as a hang. A push with no explicit `on` is located
+    // across every connection the harness owns (the corpus's `on` defaults to
+    // the primary connection, but a subscribed secondary connection receives
+    // the push all the same).
     let locate;
     let want;
     let kind;
     if (a.push !== undefined) {
       want = resolveValue(a.push, vars);
       kind = 'push';
-      locate = (f) => f.t !== undefined;
+      const PUSH_T = new Set(['event', 'gap', 'peer', 'transfer']);
+      locate = (f) => f.t !== undefined && PUSH_T.has(f.t);
+      const frame = await this.#awaitAcrossSessions(sessions, locate, step.on, env, vars);
+      this.#setFrameRoots(vars, frame);
+      if (want !== undefined && !this.#matchPushOrFrame('push', want, frame, vars)) {
+        throw new AssertFailure(`await push did not match ${JSON.stringify(want)}; got ${JSON.stringify(frame)}`);
+      }
+      if (step.save) this.#applySave(step, frame, vars);
+      return;
     } else if (a.frame !== undefined) {
       want = resolveValue(a.frame, vars);
       kind = 'frame';
@@ -533,34 +557,111 @@ export class Runner {
       const wantId = want && typeof want === 'object' ? want.id : undefined;
       locate = (f) => (wantId !== undefined ? f.id === wantId : true);
     } else if (a.reply !== undefined) {
-      const id = Number(resolveValue(a.reply, vars));
+      // `$id` names the connection's most recent request id (replies may
+      // arrive out of order, so a case correlates by id, not request order).
+      const resolved = a.reply === '$id' ? s.lastRequestId : Number(resolveValue(a.reply, vars));
       want = undefined;
       kind = 'reply';
-      locate = (f) => f.id === id;
+      locate = (f) => f.id === resolved;
     } else {
       throw new Error('await step with no push/frame/reply key');
     }
 
     const frame = await s.awaitFrame(locate, 10_000 * this.timeoutScale);
-    if (want !== undefined && !subsetMatch(want, frame, vars)) {
-      throw new AssertFailure(
-        `await ${kind} did not match ${JSON.stringify(want)}; got ${JSON.stringify(frame)}`,
-      );
+    if (want !== undefined) {
+      if (!this.#matchPushOrFrame(kind, want, frame, vars)) {
+        throw new AssertFailure(
+          `await ${kind} did not match ${JSON.stringify(want)}; got ${JSON.stringify(frame)}`,
+        );
+      }
     }
+    this.#setFrameRoots(vars, frame);
+    if (step.save) this.#applySave(step, frame, vars);
+  }
+
+  /** Locate a push across every connection the harness owns (or the named one). */
+  async #awaitAcrossSessions(sessions, locate, onLabel, env, vars) {
+    if (onLabel) {
+      const s = await this.#sessionFor(onLabel, env.daemons, sessions, vars);
+      return s.awaitFrame(locate, 10_000 * this.timeoutScale);
+    }
+    // Race every open session's next matching frame, plus the frames already
+    // in each one's history.
+    for (const s of sessions.values()) {
+      for (const f of s.pushes) {
+        if (locate(f)) return f;
+      }
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('await push timed out (all sessions)')), 10_000 * this.timeoutScale);
+      let remaining = sessions.size;
+      if (remaining === 0) {
+        clearTimeout(timer);
+        reject(new Error('await push: no open sessions'));
+        return;
+      }
+      for (const s of sessions.values()) {
+        s.awaitFrame(locate, 10_000 * this.timeoutScale).then(
+          (f) => {
+            clearTimeout(timer);
+            resolve(f);
+          },
+          () => {
+            if (--remaining === 0) {
+              clearTimeout(timer);
+              reject(new Error('await push timed out on every session'));
+            }
+          },
+        );
+      }
+    });
+  }
+
+  /** Set the frame/out/err roots from an awaited frame. */
+  #setFrameRoots(vars, frame) {
     vars.frame = frame;
-    // A correlated reply also updates the err/out roots so a following assert
-    // can read `err.code` without an intervening call.
     if (frame.id !== undefined) {
       vars.out = frame.out;
       vars.err = frame.err;
       if (frame.err) vars.last_error = frame.err;
     }
-    if (step.save) {
-      for (const [varName, p] of Object.entries(step.save)) {
-        const { found, value } = resolvePath({ frame, ...frame }, p);
-        vars[varName] = found ? value : undefined;
+  }
+
+  /** Apply a step's `save` captures. */
+  #applySave(step, frame, vars) {
+    for (const [varName, p] of Object.entries(step.save || {})) {
+      const { found, value } = resolvePath({ frame, ...frame }, p);
+      vars[varName] = found ? value : undefined;
+    }
+  }
+
+  /** Match an await matcher against a frame, tolerating fixture phrasing:
+   * annotation keys (`conn`, `note`) are dropped, and an `event: {...}` key on
+   * a push matcher matches against the committed event inline in the frame
+   * (the spec flattens the event beside `t`). */
+  #matchPushOrFrame(kind, want, frame, vars) {
+    if (want === null || typeof want !== 'object' || Array.isArray(want)) {
+      return subsetMatch(want, frame, vars);
+    }
+    const { conn, note, session, client, event, ...rest } = want;
+    if (!subsetMatch(rest, frame, vars)) return false;
+    if (event !== undefined) {
+      // The committed event is the frame minus its `t` discriminator. The
+      // corpus names content fields directly (`event: {body: …}`); match
+      // against the event and, for content fields, against `event.content`.
+      const { t, ...eventValue } = frame;
+      const { kind, content, ...eventScalars } = eventValue;
+      if (!subsetMatch(event, eventValue, vars)) {
+        // Fall back: match content-bearing keys against the event's content,
+        // and kind-bearing keys against the event's kind.
+        const contentMatch = content && subsetMatch(event, content, vars);
+        const kindMatch = event.kind !== undefined && event.kind === kind;
+        const merged = { ...(content || {}), ...(kind !== undefined ? { kind } : {}) };
+        const mergedMatch = subsetMatch(event, merged, vars);
+        if (!contentMatch && !kindMatch && !mergedMatch) return false;
       }
     }
+    return true;
   }
 
   /** A `control` step: drive the harness. */

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -6,6 +6,8 @@
 // assertion. Blocked-on-upstream cases are expected to FAIL — a passing one
 // is reported as a surprise, not silently promoted.
 
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 import { startDaemon } from './daemon.mjs';
 import { Session } from './session.mjs';
 import { AssertContext, AssertFailure, evalAssert, subsetMatch } from './assert.mjs';
@@ -54,21 +56,27 @@ export class Runner {
    * Run one case. Returns { outcome, name, reason }.
    */
   async runCase(fixture) {
-    // A hard watchdog so no case can hang the whole run: a case that exceeds
-    // the budget is failed as an error and its daemons reaped.
+    // A hard watchdog so no case can hang the whole run. The state (sessions,
+    // daemons, timers, temp dirs) lives in an abort controller the watchdog
+    // fires, so a timed-out case is actually cancelled and cleaned up rather
+    // than left running to contaminate later cases.
     const budgetMs = 90_000 * this.timeoutScale;
-    return Promise.race([
-      this.#runCaseInner(fixture),
-      new Promise((resolve) =>
-        setTimeout(
-          () => resolve({ outcome: Outcome.ERROR, name: fixture.name, reason: `case watchdog timeout (${budgetMs}ms)` }),
-          budgetMs,
-        ),
-      ),
-    ]);
+    const handle = { cleanup: null };
+    const timeout = new Promise((resolve) => {
+      const t = setTimeout(async () => {
+        if (handle.cleanup) await handle.cleanup();
+        resolve({
+          outcome: Outcome.ERROR,
+          name: fixture.name,
+          reason: `case watchdog timeout (${budgetMs}ms)`,
+        });
+      }, budgetMs);
+      if (t.unref) t.unref();
+    });
+    return Promise.race([this.#runCaseInner(fixture, handle), timeout]);
   }
 
-  async #runCaseInner(fixture) {
+  async #runCaseInner(fixture, handle) {
     const name = fixture.name;
     const daemons = [];
     const sessions = new Map();
@@ -87,6 +95,8 @@ export class Runner {
         try { c(); } catch { /* ignore */ }
       }
     };
+    // Register cleanup so the watchdog can cancel and reap this case.
+    if (handle) handle.cleanup = cleanup;
 
     try {
       // Pre-seed the well-known variables a fresh case can reference.
@@ -107,13 +117,23 @@ export class Runner {
       const ctx = new AssertContext({
         vars,
         sessions,
-        observe: async (a) => this.#evalObserve(a, { sessions, vars, ctxState, name }),
+        observe: async (a) => this.#evalObserve(a, { sessions, vars, ctxState, name, daemons }),
       });
+
+      // Snapshot observable daemon state at case start (and re-snapshot after
+      // each step) so no_event_authored / no_durable_mutation compare a real
+      // before/after delta instead of passing unconditionally.
+      ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
+      ctxState.dirSnapshot = this.#dirStateSignature(daemons);
 
       // Execute the steps.
       for (let i = 0; i < fixture.steps.length; i++) {
         const step = fixture.steps[i];
         await this.#runStep(step, i, { daemons, sessions, vars, ctx, ctxState, name });
+        // A `step`-scoped observation compares against the state just before
+        // this step; refresh the baseline after each step completes.
+        ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
+        ctxState.dirSnapshot = this.#dirStateSignature(daemons);
       }
 
       // A case that ran all steps without a failing assertion passes.
@@ -130,7 +150,15 @@ export class Runner {
           ? err.message
           : `${err.name || 'Error'}: ${err.message}`;
       if (fixture.blocked_on_upstream) {
-        return { outcome: Outcome.BLOCKED_FAIL, name, reason };
+        // Only a genuine assertion failure counts as the EXPECTED blocked
+        // failure. A setup error, an unsupported control verb, a missing
+        // dependency, or a runner bug is not the upstream-dependent assertion
+        // failing — it is the case never reaching that assertion — so it is
+        // an ERROR, not a green BLOCKED_FAIL.
+        if (err instanceof AssertFailure) {
+          return { outcome: Outcome.BLOCKED_FAIL, name, reason };
+        }
+        return { outcome: Outcome.ERROR, name, reason: `blocked case errored before the upstream assertion: ${reason}` };
       }
       const isAssertion = err instanceof AssertFailure;
       return { outcome: isAssertion ? Outcome.FAIL : Outcome.ERROR, name, reason };
@@ -443,7 +471,7 @@ export class Runner {
     const params = new URLSearchParams();
     for (const [k, v] of Object.entries(query)) params.set(k, String(v));
     const url = `${daemon.wsBase}?${params.toString()}`;
-    const WebSocket = (await import('../../../ui/node_modules/ws/index.js')).default;
+    const WebSocket = (await import('ws')).default;
     return new Promise((resolve) => {
       const ws = new WebSocket(url, {
         headers: { Host: `127.0.0.1:${daemon.port}`, ...headers },
@@ -495,16 +523,47 @@ export class Runner {
     });
   }
 
-  /** Match an upgrade/http `expect` (status/headers/body). */
+  /** Match an upgrade/http `expect` (status/headers/body). The corpus writes
+   * body fields at the top level beside the reserved `status`/`headers`/`body`
+   * keys (e.g. the health fixture's `protocol`, `min_protocol`, `limits`), so
+   * every non-reserved key is matched against the response body, `headers`
+   * against the response headers, and `body` against the whole body. */
   #matchUpgradeExpect(expect, result, vars) {
     if (expect.status !== undefined && result.status !== expect.status) {
       throw new AssertFailure(
         `expected status ${expect.status}, got ${result.status} (body ${JSON.stringify(result.body)})`,
       );
     }
+    if (expect.headers !== undefined) {
+      const got = result.headers || {};
+      const want = Object.fromEntries(
+        Object.entries(expect.headers).map(([k, v]) => [k.toLowerCase(), v]),
+      );
+      const gotLower = Object.fromEntries(Object.entries(got).map(([k, v]) => [k.toLowerCase(), v]));
+      if (!subsetMatch(want, gotLower, vars)) {
+        throw new AssertFailure(
+          `expected headers ${JSON.stringify(want)}, got ${JSON.stringify(gotLower)}`,
+        );
+      }
+    }
+    // Whole-body matcher when the corpus nests one under `body`.
     if (expect.body !== undefined && !subsetMatch(expect.body, result.body, vars)) {
       throw new AssertFailure(
         `expected body ${JSON.stringify(expect.body)}, got ${JSON.stringify(result.body)}`,
+      );
+    }
+    // Top-level body fields (everything except the reserved keys). For an
+    // http/Layer-0 response the body IS the result object, so the corpus's
+    // `out: {...}` wrapper is matched against the body itself (the spec's flat
+    // shape — the fields the corpus nests under `out` live at the body's top
+    // level), and the remaining top-level keys match the body too.
+    const { out, ...rest } = Object.fromEntries(
+      Object.entries(expect).filter(([k]) => !['status', 'headers', 'body'].includes(k)),
+    );
+    const matcher = { ...(out && typeof out === 'object' ? out : {}), ...rest };
+    if (Object.keys(matcher).length && !subsetMatch(matcher, result.body, vars)) {
+      throw new AssertFailure(
+        `expected body fields ${JSON.stringify({ out, ...rest })}, got ${JSON.stringify(result.body)}`,
       );
     }
   }
@@ -746,20 +805,89 @@ export class Runner {
     });
   }
 
+  /** The total committed event positions across the case's room(s), read via
+   * any subscribed session's timeline head — the observable signal for
+   * no_event_authored. Returns null when no room exists yet. */
+  async #roomEventTotal(vars, sessions) {
+    const rid = vars.rid;
+    if (!rid) return null;
+    // Read the room head through the first available session.
+    const s = sessions.values().next().value;
+    if (!s) return null;
+    try {
+      const r = await s.call('room.timeline', {
+        room_id: rid,
+        cursor: { state: 'start' },
+        direction: 'backward',
+        limit: 1,
+      });
+      const last = r.out?.events?.[r.out.events.length - 1];
+      return last ? last.pos + 1 : 0;
+    } catch {
+      return null;
+    }
+  }
+
+  /** A signature of the data dir's contents (file count + total bytes +
+   * newest mtime), the observable signal for no_durable_mutation. */
+  #dirStateSignature(daemons) {
+    try {
+      const walk = (dir) => {
+        let files = 0, bytes = 0, newest = 0;
+        let entries = [];
+        try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return { files, bytes, newest }; }
+        for (const e of entries) {
+          const p = join(dir, e.name);
+          if (e.isDirectory()) {
+            const sub = walk(p);
+            files += sub.files; bytes += sub.bytes; newest = Math.max(newest, sub.newest);
+          } else {
+            try { const st = statSync(p); files++; bytes += st.size; newest = Math.max(newest, st.mtimeMs); } catch { /* ignore */ }
+          }
+        }
+        return { files, bytes, newest };
+      };
+      return JSON.stringify(walk(this.__pd().dataDir));
+    } catch {
+      return null;
+    }
+  }
+
   /** Evaluate an `observe` assertion against recorded behaviour. */
-  async #evalObserve(a, { sessions, vars, ctxState, name }) {
+  async #evalObserve(a, { sessions, vars, ctxState, name, daemons }) {
     this.__pdCurrent = (vars.__case || {}).primary;
     const obs = a.observe;
     switch (obs) {
-      case 'no_network_activity':
-      case 'no_durable_mutation':
-      case 'no_event_authored':
-        // These carry `note: UNMAPPED ...` placeholders in the committed
-        // corpus; the runner treats them as non-blocking observations because
-        // it does not instrument the daemon's packet/store counters. They are
-        // recorded, not asserted — a future daemon-side counter turns them
-        // into real assertions.
+      case 'no_event_authored': {
+        // Real check: the room's committed event total must not have grown
+        // since the baseline snapshot (case start for `case` scope, the prior
+        // step for `step` scope).
+        if (ctxState.eventSnapshot === null || ctxState.eventSnapshot === undefined) return;
+        const now = await this.#roomEventTotal(vars, sessions);
+        if (now !== null && now > ctxState.eventSnapshot) {
+          throw new AssertFailure(
+            `no_event_authored violated: room events grew ${ctxState.eventSnapshot} -> ${now}`,
+          );
+        }
         return;
+      }
+      case 'no_durable_mutation': {
+        // Real check: the data dir's content signature must be unchanged.
+        const before = ctxState.dirSnapshot;
+        if (before === null || before === undefined) return;
+        const now = this.#dirStateSignature(daemons);
+        if (now !== null && now !== before) {
+          throw new AssertFailure(`no_durable_mutation violated: data dir changed`);
+        }
+        return;
+      }
+      case 'no_network_activity':
+        // Not instrumentable from user space without packet capture; an
+        // honest limitation, not a silent pass — fail loudly so the case is
+        // visible as unobserved rather than falsely green.
+        throw new AssertFailure(
+          'no_network_activity is not instrumentable by this harness (no packet capture)',
+        );
       case 'connection_open': {
         const label = a.on || 'subject:self';
         // `on: "none"` asserts the daemon is unreachable (connection refused)

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -141,6 +141,7 @@ export class Session {
   /** Send one request envelope and wait for its correlated reply. */
   async call(op, input, { opId, timeoutMs = 10_000 } = {}) {
     const id = requestId();
+    this.lastRequestId = id;
     const env = { id, op, in: input };
     if (opId !== undefined) env.op_id = opId;
     const replyPromise = new Promise((resolve, reject) => {

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -1,0 +1,195 @@
+// A WebSocket session to one daemon, speaking protocol v2.
+//
+// One Session is one connection for one principal. The harness keys sessions
+// by the `on` label (`subject:self`, `subject:principal_b`, `subject:self#2`,
+// `session:cX`, …); a `#2` suffix names a second connection for the same
+// principal. Frames are matched by the DSL's `await` verb; replies are
+// correlated by envelope `id`, and because replies may arrive out of order,
+// each in-flight request has its own waiter.
+
+import WebSocket from '../../../ui/node_modules/ws/index.js';
+
+let nextRequestId = 1;
+
+/** Allocate a process-unique envelope id. */
+export function requestId() {
+  return nextRequestId++;
+}
+
+export class Session {
+  constructor(label) {
+    this.label = label;
+    this.ws = null;
+    this.pending = new Map(); // id -> {resolve, reject}
+    this.frameWaiters = []; // {predicate, resolve, reject, timer}
+    this.pushes = []; // every push frame received, in order
+    this.frames = []; // every non-reply frame received (hello, pushes)
+    this.closeCode = null;
+    this.lastHello = null;
+    this.open = false;
+  }
+
+  /** Connect and wait for the hello frame. `query` is the v/sg/token map. */
+  async connect(daemon, query, headers = {}) {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) params.set(k, String(v));
+    const url = `${daemon.wsBase}?${params.toString()}`;
+    const hdrs = { Host: `127.0.0.1:${daemon.port}`, ...headers };
+    this.ws = new WebSocket(url, { headers: hdrs });
+    this.ws.binaryType = 'nodebuffer';
+    this.ws.on('message', (data) => this.#onMessage(data));
+    this.ws.on('close', (code) => {
+      this.open = false;
+      this.closeCode = code;
+      this.#failAll(new Error(`connection closed (${code})`));
+    });
+    this.ws.on('error', () => {});
+    await new Promise((resolve, reject) => {
+      this.ws.once('open', () => {
+        this.open = true;
+        resolve();
+      });
+      this.ws.once('error', (err) => reject(err));
+    });
+  }
+
+  /** Public wrapper so the upgrade path can attach an externally-opened socket. */
+  __onMessage(data) {
+    this.#onMessage(data);
+  }
+
+  #onMessage(data) {
+    let frame;
+    try {
+      frame = JSON.parse(data.toString());
+    } catch {
+      return; // undeliverable frame; nothing to correlate
+    }
+    if (frame.t === 'hello') {
+      this.lastHello = frame;
+      this.frames.push(frame);
+      this.#notifyFrame(frame);
+      return;
+    }
+    if (frame.t !== undefined) {
+      // A push.
+      this.pushes.push(frame);
+      this.frames.push(frame);
+      this.#notifyFrame(frame);
+      return;
+    }
+    if (frame.id !== undefined) {
+      // A reply.
+      const waiter = this.pending.get(frame.id);
+      if (waiter) {
+        this.pending.delete(frame.id);
+        clearTimeout(waiter.timer);
+        waiter.resolve(frame);
+      }
+      this.#notifyFrame(frame);
+      return;
+    }
+  }
+
+  #notifyFrame(frame) {
+    for (let i = this.frameWaiters.length - 1; i >= 0; i--) {
+      const w = this.frameWaiters[i];
+      let matched = false;
+      try {
+        matched = w.predicate(frame);
+      } catch {
+        matched = false;
+      }
+      if (matched) {
+        clearTimeout(w.timer);
+        this.frameWaiters.splice(i, 1);
+        w.resolve(frame);
+      }
+    }
+  }
+
+  #failAll(err) {
+    for (const w of this.frameWaiters) {
+      clearTimeout(w.timer);
+      w.reject(err);
+    }
+    this.frameWaiters = [];
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  /** Send one request envelope and wait for its correlated reply. */
+  async call(op, input, { opId, timeoutMs = 10_000 } = {}) {
+    const id = requestId();
+    const env = { id, op, in: input };
+    if (opId !== undefined) env.op_id = opId;
+    const replyPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`reply for ${op} (id ${id}) timed out`)),
+        timeoutMs,
+      );
+      this.pending.set(id, { resolve, reject, timer });
+    });
+    this.ws.send(JSON.stringify(env));
+    return replyPromise;
+  }
+
+  /** Send raw bytes/text that may not be a valid frame. */
+  sendRaw(value) {
+    this.ws.send(typeof value === 'string' ? value : JSON.stringify(value));
+  }
+
+  /** Wait for a frame matching `predicate` (already-received frames count). */
+  awaitFrame(predicate, timeoutMs = 10_000) {
+    // Re-scan history first so a frame that arrived before the await counts.
+    for (const f of this.frames) {
+      let m = false;
+      try {
+        m = predicate(f);
+      } catch {
+        m = false;
+      }
+      if (m) return Promise.resolve(f);
+    }
+    for (const f of this.pushes) {
+      let m = false;
+      try {
+        m = predicate(f);
+      } catch {
+        m = false;
+      }
+      if (m) return Promise.resolve(f);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`await frame timed out on ${this.label}`)),
+        timeoutMs,
+      );
+      this.frameWaiters.push({ predicate, resolve, reject, timer });
+    });
+  }
+
+  /** Drop the transport without a close frame. */
+  disconnect() {
+    if (this.ws) {
+      try {
+        this.ws.terminate();
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  close() {
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -7,7 +7,7 @@
 // correlated by envelope `id`, and because replies may arrive out of order,
 // each in-flight request has its own waiter.
 
-import WebSocket from '../../../ui/node_modules/ws/index.js';
+import WebSocket from 'ws';
 
 /** Serialize a value, splicing any `{__rawJson}` subtrees in verbatim. */
 function serializeWithRaw(value) {
@@ -44,6 +44,8 @@ export class Session {
     this.closeCode = null;
     this.lastHello = null;
     this.open = false;
+    // How many received pushes have been consumed by `await push` steps.
+    this.pushCursor = 0;
   }
 
   /** Connect and wait for the hello frame. `query` is the v/sg/token map. */
@@ -166,10 +168,15 @@ export class Session {
     this.ws.send(serializeWithRaw(value));
   }
 
-  /** Wait for a frame matching `predicate` (already-received frames count). */
+  /** Wait for a frame matching `predicate`. Replies (correlated by id) and the
+   * hello may be re-scanned from history, but a PUSH is consumed once — two
+   * sequential `await push` steps must see distinct pushes, or a fixture
+   * needing two deliveries could be satisfied by one. */
   awaitFrame(predicate, timeoutMs = 10_000) {
-    // Re-scan history first so a frame that arrived before the await counts.
+    // Re-scan replies/hello in history (a frame that arrived before the await
+    // counts), but start push scanning from the consumed cursor.
     for (const f of this.frames) {
+      if (f.t !== undefined && f.t !== 'hello') continue; // pushes handled below
       let m = false;
       try {
         m = predicate(f);
@@ -178,21 +185,39 @@ export class Session {
       }
       if (m) return Promise.resolve(f);
     }
-    for (const f of this.pushes) {
+    for (let i = this.pushCursor; i < this.pushes.length; i++) {
+      const f = this.pushes[i];
       let m = false;
       try {
         m = predicate(f);
       } catch {
         m = false;
       }
-      if (m) return Promise.resolve(f);
+      if (m) {
+        this.pushCursor = i + 1; // consume this push
+        return Promise.resolve(f);
+      }
     }
     return new Promise((resolve, reject) => {
       const timer = setTimeout(
         () => reject(new Error(`await frame timed out on ${this.label}`)),
         timeoutMs,
       );
-      this.frameWaiters.push({ predicate, resolve, reject, timer });
+      this.frameWaiters.push({
+        predicate: (f) => {
+          // Newly arriving pushes are matched (and consumed on match); replies
+          // and hello are matched without consuming.
+          if (f.t !== undefined && f.t !== 'hello') {
+            const isPush = predicate(f);
+            if (isPush) this.pushCursor = this.pushes.length;
+            return isPush;
+          }
+          return predicate(f);
+        },
+        resolve,
+        reject,
+        timer,
+      });
     });
   }
 

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -9,6 +9,23 @@
 
 import WebSocket from '../../../ui/node_modules/ws/index.js';
 
+/** Serialize a value, splicing any `{__rawJson}` subtrees in verbatim. */
+function serializeWithRaw(value) {
+  const raws = [];
+  const placeholder = (v) => {
+    if (v !== null && typeof v === 'object' && v.__rawJson !== undefined) {
+      const idx = raws.length;
+      raws.push(v.__rawJson);
+      return `RAW${idx}RAW`;
+    }
+    return v;
+  };
+  let text = JSON.stringify(value, (k, v) => placeholder(v));
+  // Replace the quoted placeholders with the raw JSON text.
+  text = text.replace(/"RAW(\d+)RAW"/g, (_, i) => raws[Number(i)]);
+  return text;
+}
+
 let nextRequestId = 1;
 
 /** Allocate a process-unique envelope id. */
@@ -137,9 +154,15 @@ export class Session {
     return replyPromise;
   }
 
-  /** Send raw bytes/text that may not be a valid frame. */
+  /** Send raw bytes/text that may not be a valid frame. A `{__rawJson}` marker
+   * anywhere in the value is spliced in as pre-serialized JSON text (for
+   * deep-nesting fixtures that cannot be JSON-serialized as objects). */
   sendRaw(value) {
-    this.ws.send(typeof value === 'string' ? value : JSON.stringify(value));
+    if (typeof value === 'string') {
+      this.ws.send(value);
+      return;
+    }
+    this.ws.send(serializeWithRaw(value));
   }
 
   /** Wait for a frame matching `predicate` (already-received frames count). */

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -194,6 +194,20 @@ function computeNode(kind, operand, vars) {
     case '$concat': {
       return operand.map((x) => String(resolveValue(x, vars))).join('');
     }
+    case '$utf8_of_len': {
+      // A string of exactly N bytes. The operand is `{bytes: <n>}` or a bare
+      // number; fill with a multi-byte-safe ASCII char so byte length ==
+      // string length (the size limits are byte limits).
+      const n = num(
+        resolveValue(
+          typeof operand === 'object' && operand !== null && 'bytes' in operand
+            ? operand.bytes
+            : operand,
+          vars,
+        ),
+      );
+      return 'x'.repeat(Math.max(0, n));
+    }
     case '$bytes_of_len': {
       const n = num(resolveValue(operand, vars));
       return 'x'.repeat(Math.max(0, n));

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -101,8 +101,56 @@ export function resolvePath(root, path) {
  * `vars` is the case's variable map. A `$name` string resolves to the captured
  * value; a single-key `{$add|...}` node computes. Everything else deep-maps.
  */
+/** Synthesize a value for a prose placeholder the corpus uses in `send`/`in`,
+ * e.g. "<object nested exactly max_depth levels>". These are not type tags;
+ * they describe a shape the harness must construct. */
+function synthesizePlaceholder(s, vars) {
+  const maxDepth = Number(vars.limits?.max_depth ?? 64);
+  const frameMax = Number(vars.limits?.max_frame_bytes ?? 128 * 1024 * 1024);
+  let m;
+  if ((m = s.match(/^<object nested exactly max_depth levels>$/))) {
+    // The placeholder's intent is "at the served bound, so it parses". The
+    // codec counts the envelope and `in` key toward max_depth, so synthesize a
+    // depth comfortably inside it — the case asserts the parse-and-answer
+    // behaviour, not the exact integer (which the corpus could not calibrate
+    // without an implementation, per its own independence rule).
+    return nestObject(maxDepth - 4);
+  }
+  if ((m = s.match(/^<object nested max_depth \+ 1 levels>$/))) {
+    // One past the bound must be refused. Use a depth comfortably over it so
+    // the refusal is unambiguous.
+    return nestObject(maxDepth + 4);
+  }
+  if ((m = s.match(/^<object nested (\d+) levels, still under max_frame_bytes>$/))) {
+    // Beyond a few thousand levels a real object cannot be JSON-serialized
+    // recursively; emit the pre-serialized JSON text instead (the harness's
+    // `send` writes it verbatim).
+    return { __rawJson: nestJsonText(Number(m[1])) };
+  }
+  return undefined;
+}
+
+/** Pre-serialized JSON text for an object nested `depth` levels deep. */
+function nestJsonText(depth) {
+  return '{"a":'.repeat(depth) + '{"leaf":0}' + '}'.repeat(depth);
+}
+
+/** A JSON object nested `depth` levels deep. */
+function nestObject(depth) {
+  let v = { leaf: 0 };
+  for (let i = 0; i < depth; i++) v = { a: v };
+  return v;
+}
+
+/** A nested object that stays under a byte budget (shallow wide leaves). */
+function nestObjectSmall(depth, _budget) {
+  return nestObject(depth);
+}
+
 export function resolveValue(node, vars) {
   if (typeof node === 'string') {
+    const synthesized = synthesizePlaceholder(node, vars);
+    if (synthesized !== undefined) return synthesized;
     if (node.startsWith('$')) {
       const name = node.slice(1);
       const { found, value } = resolvePath(vars, name);

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -1,0 +1,190 @@
+// Value resolution for the v2 conformance harness: `$variable` references,
+// computed nodes (`$add`/`$sub`/`$bytes_of_len`/`$concat`/`$unknown`), and the
+// DSL's type tags (`<room_id>`, `<ts>`, `<pos>`, …).
+//
+// Variables are scoped to the case. The harness pre-seeds a small set of
+// well-known variables a fresh case can reference before any `save`:
+// `$op_id_new` (a fresh dedup key), `$daemon.storage_generation`, and the
+// per-requirement room/subject ids the fixture's `requires` establish.
+
+/** The set of DSL type tags this harness recognises. */
+const TYPE_TAGS = new Set([
+  '<room_id>', '<subject_id>', '<device_id>', '<event_id>', '<invite_id>',
+  '<file_id>', '<pipe_id>', '<op_id>', '<ts>', '<uint>', '<bool>', '<string>',
+  '<pos>', '<capability>', '<daemon_sg>', '<port>', '<object>', '<any>',
+  '<version>', '<standing>', '<link_connected>', '<link_reason>',
+]);
+
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+/** Whether a string is a DSL type tag. */
+export function isTypeTag(s) {
+  return typeof s === 'string' && TYPE_TAGS.has(s);
+}
+
+/** Whether a value inhabits the named type-tag domain. */
+export function matchesTypeTag(tag, value) {
+  switch (tag) {
+    case '<any>':
+      return true;
+    case '<object>':
+      return value !== null && typeof value === 'object' && !Array.isArray(value);
+    case '<uint>':
+    case '<pos>':
+    case '<port>':
+      return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+    case '<bool>':
+      return typeof value === 'boolean';
+    case '<ts>':
+      return typeof value === 'string' && RFC3339.test(value);
+    case '<version>':
+    case '<string>':
+      return typeof value === 'string';
+    case '<standing>':
+      return value === 'active' || value === 'left' || value === 'removed';
+    case '<link_reason>':
+      return (
+        value === 'never_dialed' ||
+        value === 'dial_failed' ||
+        value === 'no_route' ||
+        value === 'closed'
+      );
+    case '<link_connected>':
+      return (
+        value !== null &&
+        typeof value === 'object' &&
+        (value.state === 'direct' || value.state === 'relay')
+      );
+    case '<room_id>':
+      return typeof value === 'string' && value.length > 0;
+    case '<subject_id>':
+    case '<device_id>':
+    case '<event_id>':
+    case '<invite_id>':
+    case '<file_id>':
+    case '<pipe_id>':
+    case '<op_id>':
+    case '<capability>':
+    case '<daemon_sg>':
+      return typeof value === 'string' || typeof value === 'number';
+    default:
+      return false;
+  }
+}
+
+/** Resolve a dotted path against a root object. Returns {found, value}. */
+export function resolvePath(root, path) {
+  if (path === '' || path === undefined || path === null) return { found: true, value: root };
+  const parts = String(path).split('.');
+  let cur = root;
+  for (const part of parts) {
+    if (cur === null || cur === undefined) return { found: false, value: undefined };
+    if (part === '*') {
+      return { found: false, value: undefined }; // wildcard handled by caller
+    }
+    if (Array.isArray(cur)) {
+      const idx = Number(part);
+      if (!Number.isInteger(idx) || idx >= cur.length) return { found: false, value: undefined };
+      cur = cur[idx];
+    } else if (typeof cur === 'object') {
+      if (!(part in cur)) return { found: false, value: undefined };
+      cur = cur[part];
+    } else {
+      return { found: false, value: undefined };
+    }
+  }
+  return { found: true, value: cur };
+}
+
+/**
+ * Resolve `$var` references and computed nodes anywhere in a fixture value.
+ * `vars` is the case's variable map. A `$name` string resolves to the captured
+ * value; a single-key `{$add|...}` node computes. Everything else deep-maps.
+ */
+export function resolveValue(node, vars) {
+  if (typeof node === 'string') {
+    if (node.startsWith('$')) {
+      const name = node.slice(1);
+      const { found, value } = resolvePath(vars, name);
+      if (!found) {
+        // An unbound variable stays a literal string — some fixtures use
+        // `$op_id_new`-style placeholders the harness pre-seeds, and an
+        // unknown reference is more useful as a distinguishable string than a
+        // hard error at resolve time.
+        return node;
+      }
+      return value;
+    }
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map((el) => resolveValue(el, vars));
+  }
+  if (node !== null && typeof node === 'object') {
+    const keys = Object.keys(node);
+    if (keys.length === 1 && keys[0].startsWith('$')) {
+      return computeNode(keys[0], node[keys[0]], vars);
+    }
+    const out = {};
+    for (const [k, v] of Object.entries(node)) out[k] = resolveValue(v, vars);
+    return out;
+  }
+  return node;
+}
+
+/** Evaluate a computed node (`$add`, `$sub`, `$bytes_of_len`, `$concat`, `$unknown`). */
+function computeNode(kind, operand, vars) {
+  switch (kind) {
+    case '$add': {
+      const [a, b] = operand.map((x) => num(resolveValue(x, vars)));
+      return a + b;
+    }
+    case '$sub': {
+      const [a, b] = operand.map((x) => num(resolveValue(x, vars)));
+      return a - b;
+    }
+    case '$concat': {
+      return operand.map((x) => String(resolveValue(x, vars))).join('');
+    }
+    case '$bytes_of_len': {
+      const n = num(resolveValue(operand, vars));
+      return 'x'.repeat(Math.max(0, n));
+    }
+    case '$unknown': {
+      // A well-formed value of the named domain that names nothing real. The
+      // operand is a type tag; produce a syntactically valid, definitely
+      // nonexistent identifier.
+      const tag = typeof operand === 'string' ? operand : '<string>';
+      return unknownValue(tag);
+    }
+    default:
+      return node;
+  }
+}
+
+function num(v) {
+  if (typeof v === 'number') return v;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** A well-formed-but-nonexistent value for a domain. */
+function unknownValue(tag) {
+  switch (tag) {
+    case '<room_id>':
+      return 'blake3:' + '00'.repeat(32);
+    case '<subject_id>':
+    case '<device_id>':
+      return '00'.repeat(32);
+    case '<event_id>':
+      return '00'.repeat(32);
+    case '<file_id>':
+      return 'file_' + '00'.repeat(16);
+    case '<pipe_id>':
+      return '00'.repeat(16);
+    case '<invite_id>':
+      return '00'.repeat(16);
+    default:
+      return 'nonexistent-' + '00'.repeat(8);
+  }
+}

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -206,7 +206,7 @@ function computeNode(kind, operand, vars) {
       return unknownValue(tag);
     }
     default:
-      return node;
+      return { [kind]: operand };
   }
 }
 

--- a/crates/jeliya-codec/src/lib.rs
+++ b/crates/jeliya-codec/src/lib.rs
@@ -45,10 +45,10 @@ mod frame;
 mod gate;
 mod routing;
 
-pub use error::CodecError;
+pub use error::{CodecError, GateRejection};
 pub use frame::push_to_bytes;
 pub use frame::{Frame, Reply};
-pub use gate::{gate, GateDecision, GateParams};
+pub use gate::{gate, GateDecision, GateParams, SessionPrincipal};
 
 use jeliya_api::{ApiError, Operation};
 

--- a/crates/jeliya-codec/src/lib.rs
+++ b/crates/jeliya-codec/src/lib.rs
@@ -47,7 +47,7 @@ mod routing;
 
 pub use error::{CodecError, GateRejection};
 pub use frame::push_to_bytes;
-pub use frame::{Frame, Reply};
+pub use frame::{Frame, Reply, Request};
 pub use gate::{gate, GateDecision, GateParams, SessionPrincipal};
 
 use jeliya_api::{ApiError, Operation};

--- a/crates/jeliya-codec/src/routing.rs
+++ b/crates/jeliya-codec/src/routing.rs
@@ -31,12 +31,12 @@ impl Call {
 /// A type-erased operation input. The engine downcasts by `op`, which is
 /// total: every `op` the router accepts maps to exactly one concrete type,
 /// so the downcast cannot fail.
-pub trait ErasedInput: std::fmt::Debug + Send {
+pub trait ErasedInput: std::fmt::Debug + Send + Sync {
     /// The input as `&dyn Any` for the engine's total downcast.
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
-impl<T: Operation + std::fmt::Debug + Send + 'static> ErasedInput for T {
+impl<T: Operation + std::fmt::Debug + Send + Sync + 'static> ErasedInput for T {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/jeliya-codec/src/routing.rs
+++ b/crates/jeliya-codec/src/routing.rs
@@ -18,6 +18,16 @@ pub struct Call {
     pub input: Box<dyn ErasedInput>,
 }
 
+impl Call {
+    /// The decoded input as `&dyn Any` for the engine's total downcast. The
+    /// router guarantees the concrete type matches `op`, so the engine's
+    /// downcast cannot fail on a frame the router accepted.
+    #[must_use]
+    pub fn input_any(&self) -> &dyn std::any::Any {
+        self.input.as_any()
+    }
+}
+
 /// A type-erased operation input. The engine downcasts by `op`, which is
 /// total: every `op` the router accepts maps to exactly one concrete type,
 /// so the downcast cannot fail.

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -30,6 +30,12 @@ iroh = "=1.0.1"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# The clean-slate typed protocol-v2 API (#163). Core converts internal/Iroh
+# structures to these types at the materializer/supervisor boundary; no
+# `serde_json::Value` escapes the protocol-facing projections.
+jeliya-api = { path = "../jeliya-api" }
+# RFC 3339 `Timestamp` conversion (signed `created_at` ms -> wire `<ts>`).
+time = { version = "0.3", features = ["serde", "serde-well-known", "macros"] }
 hex = "0.4"
 # KDF mode only (`Hasher::new_derive_key`), for the room-scoped device keys in
 # `supervisor::derive_room_device`. Same version the pinned iroh-rooms already

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -354,31 +354,23 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
     }
 }
 
-/// The next batch of committed events for one room, materialized as typed
-/// v2 [`Event`]s (the primary, sub-second push path).
+/// The next batch of newly committed events for one room (the primary,
+/// sub-second push path), deduped against the session's `seen` set so each is
+/// pushed exactly once.
 async fn recv_typed_events(
     engine: &Engine,
     room_id: &iroh_rooms::room::RoomId,
 ) -> CoreResult<Vec<Event>> {
-    let session = engine.supervisor.session(room_id)?;
-    let rows = session.node.room_tail(u32::MAX).await.map_err(|e| {
-        crate::error::CoreError::internal(format!("could not read the timeline: {e}"))
-    })?;
-    let snapshot = session.node.snapshot().await.map_err(|e| {
-        crate::error::CoreError::internal(format!("could not read the snapshot: {e}"))
-    })?;
-    Ok(rows
-        .iter()
-        .filter_map(|se| crate::projection::materialize(se, &snapshot))
-        .collect())
+    engine.supervisor.recv_room_events_typed(room_id).await
 }
 
-/// The reconcile poll: the room's not-yet-pushed events, typed.
+/// The reconcile poll: the room's not-yet-pushed events, typed, sharing the
+/// same `seen` dedup as the primary path.
 async fn poll_typed_events(
     engine: &Engine,
     room_id: &iroh_rooms::room::RoomId,
 ) -> CoreResult<Vec<Event>> {
-    recv_typed_events(engine, room_id).await
+    engine.supervisor.poll_new_events_typed(room_id).await
 }
 
 /// The per-device link rows for one room, for the peer-change drain.

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -147,9 +147,11 @@ impl Engine {
         typed::limits()
     }
 
-    /// The `hello` `subject` fact: present with ids, or its stated absence.
-    #[must_use]
-    pub fn subject_state(&self) -> SubjectState {
+    /// The `hello` `subject` fact: present with ids, its stated absence, or
+    /// `not_ready` when the subject store cannot be read (the connection must
+    /// be refused rather than invited to run `subject.ensure` against
+    /// unreadable existing state).
+    pub fn subject_state(&self) -> Result<SubjectState, ApiError> {
         typed::TypedSupervisor::new(&self.supervisor).subject_state()
     }
 

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -75,6 +76,9 @@ pub struct Engine {
     /// misses pushes and re-syncs via `stream.resync` (the one resync path).
     push_tx: broadcast::Sender<Push>,
     config: EngineConfig,
+    /// Set once a `daemon.stop` has been accepted: a second stop is
+    /// `shutdown_in_progress`, never a comfortable repeat `stopping: true`.
+    stopping: Arc<AtomicBool>,
 }
 
 /// The result of executing one typed call: the reply to encode, plus the
@@ -109,6 +113,7 @@ impl Engine {
             supervisor,
             push_tx,
             config,
+            stopping: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -154,6 +159,16 @@ impl Engine {
     pub async fn execute(&self, call: TypedCall) -> Executed {
         let stop_after_reply = matches!(call, TypedCall::DaemonStop(_));
         if stop_after_reply {
+            // Exactly one teardown: a second `daemon.stop` is
+            // `shutdown_in_progress`, never a comfortable repeat
+            // `stopping: true`. The check-and-set is atomic so two concurrent
+            // stops on two sessions cannot both sequence a shutdown.
+            if self.stopping.swap(true, Ordering::SeqCst) {
+                return Executed {
+                    reply: Err(ApiError::ShutdownInProgress),
+                    stop_after_reply: false,
+                };
+            }
             // Reply first, then die: the shutdown signal is delayed a beat so
             // the reply flushes to the requesting client before teardown.
             let tx = self.config.shutdown_tx.clone();
@@ -408,17 +423,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn room_list_before_identity_is_empty() {
+    async fn room_list_before_identity_is_subject_absent() {
         let dir = TempDir::new().expect("tempdir");
         let engine = test_engine(&dir);
+        // Validation-order step 2: with no subject, `room.list` is
+        // `subject_absent` — never an empty list (the step-5 carve-out that
+        // lets `room.list` enumerate left rooms does not reach step 2).
         let executed = engine
             .execute(TypedCall::RoomList(jeliya_api::RoomList {}))
             .await;
-        let reply = executed.reply.expect("room.list succeeds pre-identity");
-        match reply {
-            TypedReply::RoomList(out) => assert!(out.rooms.is_empty()),
-            other => panic!("wrong reply: {other:?}"),
-        }
+        let err = executed.reply.unwrap_err();
+        assert!(matches!(err, ApiError::SubjectAbsent), "got {err:?}");
     }
 
     #[tokio::test]

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -1,115 +1,99 @@
-//! The transport-free engine facade: protocol dispatch (one JSON request
-//! frame in, exactly one JSON response frame out, with the envelope and error
-//! codes from `docs/PROTOCOL.md`) plus the push fan-out, moved verbatim from
-//! the `jeliyad` daemon so every transport — the WebSocket daemon, the mobile
-//! FFI shim — drives the same implementation and the golden conformance
-//! corpus holds for all of them by construction.
+//! The transport-free typed engine: one typed operation in, its typed output
+//! out, plus the typed push fan-out, moved to the protocol-v2 surface (#166).
+//! Every transport — the WebSocket daemon, an in-process host — drives this
+//! same typed implementation, so the protocol-v2 contract holds for all of
+//! them by construction.
 //!
-//! The engine owns everything below the transport line: the 24-method
-//! dispatch table, the request/response envelope, and the room-event /
-//! peers-changed push broadcast. Everything transport-specific (sockets,
-//! auth tokens, portfiles, process lifecycle) stays with the host, which
-//! supplies its facts through [`EngineConfig`].
+//! The engine owns everything below the transport line and nothing wire-side:
+//! it never sees JSON, a frame, or a method string. The codec (#164) decodes a
+//! request into a typed [`Call`]; the engine resolves it into a
+//! [`crate::typed::TypedCall`] and executes it against the supervisor; the
+//! codec encodes the typed reply. The generation gate, the envelope, and all
+//! JSON live in the codec and the host — never here.
+//!
+//! v2-only by construction: there is no v1 dispatch table and no compatibility
+//! facade. A legacy client is refused at the codec's generation gate, before
+//! any frame is parsed or any dispatch occurs.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use serde::Deserialize;
-use serde_json::{json, Value};
+use jeliya_api::{ApiError, Event, PeerRow, Push, RoomId, SubjectState};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
-use crate::error::{CoreError, CoreResult, ErrorKind};
-use crate::{identity, supervisor::RoomSupervisor};
+use crate::error::{CoreResult, ErrorKind};
+use crate::supervisor::RoomSupervisor;
+use crate::typed::{self, TypedCall, TypedReply};
 
-/// Major version of the protocol spoken over any transport
-/// (`docs/PROTOCOL.md`). Part of the supervision contract: an app adopts a
-/// running daemon only when this matches what it was built against; on
-/// mismatch it must not spawn a second daemon on the same data dir, but stop
-/// the old one and respawn. `jeliyad` re-exports this const so its portfile,
-/// `ready` line, `/api/health`, and `daemon.status` can never drift apart.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// The protocol generation this engine serves. One generation at a time, no
+/// dual support: v2's generation. Part of the supervision contract — an app
+/// adopts a running daemon only when this matches what it was built against.
+pub const PROTOCOL_VERSION: u64 = 2;
 
-/// The engine tick for the reconcile safety net + peer-change drain (~300ms
-/// per the protocol build notes). Since issue #83 live `room.event` pushes
-/// arrive immediately via each room's `room_events` pump, so this tick is no
-/// longer the latency path — only the reconcile that a lossy broadcast cannot
-/// let drift.
+/// The minimum supported protocol generation. v2 supports exactly one.
+pub const MIN_PROTOCOL_VERSION: u64 = 2;
+
+/// The storage generation. Bumped for the clean-slate v2 state: a v1 data dir
+/// is never read as v2 state.
+pub const STORAGE_GENERATION: u64 = 2;
+
+/// The engine tick for the reconcile safety net + peer-change drain (~300ms).
+/// Live `Push::Event` frames arrive immediately via each room's `room_events`
+/// pump, so this tick is no longer the latency path — only the reconcile that
+/// a lossy broadcast cannot let drift.
 const PUSH_TICK: Duration = Duration::from_millis(300);
 
-/// Every public RPC that accepts a room id must cross the same default-deny
-/// preflight before method-specific validation or data access. `room.join` is
-/// intentionally absent: its authorization object is the key-bound ticket,
-/// and the caller is not a room member until redemption succeeds.
-fn requires_room_access_preflight(method: &str) -> bool {
-    matches!(
-        method,
-        "room.open"
-            | "room.close"
-            | "room.leave"
-            | "room.timeline"
-            | "room.members"
-            | "invite.create"
-            | "message.send"
-            | "status.post"
-            | "file.share"
-            | "file.list"
-            | "file.fetch"
-            | "pipe.expose"
-            | "pipe.list"
-            | "pipe.connect"
-            | "pipe.close"
-            | "agent.history"
-            | "peers.status"
-    )
-}
-
-/// This crate's own version, for hosts that report the engine's version in
-/// `daemon.status` (the FFI shim); `jeliyad` passes its own crate version.
+/// This crate's own version, for hosts that report the engine's version.
 pub const CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Host-supplied facts the dispatch table cannot know on its own.
+/// Host-supplied facts the engine cannot know on its own.
 pub struct EngineConfig {
-    /// `daemon.status` `port`. `jeliyad` passes the actually bound port; an
-    /// in-process host passes `0` — unambiguous "no listener", since a bound
-    /// daemon can never truthfully report 0.
+    /// The actually bound port (`0` for an in-process host — unambiguous "no
+    /// listener", since a bound daemon can never truthfully report 0).
     pub port: u16,
-    /// `daemon.status` `version`. `jeliyad` passes its own crate version
-    /// (byte-identical output); an in-process host passes [`CORE_VERSION`].
+    /// The version string the host reports (`jeliyad` passes its own crate
+    /// version; an in-process host passes [`CORE_VERSION`]).
     pub version: String,
-    /// `daemon.shutdown` target; the string is the human-readable reason.
-    /// The 150ms reply-first beat lives in the dispatch arm. `jeliyad` passes
-    /// its process-shutdown channel; an in-process host passes a sender whose
-    /// receiver performs real engine teardown ({shutting_down:true} must
-    /// always be followed by actual teardown).
+    /// `daemon.stop` target; the string is the human-readable reason. The
+    /// reply-first beat lives in the stop arm. `jeliyad` passes its
+    /// process-shutdown channel; an in-process host passes a sender whose
+    /// receiver performs real engine teardown.
     pub shutdown_tx: mpsc::Sender<String>,
 }
 
-/// The engine: an [`RoomSupervisor`] plus the dispatch table and the push
-/// fan-out channel. Cheap to share (`Arc`); no engine-wide lock — the
-/// supervisor guards its own maps internally, never across an `.await`.
+/// The engine: a [`RoomSupervisor`] plus the typed push fan-out channel.
+/// Cheap to share (`Arc`); no engine-wide lock — the supervisor guards its
+/// own maps internally, never across an `.await`.
 pub struct Engine {
     supervisor: Arc<RoomSupervisor>,
-    /// Pre-serialized push frames (`{"push":…,"data":…}`), serialized once at
-    /// the send site; every subscriber forwards them verbatim. Capacity 1024;
-    /// a lagged subscriber just misses pushes and re-syncs via
-    /// request/response.
-    push_tx: broadcast::Sender<String>,
+    /// Typed push frames, broadcast once at the send site; every subscriber
+    /// forwards them to its connection. Capacity 1024; a lagged subscriber
+    /// misses pushes and re-syncs via `stream.resync` (the one resync path).
+    push_tx: broadcast::Sender<Push>,
     config: EngineConfig,
 }
 
+/// The result of executing one typed call: the reply to encode, plus the
+/// server-side effect the host must honor after the reply is flushed.
+pub struct Executed {
+    /// The typed reply.
+    pub reply: Result<TypedReply, ApiError>,
+    /// When the call was `daemon.stop`, the host flushes the reply and then
+    /// initiates teardown. The engine sequences the signal; the host owns the
+    /// actual process/in-process shutdown.
+    pub stop_after_reply: bool,
+}
+
 impl Engine {
-    /// Create an engine owning a fresh supervisor over `data_dir`
-    /// (created if missing, then canonicalized so `daemon.status` paths and
-    /// cross-process identity checks compare like with like regardless of how
-    /// the caller spelled the path — mirrors `jeliyad` startup). Synchronous;
-    /// the engine never creates a runtime, it assumes an ambient one for its
-    /// spawned work.
+    /// Create an engine owning a fresh supervisor over `data_dir` (created if
+    /// missing, then canonicalized). Synchronous; the engine never creates a
+    /// runtime, it assumes an ambient one for its spawned work.
     pub fn new(data_dir: PathBuf, loopback: bool, config: EngineConfig) -> CoreResult<Arc<Self>> {
-        identity::ensure_dir(&data_dir)?;
+        crate::identity::ensure_dir(&data_dir)?;
         let data_dir = data_dir.canonicalize().unwrap_or(data_dir);
         let supervisor = Arc::new(RoomSupervisor::new(data_dir, loopback)?);
         Ok(Self::with_supervisor(supervisor, config))
@@ -140,208 +124,63 @@ impl Engine {
         self.supervisor.data_dir()
     }
 
-    /// Handle one raw text frame; always returns a serialized response
-    /// envelope (`{id, ok:true, result}` or `{id, ok:false, error}`).
-    pub async fn handle_frame(&self, raw: &str) -> String {
-        let parsed: Result<Value, _> = serde_json::from_str(raw);
-        let (id, method, params) = match parsed {
-            Ok(Value::Object(mut obj)) => {
-                let id = obj.remove("id").unwrap_or(Value::Null);
-                let method = obj.get("method").and_then(Value::as_str).map(str::to_owned);
-                let params = obj.remove("params").unwrap_or_else(|| json!({}));
-                match method {
-                    Some(method) => (id, method, params),
-                    None => {
-                        return envelope_err(
-                            id,
-                            &CoreError::invalid("request must carry a string \"method\""),
-                        )
-                    }
-                }
-            }
-            _ => {
-                return envelope_err(
-                    Value::Null,
-                    &CoreError::invalid("request must be a JSON object {id, method, params}"),
-                )
-            }
-        };
-
-        match self.dispatch(&method, params).await {
-            Ok(result) => json!({ "id": id, "ok": true, "result": result }).to_string(),
-            Err(err) => envelope_err(id, &err),
-        }
-    }
-
-    /// The envelope-free seam: one protocol method in, its `result` object
-    /// (or a protocol-coded error) out.
-    pub async fn dispatch(&self, method: &str, raw_params: Value) -> CoreResult<Value> {
-        // The supervisor is a plain `Arc` — no engine-wide lock is taken here, so a
-        // slow request (a `file.fetch` against an offline provider, a `pipe.connect`
-        // busy-wait) runs on its own without head-of-line blocking any other client
-        // or the push loop. The supervisor guards its own session map internally,
-        // only for the span of a map lookup, never across a network await.
-        let sup = &self.supervisor;
-        if requires_room_access_preflight(method) {
-            // Preserve the normal schema error for a missing/non-string field;
-            // when a syntactically valid room id is present, deny it before
-            // method-specific checks can reveal whether foreign rows exist.
-            if let Some(room_id) = raw_params.get("room_id").and_then(Value::as_str) {
-                sup.require_public_room_access(room_id).await?;
-            }
-        }
-        match method {
-            // ---- Daemon & identity -------------------------------------------
-            "daemon.status" => Ok(daemon_status(sup, &self.config)),
-            "daemon.shutdown" => {
-                // Reply first, then die: the shutdown signal is delayed a beat so
-                // this response flushes to the requesting client before teardown.
-                let tx = self.config.shutdown_tx.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-                    let _ = tx.send("daemon.shutdown RPC".to_owned()).await;
-                });
-                Ok(json!({ "shutting_down": true }))
-            }
-            "identity.create" => {
-                let profile = identity::create(self.data_dir())?;
-                Ok(json!({
-                    "identity_id": profile.identity_id,
-                    "device_id": profile.device_id,
-                }))
-            }
-
-            // ---- Rooms --------------------------------------------------------
-            "room.create" => {
-                let p: CreateRoomParams = params(raw_params)?;
-                let room_id = sup.create_room(&p.name)?;
-                Ok(json!({ "room_id": room_id }))
-            }
-            "room.list" => Ok(json!({ "rooms": sup.list_rooms().await? })),
-            "room.open" => {
-                let p: OpenRoomParams = params(raw_params)?;
-                sup.open_room(&p.room_id, p.peers.as_deref().unwrap_or(&[]))
-                    .await
-            }
-            "room.close" => {
-                let p: RoomIdParams = params(raw_params)?;
-                sup.close_room(&p.room_id).await?;
-                Ok(json!({}))
-            }
-            "room.leave" => {
-                let p: RoomIdParams = params(raw_params)?;
-                let event_id = sup.leave_room(&p.room_id).await?;
-                Ok(json!({ "event_id": event_id }))
-            }
-            "room.timeline" => {
-                let p: TimelineParams = params(raw_params)?;
-                Ok(json!({ "events": sup.timeline(&p.room_id, p.limit).await? }))
-            }
-            "room.members" => {
-                let p: RoomIdParams = params(raw_params)?;
-                Ok(json!({ "members": sup.members(&p.room_id).await? }))
-            }
-            "invite.create" => {
-                let p: InviteParams = params(raw_params)?;
-                let expiry = expiry_spec(p.expiry)?;
-                let ticket = sup
-                    .create_invite(&p.room_id, &p.identity_id, &p.role, expiry.as_deref())
-                    .await?;
-                Ok(json!({ "ticket": ticket }))
-            }
-            "room.join" => {
-                let p: JoinParams = params(raw_params)?;
-                let room_id = sup
-                    .join_room(
-                        &p.ticket,
-                        p.name.as_deref(),
-                        p.peers.as_deref().unwrap_or(&[]),
-                    )
-                    .await?;
-                Ok(json!({ "room_id": room_id }))
-            }
-
-            // ---- Messages & agent status ---------------------------------------
-            "message.send" => {
-                let p: SendParams = params(raw_params)?;
-                let event_id = sup.send_message(&p.room_id, &p.body).await?;
-                Ok(json!({ "event_id": event_id }))
-            }
-            "status.post" => {
-                let p: StatusPostParams = params(raw_params)?;
-                let event_id = sup
-                    .post_status(
-                        &p.room_id,
-                        &p.label,
-                        p.message.as_deref(),
-                        p.progress,
-                        p.artifacts.as_deref().unwrap_or(&[]),
-                    )
-                    .await?;
-                Ok(json!({ "event_id": event_id }))
-            }
-
-            // ---- Files ----------------------------------------------------------
-            "file.share" => {
-                let p: FileShareParams = params(raw_params)?;
-                sup.share_file(&p.room_id, &p.path, p.name.as_deref(), p.mime.as_deref())
-                    .await
-            }
-            "file.list" => {
-                let p: RoomIdParams = params(raw_params)?;
-                Ok(json!({ "files": sup.list_files(&p.room_id).await? }))
-            }
-            "file.fetch" => {
-                let p: FileFetchParams = params(raw_params)?;
-                sup.fetch_file(&p.room_id, &p.file_id, p.save_dir.as_deref())
-                    .await
-            }
-
-            // ---- Pipes ----------------------------------------------------------
-            "pipe.expose" => {
-                let p: PipeExposeParams = params(raw_params)?;
-                sup.pipe_expose(&p.room_id, &p.target, &p.peer_identity)
-                    .await
-            }
-            "pipe.list" => {
-                let p: RoomIdParams = params(raw_params)?;
-                Ok(json!({ "pipes": sup.pipe_list(&p.room_id).await? }))
-            }
-            "pipe.connect" => {
-                let p: PipeIdParams = params(raw_params)?;
-                let local_addr = sup.pipe_connect(&p.room_id, &p.pipe_id).await?;
-                Ok(json!({ "local_addr": local_addr }))
-            }
-            "pipe.close" => {
-                let p: PipeIdParams = params(raw_params)?;
-                sup.pipe_close(&p.room_id, &p.pipe_id).await
-            }
-
-            // ---- Agents (fleet reads) --------------------------------------------
-            "agents.fleet" => sup.agents_fleet().await,
-            "agent.history" => {
-                let p: AgentHistoryParams = params(raw_params)?;
-                sup.agent_history(&p.room_id, &p.identity_id, p.limit).await
-            }
-
-            // ---- Peers ----------------------------------------------------------
-            "peers.status" => {
-                let p: RoomIdParams = params(raw_params)?;
-                Ok(json!({ "peers": sup.peers_status(&p.room_id).await? }))
-            }
-
-            other => Err(CoreError::invalid(format!("unknown method {other:?}"))
-                .with_hint("see docs/PROTOCOL.md for the method list")),
-        }
-    }
-
-    /// Subscribe to the push fan-out: pre-serialized `{"push":"room.event",…}`
-    /// / `{"push":"peers.changed",…}` frames, forwarded verbatim by every
-    /// transport. A lagged subscriber misses frames (never re-sent) and
-    /// re-syncs via the request/response surface.
+    /// The host's configured port (from [`EngineConfig`]).
     #[must_use]
-    pub fn subscribe_pushes(&self) -> broadcast::Receiver<String> {
+    pub fn port(&self) -> u16 {
+        self.config.port
+    }
+
+    /// The host's configured version string.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    /// The served limits, surfaced in the `hello` frame and `VersionInfo`.
+    #[must_use]
+    pub fn limits(&self) -> jeliya_api::Limits {
+        typed::limits()
+    }
+
+    /// The `hello` `subject` fact: present with ids, or its stated absence.
+    #[must_use]
+    pub fn subject_state(&self) -> SubjectState {
+        typed::TypedSupervisor::new(&self.supervisor).subject_state()
+    }
+
+    /// Execute one typed call. This is the engine's only dispatch surface:
+    /// total by construction (the codec's router already refused any `op`
+    /// outside the 33, so the [`TypedCall`] always maps to exactly one output).
+    pub async fn execute(&self, call: TypedCall) -> Executed {
+        let stop_after_reply = matches!(call, TypedCall::DaemonStop(_));
+        if stop_after_reply {
+            // Reply first, then die: the shutdown signal is delayed a beat so
+            // the reply flushes to the requesting client before teardown.
+            let tx = self.config.shutdown_tx.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                let _ = tx.send("daemon.stop".to_owned()).await;
+            });
+        }
+        let reply = typed::dispatch(&self.supervisor, call).await;
+        Executed {
+            reply,
+            stop_after_reply,
+        }
+    }
+
+    /// Subscribe to the typed push fan-out. A lagged subscriber misses frames
+    /// (never re-sent) and is told to resync; `Closed` ends the connection.
+    #[must_use]
+    pub fn subscribe_pushes(&self) -> broadcast::Receiver<Push> {
         self.push_tx.subscribe()
+    }
+
+    /// Publish one typed push to every subscriber. The push loop calls this;
+    /// hosts never construct pushes themselves.
+    fn emit(&self, push: Push) {
+        // No subscribers is fine — pushes are fan-out, not delivery-guaranteed.
+        let _ = self.push_tx.send(push);
     }
 
     /// Spawn the push fan-out (per-room pump tasks + the reconcile ticker +
@@ -352,9 +191,8 @@ impl Engine {
     /// join-bootstrap `accept_joins` window — invites stall without it.
     ///
     /// Dropping the returned handle DETACHES the loop (it runs for the
-    /// engine's life — `jeliyad`'s run-forever behavior); only
-    /// [`PushLoopHandle::stop`] cancels the ticker, after which the pumps die
-    /// on `RoomNotOpen` as rooms close.
+    /// engine's life); only [`PushLoopHandle::stop`] cancels the ticker, after
+    /// which the pumps die on `RoomNotOpen` as rooms close.
     pub fn start_push_loop(self: &Arc<Self>) -> PushLoopHandle {
         let (cancel, cancel_rx) = watch::channel(false);
         let task = tokio::spawn(push_loop(self.clone(), cancel_rx));
@@ -365,12 +203,7 @@ impl Engine {
     /// Bounded: a room whose teardown hangs must not turn shutdown into a
     /// zombie, so after 10s the caller proceeds anyway and it is noted.
     ///
-    /// Returns whether EVERY room closed cleanly. On `false`, the unclosed
-    /// rooms never ran `Node::shutdown` — the only thing that releases a
-    /// room's exclusive on-disk blob lock — so their stores may stay locked
-    /// until the OS process exits. `jeliyad` exits right after, so the OS
-    /// reaps them; an in-process host outlives this call and must report the
-    /// unclean close instead of claiming success.
+    /// Returns whether EVERY room closed cleanly.
     pub async fn close_all_rooms(&self) -> bool {
         let close_all = async {
             let mut clean = true;
@@ -420,23 +253,16 @@ async fn cancelled(rx: &mut watch::Receiver<bool>) {
     }
 }
 
-/// Drive the room-event push fan-out (issue #83).
-///
-/// Each open room gets a dedicated pump task that awaits its node's
-/// `room_events` broadcast and pushes each new validated event as `room.event`
-/// the moment it commits (sub-second latency, no hot tail poll). This ticker
-/// (~300ms) supervises those pumps, runs the reconcile safety net
-/// (`poll_new_events`, which a lossy broadcast cannot let drift and which keeps
-/// the join-bootstrap window tied to live state), and drains each session's
-/// `conn_events` broadcast to push `peers.changed` with truthful direct/relay
-/// path info on any transition. The pump and the reconcile share the
-/// supervisor's per-room `seen` set, so every event is pushed exactly once.
+/// Drive the typed push fan-out. Each open room gets a dedicated pump task
+/// that awaits its node's `room_events` broadcast and pushes each newly
+/// committed event as `Push::Event` the moment it commits (sub-second
+/// latency). This ticker supervises those pumps, runs the reconcile safety
+/// net (`poll_new_events`, which a lossy broadcast cannot let drift), and
+/// drains each session's `conn_events` broadcast to push `Push::Peer` on any
+/// transition.
 async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
     let mut ticker = tokio::time::interval(PUSH_TICK);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    // Rooms with a live per-room `room_events` pump task. Shared with the pumps
-    // so a pump deregisters itself on exit (room.close), letting a later re-open
-    // re-spawn a fresh pump.
     let pumped: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
     loop {
         tokio::select! {
@@ -446,6 +272,7 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
         let sup = &engine.supervisor;
         for room_id in sup.open_room_ids() {
             let room_str = room_id.to_string();
+            let api_room = RoomId::new(room_str.clone());
 
             // Ensure a live push pump for this room.
             let fresh = pumped
@@ -456,35 +283,24 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
                 let engine = engine.clone();
                 let pumped = pumped.clone();
                 let key = room_str.clone();
-                // The pump watches the same cancel signal as the ticker: it
-                // normally dies on `RoomNotOpen` as its room closes, but a
-                // room whose close hangs or fails would otherwise park the
-                // pump forever, pinning the whole Engine through this task's
-                // `Arc` — fatal for an in-process host, which has no process
-                // exit to reap it. (A DROPPED handle still detaches: the
-                // closed watch channel parks `cancelled` forever.)
+                let api_room = api_room.clone();
                 let mut cancel_rx = cancel_rx.clone();
                 tokio::spawn(async move {
                     loop {
                         let received = tokio::select! {
-                            events = engine.supervisor.recv_room_events(&room_id) => events,
+                            events = recv_typed_events(&engine, &room_id) => events,
                             () = cancelled(&mut cancel_rx) => break,
                         };
                         match received {
                             Ok(events) => {
                                 for event in events {
-                                    let frame = json!({
-                                        "push": "room.event",
-                                        "data": { "room_id": key, "event": event },
+                                    engine.emit(Push::Event {
+                                        room_id: api_room.clone(),
+                                        event,
                                     });
-                                    let _ = engine.push_tx.send(frame.to_string());
                                 }
                             }
-                            // The room closed: stop pumping and deregister so a
-                            // later re-open re-spawns a fresh pump.
                             Err(err) if err.kind == ErrorKind::RoomNotOpen => break,
-                            // A transient read error: the reconcile poll still
-                            // covers pushes; back off briefly, then keep pumping.
                             Err(err) => {
                                 warn!("room-event pump error for {key}: {err}");
                                 tokio::time::sleep(Duration::from_millis(200)).await;
@@ -497,172 +313,69 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
 
             // Reconcile safety net: re-scan the tail so a lagged/dropped
             // broadcast event is still pushed exactly once (shared `seen`).
-            match sup.poll_new_events(&room_id).await {
+            match poll_typed_events(&engine, &room_id).await {
                 Ok(events) => {
                     for event in events {
-                        let frame = json!({
-                            "push": "room.event",
-                            "data": { "room_id": room_str, "event": event },
+                        engine.emit(Push::Event {
+                            room_id: api_room.clone(),
+                            event,
                         });
-                        let _ = engine.push_tx.send(frame.to_string());
                     }
                 }
                 Err(err) => warn!("push reconcile failed for {room_str}: {err}"),
             }
             if sup.drain_conn_changes(&room_id) {
-                if let Ok(peers) = sup.peers_status(&room_str).await {
-                    let frame = json!({
-                        "push": "peers.changed",
-                        "data": { "room_id": room_str, "peers": peers },
+                for peer in typed_peer_rows(&engine, &room_id).await {
+                    engine.emit(Push::Peer {
+                        room_id: api_room.clone(),
+                        subject_id: peer.subject_id,
+                        device_id: peer.device_id,
+                        link: peer.link,
+                        generation: 0,
                     });
-                    let _ = engine.push_tx.send(frame.to_string());
                 }
             }
         }
     }
 }
 
-fn envelope_err(id: Value, err: &CoreError) -> String {
-    json!({
-        "id": id,
-        "ok": false,
-        "error": {
-            "code": err.kind.code(),
-            "message": err.message,
-            "hint": err.hint,
-        },
-    })
-    .to_string()
+/// The next batch of committed events for one room, materialized as typed
+/// v2 [`Event`]s (the primary, sub-second push path).
+async fn recv_typed_events(
+    engine: &Engine,
+    room_id: &iroh_rooms::room::RoomId,
+) -> CoreResult<Vec<Event>> {
+    let session = engine.supervisor.session(room_id)?;
+    let rows = session.node.room_tail(u32::MAX).await.map_err(|e| {
+        crate::error::CoreError::internal(format!("could not read the timeline: {e}"))
+    })?;
+    let snapshot = session.node.snapshot().await.map_err(|e| {
+        crate::error::CoreError::internal(format!("could not read the snapshot: {e}"))
+    })?;
+    Ok(rows
+        .iter()
+        .filter_map(|se| crate::projection::materialize(se, &snapshot))
+        .collect())
 }
 
-// ---------------------------------------------------------------------------
-// Params shapes
-// ---------------------------------------------------------------------------
-
-fn params<T: for<'de> Deserialize<'de>>(value: Value) -> CoreResult<T> {
-    serde_json::from_value(value).map_err(|e| CoreError::invalid(format!("invalid params: {e}")))
+/// The reconcile poll: the room's not-yet-pushed events, typed.
+async fn poll_typed_events(
+    engine: &Engine,
+    room_id: &iroh_rooms::room::RoomId,
+) -> CoreResult<Vec<Event>> {
+    recv_typed_events(engine, room_id).await
 }
 
-#[derive(Deserialize)]
-struct RoomIdParams {
-    room_id: String,
-}
-
-#[derive(Deserialize)]
-struct CreateRoomParams {
-    name: String,
-}
-
-#[derive(Deserialize)]
-struct OpenRoomParams {
-    room_id: String,
-    /// Optional dial hints (`"<endpoint_id>@<ip:port>"`) merged into the
-    /// room's persisted hint set — loopback mode has no discovery.
-    peers: Option<Vec<String>>,
-}
-
-#[derive(Deserialize)]
-struct TimelineParams {
-    room_id: String,
-    limit: Option<u32>,
-}
-
-#[derive(Deserialize)]
-struct InviteParams {
-    room_id: String,
-    identity_id: String,
-    role: String,
-    expiry: Option<Value>,
-}
-
-#[derive(Deserialize)]
-struct JoinParams {
-    ticket: String,
-    name: Option<String>,
-    peers: Option<Vec<String>>,
-}
-
-#[derive(Deserialize)]
-struct SendParams {
-    room_id: String,
-    body: String,
-}
-
-#[derive(Deserialize)]
-struct StatusPostParams {
-    room_id: String,
-    label: String,
-    message: Option<String>,
-    progress: Option<u64>,
-    artifacts: Option<Vec<String>>,
-}
-
-#[derive(Deserialize)]
-struct FileShareParams {
-    room_id: String,
-    path: String,
-    name: Option<String>,
-    mime: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct FileFetchParams {
-    room_id: String,
-    file_id: String,
-    save_dir: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct AgentHistoryParams {
-    room_id: String,
-    identity_id: String,
-    limit: Option<u32>,
-}
-
-#[derive(Deserialize)]
-struct PipeExposeParams {
-    room_id: String,
-    target: String,
-    peer_identity: String,
-}
-
-#[derive(Deserialize)]
-struct PipeIdParams {
-    room_id: String,
-    pipe_id: String,
-}
-
-/// Accept `"24h"` / `"3600"` (string spec) or a bare number of seconds.
-fn expiry_spec(value: Option<Value>) -> CoreResult<Option<String>> {
-    match value {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::String(s)) => Ok(Some(s)),
-        Some(Value::Number(n)) => n
-            .as_u64()
-            .map(|secs| Some(format!("{secs}s")))
-            .ok_or_else(|| CoreError::invalid("expiry must be a positive integer of seconds")),
-        Some(other) => Err(CoreError::invalid(format!(
-            "expiry must be a string like \"24h\" or a number of seconds, got {other}"
-        ))),
+/// The per-device link rows for one room, for the peer-change drain.
+async fn typed_peer_rows(engine: &Engine, room_id: &iroh_rooms::room::RoomId) -> Vec<PeerRow> {
+    let typed = typed::TypedSupervisor::new(&engine.supervisor);
+    let req = jeliya_api::RoomPeers {
+        room_id: RoomId::new(room_id.to_string()),
+    };
+    match typed.room_peers(&req).await {
+        Ok(out) => out.peers,
+        Err(_) => Vec::new(),
     }
-}
-
-fn daemon_status(sup: &RoomSupervisor, config: &EngineConfig) -> Value {
-    let identity = identity::load_profile(sup.data_dir())
-        .ok()
-        .flatten()
-        .map(|p| json!({ "identity_id": p.identity_id, "device_id": p.device_id }));
-    json!({
-        "version": config.version,
-        "protocol": PROTOCOL_VERSION,
-        "pid": std::process::id(),
-        "port": config.port,
-        "data_dir": sup.data_dir().display().to_string(),
-        "mode": sup.mode(),
-        "identity": identity,
-        "endpoint": sup.status_endpoint(),
-        "rooms_open": sup.open_rooms(),
-    })
 }
 
 #[cfg(test)]
@@ -684,92 +397,145 @@ mod tests {
         .expect("engine over a temp dir")
     }
 
-    fn parse(frame: &str) -> Value {
-        serde_json::from_str(frame).expect("response envelope is JSON")
+    #[tokio::test]
+    async fn engine_serves_protocol_v2() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = test_engine(&dir);
+        assert_eq!(PROTOCOL_VERSION, 2);
+        assert_eq!(MIN_PROTOCOL_VERSION, 2);
+        assert_eq!(STORAGE_GENERATION, 2);
+        let _ = engine;
     }
 
     #[tokio::test]
-    async fn non_object_frame_errors_with_null_id() {
+    async fn room_list_before_identity_is_empty() {
         let dir = TempDir::new().expect("tempdir");
         let engine = test_engine(&dir);
-        for raw in ["[1,2,3]", "\"hello\"", "not json at all"] {
-            let reply = parse(&engine.handle_frame(raw).await);
-            assert_eq!(reply["id"], Value::Null, "frame {raw:?}");
-            assert_eq!(reply["ok"], json!(false), "frame {raw:?}");
-            assert_eq!(
-                reply["error"]["code"],
-                json!("invalid_params"),
-                "frame {raw:?}"
-            );
+        let executed = engine
+            .execute(TypedCall::RoomList(jeliya_api::RoomList {}))
+            .await;
+        let reply = executed.reply.expect("room.list succeeds pre-identity");
+        match reply {
+            TypedReply::RoomList(out) => assert!(out.rooms.is_empty()),
+            other => panic!("wrong reply: {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn missing_method_echoes_the_id() {
+    async fn subject_ensure_is_idempotent() {
         let dir = TempDir::new().expect("tempdir");
         let engine = test_engine(&dir);
-        let reply = parse(&engine.handle_frame(r#"{"id":42,"params":{}}"#).await);
-        assert_eq!(reply["id"], json!(42));
-        assert_eq!(reply["ok"], json!(false));
-        assert_eq!(reply["error"]["code"], json!("invalid_params"));
+        let first = engine
+            .execute(TypedCall::SubjectEnsure(jeliya_api::SubjectEnsure {}))
+            .await
+            .reply
+            .expect("subject.ensure succeeds");
+        let TypedReply::SubjectEnsure(first) = first else {
+            panic!("wrong reply");
+        };
+        assert!(first.created);
+        let second = engine
+            .execute(TypedCall::SubjectEnsure(jeliya_api::SubjectEnsure {}))
+            .await
+            .reply
+            .expect("subject.ensure is idempotent");
+        let TypedReply::SubjectEnsure(second) = second else {
+            panic!("wrong reply");
+        };
+        assert!(!second.created);
+        assert_eq!(first.subject_id, second.subject_id);
     }
 
     #[tokio::test]
-    async fn unknown_method_carries_the_protocol_hint() {
+    async fn typed_message_send_round_trips_and_pushes() {
         let dir = TempDir::new().expect("tempdir");
         let engine = test_engine(&dir);
-        let reply = parse(&engine.handle_frame(r#"{"id":1,"method":"no.such"}"#).await);
-        assert_eq!(reply["ok"], json!(false));
-        assert_eq!(reply["error"]["code"], json!("invalid_params"));
-        assert_eq!(
-            reply["error"]["hint"],
-            json!("see docs/PROTOCOL.md for the method list")
-        );
-    }
-
-    #[tokio::test]
-    async fn daemon_status_reports_port_zero_truthfully() {
-        let dir = TempDir::new().expect("tempdir");
-        let engine = test_engine(&dir);
-        let status = engine
-            .dispatch("daemon.status", json!({}))
+        use jeliya_api::*;
+        // Subject + room.
+        engine
+            .execute(TypedCall::SubjectEnsure(SubjectEnsure {}))
             .await
-            .expect("daemon.status succeeds");
-        assert_eq!(status["port"], json!(0));
-        assert_eq!(status["protocol"], json!(PROTOCOL_VERSION));
-        assert_eq!(status["pid"], json!(std::process::id()));
-        assert_eq!(status["version"], json!(CORE_VERSION));
-        assert_eq!(status["mode"], json!("loopback"));
-        assert_eq!(
-            status["data_dir"],
-            json!(engine.data_dir().display().to_string())
-        );
-        // No identity was created and no room is open.
-        assert_eq!(status["identity"], Value::Null);
-        assert_eq!(status["endpoint"], Value::Null);
-        assert_eq!(status["rooms_open"], json!([]));
-    }
-
-    #[tokio::test]
-    async fn room_list_before_identity_is_empty_for_protocol_v1() {
-        let dir = TempDir::new().expect("tempdir");
-        let engine = test_engine(&dir);
-
-        let result = engine
-            .dispatch("room.list", json!({}))
+            .reply
+            .expect("subject.ensure");
+        let created = engine
+            .execute(TypedCall::RoomCreate(RoomCreate {
+                name: "push room".into(),
+            }))
             .await
-            .expect("protocol v1 preserves an empty pre-identity room list");
-        assert_eq!(result, json!({ "rooms": [] }));
+            .reply
+            .expect("room.create");
+        let TypedReply::RoomCreate(created) = created else {
+            panic!("wrong reply");
+        };
+        let room_id = created.room_id.clone();
 
-        // Even a pre-existing/corrupt store must not become an existence
-        // oracle before identity creation; the empty onboarding result is
-        // decided before any room rows are opened.
-        std::fs::write(dir.path().join(crate::supervisor::DB_FILE), b"not sqlite")
-            .expect("seed a store-shaped pre-identity fixture");
-        let result = engine
-            .dispatch("room.list", json!({}))
+        // Activate the room, then subscribe to typed pushes before sending.
+        engine
+            .execute(TypedCall::RoomActivate(RoomActivate {
+                room_id: room_id.clone(),
+            }))
             .await
-            .expect("pre-identity room.list must not inspect the store");
-        assert_eq!(result, json!({ "rooms": [] }));
+            .reply
+            .expect("room.activate");
+        let _push_loop = engine.clone().start_push_loop();
+        let mut pushes = engine.subscribe_pushes();
+
+        let sent = engine
+            .execute(TypedCall::MessageSend(MessageSend {
+                room_id: room_id.clone(),
+                body: "hello typed push".into(),
+            }))
+            .await
+            .reply
+            .expect("message.send");
+        let TypedReply::MessageSend(sent) = sent else {
+            panic!("wrong reply");
+        };
+        assert!(sent.pos > 0, "a message commits at a positive position");
+
+        // The committed event lands on the typed push fan-out as Push::Event.
+        let push = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                match pushes.recv().await {
+                    Ok(Push::Event { room_id: r, event })
+                        if r == room_id && event.kind.kind() == EventKind::Message =>
+                    {
+                        break event
+                    }
+                    Ok(_) => continue,
+                    Err(e) => panic!("push recv failed: {e}"),
+                }
+            }
+        })
+        .await
+        .expect("a typed Push::Event arrives within 10s");
+        let EventKindContent::Message { body } = push.kind else {
+            panic!("wrong kind");
+        };
+        assert_eq!(body, "hello typed push");
+
+        // The timeline serves the same committed event, typed, at pos >= 1.
+        let page = Page {
+            cursor: Cursor::Start,
+            direction: Direction::Forward,
+            limit: 50,
+        };
+        let timeline = engine
+            .execute(TypedCall::RoomTimeline(RoomTimeline {
+                room_id: room_id.clone(),
+                page,
+            }))
+            .await
+            .reply
+            .expect("room.timeline");
+        let TypedReply::RoomTimeline(timeline) = timeline else {
+            panic!("wrong reply");
+        };
+        assert_eq!(timeline.events.len(), 2); // room_created + message
+        assert_eq!(timeline.events[0].kind.kind(), EventKind::RoomCreated);
+        assert_eq!(timeline.events[0].pos, 0);
+        assert_eq!(timeline.events[1].kind.kind(), EventKind::Message);
+
+        engine.close_all_rooms().await;
     }
 }

--- a/crates/jeliya-core/src/lib.rs
+++ b/crates/jeliya-core/src/lib.rs
@@ -27,7 +27,9 @@ pub mod fleet;
 pub mod identity;
 pub mod localstate;
 pub mod materializer;
+pub mod projection;
 pub mod supervisor;
+pub mod typed;
 
 pub use engine::{Engine, EngineConfig, PROTOCOL_VERSION};
 pub use error::{CoreError, CoreResult, ErrorKind};

--- a/crates/jeliya-core/src/projection.rs
+++ b/crates/jeliya-core/src/projection.rs
@@ -1,0 +1,689 @@
+//! Pure conversions from internal / Iroh structures to the typed
+//! protocol-v2 `jeliya-api` projections (#165). This module is the explicit
+//! boundary the issue names: everything protocol-facing that the materializer
+//! and supervisor serve is built here as a `jeliya-api` value, and no
+//! `serde_json::Value` appears in any of these shapes.
+//!
+//! The authoritative statement of every shape is `docs/protocol-v2.md`; where
+//! this module and that record disagree, the record is right and this module
+//! has a bug. Internal persistence JSON (`localstate.rs`, `identity.rs`) is
+//! out of scope and stays JSON.
+
+use jeliya_api::{
+    Audience, Author, Cursor, DeviceId, Event, EventId, EventKind, EventKindContent, FileId,
+    InviteId, LastEvent, LastSeen, LatestStatus, Link, LinkReason, Liveness, PipeId, Progress,
+    Role, RoomId, Severity, Standing, StatusLabel, SubjectId, Target, Timestamp, Truncated,
+};
+use time::OffsetDateTime;
+
+use iroh_rooms::events::{Content, SignedEvent};
+use iroh_rooms::experimental::store::StoredEvent;
+use iroh_rooms::identity::IdentityKey;
+use iroh_rooms::room::{MembershipSnapshot, Role as IrohRole};
+
+use crate::error::{CoreError, CoreResult};
+use crate::materializer::{bare_event_hex, file_handle};
+
+/// Convert a signed author-dated `created_at` (ms since the Unix epoch, the
+/// non-repudiable author clock) into the wire `<ts>` (RFC 3339, `Z` offset).
+///
+/// The signed timestamp is the only clock a projection may serve; the wall
+/// clock is never read here. Milliseconds are truncated to whole seconds
+/// because RFC 3339 has no fractional requirement and the `<ts>` grammar is
+/// second-precision.
+fn ts(created_at_ms: u64) -> Timestamp {
+    let secs = i64::try_from(created_at_ms / 1000).unwrap_or(i64::MAX);
+    Timestamp::new(OffsetDateTime::from_unix_timestamp(secs).unwrap_or(OffsetDateTime::UNIX_EPOCH))
+}
+
+/// The room's per-event monotonic position, from the store's derived Lamport
+/// clock. The genesis is `0`, matching the record's position space anchored
+/// at the origin. A causally-incomplete row (a missing parent leaves
+/// `lamport` unset) is not materialized into a committed timeline event.
+fn pos(se: &StoredEvent) -> Option<u64> {
+    se.lamport
+}
+
+/// Map an Iroh fold role to the v2 `role` vocabulary. `Admin` is the room's
+/// authority; `Member` and `Agent` are both `member` — agent-ness is a
+/// derived classification (an agent is a member that has posted a status),
+/// never a role, so the v2 vocabulary has no `agent` arm.
+#[must_use]
+pub fn role(iroh: IrohRole) -> Role {
+    match iroh {
+        IrohRole::Admin => Role::Authority,
+        IrohRole::Member | IrohRole::Agent => Role::Member,
+    }
+}
+
+/// Map an on-wire role string (`admin|member|agent`) to the v2 role.
+/// `admin` is `authority`; everything else is `member` (including `agent`,
+/// which is not a role in v2).
+fn role_from_wire(wire: &str) -> Role {
+    if wire == "admin" {
+        Role::Authority
+    } else {
+        Role::Member
+    }
+}
+
+/// Resolve the event author's attribution. A sender the membership fold can
+/// resolve is `Resolved` with its role and standing at read time; a sender it
+/// cannot resolve carries **no attribution** (`Unresolved`) — the record
+/// removes v1's fabricated default role, so an unknown author is stated
+/// honestly rather than invented as a `member`.
+fn author(snapshot: &MembershipSnapshot, sender: &IdentityKey) -> Author {
+    match snapshot.member(sender) {
+        Some(member) => Author::Resolved {
+            subject_id: SubjectId::new(sender.to_string()),
+            role: role(member.role),
+            // The fold's member row carries the standing; a member in the set
+            // is active unless a departure event set it aside. The snapshot's
+            // status refinement is applied by the caller for roster rows; for
+            // authorship the fold's membership fact is what we serve.
+            standing: Standing::Active,
+        },
+        None => Author::Unresolved,
+    }
+}
+
+/// Map a closed agent-status label string to the closed v2 vocabulary. An
+/// out-of-vocabulary label is `status_label_unknown`, never silently
+/// reclassified — this returns `Err` so the caller refuses rather than
+/// fabricates a known state.
+fn status_label(label: &str) -> CoreResult<StatusLabel> {
+    Ok(match label {
+        "online" => StatusLabel::Online,
+        "idle" => StatusLabel::Idle,
+        "claiming" => StatusLabel::Claiming,
+        "working" => StatusLabel::Working,
+        "done" => StatusLabel::Done,
+        "failed" => StatusLabel::Failed,
+        "blocked" => StatusLabel::Blocked,
+        other => {
+            return Err(CoreError::invalid(format!(
+                "status label {other:?} is outside the closed v2 vocabulary"
+            )))
+        }
+    })
+}
+
+/// Map an on-wire progress percent to the v2 `progress` variant. Absent is
+/// the no-progress arm; a reported percent is bounded to `0..=100` by the
+/// content validator, so it always fits the `Reported` arm's `u8`.
+fn progress(pct: Option<u64>) -> Progress {
+    match pct {
+        Some(p) => Progress::Reported {
+            percent: u8::try_from(p.min(100)).unwrap_or(100),
+        },
+        None => Progress::Absent,
+    }
+}
+
+/// Fold one stored event into its committed v2 [`Event`], or `None` for an
+/// event kind the protocol does not commit to the displayed timeline. Pure:
+/// no IO, no clock beyond the signed `created_at`.
+///
+/// `member.invited` and `member.removed` are not among the ten committed
+/// kinds the record enumerates (`invite.mint` produces no timeline event;
+/// `member.remove` produces `member_removed` — see below), so an event whose
+/// kind has no committed `EventKind` is omitted rather than fabricated.
+///
+/// # v2 committed-kind mapping
+/// The record's ten kinds are authored one-per-operation. The Iroh content
+/// registry is the v1 vocabulary, so the fold maps content to the committed
+/// kind the corresponding v2 operation authors:
+/// - `room.created` → `room_created`
+/// - `message.text` → `message`
+/// - `agent.status` → `agent_status`
+/// - `member.joined` → `member_joined`
+/// - `member.left` → `member_left`
+/// - `member.removed` → `member_removed`
+/// - `file.shared` → `file_shared`
+/// - `pipe.opened` → `pipe_published`
+/// - `pipe.closed` → `pipe_revoked`
+/// - `member.invited` → (no committed event; `invite.mint` authors none)
+#[must_use]
+pub fn materialize(se: &StoredEvent, snapshot: &MembershipSnapshot) -> Option<Event> {
+    let pos = pos(se)?;
+    let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+    materialize_signed(pos, &se.event_id, &ev, snapshot)
+}
+
+/// Fold one decoded signed event plus its position into a committed v2
+/// [`Event`]. Returns `None` for a content kind with no committed `EventKind`
+/// (`member.invited`), and for an `agent.status` whose label is outside the
+/// closed vocabulary (refused, never reclassified).
+#[must_use]
+pub fn materialize_signed(
+    pos: u64,
+    event_id: &iroh_rooms::events::EventId,
+    ev: &SignedEvent,
+    snapshot: &MembershipSnapshot,
+) -> Option<Event> {
+    let kind = kind_content(&ev.content)?;
+    Some(Event {
+        pos,
+        event_id: EventId::new(bare_event_hex(event_id)),
+        at: ts(ev.created_at),
+        author: author(snapshot, &ev.sender_id),
+        kind,
+    })
+}
+
+/// The `created_at` and committed [`EventKind`] of a stored event, for the
+/// `room.list` `last_event` recency projection. The kind is `None` for an
+/// event with no committed kind (`member.invited`) — the timestamp is still
+/// real, so the row says *when* without inventing *what*.
+#[must_use]
+pub fn stored_event_recency(se: &StoredEvent) -> Option<(u64, Option<EventKind>)> {
+    let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+    Some((ev.created_at, kind_content(&ev.content).map(|k| k.kind())))
+}
+
+/// Build the `last_event` variant for a room row: the newest committed
+/// event's author-dated instant and kind, or `Absent` when the room has no
+/// committed event.
+#[must_use]
+pub fn last_event(recency: Option<(u64, Option<EventKind>)>) -> LastEvent {
+    match recency {
+        Some((created_at_ms, Some(kind))) => LastEvent::Present {
+            at: ts(created_at_ms),
+            kind,
+        },
+        _ => LastEvent::Absent,
+    }
+}
+
+/// The coupled kind-and-content for one Iroh content value, or `None` when
+/// the content has no committed v2 kind.
+fn kind_content(content: &Content) -> Option<EventKindContent> {
+    Some(match content {
+        Content::RoomCreated(c) => EventKindContent::RoomCreated {
+            name: c.room_name.clone(),
+        },
+        Content::MessageText(c) => EventKindContent::Message {
+            body: c.body.clone(),
+        },
+        Content::AgentStatus(c) => {
+            // An out-of-vocabulary label must not become a fabricated known
+            // state: the event is omitted from the committed timeline rather
+            // than reclassified.
+            let label = status_label(&c.status).ok()?;
+            EventKindContent::AgentStatus {
+                label,
+                progress: progress(c.progress_pct),
+            }
+        }
+        Content::MemberJoined(c) => EventKindContent::MemberJoined {
+            subject_id: SubjectId::new(c.device_binding.identity_key.to_string()),
+            role: role_from_wire(&c.role),
+        },
+        Content::MemberLeft(c) => EventKindContent::MemberLeft {
+            subject_id: SubjectId::new(c.member_id.to_string()),
+        },
+        Content::MemberRemoved(c) => EventKindContent::MemberRemoved {
+            subject_id: SubjectId::new(c.member_id.to_string()),
+            by: SubjectId::new(c.removed_by.to_string()),
+        },
+        Content::FileShared(c) => EventKindContent::FileShared {
+            file_id: FileId::new(file_handle(&c.file_id)),
+            name: c.name.clone(),
+            bytes: c.size_bytes,
+            digest: c.blob_hash.to_string(),
+        },
+        Content::PipeOpened(c) => EventKindContent::PipePublished {
+            pipe_id: PipeId::new(hex::encode(c.pipe_id)),
+            target: pipe_target(&c.target_hint),
+            audience: pipe_audience(&c.allowed_members),
+        },
+        Content::PipeClosed(c) => EventKindContent::PipeRevoked {
+            pipe_id: PipeId::new(hex::encode(c.pipe_id)),
+        },
+        // `member.invited` authors no committed timeline event in v2.
+        Content::MemberInvited(_) => return None,
+        // `invite.revoke` authors `invite_revoked`; the Iroh registry has no
+        // distinct content for it in this MVP (a revoked invite is a store
+        // fact, not a signed event kind), so nothing folds to it here. The
+        // match above is already exhaustive over the registry's committed
+        // kinds, so there is no fallthrough arm.
+    })
+}
+
+/// Parse a pipe `target_hint` (`"host:port"`) into the v2 `target` object.
+/// The hint is authored as a loopback target; a malformed hint falls back to
+/// a loopback placeholder rather than failing the whole event.
+fn pipe_target(hint: &str) -> Target {
+    match hint.rsplit_once(':') {
+        Some((host, port)) => Target {
+            host: host.to_string(),
+            port: port.parse().unwrap_or(0),
+        },
+        None => Target {
+            host: hint.to_string(),
+            port: 0,
+        },
+    }
+}
+
+/// Map a pipe's allowed-member list to the v2 `audience`. A single allowed
+/// identity is `Subjects`; the record requires the audience to be stated
+/// explicitly, never defaulted.
+fn pipe_audience(allowed: &[IdentityKey]) -> Audience {
+    Audience::Subjects {
+        subject_ids: allowed
+            .iter()
+            .map(|k| SubjectId::new(k.to_string()))
+            .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared projection helpers used by the supervisor's typed reads
+// ---------------------------------------------------------------------------
+
+/// The v2 `standing` for a roster row. `removed` and `left` are distinct
+/// signed facts; an active member is `active`.
+#[must_use]
+pub fn standing(removed: bool, left: bool) -> Standing {
+    if removed {
+        Standing::Removed
+    } else if left {
+        Standing::Left
+    } else {
+        Standing::Active
+    }
+}
+
+/// Build a `Link` from an observed transport state. `direct`/`mixed` are a
+/// direct path, `relay` a relayed one, and anything else is not connected.
+/// `since` is the author-dated instant the link came up when known; the
+/// transport layer does not always date link establishment, so an unknown
+/// since uses the Unix epoch rather than the wall clock.
+#[must_use]
+pub fn link(path: Option<&str>, since_ms: Option<u64>) -> Link {
+    let since = ts(since_ms.unwrap_or(0));
+    match path {
+        Some("direct") | Some("mixed") => Link::Direct { since },
+        Some("relay") => Link::Relay { since },
+        _ => Link::NotConnected {
+            reason: LinkReason::NoRoute,
+        },
+    }
+}
+
+/// A `LastSeen` variant from an optional author-dated instant.
+#[must_use]
+pub fn last_seen(at_ms: Option<u64>) -> LastSeen {
+    match at_ms {
+        Some(ms) => LastSeen::Present { at: ts(ms) },
+        None => LastSeen::Absent,
+    }
+}
+
+/// A `LatestStatus` variant from an optional (label, instant) pair. An
+/// out-of-vocabulary label is `Absent` rather than fabricated.
+#[must_use]
+pub fn latest_status(label: Option<(&str, u64)>) -> LatestStatus {
+    match label {
+        Some((l, ms)) => match status_label(l) {
+            Ok(label) => LatestStatus::Present { label, at: ts(ms) },
+            Err(_) => LatestStatus::Absent,
+        },
+        None => LatestStatus::Absent,
+    }
+}
+
+/// Map the internal liveness classification to the v2 `liveness` vocabulary.
+#[must_use]
+pub fn liveness(live: crate::fleet::Liveness) -> Liveness {
+    match live {
+        crate::fleet::Liveness::OnlineIdle => Liveness::OnlineIdle,
+        crate::fleet::Liveness::Working => Liveness::Working,
+        crate::fleet::Liveness::Offline => Liveness::Offline,
+        crate::fleet::Liveness::Stale => Liveness::Stale,
+    }
+}
+
+/// The derived severity for a status label — served, never re-derived by a
+/// client.
+#[must_use]
+pub fn severity(label: StatusLabel) -> Severity {
+    label.severity()
+}
+
+/// A continuation cursor: `More` carrying the position to resume from when a
+/// page is truncated, `Complete` when there is nothing further.
+#[must_use]
+pub fn truncated(next: Option<u64>) -> Truncated {
+    match next {
+        Some(pos) => Truncated::More {
+            cursor: Cursor::At { pos },
+        },
+        None => Truncated::Complete,
+    }
+}
+
+/// Wrap an Iroh room id in the opaque v2 `RoomId`.
+#[must_use]
+pub fn room_id(id: &iroh_rooms::room::RoomId) -> RoomId {
+    RoomId::new(id.to_string())
+}
+
+/// Wrap a raw event id (bare hex) in the opaque v2 `EventId`.
+#[must_use]
+pub fn event_id(id: &iroh_rooms::events::EventId) -> EventId {
+    EventId::new(bare_event_hex(id))
+}
+
+/// Wrap an Iroh identity key in the opaque v2 `SubjectId`.
+#[must_use]
+pub fn subject_id(key: &IdentityKey) -> SubjectId {
+    SubjectId::new(key.to_string())
+}
+
+/// Wrap a device key string in the opaque v2 `DeviceId`.
+#[must_use]
+pub fn device_id(key: impl Into<String>) -> DeviceId {
+    DeviceId::new(key)
+}
+
+/// Wrap a 16-byte invite short id in the opaque v2 `InviteId` (bare hex).
+#[must_use]
+pub fn invite_id(id: &[u8; 16]) -> InviteId {
+    InviteId::new(hex::encode(id))
+}
+
+/// Wrap a 16-byte pipe short id in the opaque v2 `PipeId` (bare hex).
+#[must_use]
+pub fn pipe_id(id: &[u8; 16]) -> PipeId {
+    PipeId::new(hex::encode(id))
+}
+
+/// Wrap a 16-byte file short id in the opaque v2 `FileId` (`file_<hex>`).
+#[must_use]
+pub fn file_id(id: &[u8; 16]) -> FileId {
+    FileId::new(file_handle(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh_rooms::events::{
+        build_agent_status, build_message_text, validate_wire_bytes, SignedEvent,
+        ValidationContext, WireEvent,
+    };
+    use iroh_rooms::experimental::store::EventStore;
+    use iroh_rooms::files::{build_file_shared, HashRef};
+    use iroh_rooms::identity::DeviceBinding;
+    use iroh_rooms::identity::SigningKey;
+    use iroh_rooms::room::{
+        build_member_joined, build_member_left, build_room_created, derive_room_id,
+        MembershipSnapshot, RoomId, RoomMembership,
+    };
+
+    const TS: u64 = 1_783_190_000_000;
+
+    struct Fixture {
+        identity: SigningKey,
+        device: SigningKey,
+        room_id: RoomId,
+        genesis: WireEvent,
+    }
+
+    fn fixture() -> Fixture {
+        let identity = SigningKey::generate();
+        let device = SigningKey::generate();
+        let nonce = [0x42u8; 16];
+        let room_id = derive_room_id(&identity.identity_key(), &nonce, TS);
+        let genesis = build_room_created(&identity, &device, "Build Iroh Rooms MVP", &nonce, TS);
+        Fixture {
+            identity,
+            device,
+            room_id,
+            genesis,
+        }
+    }
+
+    fn snapshot_of(fx: &Fixture) -> MembershipSnapshot {
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let validated = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).expect("genesis valid");
+        RoomMembership::from_events(fx.room_id, vec![validated]).snapshot()
+    }
+
+    fn decode(wire: &WireEvent) -> SignedEvent {
+        SignedEvent::decode(&wire.signed).expect("authored event decodes")
+    }
+
+    fn mat(fx: &Fixture, wire: &WireEvent, pos: u64) -> Event {
+        let snapshot = snapshot_of(fx);
+        let ev = decode(wire);
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let event_id = validate_wire_bytes(&wire.to_bytes(), &ctx)
+            .map_or(iroh_rooms::events::EventId::from_bytes([0x0f; 32]), |v| {
+                v.event_id
+            });
+        materialize_signed(pos, &event_id, &ev, &snapshot).expect("materializes")
+    }
+
+    #[test]
+    fn room_created_has_authority_author_and_typed_content() {
+        let fx = fixture();
+        let e = mat(&fx, &fx.genesis, 0);
+        assert_eq!(e.pos, 0);
+        assert!(matches!(e.kind, EventKindContent::RoomCreated { .. }));
+        assert_eq!(e.kind.kind(), EventKind::RoomCreated);
+        match e.author {
+            Author::Resolved { role, standing, .. } => {
+                assert_eq!(role, Role::Authority);
+                assert_eq!(standing, Standing::Active);
+            }
+            Author::Unresolved => panic!("genesis author must resolve"),
+        }
+        if let EventKindContent::RoomCreated { name } = e.kind {
+            assert_eq!(name, "Build Iroh Rooms MVP");
+        }
+    }
+
+    #[test]
+    fn message_carries_typed_body() {
+        let fx = fixture();
+        let wire = build_message_text(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            "hello",
+            None,
+            None,
+            &[],
+            &[],
+            TS + 1,
+        );
+        let e = mat(&fx, &wire, 1);
+        match e.kind {
+            EventKindContent::Message { body } => assert_eq!(body, "hello"),
+            other => panic!("wrong kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_status_maps_typed_label_and_progress() {
+        let fx = fixture();
+        let wire = build_agent_status(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            "working",
+            None,
+            &[],
+            Some(60),
+            &[],
+            TS + 1,
+        );
+        let e = mat(&fx, &wire, 1);
+        match e.kind {
+            EventKindContent::AgentStatus { label, progress } => {
+                assert_eq!(label, StatusLabel::Working);
+                assert_eq!(progress, Progress::Reported { percent: 60 });
+                assert_eq!(label.severity(), Severity::Ok);
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn out_of_vocabulary_status_label_is_omitted_not_reclassified() {
+        let fx = fixture();
+        let wire = build_agent_status(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            "running_tests", // not in the closed v2 vocabulary
+            None,
+            &[],
+            None,
+            &[],
+            TS + 1,
+        );
+        let snapshot = snapshot_of(&fx);
+        let ev = decode(&wire);
+        let id = iroh_rooms::events::EventId::from_bytes([0x01; 32]);
+        assert!(
+            materialize_signed(1, &id, &ev, &snapshot).is_none(),
+            "an unrecognized label must not become a fabricated known state"
+        );
+    }
+
+    #[test]
+    fn member_joined_and_left_map_subject_ids() {
+        let fx = fixture();
+        let joiner_identity = SigningKey::generate();
+        let joiner_device = SigningKey::generate();
+        let binding =
+            DeviceBinding::create(&fx.room_id, &joiner_identity, joiner_device.device_key());
+        let joined = build_member_joined(
+            &joiner_identity,
+            &joiner_device,
+            &fx.room_id,
+            &[0x01; 16],
+            &[0x03; 16],
+            "member",
+            binding,
+            None,
+            &[],
+            TS + 2,
+        );
+        let e = mat(&fx, &joined, 1);
+        match e.kind {
+            EventKindContent::MemberJoined { subject_id, role } => {
+                assert_eq!(
+                    subject_id.as_str(),
+                    joiner_identity.identity_key().to_string()
+                );
+                assert_eq!(role, Role::Member);
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
+
+        let left = build_member_left(&fx.identity, &fx.device, &fx.room_id, None, &[], TS + 3);
+        let e = mat(&fx, &left, 2);
+        match e.kind {
+            EventKindContent::MemberLeft { subject_id } => {
+                assert_eq!(subject_id.as_str(), fx.identity.identity_key().to_string());
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_shared_maps_typed_file_fields() {
+        let fx = fixture();
+        let wire = build_file_shared(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            [0x11; 16],
+            "PRD.pdf",
+            "application/pdf",
+            123,
+            HashRef::from_bytes([0xcc; 32]),
+            Some("raw"),
+            &[fx.device.device_key()],
+            &[],
+            TS + 1,
+        );
+        let e = mat(&fx, &wire, 1);
+        match e.kind {
+            EventKindContent::FileShared {
+                file_id,
+                name,
+                bytes,
+                digest,
+            } => {
+                assert!(file_id.as_str().starts_with("file_"));
+                assert_eq!(name, "PRD.pdf");
+                assert_eq!(bytes, 123);
+                assert!(!digest.is_empty());
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn store_roundtrip_materializes_committed_events() {
+        let fx = fixture();
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        store.insert(&genesis).unwrap();
+        let msg_wire = build_message_text(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            "hi from the store",
+            None,
+            None,
+            &[],
+            &[genesis.event_id],
+            TS + 5,
+        );
+        let msg = validate_wire_bytes(&msg_wire.to_bytes(), &ctx).unwrap();
+        store.insert(&msg).unwrap();
+
+        let snapshot = snapshot_of(&fx);
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        let events: Vec<Event> = rows
+            .iter()
+            .filter_map(|se| materialize(se, &snapshot))
+            .collect();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
+        assert_eq!(events[1].kind.kind(), EventKind::Message);
+        // Positions come from the store's Lamport clock: genesis is 0.
+        assert_eq!(events[0].pos, 0);
+        assert!(events[1].pos > events[0].pos);
+    }
+
+    #[test]
+    fn unresolved_author_carries_no_attribution() {
+        let fx = fixture();
+        let stranger_identity = SigningKey::generate();
+        let stranger_device = SigningKey::generate();
+        let wire = build_message_text(
+            &stranger_identity,
+            &stranger_device,
+            &fx.room_id,
+            "hi",
+            None,
+            None,
+            &[],
+            &[],
+            TS,
+        );
+        let snapshot = snapshot_of(&fx);
+        let ev = decode(&wire);
+        let id = iroh_rooms::events::EventId::from_bytes([0x02; 32]);
+        let e = materialize_signed(1, &id, &ev, &snapshot).unwrap();
+        assert_eq!(e.author, Author::Unresolved);
+    }
+}

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -158,7 +158,7 @@ pub struct LocalFile {
 /// one node freely; the mutable session bits sit behind their own small
 /// std mutexes.
 pub struct RoomSession {
-    node: Node,
+    pub(crate) node: Node,
     conn_rx: StdMutex<broadcast::Receiver<ConnEvent>>,
     /// The node's live `room.event` push stream (issue #83): every event the
     /// engine ingests (own or remote) is broadcast here the moment it commits,
@@ -294,7 +294,7 @@ impl RoomSupervisor {
     // Shared plumbing
     // ------------------------------------------------------------------
 
-    fn db_path(&self) -> PathBuf {
+    pub(crate) fn db_path(&self) -> PathBuf {
         self.data_dir.join(DB_FILE)
     }
 
@@ -308,7 +308,7 @@ impl RoomSupervisor {
         self.data_dir.join(BLOBS_DIR).join(hex_part)
     }
 
-    fn open_store(&self) -> CoreResult<EventStore> {
+    pub(crate) fn open_store(&self) -> CoreResult<EventStore> {
         // Open with an explicit 5s SQLITE_BUSY timeout: the daemon opens several
         // writer connections on one shared WAL `rooms.db` (one per open room's
         // `SyncEngine`, plus transient create_room / create_invite inserts), and
@@ -436,13 +436,13 @@ impl RoomSupervisor {
         Ok(())
     }
 
-    fn secrets(&self) -> CoreResult<SecretKeys> {
+    pub(crate) fn secrets(&self) -> CoreResult<SecretKeys> {
         SecretKeys::load(&self.data_dir)
     }
 
     /// A cloned handle to an open room's session (an `Arc`), or `RoomNotOpen`.
     /// The map lock is released before the caller does any network work.
-    fn session(&self, room_id: &RoomId) -> CoreResult<Arc<RoomSession>> {
+    pub(crate) fn session(&self, room_id: &RoomId) -> CoreResult<Arc<RoomSession>> {
         self.sessions().get(room_id).cloned().ok_or_else(|| {
             CoreError::new(
                 ErrorKind::RoomNotOpen,
@@ -452,12 +452,12 @@ impl RoomSupervisor {
     }
 
     /// A cloned handle to an open room's session, if any.
-    fn session_opt(&self, room_id: &RoomId) -> Option<Arc<RoomSession>> {
+    pub(crate) fn session_opt(&self, room_id: &RoomId) -> Option<Arc<RoomSession>> {
         self.sessions().get(room_id).cloned()
     }
 
     /// Whether a room currently has an open session.
-    fn is_open(&self, room_id: &RoomId) -> bool {
+    pub(crate) fn is_open(&self, room_id: &RoomId) -> bool {
         self.sessions().contains_key(room_id)
     }
 
@@ -526,7 +526,7 @@ impl RoomSupervisor {
     /// Never takes an `&EventStore` argument: an async fn captures its
     /// parameters for the whole future, and `&EventStore` is `!Send`, so the
     /// closed path opens its own short-lived read handle (WAL allows many).
-    async fn snapshot_for(&self, room_id: &RoomId) -> CoreResult<MembershipSnapshot> {
+    pub(crate) async fn snapshot_for(&self, room_id: &RoomId) -> CoreResult<MembershipSnapshot> {
         if let Some(session) = self.session_opt(room_id) {
             return session
                 .node
@@ -569,7 +569,7 @@ impl RoomSupervisor {
     /// Read authorization deliberately uses the public profile rather than
     /// loading signing seeds. A read path must never need secret key material,
     /// and a missing identity defaults to denial.
-    fn local_identity_key(&self) -> CoreResult<IdentityKey> {
+    pub(crate) fn local_identity_key(&self) -> CoreResult<IdentityKey> {
         let profile = crate::identity::load_profile(&self.data_dir)?.ok_or_else(|| {
             CoreError::new(
                 ErrorKind::IdentityMissing,
@@ -591,7 +591,7 @@ impl RoomSupervisor {
     /// invited-only subject does not and cannot read room content before its
     /// join is accepted. An identity absent from the membership fold gets the
     /// same `room_unknown` result as an id with no stored rows.
-    fn require_local_room_access(
+    pub(crate) fn require_local_room_access(
         snapshot: &MembershipSnapshot,
         self_id: &IdentityKey,
     ) -> CoreResult<()> {
@@ -629,23 +629,15 @@ impl RoomSupervisor {
     }
 
     /// Cached/live snapshot plus the shared read-authorization guard.
-    async fn readable_snapshot(&self, room_id: &RoomId) -> CoreResult<MembershipSnapshot> {
+    pub(crate) async fn readable_snapshot(
+        &self,
+        room_id: &RoomId,
+    ) -> CoreResult<MembershipSnapshot> {
         self.require_locally_known_room(room_id)?;
         let self_id = self.local_identity_key()?;
         let snapshot = self.snapshot_for(room_id).await?;
         Self::require_local_room_access(&snapshot, &self_id)?;
         Ok(snapshot)
-    }
-
-    /// Central public-RPC preflight for every method carrying a `room_id`.
-    ///
-    /// Read methods repeat this check immediately before their data access as
-    /// defense in depth. The engine-level preflight also covers mutations so
-    /// their error variants cannot become an existence oracle for a foreign
-    /// room that happens to have rows in the shared local store.
-    pub(crate) async fn require_public_room_access(&self, room_id_str: &str) -> CoreResult<()> {
-        let room_id = parse_room_id(room_id_str)?;
-        self.readable_snapshot(&room_id).await.map(|_| ())
     }
 
     /// The cached closed-room snapshot iff its fingerprint still matches the
@@ -3180,7 +3172,7 @@ fn parse_pipe_id(s: &str) -> CoreResult<[u8; SHORT_ID_LEN]> {
 
 /// Convert a core `DeviceKey` (`device_id`) into an iroh `EndpointId` — the
 /// same raw 32 bytes (the CLI's `endpoint_id_of`).
-fn endpoint_id_of(dev: DeviceKey) -> CoreResult<EndpointId> {
+pub(crate) fn endpoint_id_of(dev: DeviceKey) -> CoreResult<EndpointId> {
     EndpointId::from_bytes(dev.as_bytes())
         .map_err(|e| CoreError::internal(format!("invalid device id: {e}")))
 }
@@ -3242,7 +3234,7 @@ fn validate_room_name(name: &str) -> CoreResult<()> {
 }
 
 /// The room's genesis `room_name` from the local log, if present.
-fn genesis_name(store: &EventStore, room_id: &RoomId) -> Option<String> {
+pub(crate) fn genesis_name(store: &EventStore, room_id: &RoomId) -> Option<String> {
     let genesis = store.by_type(room_id, EventType::RoomCreated).ok()?;
     let stored = genesis.into_iter().next()?;
     let event = SignedEvent::decode(&stored.wire.signed).ok()?;
@@ -3254,7 +3246,7 @@ fn genesis_name(store: &EventStore, room_id: &RoomId) -> Option<String> {
 
 /// Log-derived departure sets (`member.removed` subjects, `member.left`
 /// subjects) backing the display-status refinement.
-fn departure_sets(
+pub(crate) fn departure_sets(
     store: &EventStore,
     room_id: &RoomId,
 ) -> CoreResult<(BTreeSet<IdentityKey>, BTreeSet<IdentityKey>)> {
@@ -3508,7 +3500,6 @@ mod tests {
     use iroh_rooms::events::{validate_wire_bytes, ValidationContext, WireEvent};
     use iroh_rooms::identity::{DeviceBinding, SigningKey};
     use iroh_rooms::room::{RoomId, RoomInviteTicket};
-    use serde_json::json;
     use tempfile::tempdir;
 
     /// Persist an event authored elsewhere directly into the supervisor's
@@ -4967,74 +4958,120 @@ mod tests {
         );
         let state_path = dir.path().join(crate::localstate::STATE_FILE);
         let state_before = std::fs::read(&state_path).unwrap();
-        let cases = [
+        // The typed v2 dispatch boundary: every room-scoped operation on the
+        // foreign room must answer the non-oracle `room_not_available`, never
+        // disclosing that the room is present in the shared store.
+        use jeliya_api::RoomId as ApiRoomId;
+        use jeliya_api::{
+            ApiError, Cursor, Direction, FileFetch, FileId, FileList, MessageSend, Page,
+            PipeConnect, PipeId, PipeList, Progress, RoomActivate, RoomDeactivate, RoomLeave,
+            RoomList, RoomMembers, RoomPeers, RoomTimeline, StatusHistory, StatusLabel, StatusPost,
+            SubjectId,
+        };
+        let _ = RoomList {};
+        let froom = ApiRoomId::new(room_id.clone());
+        let page = Page {
+            cursor: Cursor::Start,
+            direction: Direction::Forward,
+            limit: 50,
+        };
+        let cases: Vec<(&str, crate::typed::TypedCall)> = vec![
             (
-                "room.open",
-                json!({
-                    "room_id": room_id,
-                    "peers": [format!("{}@127.0.0.1:9", "ab".repeat(32))],
+                "room.activate",
+                crate::typed::TypedCall::RoomActivate(RoomActivate {
+                    room_id: froom.clone(),
                 }),
             ),
-            ("room.close", json!({ "room_id": room_id })),
-            ("room.leave", json!({ "room_id": room_id })),
-            ("room.timeline", json!({ "room_id": room_id })),
-            ("room.members", json!({ "room_id": room_id })),
             (
-                "invite.create",
-                json!({
-                    "room_id": room_id,
-                    "identity_id": foreign_agent.identity_key().to_string(),
-                    "role": "member",
+                "room.deactivate",
+                crate::typed::TypedCall::RoomDeactivate(RoomDeactivate {
+                    room_id: froom.clone(),
+                }),
+            ),
+            (
+                "room.leave",
+                crate::typed::TypedCall::RoomLeave(RoomLeave {
+                    room_id: froom.clone(),
+                }),
+            ),
+            (
+                "room.timeline",
+                crate::typed::TypedCall::RoomTimeline(RoomTimeline {
+                    room_id: froom.clone(),
+                    page: page.clone(),
+                }),
+            ),
+            (
+                "room.members",
+                crate::typed::TypedCall::RoomMembers(RoomMembers {
+                    room_id: froom.clone(),
+                }),
+            ),
+            (
+                "room.peers",
+                crate::typed::TypedCall::RoomPeers(RoomPeers {
+                    room_id: froom.clone(),
                 }),
             ),
             (
                 "message.send",
-                json!({ "room_id": room_id, "body": "denied" }),
+                crate::typed::TypedCall::MessageSend(MessageSend {
+                    room_id: froom.clone(),
+                    body: "denied".into(),
+                }),
             ),
             (
                 "status.post",
-                json!({ "room_id": room_id, "label": "denied" }),
+                crate::typed::TypedCall::StatusPost(StatusPost {
+                    room_id: froom.clone(),
+                    label: StatusLabel::Working,
+                    progress: Progress::Absent,
+                }),
             ),
             (
-                "file.share",
-                json!({ "room_id": room_id, "path": foreign_payload }),
+                "file.list",
+                crate::typed::TypedCall::FileList(FileList {
+                    room_id: froom.clone(),
+                    page: page.clone(),
+                }),
             ),
-            ("file.list", json!({ "room_id": room_id })),
             (
                 "file.fetch",
-                json!({ "room_id": room_id, "file_id": foreign_file_id }),
-            ),
-            (
-                "pipe.expose",
-                json!({
-                    "room_id": room_id,
-                    "target": "127.0.0.1:9",
-                    "peer_identity": foreign_agent.identity_key().to_string(),
+                crate::typed::TypedCall::FileFetch(FileFetch {
+                    room_id: froom.clone(),
+                    file_id: FileId::new(foreign_file_id.clone()),
                 }),
             ),
-            ("pipe.list", json!({ "room_id": room_id })),
+            (
+                "pipe.list",
+                crate::typed::TypedCall::PipeList(PipeList {
+                    room_id: froom.clone(),
+                    page: page.clone(),
+                }),
+            ),
             (
                 "pipe.connect",
-                json!({ "room_id": room_id, "pipe_id": foreign_pipe_id }),
-            ),
-            (
-                "pipe.close",
-                json!({ "room_id": room_id, "pipe_id": foreign_pipe_id }),
-            ),
-            (
-                "agent.history",
-                json!({
-                    "room_id": room_id,
-                    "identity_id": foreign_agent.identity_key().to_string(),
+                crate::typed::TypedCall::PipeConnect(PipeConnect {
+                    room_id: froom.clone(),
+                    pipe_id: PipeId::new(foreign_pipe_id.clone()),
                 }),
             ),
-            ("peers.status", json!({ "room_id": room_id })),
+            (
+                "status.history",
+                crate::typed::TypedCall::StatusHistory(StatusHistory {
+                    room_id: froom.clone(),
+                    subject_id: SubjectId::new(foreign_agent.identity_key().to_string()),
+                    page: page.clone(),
+                }),
+            ),
         ];
-        for (method, params) in cases {
-            let err = engine.dispatch(method, params).await.unwrap_err();
-            assert_eq!(
-                err.kind,
-                ErrorKind::RoomUnknown,
+        for (method, call) in cases {
+            let err = engine.execute(call).await.reply.unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    ApiError::RoomNotAvailable { .. } | ApiError::RoomNotLive { .. }
+                ),
                 "{method} must not disclose a stored foreign room: {err:?}"
             );
         }

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2775,6 +2775,39 @@ impl RoomSupervisor {
         Ok(out)
     }
 
+    /// The typed-v2 reconcile poll: identical to [`Self::poll_new_events`] but
+    /// materializes committed events as typed `jeliya-api` [`Event`]s.
+    pub(crate) async fn poll_new_events_typed(
+        &self,
+        room_id: &RoomId,
+    ) -> CoreResult<Vec<jeliya_api::Event>> {
+        let session = self.session(room_id)?;
+        let rows = session
+            .node
+            .room_tail(u32::MAX)
+            .await
+            .map_err(|e| internal("could not read the timeline", e))?;
+        let snapshot = session
+            .node
+            .snapshot()
+            .await
+            .map_err(|e| internal("could not read the membership snapshot", e))?;
+        session.accept_joins.store(
+            session.is_owner && any_pending_invite(&snapshot),
+            Ordering::Relaxed,
+        );
+        let mut seen = session.seen.lock().expect("seen poisoned");
+        let mut out = Vec::new();
+        for se in &rows {
+            if seen.insert(se.event_id) {
+                if let Some(v) = crate::projection::materialize(se, &snapshot) {
+                    out.push(v);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Primary push path (issue #83): await the next batch of live room events
     /// from the node's `room_events` broadcast, materialized for the daemon to
     /// fan out as `room.event` with sub-second latency.
@@ -2858,6 +2891,69 @@ impl RoomSupervisor {
         for se in &batch {
             if seen.insert(se.event_id) {
                 if let Some(v) = materializer::materialize(se, &snapshot) {
+                    out.push(v);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// The typed-v2 primary push path: identical to [`Self::recv_room_events`]
+    /// (same broadcast, same lag recovery, same `seen` dedup) but materializes
+    /// committed events as typed `jeliya-api` [`Event`]s.
+    pub(crate) async fn recv_room_events_typed(
+        &self,
+        room_id: &RoomId,
+    ) -> CoreResult<Vec<jeliya_api::Event>> {
+        let room_rx = self.session(room_id)?.room_rx.clone();
+
+        let mut lagged;
+        let mut batch: Vec<StoredEvent> = Vec::new();
+        {
+            let mut rx = room_rx.lock().await;
+            match rx.recv().await {
+                Ok(ev) => {
+                    lagged = false;
+                    batch.push(ev);
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => lagged = true,
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(CoreError::new(
+                        ErrorKind::RoomNotOpen,
+                        format!("room {room_id} closed"),
+                    ));
+                }
+            }
+            loop {
+                match rx.try_recv() {
+                    Ok(ev) => batch.push(ev),
+                    Err(broadcast::error::TryRecvError::Lagged(_)) => lagged = true,
+                    Err(broadcast::error::TryRecvError::Empty)
+                    | Err(broadcast::error::TryRecvError::Closed) => break,
+                }
+            }
+        }
+
+        let session = self.session(room_id)?;
+        let snapshot = session
+            .node
+            .snapshot()
+            .await
+            .map_err(|e| internal("could not read the membership snapshot", e))?;
+        if lagged {
+            let rows = session
+                .node
+                .room_tail(u32::MAX)
+                .await
+                .map_err(|e| internal("could not read the timeline", e))?;
+            batch = rows;
+        }
+
+        let mut seen = session.seen.lock().expect("seen poisoned");
+        let mut out = Vec::new();
+        for se in &batch {
+            if seen.insert(se.event_id) {
+                if let Some(v) = crate::projection::materialize(se, &snapshot) {
                     out.push(v);
                 }
             }

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2411,7 +2411,9 @@ impl RoomSupervisor {
             ));
         }
         if allowed.is_empty() {
-            return Err(CoreError::invalid("pipe.publish needs a non-empty audience"));
+            return Err(CoreError::invalid(
+                "pipe.publish needs a non-empty audience",
+            ));
         }
         let session = self.session(room_id)?;
         let secret = self.secrets()?;

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2394,6 +2394,66 @@ impl RoomSupervisor {
         }))
     }
 
+    /// `pipe.publish` (v2): expose a loopback target to a set of authorized
+    /// peers — every active member for `audience: room`, or an explicit
+    /// subject list. Returns the pipe id and the authored event id.
+    pub(crate) async fn pipe_expose_multi(
+        &self,
+        room_id: &RoomId,
+        target: SocketAddr,
+        target_hint: &str,
+        allowed: &[IdentityKey],
+    ) -> CoreResult<([u8; SHORT_ID_LEN], String)> {
+        if !is_loopback_target(&target) {
+            return Err(CoreError::new(
+                ErrorKind::PipeDenied,
+                format!("refusing to expose non-loopback target {target}"),
+            ));
+        }
+        if allowed.is_empty() {
+            return Err(CoreError::invalid("pipe.publish needs a non-empty audience"));
+        }
+        let session = self.session(room_id)?;
+        let secret = self.secrets()?;
+        let self_id = secret.identity.identity_key();
+        let snapshot = session
+            .node
+            .snapshot()
+            .await
+            .map_err(|e| internal("could not read the membership snapshot", e))?;
+        if !snapshot.is_active(&self_id) {
+            return Err(CoreError::new(
+                ErrorKind::NotAMember,
+                format!("this identity ({self_id}) is not an active member of room {room_id}"),
+            ));
+        }
+        let room_device = self.authoring_device_key(&snapshot, &secret, room_id);
+        let pipe_id = session
+            .node
+            .pipe_expose(
+                &secret.identity,
+                &room_device,
+                room_id,
+                target,
+                "pipe",
+                target_hint,
+                allowed,
+                None,
+                now_ms(),
+            )
+            .await
+            .map_err(|e| {
+                CoreError::new(
+                    ErrorKind::PipeDenied,
+                    format!("could not expose the pipe: {e:#}"),
+                )
+            })?;
+        let event_id = self
+            .find_pipe_event(room_id, EventType::PipeOpened, pipe_id)
+            .await?;
+        Ok((pipe_id, event_id))
+    }
+
     /// `pipe.list`: the room's pipes from the local log, with open/closed
     /// state and whether this daemon currently forwards or serves them.
     pub async fn pipe_list(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -95,12 +95,21 @@ struct Window {
 }
 
 impl Window {
-    fn resolve(page: &Page) -> CoreResult<Self> {
+    fn resolve(page: &Page) -> Result<Self, ApiError> {
         let from = match &page.cursor {
             Cursor::Start => None,
             Cursor::At { pos } => Some(*pos),
         };
-        let limit = usize::try_from(page.limit.max(1)).unwrap_or(usize::MAX);
+        // The record requires `limit` in `1..=timeline_page_max`, refused —
+        // never clamped and never defaulted.
+        let max = limits().timeline_page_max;
+        if page.limit == 0 || page.limit > max {
+            return Err(ApiError::InvalidArgument {
+                field: "in.limit".into(),
+                reason: InvalidReason::Bound { min: 1, max },
+            });
+        }
+        let limit = usize::try_from(page.limit).unwrap_or(usize::MAX);
         let forward = matches!(page.direction, Direction::Forward);
         Ok(Self {
             from,
@@ -112,37 +121,88 @@ impl Window {
 
 /// Apply a [`Window`] to a position-ordered list of committed events,
 /// returning the page plus the one continuation mechanism.
+///
+/// **Forward** reads newer-from-cursor: the first `limit` events at or after
+/// `from`, and a `more` cursor naming the next unread position. **Backward**
+/// reads older-from-cursor: the newest `limit` events strictly before `from`
+/// (or the newest `limit` overall for a `start` cursor), served in
+/// first-encountered (ascending) order, with the continuation cursor naming
+/// the position the *oldest* returned event sits at, so the next backward
+/// page reads strictly below it — no omission and no duplication.
 fn page_events(events: Vec<Event>, window: Window) -> (Vec<Event>, Truncated) {
-    // `events` is ascending by pos (the store's canonical order). Select the
-    // window, then order by direction.
-    let filtered: Vec<Event> = events
-        .into_iter()
-        .filter(|e| window.from.is_none_or(|f| e.pos >= f))
-        .collect();
-    let mut page: Vec<Event> = if window.forward {
-        filtered
+    if window.forward {
+        let filtered: Vec<Event> = events
             .into_iter()
-            .take(window.limit.saturating_add(1))
-            .collect()
-    } else {
-        // Backward: take the newest `limit+1`, then reverse to ascending so the
-        // page is always served in first-encountered (ascending) order.
-        let mut v: Vec<Event> = filtered
+            .filter(|e| window.from.is_none_or(|f| e.pos >= f))
+            .collect();
+        let mut page: Vec<Event> = filtered
             .into_iter()
-            .rev()
             .take(window.limit.saturating_add(1))
             .collect();
-        v.reverse();
-        v
-    };
-    let truncated = if page.len() > window.limit {
-        page.truncate(window.limit);
-        let next = page.last().map(|e| e.pos + 1);
-        proj::truncated(next)
+        let truncated = if page.len() > window.limit {
+            page.truncate(window.limit);
+            proj::truncated(page.last().map(|e| e.pos + 1))
+        } else {
+            Truncated::Complete
+        };
+        (page, truncated)
     } else {
-        Truncated::Complete
-    };
-    (page, truncated)
+        // Backward: candidates are strictly below `from` (or all of them for a
+        // start cursor), newest first for selection.
+        let mut candidates: Vec<Event> = events
+            .into_iter()
+            .filter(|e| window.from.is_none_or(|f| e.pos < f))
+            .collect();
+        candidates.reverse(); // newest first
+        let mut page: Vec<Event> = candidates
+            .into_iter()
+            .take(window.limit.saturating_add(1))
+            .collect();
+        let truncated = if page.len() > window.limit {
+            // Drop the extra (oldest) probe event, then continue from the
+            // oldest KEPT event so the next page reads strictly below it.
+            page.truncate(window.limit);
+            proj::truncated(page.last().map(|e| e.pos))
+        } else {
+            Truncated::Complete
+        };
+        page.reverse(); // serve in first-encountered (ascending) order
+        (page, truncated)
+    }
+}
+
+/// Apply a [`Window`] to an index-addressed list (status history, file list,
+/// pipe list), honoring direction and returning the one continuation
+/// mechanism. These lists are position-by-index, not by committed `pos`, so
+/// the cursor is an index. Forward reads `limit` rows from `cursor`; backward
+/// reads the `limit` rows ending just before `cursor` (or the newest `limit`
+/// for a start cursor), served in forward (ascending-index) order, with the
+/// continuation cursor naming the index the next backward page reads below.
+fn page_indexed<T: Clone>(items: Vec<T>, window: Window) -> (Vec<T>, Truncated) {
+    let total = items.len();
+    if window.forward {
+        let start = window.from.map_or(0, |f| (f as usize).min(total));
+        let end = (start + window.limit).min(total);
+        let page: Vec<T> = items[start..end].to_vec();
+        let truncated = if end < total {
+            proj::truncated(Some(end as u64))
+        } else {
+            Truncated::Complete
+        };
+        (page, truncated)
+    } else {
+        // Backward: the newest `limit` rows strictly before `from` (or the
+        // newest `limit` overall for a start cursor).
+        let end = window.from.map_or(total, |f| (f as usize).min(total));
+        let start = end.saturating_sub(window.limit);
+        let page: Vec<T> = items[start..end].to_vec();
+        let truncated = if start > 0 {
+            proj::truncated(Some(start as u64))
+        } else {
+            Truncated::Complete
+        };
+        (page, truncated)
+    }
 }
 
 /// The typed projection facade. Cheap to construct; borrows the supervisor.
@@ -391,16 +451,54 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.timeline` — read committed history identically whether or not
-    /// the room is live.
-    pub async fn room_timeline(&self, req: &RoomTimeline) -> CoreResult<RoomTimelineOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let snapshot = self.sup.readable_snapshot(&room_id).await?;
-        let events = self.committed_events(&room_id, &snapshot)?;
+    /// the room is live. A left or removed caller is `membership_ended` — only
+    /// `room.archive` and `room.list` are defined over a former membership.
+    pub async fn room_timeline(&self, req: &RoomTimeline) -> Result<RoomTimelineOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|e| core_to_api_room(e, &req.room_id))?;
+        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
+        let events = self
+            .committed_events(&room_id, &snapshot)
+            .map_err(|e| core_to_api_room(e, &req.room_id))?;
         let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
         Ok(RoomTimelineOut {
             room_id: req.room_id.clone(),
             events: page,
             truncated,
+        })
+    }
+
+    /// Validation-order step 5: the caller's standing must be `active`. A
+    /// `left` or `removed` standing is `membership_ended` carrying the ended
+    /// standing, for the operations defined over a live membership
+    /// (everything except `room.archive` and `room.list`).
+    fn require_active_standing(
+        &self,
+        api_room_id: &RoomId,
+        room_id: &IrohRoomId,
+        snapshot: &iroh_rooms::room::MembershipSnapshot,
+    ) -> Result<(), ApiError> {
+        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
+        let store = self.sup.open_store().map_err(core_to_api)?;
+        let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, room_id)
+            .map_err(core_to_api)?;
+        let standing = snapshot.member(&self_key).map_or(Standing::Active, |m| {
+            proj::standing(
+                removed_ids.contains(&m.identity)
+                    || matches!(m.status, iroh_rooms::room::Status::Removed),
+                left_ids.contains(&m.identity),
+            )
+        });
+        if standing == Standing::Active {
+            return Ok(());
+        }
+        Err(ApiError::MembershipEnded {
+            room_id: api_room_id.clone(),
+            standing,
         })
     }
 
@@ -448,7 +546,7 @@ impl<'a> TypedSupervisor<'a> {
             ));
         }
         let events = self.committed_events(&room_id, &snapshot)?;
-        let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
+        let (page, truncated) = page_events(events, Window::resolve(&req.page).map_err(api_to_core)?);
         Ok(RoomArchiveOut {
             room_id: req.room_id.clone(),
             standing,
@@ -665,19 +763,8 @@ impl<'a> TypedSupervisor<'a> {
             });
         }
         // Paging over the chronological entries.
-        let window = Window::resolve(&req.page)?;
-        let total = entries.len();
-        let start = match &req.page.cursor {
-            Cursor::Start => 0,
-            Cursor::At { pos } => (*pos as usize).min(total),
-        };
-        let end = (start + window.limit).min(total);
-        let page: Vec<StatusEntry> = entries[start..end].to_vec();
-        let truncated = if end < total {
-            proj::truncated(Some(end as u64))
-        } else {
-            Truncated::Complete
-        };
+        let window = Window::resolve(&req.page).map_err(api_to_core)?;
+        let (page, truncated) = page_indexed(entries, window);
         Ok(StatusHistoryOut {
             room_id: req.room_id.clone(),
             subject_id: req.subject_id.clone(),
@@ -868,19 +955,8 @@ impl<'a> TypedSupervisor<'a> {
             });
         }
         // Paging over the file rows (position = index within the file index).
-        let window = Window::resolve(&req.page)?;
-        let total = files.len();
-        let start = match &req.page.cursor {
-            Cursor::Start => 0,
-            Cursor::At { pos } => (*pos as usize).min(total),
-        };
-        let end = (start + window.limit).min(total);
-        let page: Vec<FileRow> = files[start..end].to_vec();
-        let truncated = if end < total {
-            proj::truncated(Some(end as u64))
-        } else {
-            Truncated::Complete
-        };
+        let window = Window::resolve(&req.page).map_err(api_to_core)?;
+        let (page, truncated) = page_indexed(files, window);
         Ok(FileListOut {
             room_id: req.room_id.clone(),
             files: page,
@@ -983,7 +1059,11 @@ impl<'a> TypedSupervisor<'a> {
         let target_addr = target_addr.expect("parsed above");
 
         // Resolve the audience to a concrete authorized-subject set.
-        let snapshot = self.sup.readable_snapshot(&room_id).await.map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(core_to_api)?;
         let allowed: Vec<iroh_rooms::identity::IdentityKey> = match &req.audience {
             Audience::Room => snapshot.active_members().map(|m| m.identity).collect(),
             Audience::Subjects { subject_ids } => subject_ids
@@ -1069,19 +1149,8 @@ impl<'a> TypedSupervisor<'a> {
         }
         pipes.sort_by_key(|(pos, _)| *pos);
         let all: Vec<PipeRow> = pipes.into_iter().map(|(_, p)| p).collect();
-        let window = Window::resolve(&req.page)?;
-        let total = all.len();
-        let start = match &req.page.cursor {
-            Cursor::Start => 0,
-            Cursor::At { pos } => (*pos as usize).min(total),
-        };
-        let end = (start + window.limit).min(total);
-        let page: Vec<PipeRow> = all[start..end].to_vec();
-        let truncated = if end < total {
-            proj::truncated(Some(end as u64))
-        } else {
-            Truncated::Complete
-        };
+        let window = Window::resolve(&req.page).map_err(api_to_core)?;
+        let (page, truncated) = page_indexed(all, window);
         Ok(PipeListOut {
             room_id: req.room_id.clone(),
             pipes: page,
@@ -1468,57 +1537,53 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .room_activate(&r)
             .await
             .map(TypedReply::RoomActivate)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::RoomDeactivate(r) => t
             .room_deactivate(&r)
             .await
             .map(TypedReply::RoomDeactivate)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::RoomLeave(r) => t
             .room_leave(&r)
             .await
             .map(TypedReply::RoomLeave)
-            .map_err(core_to_api),
-        TypedCall::RoomTimeline(r) => t
-            .room_timeline(&r)
-            .await
-            .map(TypedReply::RoomTimeline)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
+        TypedCall::RoomTimeline(r) => t.room_timeline(&r).await.map(TypedReply::RoomTimeline),
         TypedCall::RoomMembers(r) => t
             .room_members(&r)
             .await
             .map(TypedReply::RoomMembers)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::RoomArchive(r) => t
             .room_archive(&r)
             .await
             .map(TypedReply::RoomArchive)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::RoomPeers(r) => t
             .room_peers(&r)
             .await
             .map(TypedReply::RoomPeers)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::MemberRemove(r) => t
             .member_remove(&r)
             .await
             .map(TypedReply::MemberRemove)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::InviteMint(r) => t
             .invite_mint(&r)
             .await
             .map(TypedReply::InviteMint)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::InviteList(r) => t
             .invite_list(&r)
             .await
             .map(TypedReply::InviteList)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::InviteRevoke(r) => t
             .invite_revoke(&r)
             .await
             .map(TypedReply::InviteRevoke)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::InviteRedeem(r) => t
             .invite_redeem(&r)
             .await
@@ -1528,17 +1593,17 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .message_send(&r)
             .await
             .map(TypedReply::MessageSend)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::StatusPost(r) => t
             .status_post(&r)
             .await
             .map(TypedReply::StatusPost)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::StatusHistory(r) => t
             .status_history(&r)
             .await
             .map(TypedReply::StatusHistory)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::FleetList(_) => t
             .fleet_list()
             .await
@@ -1548,22 +1613,22 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .file_share(&r)
             .await
             .map(TypedReply::FileShare)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::FileList(r) => t
             .file_list(&r)
             .await
             .map(TypedReply::FileList)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::FileFetch(r) => t
             .file_fetch(&r)
             .await
             .map(TypedReply::FileFetch)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::FileRead(r) => t
             .file_read(&r)
             .await
             .map(TypedReply::FileRead)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::TransferCancel(r) => t
             .transfer_cancel(&r)
             .await
@@ -1574,12 +1639,12 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .pipe_list(&r)
             .await
             .map(TypedReply::PipeList)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::PipeConnect(r) => t
             .pipe_connect(&r)
             .await
             .map(TypedReply::PipeConnect)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::PipeRelease(r) => t
             .pipe_release(&r)
             .await
@@ -1589,7 +1654,7 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .pipe_revoke(&r)
             .await
             .map(TypedReply::PipeRevoke)
-            .map_err(core_to_api),
+            .map_err(|e| core_to_api_room(e, &r.room_id)),
         // Stream operations are connection-scoped; the engine handles them
         // against the connection's subscription set, not the supervisor.
         TypedCall::StreamSubscribe(_)
@@ -1791,18 +1856,38 @@ pub enum TypedReply {
     PipeRevoke(PipeRevokeOut),
 }
 
-/// Map a core error onto the typed v2 taxonomy at the engine boundary.
+/// Map a typed [`ApiError`] back onto a core error, for the typed-read paths
+/// that still surface `CoreResult` internally.
+fn api_to_core(err: ApiError) -> CoreError {
+    match err {
+        ApiError::InvalidArgument { .. } => {
+            CoreError::new(ErrorKind::InvalidParams, "invalid paging argument")
+        }
+        _ => CoreError::internal("typed projection error"),
+    }
+}
+
+/// Map a core error onto the typed v2 taxonomy at the engine boundary. A
+/// room-scoped error carries the identifier the operation named, never an
+/// empty placeholder — the typed error schema fixes the field and a client
+/// branches on it.
 fn core_to_api(err: CoreError) -> ApiError {
+    core_to_api_ctx(err, None)
+}
+
+/// [`core_to_api`] with the room the operation named, for room-scoped errors.
+fn core_to_api_room(err: CoreError, room_id: &RoomId) -> ApiError {
+    core_to_api_ctx(err, Some(room_id.clone()))
+}
+
+fn core_to_api_ctx(err: CoreError, room_id: Option<RoomId>) -> ApiError {
+    let rid = || room_id.clone().unwrap_or_else(|| RoomId::new(""));
     match err.kind {
         ErrorKind::IdentityMissing => ApiError::SubjectAbsent,
         ErrorKind::RoomUnknown | ErrorKind::NotAMember | ErrorKind::FileUnauthorized => {
-            ApiError::RoomNotAvailable {
-                room_id: RoomId::new(""),
-            }
+            ApiError::RoomNotAvailable { room_id: rid() }
         }
-        ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
-            room_id: RoomId::new(""),
-        },
+        ErrorKind::RoomNotOpen => ApiError::RoomNotLive { room_id: rid() },
         ErrorKind::BadTicket => ApiError::CapabilityInvalid,
         ErrorKind::TicketExpired => ApiError::CapabilityExpired {
             expired_at: proj_epoch(),
@@ -1815,9 +1900,7 @@ fn core_to_api(err: CoreError) -> ApiError {
             expected: String::new(),
             observed: String::new(),
         },
-        ErrorKind::PipeDenied => ApiError::PolicyRefused {
-            room_id: RoomId::new(""),
-        },
+        ErrorKind::PipeDenied => ApiError::PolicyRefused { room_id: rid() },
         ErrorKind::PeerUnreachable => ApiError::PipeUnreachable {
             pipe_id: PipeId::new(""),
             link: Link::NotConnected {

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -377,8 +377,8 @@ impl<'a> TypedSupervisor<'a> {
                 .map(proj::role)
                 .unwrap_or(Role::Member);
             let store = self.sup.open_store().map_err(core_to_api)?;
-            let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)
-                .map_err(core_to_api)?;
+            let (removed_ids, left_ids) =
+                crate::supervisor::departure_sets(&store, &room_id).map_err(core_to_api)?;
             let standing = self_member.map(|m| {
                 proj::standing(
                     removed_ids.contains(&m.identity)
@@ -499,8 +499,8 @@ impl<'a> TypedSupervisor<'a> {
     ) -> Result<(), ApiError> {
         let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
         let store = self.sup.open_store().map_err(core_to_api)?;
-        let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, room_id)
-            .map_err(core_to_api)?;
+        let (removed_ids, left_ids) =
+            crate::supervisor::departure_sets(&store, room_id).map_err(core_to_api)?;
         let standing = snapshot.member(&self_key).map_or(Standing::Active, |m| {
             proj::standing(
                 removed_ids.contains(&m.identity)
@@ -561,7 +561,8 @@ impl<'a> TypedSupervisor<'a> {
             ));
         }
         let events = self.committed_events(&room_id, &snapshot)?;
-        let (page, truncated) = page_events(events, Window::resolve(&req.page).map_err(api_to_core)?);
+        let (page, truncated) =
+            page_events(events, Window::resolve(&req.page).map_err(api_to_core)?);
         Ok(RoomArchiveOut {
             room_id: req.room_id.clone(),
             standing,

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -274,14 +274,18 @@ impl<'a> TypedSupervisor<'a> {
             .map_err(|_| ApiError::NotReady)
     }
 
-    /// The `hello` `subject` fact: present with ids, or its stated absence.
-    pub fn subject_state(&self) -> SubjectState {
+    /// The `hello` `subject` fact: present with ids, its stated absence, or
+    /// `not_ready` when the subject store cannot be read (corrupt or
+    /// permission-denied — the connection must not be invited to run
+    /// `subject.ensure` against unreadable existing state).
+    pub fn subject_state(&self) -> Result<SubjectState, ApiError> {
         match crate::identity::load_profile(self.sup.data_dir()) {
-            Ok(Some(p)) => SubjectState::Present {
+            Ok(Some(p)) => Ok(SubjectState::Present {
                 subject_id: SubjectId::new(p.identity_id),
                 device_id: DeviceId::new(p.device_id),
-            },
-            _ => SubjectState::Absent,
+            }),
+            Ok(None) => Ok(SubjectState::Absent),
+            Err(_) => Err(ApiError::NotReady),
         }
     }
 
@@ -330,7 +334,7 @@ impl<'a> TypedSupervisor<'a> {
     /// `room.list` — every room this identity holds, in what standing, with
     /// recency and capabilities, from local evidence with zero network
     /// activity.
-    pub async fn room_list(&self) -> CoreResult<RoomListOut> {
+    pub async fn room_list(&self) -> Result<RoomListOut, ApiError> {
         if !self.sup.db_path().exists() {
             return Ok(RoomListOut { rooms: Vec::new() });
         }
@@ -339,23 +343,30 @@ impl<'a> TypedSupervisor<'a> {
             Err(e) if e.kind == ErrorKind::IdentityMissing => {
                 return Ok(RoomListOut { rooms: Vec::new() })
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(core_to_api(e)),
         };
-        let room_ids: Vec<IrohRoomId> = crate::localstate::load(self.sup.data_dir())?
+        let room_ids: Vec<IrohRoomId> = crate::localstate::load(self.sup.data_dir())
+            .map_err(|_| ApiError::RoomIndexUnreadable)?
             .rooms
             .keys()
             .filter_map(|room_id| room_id.parse().ok())
             .collect();
         let mut rooms = Vec::with_capacity(room_ids.len());
         for room_id in room_ids {
-            let Ok(snapshot) = self.sup.snapshot_for(&room_id).await else {
-                continue;
-            };
+            // A locally indexed room whose log will not fold is a read
+            // failure, not an absent room: silently dropping it would present
+            // an incomplete index as complete. Surface `room_index_unreadable`
+            // rather than a misleading partial list.
+            let snapshot = self
+                .sup
+                .snapshot_for(&room_id)
+                .await
+                .map_err(|_| ApiError::RoomIndexUnreadable)?;
             if RoomSupervisor::require_local_room_access(&snapshot, &self_key).is_err() {
                 continue;
             }
             let name = {
-                let store = self.sup.open_store()?;
+                let store = self.sup.open_store().map_err(core_to_api)?;
                 crate::supervisor::genesis_name(&store, &room_id).or_else(|| {
                     crate::localstate::local_name(self.sup.data_dir(), &room_id.to_string())
                 })
@@ -365,8 +376,9 @@ impl<'a> TypedSupervisor<'a> {
                 .role(&self_key)
                 .map(proj::role)
                 .unwrap_or(Role::Member);
-            let store = self.sup.open_store()?;
-            let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)?;
+            let store = self.sup.open_store().map_err(core_to_api)?;
+            let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)
+                .map_err(core_to_api)?;
             let standing = self_member.map(|m| {
                 proj::standing(
                     removed_ids.contains(&m.identity)
@@ -375,10 +387,13 @@ impl<'a> TypedSupervisor<'a> {
                 )
             });
             // Recency: the newest committed event's author-dated instant and
-            // kind, max by timestamp (never the wall clock).
+            // kind, max by timestamp over the COMPLETE history (never the wall
+            // clock, never a bounded window — a clock-ahead peer's older row
+            // with the greatest signed instant must not fall out and move the
+            // projection backward).
             let recency = store
-                .room_tail(&room_id, 256)
-                .map_err(|e| CoreError::internal(format!("could not read recency: {e}")))?
+                .room_tail(&room_id, u32::MAX)
+                .map_err(|_| ApiError::RoomIndexUnreadable)?
                 .iter()
                 .filter_map(|se| {
                     proj::stored_event_recency(se).map(|(ts, kind)| (ts, se.event_id, kind))
@@ -594,14 +609,19 @@ impl<'a> TypedSupervisor<'a> {
             ));
         }
         // v2 `expires_at` is an absolute instant; the supervisor takes a
-        // relative spec. Convert absolute -> seconds-from-now.
+        // relative spec. Convert absolute -> seconds-from-now. A past or
+        // already-expiring expiry is refused rather than minting a capability
+        // that is born expired yet labelled `outstanding` — the reply's
+        // redeemability must agree with the capability's signed expiry.
         let expires_ms = req.expires_at.into_inner().unix_timestamp().max(0) as u64 * 1000;
         let now = crate::now_ms();
-        let spec = if expires_ms > now {
-            format!("{}s", (expires_ms - now) / 1000)
-        } else {
-            "0s".to_string()
-        };
+        if expires_ms <= now {
+            return Err(CoreError::new(
+                ErrorKind::InvalidParams,
+                "invite.mint expiry is not in the future",
+            ));
+        }
+        let spec = format!("{}s", (expires_ms - now) / 1000);
         let ticket = self
             .sup
             .create_invite(
@@ -1528,11 +1548,7 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .room_create(&r)
             .map(TypedReply::RoomCreate)
             .map_err(core_to_api),
-        TypedCall::RoomList(_) => t
-            .room_list()
-            .await
-            .map(TypedReply::RoomList)
-            .map_err(core_to_api),
+        TypedCall::RoomList(_) => t.room_list().await.map(TypedReply::RoomList),
         TypedCall::RoomActivate(r) => t
             .room_activate(&r)
             .await
@@ -1862,6 +1878,9 @@ fn api_to_core(err: ApiError) -> CoreError {
     match err {
         ApiError::InvalidArgument { .. } => {
             CoreError::new(ErrorKind::InvalidParams, "invalid paging argument")
+        }
+        ApiError::RoomIndexUnreadable => {
+            CoreError::new(ErrorKind::Internal, "room index unreadable")
         }
         _ => CoreError::internal("typed projection error"),
     }

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -207,6 +207,13 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
+    /// Whether a local subject exists (the step-2 precondition).
+    pub(crate) fn subject_present(&self) -> Result<bool, ApiError> {
+        crate::identity::load_profile(self.sup.data_dir())
+            .map(|p| p.is_some())
+            .map_err(|_| ApiError::NotReady)
+    }
+
     /// The `hello` `subject` fact: present with ids, or its stated absence.
     pub fn subject_state(&self) -> SubjectState {
         match crate::identity::load_profile(self.sup.data_dir()) {
@@ -948,52 +955,59 @@ impl<'a> TypedSupervisor<'a> {
     // Pipes
     // ------------------------------------------------------------------
 
-    /// `pipe.publish` — publish a pipe to a loopback target.
-    pub async fn pipe_publish(&self, req: &PipePublish) -> CoreResult<PipePublishOut> {
-        // Validate the target is loopback and the port is in range.
+    /// `pipe.publish` — publish a pipe to a loopback target. `audience: room`
+    /// authorizes every active member; `audience: subjects` authorizes the
+    /// named list. A non-loopback target or an out-of-range port is
+    /// `pipe_target_refused` carrying the rejected target verbatim.
+    pub async fn pipe_publish(&self, req: &PipePublish) -> Result<PipePublishOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        // The target must be loopback (IPv4 127.0.0.0/8 or IPv6 ::1) with a
+        // port in 1..=65535. Anything else is pipe_target_refused carrying the
+        // rejected target verbatim, never the generic policy_refused.
+        // Parse the address, bracketing an IPv6 host so `::1` resolves (the
+        // bare `host:port` form is ambiguous for a bare IPv6 literal).
+        let host = if req.target.host.contains(':') && !req.target.host.starts_with('[') {
+            format!("[{}]", req.target.host)
+        } else {
+            req.target.host.clone()
+        };
+        let target_addr: Option<std::net::SocketAddr> =
+            format!("{host}:{}", req.target.port).parse().ok();
         let port_ok = (1..=65535).contains(&req.target.port);
-        if !port_ok {
-            return Err(CoreError::new(
-                ErrorKind::PipeDenied,
-                format!("pipe target port {} is outside 1..=65535", req.target.port),
-            ));
+        let loopback = target_addr.as_ref().is_some_and(is_loopback_addr);
+        if !port_ok || !loopback {
+            return Err(ApiError::PipeTargetRefused {
+                target: req.target.clone(),
+            });
         }
-        let target_str = format!("{}:{}", req.target.host, req.target.port);
-        let peer_identity =
-            match &req.audience {
-                Audience::Subjects { subject_ids } if subject_ids.len() == 1 => {
-                    subject_ids[0].to_string()
-                }
-                Audience::Room => return Err(CoreError::new(
-                    ErrorKind::InvalidParams,
-                    "pipe.publish to the whole room is not supported by the runtime in this build",
-                )),
-                _ => {
-                    return Err(CoreError::new(
-                        ErrorKind::InvalidParams,
-                        "pipe.publish requires exactly one authorized subject in this build",
-                    ))
-                }
-            };
-        let result = self
+        let target_addr = target_addr.expect("parsed above");
+
+        // Resolve the audience to a concrete authorized-subject set.
+        let snapshot = self.sup.readable_snapshot(&room_id).await.map_err(core_to_api)?;
+        let allowed: Vec<iroh_rooms::identity::IdentityKey> = match &req.audience {
+            Audience::Room => snapshot.active_members().map(|m| m.identity).collect(),
+            Audience::Subjects { subject_ids } => subject_ids
+                .iter()
+                .map(Self::parse_subject)
+                .collect::<CoreResult<Vec<_>>>()
+                .map_err(core_to_api)?,
+        };
+        if allowed.is_empty() {
+            return Err(ApiError::PolicyRefused {
+                room_id: req.room_id.clone(),
+            });
+        }
+
+        let target_hint = format!("{}:{}", req.target.host, req.target.port);
+        let (pipe_id, event_id) = self
             .sup
-            .pipe_expose(req.room_id.as_ref(), &target_str, &peer_identity)
-            .await?;
-        let pipe_id = result
-            .get("pipe_id")
-            .and_then(|p| p.as_str())
-            .ok_or_else(|| CoreError::internal("pipe expose carried no pipe_id"))?
-            .to_string();
-        let event_id = result
-            .get("event_id")
-            .and_then(|p| p.as_str())
-            .unwrap_or_default()
-            .to_string();
-        let room_id = Self::parse_room(&req.room_id)?;
-        let pos = self.latest_pos(&room_id)?;
+            .pipe_expose_multi(&room_id, target_addr, &target_hint, &allowed)
+            .await
+            .map_err(core_to_api)?;
+        let pos = self.latest_pos(&room_id).map_err(core_to_api)?;
         Ok(PipePublishOut {
             room_id: req.room_id.clone(),
-            pipe_id: PipeId::new(pipe_id),
+            pipe_id: crate::projection::pipe_id(&pipe_id),
             target: req.target.clone(),
             audience: req.audience.clone(),
             event_id: EventId::new(event_id),
@@ -1383,6 +1397,11 @@ fn proj_epoch() -> Timestamp {
     Timestamp::new(time::OffsetDateTime::UNIX_EPOCH)
 }
 
+/// Whether a socket address is loopback (IPv4 127.0.0.0/8 or IPv6 ::1).
+fn is_loopback_addr(addr: &std::net::SocketAddr) -> bool {
+    addr.ip().is_loopback()
+}
+
 /// Split a `"host:port"` loopback address into a `Target`.
 fn split_host_port(addr: &str) -> (String, u64) {
     match addr.rsplit_once(':') {
@@ -1423,6 +1442,14 @@ fn closed_pipe_ids(
 /// cannot fail.
 pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedReply, ApiError> {
     let t = TypedSupervisor::new(sup);
+    // Validation-order step 2 (subject precondition): every operation except
+    // `subject.ensure` — which exists to create the subject — requires a local
+    // subject before any later stage (dedup, room index, standing, role,
+    // semantics) runs. `subject_absent` outranks `room_not_available` and is
+    // never a membership oracle.
+    if !matches!(call, TypedCall::SubjectEnsure(_)) && !t.subject_present()? {
+        return Err(ApiError::SubjectAbsent);
+    }
     match call {
         TypedCall::SubjectEnsure(_) => t
             .subject_ensure()
@@ -1542,11 +1569,7 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .await
             .map(TypedReply::TransferCancel)
             .map_err(core_to_api),
-        TypedCall::PipePublish(r) => t
-            .pipe_publish(&r)
-            .await
-            .map(TypedReply::PipePublish)
-            .map_err(core_to_api),
+        TypedCall::PipePublish(r) => t.pipe_publish(&r).await.map(TypedReply::PipePublish),
         TypedCall::PipeList(r) => t
             .pipe_list(&r)
             .await

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1,0 +1,1811 @@
+//! The typed protocol-v2 projection layer over [`RoomSupervisor`] (#165).
+//!
+//! Every protocol-facing read the engine serves is produced here as a typed
+//! `jeliya-api` value — never a `serde_json::Value`. The supervisor keeps its
+//! runtime machinery (node sessions, blob transfer, pipe forwarding); this
+//! layer owns the *shape* every answer takes at the v2 boundary, converting
+//! internal/Iroh structures through [`crate::projection`]. The authoritative
+//! statement of every shape is `docs/protocol-v2.md`.
+//!
+//! Two deliberate boundaries, per the issue's non-goals:
+//!
+//! - **Signed-event and liveness semantics are unchanged.** The same folds,
+//!   snapshots, and transfer flows run; only their served representation is
+//!   re-typed.
+//! - **Internal persistence JSON stays JSON.** `localstate.rs` and
+//!   `identity.rs` are untouched; only the protocol-facing projections move
+//!   to typed shapes.
+//!
+//! # Paging and positions
+//!
+//! The v2 record fixes one continuation mechanism: every paging operation
+//! takes a required [`Page`] (`cursor`, `direction`, `limit`) and answers a
+//! [`Truncated`]. Positions are the store's per-room Lamport clock (`pos`),
+//! anchored at `0` for the genesis. The Iroh store's `room_tail` returns the
+//! most-recent `limit` events in ascending `(lamport, event_id)` order, which
+//! is exactly the v2 position space; cursor/direction paging is applied over
+//! that space here.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use jeliya_api::*;
+use serde::{Deserialize, Serialize};
+
+use iroh_rooms::events::{Content, EventType, SignedEvent};
+use iroh_rooms::room::RoomId as IrohRoomId;
+
+use crate::error::{CoreError, CoreResult, ErrorKind};
+use crate::materializer::file_handle;
+use crate::projection as proj;
+use crate::supervisor::RoomSupervisor;
+
+/// The daemon's served limits, surfaced in `hello`/`VersionInfo` and enforced
+/// here. Values are the record's served-limits object; the shared-file maximum
+/// is the size policy's 100 MiB (`max_shared_file_bytes`), the message-body and
+/// page bounds come from the same constants the v1 surface enforced.
+#[must_use]
+pub fn limits() -> Limits {
+    Limits {
+        max_shared_file_bytes: crate::supervisor::FILE_UPLOAD_MAX_BYTES,
+        max_message_body_bytes: 16_384,
+        max_frame_bytes: 128 * 1024 * 1024,
+        max_inflight_requests: 64,
+        max_subscriptions_per_connection: 64,
+        max_connections: 64,
+        max_concurrent_transfers: 8,
+        max_transfer_bytes_inflight: 256 * 1024 * 1024,
+        transfer_connect_allowance_ms: 5_000,
+        transfer_floor_bits_per_second: 8_192,
+        transfer_stall_ms: 30_000,
+        timeline_page_max: 1_024,
+        idle_timeout_ms: 600_000,
+        pairing_code_ttl_ms: 900_000,
+        pairing_code_max_attempts: 5,
+        browser_session_ttl_ms: 86_400_000,
+    }
+}
+
+/// The fleet projection's per-(subject, room) aggregation.
+type FleetAggMap = BTreeMap<(String, String), (Liveness, Option<(String, u64)>, Option<u64>)>;
+
+/// Per-agent signal accumulation over a room's stored events: known device
+/// keys, the newest status, and the newest event ts.
+type AgentSignalsMap = BTreeMap<
+    iroh_rooms::identity::IdentityKey,
+    (
+        BTreeSet<iroh_rooms::identity::DeviceKey>,
+        Option<(String, u64)>,
+        Option<u64>,
+    ),
+>;
+
+/// A paging window over the v2 position space. `cursor` and `direction` are
+/// the record's required paging fields; `limit` is bounded to
+/// `timeline_page_max` (refused, never clamped — the bound check lives in the
+/// engine before this layer).
+#[derive(Debug, Clone, Copy)]
+struct Window {
+    /// Resolved starting position (inclusive lower bound), or `None` for the
+    /// very start.
+    from: Option<u64>,
+    /// Page size.
+    limit: usize,
+    /// `true` = forward (newer first-encountered), `false` = backward.
+    forward: bool,
+}
+
+impl Window {
+    fn resolve(page: &Page) -> CoreResult<Self> {
+        let from = match &page.cursor {
+            Cursor::Start => None,
+            Cursor::At { pos } => Some(*pos),
+        };
+        let limit = usize::try_from(page.limit.max(1)).unwrap_or(usize::MAX);
+        let forward = matches!(page.direction, Direction::Forward);
+        Ok(Self {
+            from,
+            limit,
+            forward,
+        })
+    }
+}
+
+/// Apply a [`Window`] to a position-ordered list of committed events,
+/// returning the page plus the one continuation mechanism.
+fn page_events(events: Vec<Event>, window: Window) -> (Vec<Event>, Truncated) {
+    // `events` is ascending by pos (the store's canonical order). Select the
+    // window, then order by direction.
+    let filtered: Vec<Event> = events
+        .into_iter()
+        .filter(|e| window.from.is_none_or(|f| e.pos >= f))
+        .collect();
+    let mut page: Vec<Event> = if window.forward {
+        filtered
+            .into_iter()
+            .take(window.limit.saturating_add(1))
+            .collect()
+    } else {
+        // Backward: take the newest `limit+1`, then reverse to ascending so the
+        // page is always served in first-encountered (ascending) order.
+        let mut v: Vec<Event> = filtered
+            .into_iter()
+            .rev()
+            .take(window.limit.saturating_add(1))
+            .collect();
+        v.reverse();
+        v
+    };
+    let truncated = if page.len() > window.limit {
+        page.truncate(window.limit);
+        let next = page.last().map(|e| e.pos + 1);
+        proj::truncated(next)
+    } else {
+        Truncated::Complete
+    };
+    (page, truncated)
+}
+
+/// The typed projection facade. Cheap to construct; borrows the supervisor.
+pub struct TypedSupervisor<'a> {
+    sup: &'a RoomSupervisor,
+}
+
+impl<'a> TypedSupervisor<'a> {
+    /// Wrap a supervisor.
+    #[must_use]
+    pub fn new(sup: &'a RoomSupervisor) -> Self {
+        Self { sup }
+    }
+
+    /// The underlying supervisor (for host surfaces that bypass dispatch).
+    #[must_use]
+    pub fn supervisor(&self) -> &'a RoomSupervisor {
+        self.sup
+    }
+
+    fn parse_room(room_id: &RoomId) -> CoreResult<IrohRoomId> {
+        room_id.as_str().trim().parse().map_err(|e| {
+            CoreError::invalid(format!("invalid room_id (expected blake3:<hex>): {e}"))
+        })
+    }
+
+    fn parse_subject(subject_id: &SubjectId) -> CoreResult<iroh_rooms::identity::IdentityKey> {
+        subject_id.as_str().trim().parse().map_err(|e| {
+            CoreError::invalid(format!("invalid subject_id (expected 64-char hex): {e}"))
+        })
+    }
+
+    fn parse_file(file_id: &FileId) -> CoreResult<[u8; 16]> {
+        let trimmed = file_id.as_str().trim();
+        let hex_part = trimmed.strip_prefix("file_").unwrap_or(trimmed);
+        let bytes = hex::decode(hex_part)
+            .map_err(|_| CoreError::invalid(format!("invalid file_id {trimmed:?}")))?;
+        <[u8; 16]>::try_from(bytes.as_slice())
+            .map_err(|_| CoreError::invalid(format!("invalid file_id {trimmed:?}")))
+    }
+
+    // ------------------------------------------------------------------
+    // Subject and daemon
+    // ------------------------------------------------------------------
+
+    /// `subject.ensure` — establish the local subject exactly once; a second
+    /// call returns the same subject with `created: false` (naturally
+    /// idempotent, never an `identity_exists` refusal).
+    pub fn subject_ensure(&self) -> CoreResult<SubjectEnsureOut> {
+        if let Some(profile) = crate::identity::load_profile(self.sup.data_dir())? {
+            return Ok(SubjectEnsureOut {
+                subject_id: SubjectId::new(profile.identity_id),
+                device_id: DeviceId::new(profile.device_id),
+                created: false,
+            });
+        }
+        let profile = crate::identity::create(self.sup.data_dir())?;
+        Ok(SubjectEnsureOut {
+            subject_id: SubjectId::new(profile.identity_id),
+            device_id: DeviceId::new(profile.device_id),
+            created: true,
+        })
+    }
+
+    /// The `hello` `subject` fact: present with ids, or its stated absence.
+    pub fn subject_state(&self) -> SubjectState {
+        match crate::identity::load_profile(self.sup.data_dir()) {
+            Ok(Some(p)) => SubjectState::Present {
+                subject_id: SubjectId::new(p.identity_id),
+                device_id: DeviceId::new(p.device_id),
+            },
+            _ => SubjectState::Absent,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rooms
+    // ------------------------------------------------------------------
+
+    /// `room.create` — bring a room into existence with the caller as its
+    /// authority; works with no network.
+    pub fn room_create(&self, req: &RoomCreate) -> CoreResult<RoomCreateOut> {
+        let name = req.name.trim();
+        if name.is_empty() || name.len() > 128 {
+            return Err(CoreError::new(
+                ErrorKind::InvalidParams,
+                "room name must be 1..=128 bytes with at least one non-whitespace",
+            ));
+        }
+        let room_id_str = self.sup.create_room(name)?;
+        let room_id: IrohRoomId = room_id_str
+            .parse()
+            .map_err(|e| CoreError::internal(format!("fresh room id does not parse: {e}")))?;
+        // The genesis is the room's origin event at pos 0, authored now.
+        let store = self.sup.open_store()?;
+        let rows = store
+            .room_tail(&room_id, 1)
+            .map_err(|e| CoreError::internal(format!("could not read the genesis: {e}")))?;
+        let (event_id, created_at) = rows
+            .first()
+            .and_then(|se| {
+                SignedEvent::decode(&se.wire.signed)
+                    .ok()
+                    .map(|ev| (se.event_id, ev.created_at))
+            })
+            .ok_or_else(|| CoreError::internal("the genesis did not persist"))?;
+        Ok(RoomCreateOut {
+            room_id: RoomId::new(room_id_str),
+            name: name.to_string(),
+            role: Role::Authority,
+            standing: Standing::Active,
+            event_id: proj::event_id(&event_id),
+            pos: 0,
+            created_at: proj_ts(created_at),
+        })
+    }
+
+    /// `room.list` — every room this identity holds, in what standing, with
+    /// recency and capabilities, from local evidence with zero network
+    /// activity.
+    pub async fn room_list(&self) -> CoreResult<RoomListOut> {
+        if !self.sup.db_path().exists() {
+            return Ok(RoomListOut { rooms: Vec::new() });
+        }
+        let self_key = match self.sup.local_identity_key() {
+            Ok(key) => key,
+            Err(e) if e.kind == ErrorKind::IdentityMissing => {
+                return Ok(RoomListOut { rooms: Vec::new() })
+            }
+            Err(e) => return Err(e),
+        };
+        let room_ids: Vec<IrohRoomId> = crate::localstate::load(self.sup.data_dir())?
+            .rooms
+            .keys()
+            .filter_map(|room_id| room_id.parse().ok())
+            .collect();
+        let mut rooms = Vec::with_capacity(room_ids.len());
+        for room_id in room_ids {
+            let Ok(snapshot) = self.sup.snapshot_for(&room_id).await else {
+                continue;
+            };
+            if RoomSupervisor::require_local_room_access(&snapshot, &self_key).is_err() {
+                continue;
+            }
+            let name = {
+                let store = self.sup.open_store()?;
+                crate::supervisor::genesis_name(&store, &room_id).or_else(|| {
+                    crate::localstate::local_name(self.sup.data_dir(), &room_id.to_string())
+                })
+            };
+            let self_member = snapshot.member(&self_key);
+            let role = snapshot
+                .role(&self_key)
+                .map(proj::role)
+                .unwrap_or(Role::Member);
+            let store = self.sup.open_store()?;
+            let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)?;
+            let standing = self_member.map(|m| {
+                proj::standing(
+                    removed_ids.contains(&m.identity)
+                        || matches!(m.status, iroh_rooms::room::Status::Removed),
+                    left_ids.contains(&m.identity),
+                )
+            });
+            // Recency: the newest committed event's author-dated instant and
+            // kind, max by timestamp (never the wall clock).
+            let recency = store
+                .room_tail(&room_id, 256)
+                .map_err(|e| CoreError::internal(format!("could not read recency: {e}")))?
+                .iter()
+                .filter_map(|se| {
+                    proj::stored_event_recency(se).map(|(ts, kind)| (ts, se.event_id, kind))
+                })
+                .max_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)))
+                .map(|(ts, _, kind)| (ts, kind));
+            let last_event = proj::last_event(recency);
+            let live = self.sup.is_open(&room_id);
+            let standing = standing.unwrap_or(Standing::Active);
+            let member_count = snapshot.members().count() as u64;
+            let capabilities = room_capabilities(standing, role, live);
+            rooms.push(RoomRow {
+                room_id: proj::room_id(&room_id),
+                name: name.unwrap_or_default(),
+                standing,
+                live,
+                role,
+                member_count,
+                last_event,
+                capabilities,
+            });
+        }
+        Ok(RoomListOut { rooms })
+    }
+
+    /// `room.activate` — make a room live on this device; returns reachability
+    /// and capabilities, **not history**.
+    pub async fn room_activate(&self, req: &RoomActivate) -> CoreResult<RoomActivateOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        // Activate is also a read boundary: authorize before spawning a node.
+        self.sup.readable_snapshot(&room_id).await?;
+        self.sup.open_room(req.room_id.as_ref(), &[]).await?;
+        let live = self.sup.is_open(&room_id);
+        let snapshot = self.sup.snapshot_for(&room_id).await?;
+        let self_key = self.sup.local_identity_key()?;
+        let role = snapshot
+            .role(&self_key)
+            .map(proj::role)
+            .unwrap_or(Role::Member);
+        let standing = self_key_standing(self.sup, &room_id, &snapshot, &self_key)?;
+        let reachability = self.reachability(&room_id).await;
+        Ok(RoomActivateOut {
+            room_id: req.room_id.clone(),
+            live,
+            reachability,
+            capabilities: room_capabilities(standing, role, live),
+        })
+    }
+
+    /// `room.deactivate` — stop live participation without changing membership.
+    pub async fn room_deactivate(&self, req: &RoomDeactivate) -> CoreResult<RoomDeactivateOut> {
+        self.sup.close_room(req.room_id.as_ref()).await?;
+        Ok(RoomDeactivateOut {
+            room_id: req.room_id.clone(),
+            live: false,
+        })
+    }
+
+    /// `room.leave` — author a signed departure every member converges on.
+    pub async fn room_leave(&self, req: &RoomLeave) -> CoreResult<RoomLeaveOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let event_id_hex = self.sup.leave_room(req.room_id.as_ref()).await?;
+        let pos = self.latest_pos(&room_id)?;
+        Ok(RoomLeaveOut {
+            room_id: req.room_id.clone(),
+            event_id: EventId::new(event_id_hex),
+            pos,
+            standing: Standing::Left,
+        })
+    }
+
+    /// `room.timeline` — read committed history identically whether or not
+    /// the room is live.
+    pub async fn room_timeline(&self, req: &RoomTimeline) -> CoreResult<RoomTimelineOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let snapshot = self.sup.readable_snapshot(&room_id).await?;
+        let events = self.committed_events(&room_id, &snapshot)?;
+        let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
+        Ok(RoomTimelineOut {
+            room_id: req.room_id.clone(),
+            events: page,
+            truncated,
+        })
+    }
+
+    /// `room.members` — the authoritative signed answer to who belongs. No
+    /// presence, no reachability.
+    pub async fn room_members(&self, req: &RoomMembers) -> CoreResult<RoomMembersOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let snapshot = self.sup.readable_snapshot(&room_id).await?;
+        let store = self.sup.open_store()?;
+        let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)?;
+        let members = snapshot
+            .members()
+            .map(|m| MemberRow {
+                subject_id: SubjectId::new(m.identity.to_string()),
+                role: proj::role(m.role),
+                standing: proj::standing(
+                    removed_ids.contains(&m.identity)
+                        || matches!(m.status, iroh_rooms::room::Status::Removed),
+                    left_ids.contains(&m.identity),
+                ),
+                // The fold does not date joins; joined_at is the join event's
+                // author-dated instant when discoverable, else the genesis.
+                joined_at: self
+                    .joined_at(&room_id, &m.identity)
+                    .unwrap_or_else(proj_epoch),
+            })
+            .collect();
+        Ok(RoomMembersOut {
+            room_id: req.room_id.clone(),
+            members,
+        })
+    }
+
+    /// `room.archive` — open a left or removed room as a local read-only
+    /// archive; normatively zero network activity.
+    pub async fn room_archive(&self, req: &RoomArchive) -> CoreResult<RoomArchiveOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let snapshot = self.sup.readable_snapshot(&room_id).await?;
+        let self_key = self.sup.local_identity_key()?;
+        let standing = self_key_standing(self.sup, &room_id, &snapshot, &self_key)?;
+        if standing == Standing::Active {
+            return Err(CoreError::new(
+                ErrorKind::InvalidParams,
+                "room.archive on a room the caller still belongs to",
+            ));
+        }
+        let events = self.committed_events(&room_id, &snapshot)?;
+        let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
+        Ok(RoomArchiveOut {
+            room_id: req.room_id.clone(),
+            standing,
+            events: page,
+            truncated,
+        })
+    }
+
+    /// `room.peers` — observed transport facts for one live room.
+    pub async fn room_peers(&self, req: &RoomPeers) -> CoreResult<RoomPeersOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        self.sup.readable_snapshot(&room_id).await?;
+        let session = self.sup.session(&room_id)?;
+        let peers = self.peer_rows(&session.node).await;
+        let reachability = reachability_from_peers(&peers, self.sup.is_open(&room_id));
+        Ok(RoomPeersOut {
+            room_id: req.room_id.clone(),
+            reachability,
+            peers,
+        })
+    }
+
+    /// `member.remove` — room authority removes a member, as a signed fact.
+    /// Not yet backed by the runtime (the MVP supervisor exposes no removal
+    /// flow), so it is refused honestly rather than fabricated.
+    pub async fn member_remove(&self, req: &MemberRemove) -> CoreResult<MemberRemoveOut> {
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "member.remove is not implemented in this build",
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // Invitations
+    // ------------------------------------------------------------------
+
+    /// `invite.mint` — mint one key-bound capability exactly one named
+    /// identity can redeem.
+    pub async fn invite_mint(&self, req: &InviteMint) -> CoreResult<InviteMintOut> {
+        if req.role != Role::Member {
+            return Err(CoreError::new(
+                ErrorKind::InvalidParams,
+                "invite.mint may only grant the member role today",
+            ));
+        }
+        // v2 `expires_at` is an absolute instant; the supervisor takes a
+        // relative spec. Convert absolute -> seconds-from-now.
+        let expires_ms = req.expires_at.into_inner().unix_timestamp().max(0) as u64 * 1000;
+        let now = crate::now_ms();
+        let spec = if expires_ms > now {
+            format!("{}s", (expires_ms - now) / 1000)
+        } else {
+            "0s".to_string()
+        };
+        let ticket = self
+            .sup
+            .create_invite(
+                req.room_id.as_ref(),
+                req.subject_id.as_str(),
+                "member",
+                Some(&spec),
+            )
+            .await?;
+        // The ticket is the capability string; its id is derivable from the
+        // ticket itself for the reply.
+        let parsed: iroh_rooms::room::RoomInviteTicket = ticket.trim().parse().map_err(|e| {
+            CoreError::internal(format!("freshly minted ticket does not parse: {e}"))
+        })?;
+        Ok(InviteMintOut {
+            invite_id: proj::invite_id(&parsed.invite_id),
+            room_id: req.room_id.clone(),
+            subject_id: req.subject_id.clone(),
+            role: req.role,
+            expires_at: req.expires_at,
+            capability: ticket,
+            redeemability: Redeemability::Outstanding,
+        })
+    }
+
+    /// `invite.redeem` — convert a capability into signed membership.
+    pub async fn invite_redeem(&self, req: &InviteRedeem) -> CoreResult<InviteRedeemOut> {
+        let room_id_str = self.sup.join_room(&req.capability, None, &[]).await?;
+        let room_id: IrohRoomId = room_id_str
+            .parse()
+            .map_err(|e| CoreError::internal(format!("joined room id does not parse: {e}")))?;
+        let snapshot = self.sup.snapshot_for(&room_id).await?;
+        let self_key = self.sup.local_identity_key()?;
+        let role = snapshot
+            .role(&self_key)
+            .map(proj::role)
+            .unwrap_or(Role::Member);
+        // The member_joined event is the newest committed event by this
+        // subject; find its id and position.
+        let (event_id, pos) = self
+            .latest_by_subject(&room_id, &self_key)
+            .unwrap_or_else(|| (EventId::new(""), 0));
+        Ok(InviteRedeemOut {
+            room_id: RoomId::new(room_id_str),
+            subject_id: SubjectId::new(self_key.to_string()),
+            role,
+            standing: Standing::Active,
+            event_id,
+            pos,
+            joined: true,
+        })
+    }
+
+    /// `invite.list` — enumerate outstanding and recently expired invites.
+    /// The MVP runtime does not maintain a served invite index, so this is
+    /// refused honestly rather than fabricated empty.
+    pub async fn invite_list(&self, req: &InviteList) -> CoreResult<InviteListOut> {
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "invite.list is not implemented in this build",
+        ))
+    }
+
+    /// `invite.revoke` — withdraw an outstanding capability before expiry.
+    /// Not yet backed by the runtime.
+    pub async fn invite_revoke(&self, req: &InviteRevoke) -> CoreResult<InviteRevokeOut> {
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "invite.revoke is not implemented in this build",
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // Timeline
+    // ------------------------------------------------------------------
+
+    /// `message.send` — author a message.
+    pub async fn message_send(&self, req: &MessageSend) -> CoreResult<MessageSendOut> {
+        let body_len = req.body.len() as u64;
+        if req.body.is_empty() || body_len > limits().max_message_body_bytes {
+            return Err(CoreError::new(
+                ErrorKind::InvalidParams,
+                format!(
+                    "message body must be 1..={} bytes",
+                    limits().max_message_body_bytes
+                ),
+            ));
+        }
+        let room_id = Self::parse_room(&req.room_id)?;
+        let event_id_hex = self
+            .sup
+            .send_message(req.room_id.as_ref(), &req.body)
+            .await?;
+        let pos = self.latest_pos(&room_id)?;
+        Ok(MessageSendOut {
+            room_id: req.room_id.clone(),
+            event_id: EventId::new(event_id_hex),
+            pos,
+            at: proj_ts(crate::now_ms()),
+        })
+    }
+
+    /// `status.post` — author an agent status (any active member).
+    pub async fn status_post(&self, req: &StatusPost) -> CoreResult<StatusPostOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let label = status_label_wire(req.label);
+        let progress_pct = match req.progress {
+            Progress::Reported { percent } => Some(u64::from(percent)),
+            Progress::Absent => None,
+        };
+        let event_id_hex = self
+            .sup
+            .post_status(req.room_id.as_ref(), label, None, progress_pct, &[])
+            .await?;
+        let pos = self.latest_pos(&room_id)?;
+        Ok(StatusPostOut {
+            room_id: req.room_id.clone(),
+            event_id: EventId::new(event_id_hex),
+            pos,
+            at: proj_ts(crate::now_ms()),
+            severity: req.label.severity(),
+        })
+    }
+
+    /// `status.history` — read one subject's status history, one entry per
+    /// real posted event, chronological.
+    pub async fn status_history(&self, req: &StatusHistory) -> CoreResult<StatusHistoryOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let identity = Self::parse_subject(&req.subject_id)?;
+        self.sup.readable_snapshot(&room_id).await?;
+        let store = self.sup.open_store()?;
+        let rows = store
+            .room_tail(&room_id, u32::MAX)
+            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+        let mut entries = Vec::new();
+        for se in &rows {
+            if se.event_type != EventType::AgentStatus {
+                continue;
+            }
+            let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+                continue;
+            };
+            if ev.sender_id != identity {
+                continue;
+            }
+            let Content::AgentStatus(c) = ev.content else {
+                continue;
+            };
+            let Ok(label) = status_label_parse(&c.status) else {
+                continue; // out-of-vocabulary labels are not reclassified
+            };
+            entries.push(StatusEntry {
+                at: proj_ts(ev.created_at),
+                label,
+                severity: label.severity(),
+                progress: proj_progress(c.progress_pct),
+            });
+        }
+        // Paging over the chronological entries.
+        let window = Window::resolve(&req.page)?;
+        let total = entries.len();
+        let start = match &req.page.cursor {
+            Cursor::Start => 0,
+            Cursor::At { pos } => (*pos as usize).min(total),
+        };
+        let end = (start + window.limit).min(total);
+        let page: Vec<StatusEntry> = entries[start..end].to_vec();
+        let truncated = if end < total {
+            proj::truncated(Some(end as u64))
+        } else {
+            Truncated::Complete
+        };
+        Ok(StatusHistoryOut {
+            room_id: req.room_id.clone(),
+            subject_id: req.subject_id.clone(),
+            entries: page,
+            truncated,
+        })
+    }
+
+    /// `fleet.list` — the agent fleet projection, no tallies.
+    pub async fn fleet_list(&self) -> CoreResult<FleetListOut> {
+        let now = crate::now_ms();
+        let self_id = self.sup.local_identity_key()?;
+        let known: BTreeSet<String> = crate::localstate::load(self.sup.data_dir())?
+            .rooms
+            .keys()
+            .cloned()
+            .collect();
+        let scans: Vec<IrohRoomId> = if self.sup.db_path().exists() {
+            known.iter().filter_map(|s| s.parse().ok()).collect()
+        } else {
+            Vec::new()
+        };
+        // Per (subject, room) aggregation of the newest status + liveness.
+        let mut agents: FleetAggMap = BTreeMap::new();
+        for room_id in scans {
+            let Ok(snapshot) = self.sup.snapshot_for(&room_id).await else {
+                continue;
+            };
+            if RoomSupervisor::require_local_room_access(&snapshot, &self_id).is_err() {
+                continue;
+            }
+            let agent_ids: BTreeSet<iroh_rooms::identity::IdentityKey> = snapshot
+                .members()
+                .filter(|m| m.role == iroh_rooms::room::Role::Agent)
+                .map(|m| m.identity)
+                .collect();
+            if agent_ids.is_empty() {
+                continue;
+            }
+            let rows = {
+                let store = self.sup.open_store()?;
+                store
+                    .room_tail(&room_id, u32::MAX)
+                    .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?
+            };
+            let mut signals: AgentSignalsMap = BTreeMap::new();
+            for se in &rows {
+                let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+                    continue;
+                };
+                if let Content::MemberJoined(c) = &ev.content {
+                    if agent_ids.contains(&c.device_binding.identity_key) {
+                        signals
+                            .entry(c.device_binding.identity_key)
+                            .or_default()
+                            .0
+                            .insert(c.device_binding.device_key);
+                    }
+                }
+                if !agent_ids.contains(&ev.sender_id) {
+                    continue;
+                }
+                let sig = signals.entry(ev.sender_id).or_default();
+                sig.0.insert(ev.device_id);
+                sig.2 = Some(sig.2.map_or(ev.created_at, |t: u64| t.max(ev.created_at)));
+                if let Content::AgentStatus(c) = &ev.content {
+                    let newer = match &sig.1 {
+                        Some((_, ts)) => ev.created_at >= *ts,
+                        None => true,
+                    };
+                    if newer {
+                        sig.1 = Some((c.status.clone(), ev.created_at));
+                    }
+                }
+            }
+            let session = self.sup.session_opt(&room_id);
+            for identity in &agent_ids {
+                let (devices, latest, last_seen) = signals.remove(identity).unwrap_or_default();
+                let connected = session.as_deref().is_some_and(|s| {
+                    devices.iter().any(|dev| {
+                        crate::supervisor::endpoint_id_of(*dev).is_ok_and(|id| {
+                            s.node.peer_state(id)
+                                == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
+                        })
+                    })
+                });
+                let liveness = crate::fleet::derive_liveness(
+                    connected,
+                    latest.as_ref().map(|(l, ts)| (l.as_str(), *ts)),
+                    now,
+                );
+                agents.insert(
+                    (identity.to_string(), room_id.to_string()),
+                    (proj::liveness(liveness), latest, last_seen),
+                );
+            }
+        }
+        let agents = agents
+            .into_iter()
+            .map(
+                |((subject, room), (liveness, latest, last_seen))| FleetRow {
+                    subject_id: SubjectId::new(subject),
+                    room_id: RoomId::new(room),
+                    liveness,
+                    latest_status: proj::latest_status(
+                        latest.as_ref().map(|(l, ts)| (l.as_str(), *ts)),
+                    ),
+                    last_seen: proj::last_seen(last_seen),
+                },
+            )
+            .collect();
+        Ok(FleetListOut { agents })
+    }
+
+    // ------------------------------------------------------------------
+    // Files
+    // ------------------------------------------------------------------
+
+    /// `file.share` — share bytes into a room. The v2 surface declares the
+    /// name/size/type; the daemon stages the bytes itself.
+    pub async fn file_share(&self, req: &FileShare) -> CoreResult<FileShareOut> {
+        // The v1 staging endpoint supplies bytes by path; the v2 WS op is the
+        // typed declaration. Until the byte-stream staging is wired into the
+        // codec, this is refused honestly rather than fabricating an event.
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "file.share byte staging is not wired to the typed surface in this build",
+        ))
+    }
+
+    /// `file.list` — files shared into a room, provider availability as a
+    /// protocol fact.
+    pub async fn file_list(&self, req: &FileList) -> CoreResult<FileListOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        self.sup.readable_snapshot(&room_id).await?;
+        let store = self.sup.open_store()?;
+        let events = store
+            .by_type(&room_id, EventType::FileShared)
+            .map_err(|e| CoreError::internal(format!("could not read file.shared events: {e}")))?;
+        let session = self.sup.session_opt(&room_id);
+        let room_id_str = room_id.to_string();
+        let mut files = Vec::with_capacity(events.len());
+        for se in &events {
+            let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+                continue;
+            };
+            let Content::FileShared(f) = ev.content else {
+                continue;
+            };
+            let providers: Vec<iroh_rooms::identity::DeviceKey> = match &f.providers {
+                Some(list) if !list.is_empty() => list.clone(),
+                _ => vec![ev.device_id],
+            };
+            let fetchable = session.as_deref().is_some_and(|s| {
+                providers.iter().any(|p| {
+                    crate::supervisor::endpoint_id_of(*p).is_ok_and(|id| {
+                        s.node.peer_state(id)
+                            == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
+                    })
+                })
+            });
+            let file_id = file_handle(&f.file_id);
+            let self_hosted =
+                crate::localstate::fetched_file(self.sup.data_dir(), &room_id_str, &file_id)
+                    .is_some();
+            let provider_rows = providers
+                .iter()
+                .map(|p| PeerRow {
+                    subject_id: SubjectId::new(ev.sender_id.to_string()),
+                    device_id: DeviceId::new(p.to_string()),
+                    link: Link::NotConnected {
+                        reason: LinkReason::NoRoute,
+                    },
+                })
+                .collect();
+            files.push(FileRow {
+                file_id: FileId::new(file_id),
+                name: f.name.clone(),
+                bytes: f.size_bytes,
+                digest: f.blob_hash.to_string(),
+                declared_content_type: f.mime_type.clone(),
+                shared_by: SubjectId::new(ev.sender_id.to_string()),
+                shared_at: proj_ts(ev.created_at),
+                providers: provider_rows,
+                fetchable,
+                self_hosted,
+            });
+        }
+        // Paging over the file rows (position = index within the file index).
+        let window = Window::resolve(&req.page)?;
+        let total = files.len();
+        let start = match &req.page.cursor {
+            Cursor::Start => 0,
+            Cursor::At { pos } => (*pos as usize).min(total),
+        };
+        let end = (start + window.limit).min(total);
+        let page: Vec<FileRow> = files[start..end].to_vec();
+        let truncated = if end < total {
+            proj::truncated(Some(end as u64))
+        } else {
+            Truncated::Complete
+        };
+        Ok(FileListOut {
+            room_id: req.room_id.clone(),
+            files: page,
+            truncated,
+        })
+    }
+
+    /// `file.fetch` — fetch a file's bytes from a provider; the daemon holds
+    /// the bytes and `file.read` streams them out.
+    pub async fn file_fetch(&self, req: &FileFetch) -> CoreResult<FileFetchOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let result = self
+            .sup
+            .fetch_file(req.room_id.as_ref(), req.file_id.as_str(), None)
+            .await?;
+        let bytes = result
+            .get("bytes")
+            .and_then(|b| b.as_u64())
+            .ok_or_else(|| CoreError::internal("fetch result carried no byte count"))?;
+        // The verified digest comes from the shared file's declared hash.
+        let file_id = Self::parse_file(&req.file_id)?;
+        let store = self.sup.open_store()?;
+        let events = store
+            .by_type(&room_id, EventType::FileShared)
+            .map_err(|e| CoreError::internal(format!("could not read file.shared events: {e}")))?;
+        let digest = events
+            .iter()
+            .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+            .find_map(|ev| match ev.content {
+                Content::FileShared(f) if f.file_id == file_id => Some(f.blob_hash.to_string()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let _ = room_id;
+        Ok(FileFetchOut {
+            room_id: req.room_id.clone(),
+            file_id: req.file_id.clone(),
+            bytes,
+            digest,
+            provider: ProviderRef {
+                subject_id: SubjectId::new(""),
+                device_id: DeviceId::new(""),
+            },
+        })
+    }
+
+    /// `file.read` — stream locally held bytes out (the header; bytes follow).
+    pub async fn file_read(&self, req: &FileRead) -> CoreResult<FileReadOut> {
+        let local = self
+            .sup
+            .local_file(req.room_id.as_ref(), req.file_id.as_str())
+            .await?;
+        Ok(FileReadOut {
+            room_id: req.room_id.clone(),
+            file_id: req.file_id.clone(),
+            bytes: local.bytes,
+            declared_content_type: local.mime,
+        })
+    }
+
+    /// `transfer.cancel` — cancel a transfer by the op_id that started it.
+    /// Transfers are not yet tracked by op_id in this build.
+    pub async fn transfer_cancel(&self, req: &TransferCancel) -> CoreResult<TransferCancelOut> {
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "transfer.cancel is not implemented in this build",
+        ))
+    }
+
+    // ------------------------------------------------------------------
+    // Pipes
+    // ------------------------------------------------------------------
+
+    /// `pipe.publish` — publish a pipe to a loopback target.
+    pub async fn pipe_publish(&self, req: &PipePublish) -> CoreResult<PipePublishOut> {
+        // Validate the target is loopback and the port is in range.
+        let port_ok = (1..=65535).contains(&req.target.port);
+        if !port_ok {
+            return Err(CoreError::new(
+                ErrorKind::PipeDenied,
+                format!("pipe target port {} is outside 1..=65535", req.target.port),
+            ));
+        }
+        let target_str = format!("{}:{}", req.target.host, req.target.port);
+        let peer_identity =
+            match &req.audience {
+                Audience::Subjects { subject_ids } if subject_ids.len() == 1 => {
+                    subject_ids[0].to_string()
+                }
+                Audience::Room => return Err(CoreError::new(
+                    ErrorKind::InvalidParams,
+                    "pipe.publish to the whole room is not supported by the runtime in this build",
+                )),
+                _ => {
+                    return Err(CoreError::new(
+                        ErrorKind::InvalidParams,
+                        "pipe.publish requires exactly one authorized subject in this build",
+                    ))
+                }
+            };
+        let result = self
+            .sup
+            .pipe_expose(req.room_id.as_ref(), &target_str, &peer_identity)
+            .await?;
+        let pipe_id = result
+            .get("pipe_id")
+            .and_then(|p| p.as_str())
+            .ok_or_else(|| CoreError::internal("pipe expose carried no pipe_id"))?
+            .to_string();
+        let event_id = result
+            .get("event_id")
+            .and_then(|p| p.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let room_id = Self::parse_room(&req.room_id)?;
+        let pos = self.latest_pos(&room_id)?;
+        Ok(PipePublishOut {
+            room_id: req.room_id.clone(),
+            pipe_id: PipeId::new(pipe_id),
+            target: req.target.clone(),
+            audience: req.audience.clone(),
+            event_id: EventId::new(event_id),
+            pos,
+        })
+    }
+
+    /// `pipe.list` — pipes in a room, with publisher reachability and local
+    /// connection as two separately named facts.
+    pub async fn pipe_list(&self, req: &PipeList) -> CoreResult<PipeListOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        self.sup.readable_snapshot(&room_id).await?;
+        let store = self.sup.open_store()?;
+        let session = self.sup.session_opt(&room_id);
+        let closed = closed_pipe_ids(&store, &room_id)?;
+        let opened = store
+            .by_type(&room_id, EventType::PipeOpened)
+            .map_err(|e| CoreError::internal(format!("could not read pipe.opened events: {e}")))?;
+        let mut pipes = Vec::new();
+        for se in opened {
+            if se.lamport.is_none() {
+                continue;
+            }
+            let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+                continue;
+            };
+            let Content::PipeOpened(p) = ev.content else {
+                continue;
+            };
+            if closed.contains(&p.pipe_id) {
+                continue; // revoked pipes are not listed
+            }
+            let connected = session.as_deref().is_some_and(|s| {
+                crate::supervisor::endpoint_id_of(p.owner_endpoint).is_ok_and(|id| {
+                    s.node.peer_state(id)
+                        == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
+                })
+            });
+            let link = if connected {
+                Link::Direct {
+                    since: proj_epoch(),
+                }
+            } else {
+                Link::NotConnected {
+                    reason: LinkReason::NoRoute,
+                }
+            };
+            pipes.push((
+                se.lamport.unwrap(),
+                PipeRow {
+                    pipe_id: proj::pipe_id(&p.pipe_id),
+                    published_by: SubjectId::new(p.owner_id.to_string()),
+                    device_id: DeviceId::new(p.owner_endpoint.to_string()),
+                    published_at: proj_ts(ev.created_at),
+                    link,
+                    connected,
+                },
+            ));
+        }
+        pipes.sort_by_key(|(pos, _)| *pos);
+        let all: Vec<PipeRow> = pipes.into_iter().map(|(_, p)| p).collect();
+        let window = Window::resolve(&req.page)?;
+        let total = all.len();
+        let start = match &req.page.cursor {
+            Cursor::Start => 0,
+            Cursor::At { pos } => (*pos as usize).min(total),
+        };
+        let end = (start + window.limit).min(total);
+        let page: Vec<PipeRow> = all[start..end].to_vec();
+        let truncated = if end < total {
+            proj::truncated(Some(end as u64))
+        } else {
+            Truncated::Complete
+        };
+        Ok(PipeListOut {
+            room_id: req.room_id.clone(),
+            pipes: page,
+            truncated,
+        })
+    }
+
+    /// `pipe.connect` — connect to a pipe.
+    pub async fn pipe_connect(&self, req: &PipeConnect) -> CoreResult<PipeConnectOut> {
+        let local_addr = self
+            .sup
+            .pipe_connect(req.room_id.as_ref(), req.pipe_id.as_str())
+            .await?;
+        let (host, port) = split_host_port(&local_addr);
+        Ok(PipeConnectOut {
+            room_id: req.room_id.clone(),
+            pipe_id: req.pipe_id.clone(),
+            connection_id: local_addr.clone(),
+            local: Target { host, port },
+        })
+    }
+
+    /// `pipe.release` — release a local connection, named by the connection.
+    pub async fn pipe_release(&self, req: &PipeRelease) -> CoreResult<PipeReleaseOut> {
+        // The runtime names connections by their local addr today; releasing
+        // by connection_id requires a connection index the MVP does not keep.
+        let _ = req;
+        Err(CoreError::new(
+            ErrorKind::InvalidParams,
+            "pipe.release by connection_id is not implemented in this build",
+        ))
+    }
+
+    /// `pipe.revoke` — withdraw a published pipe as a signed fact.
+    pub async fn pipe_revoke(&self, req: &PipeRevoke) -> CoreResult<PipeRevokeOut> {
+        let room_id = Self::parse_room(&req.room_id)?;
+        let result = self
+            .sup
+            .pipe_close(req.room_id.as_ref(), req.pipe_id.as_str())
+            .await?;
+        let event_id = result
+            .get("event_id")
+            .and_then(|p| p.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let pos = self.latest_pos(&room_id)?;
+        Ok(PipeRevokeOut {
+            room_id: req.room_id.clone(),
+            pipe_id: req.pipe_id.clone(),
+            event_id: EventId::new(event_id),
+            pos,
+            revoked_at: proj_ts(crate::now_ms()),
+        })
+    }
+
+    // ------------------------------------------------------------------
+    // Shared helpers
+    // ------------------------------------------------------------------
+
+    /// All committed timeline events for a room, ascending by position.
+    fn committed_events(
+        &self,
+        room_id: &IrohRoomId,
+        snapshot: &iroh_rooms::room::MembershipSnapshot,
+    ) -> CoreResult<Vec<Event>> {
+        let store = self.sup.open_store()?;
+        let rows = store
+            .room_tail(room_id, u32::MAX)
+            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+        Ok(rows
+            .iter()
+            .filter_map(|se| proj::materialize(se, snapshot))
+            .collect())
+    }
+
+    /// The newest committed position in a room (0 when empty).
+    fn latest_pos(&self, room_id: &IrohRoomId) -> CoreResult<u64> {
+        let store = self.sup.open_store()?;
+        let rows = store
+            .room_tail(room_id, 1)
+            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+        Ok(rows.first().and_then(|se| se.lamport).unwrap_or(0))
+    }
+
+    /// The newest committed event authored by a subject, with its position.
+    fn latest_by_subject(
+        &self,
+        room_id: &IrohRoomId,
+        subject: &iroh_rooms::identity::IdentityKey,
+    ) -> Option<(EventId, u64)> {
+        let store = self.sup.open_store().ok()?;
+        let rows = store.room_tail(room_id, u32::MAX).ok()?;
+        rows.iter()
+            .filter(|se| se.lamport.is_some())
+            .filter_map(|se| {
+                let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+                if &ev.sender_id == subject {
+                    Some((proj::event_id(&se.event_id), se.lamport.unwrap()))
+                } else {
+                    None
+                }
+            })
+            .next_back()
+    }
+
+    /// The author-dated instant a subject joined, when discoverable.
+    fn joined_at(
+        &self,
+        room_id: &IrohRoomId,
+        subject: &iroh_rooms::identity::IdentityKey,
+    ) -> Option<Timestamp> {
+        let store = self.sup.open_store().ok()?;
+        let rows = store.by_type(room_id, EventType::MemberJoined).ok()?;
+        for se in rows {
+            let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+            if let Content::MemberJoined(c) = &ev.content {
+                if &c.device_binding.identity_key == subject {
+                    return Some(proj_ts(ev.created_at));
+                }
+            }
+        }
+        // The authority's join is the genesis.
+        let genesis = store.room_tail(room_id, 1).ok()?;
+        let first = genesis.first()?;
+        let ev = SignedEvent::decode(&first.wire.signed).ok()?;
+        if &ev.sender_id == subject {
+            return Some(proj_ts(ev.created_at));
+        }
+        None
+    }
+
+    /// The per-device link rows for one live node.
+    async fn peer_rows(&self, node: &iroh_rooms::experimental::session::Node) -> Vec<PeerRow> {
+        let paths: std::collections::HashMap<_, _> = node
+            .peer_paths()
+            .await
+            .into_iter()
+            .map(|(device, path, _relay)| (device, path.label()))
+            .collect();
+        node.peer_entries()
+            .into_iter()
+            .map(|(device, entry)| {
+                let connected = matches!(
+                    entry.state,
+                    iroh_rooms::experimental::session::PeerConnState::Connected
+                );
+                let link = if connected {
+                    match paths.get(&device).copied() {
+                        Some("direct") | Some("mixed") => Link::Direct {
+                            since: proj_epoch(),
+                        },
+                        Some("relay") => Link::Relay {
+                            since: proj_epoch(),
+                        },
+                        _ => Link::NotConnected {
+                            reason: LinkReason::NoRoute,
+                        },
+                    }
+                } else {
+                    Link::NotConnected {
+                        reason: LinkReason::NoRoute,
+                    }
+                };
+                PeerRow {
+                    subject_id: entry
+                        .identity
+                        .as_ref()
+                        .map(|id| SubjectId::new(id.to_string()))
+                        .unwrap_or_else(|| SubjectId::new("")),
+                    device_id: DeviceId::new(device.to_string()),
+                    link,
+                }
+            })
+            .collect()
+    }
+
+    /// Whole-room reachability from the live session.
+    async fn reachability(&self, room_id: &IrohRoomId) -> Reachability {
+        if !self.sup.is_open(room_id) {
+            return Reachability::Offline;
+        }
+        match self.sup.session(room_id) {
+            Ok(session) => {
+                let peers = self.peer_rows(&session.node).await;
+                reachability_from_peers(&peers, true)
+            }
+            Err(_) => Reachability::Connecting,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// The capabilities a caller holds in a room, derived from standing/role/live.
+fn room_capabilities(standing: Standing, role: Role, live: bool) -> Vec<CapabilityToken> {
+    use CapabilityToken::*;
+    let mut caps = vec![RoomTimeline, RoomMembers, RoomList, RoomArchive];
+    if standing == Standing::Active {
+        caps.extend([RoomLeave, InviteList, FileList, PipeList, StatusHistory]);
+        if live {
+            caps.extend([
+                RoomDeactivate,
+                RoomPeers,
+                MessageSend,
+                StatusPost,
+                FileShare,
+                FileFetch,
+                FileRead,
+                PipePublish,
+                PipeConnect,
+                StreamSubscribe,
+                StreamUnsubscribe,
+                StreamResync,
+            ]);
+        } else {
+            caps.push(RoomActivate);
+        }
+        if role == Role::Authority {
+            caps.extend([InviteMint, InviteRevoke, MemberRemove, PipeRevoke]);
+        }
+    }
+    caps
+}
+
+/// Whole-room reachability from per-device links and liveness.
+fn reachability_from_peers(peers: &[PeerRow], live: bool) -> Reachability {
+    if !live {
+        return Reachability::Offline;
+    }
+    let any_connected = peers
+        .iter()
+        .any(|p| matches!(p.link, Link::Direct { .. } | Link::Relay { .. }));
+    if any_connected {
+        Reachability::Connected
+    } else {
+        Reachability::Alone
+    }
+}
+
+/// The caller's own standing in a room.
+fn self_key_standing(
+    sup: &RoomSupervisor,
+    room_id: &IrohRoomId,
+    snapshot: &iroh_rooms::room::MembershipSnapshot,
+    self_key: &iroh_rooms::identity::IdentityKey,
+) -> CoreResult<Standing> {
+    let store = sup.open_store()?;
+    let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, room_id)?;
+    Ok(snapshot.member(self_key).map_or(Standing::Active, |m| {
+        proj::standing(
+            removed_ids.contains(&m.identity)
+                || matches!(m.status, iroh_rooms::room::Status::Removed),
+            left_ids.contains(&m.identity),
+        )
+    }))
+}
+
+/// The v2 wire label for a status label (snake_case, matching the Iroh
+/// content vocabulary the runtime authors).
+fn status_label_wire(label: StatusLabel) -> &'static str {
+    match label {
+        StatusLabel::Online => "online",
+        StatusLabel::Idle => "idle",
+        StatusLabel::Claiming => "claiming",
+        StatusLabel::Working => "working",
+        StatusLabel::Done => "done",
+        StatusLabel::Failed => "failed",
+        StatusLabel::Blocked => "blocked",
+    }
+}
+
+/// Parse an on-wire status label into the closed vocabulary.
+fn status_label_parse(label: &str) -> CoreResult<StatusLabel> {
+    Ok(match label {
+        "online" => StatusLabel::Online,
+        "idle" => StatusLabel::Idle,
+        "claiming" => StatusLabel::Claiming,
+        "working" => StatusLabel::Working,
+        "done" => StatusLabel::Done,
+        "failed" => StatusLabel::Failed,
+        "blocked" => StatusLabel::Blocked,
+        other => {
+            return Err(CoreError::invalid(format!(
+                "status label {other:?} is outside the closed v2 vocabulary"
+            )))
+        }
+    })
+}
+
+/// Map an on-wire progress percent to the v2 variant.
+fn proj_progress(pct: Option<u64>) -> Progress {
+    match pct {
+        Some(p) => Progress::Reported {
+            percent: u8::try_from(p.min(100)).unwrap_or(100),
+        },
+        None => Progress::Absent,
+    }
+}
+
+/// The wire `<ts>` for an author-dated ms instant.
+fn proj_ts(created_at_ms: u64) -> Timestamp {
+    let secs = i64::try_from(created_at_ms / 1000).unwrap_or(i64::MAX);
+    Timestamp::new(
+        time::OffsetDateTime::from_unix_timestamp(secs).unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
+    )
+}
+
+/// The Unix epoch as a `<ts>` (an honest "unknown instant", never the wall
+/// clock).
+fn proj_epoch() -> Timestamp {
+    Timestamp::new(time::OffsetDateTime::UNIX_EPOCH)
+}
+
+/// Split a `"host:port"` loopback address into a `Target`.
+fn split_host_port(addr: &str) -> (String, u64) {
+    match addr.rsplit_once(':') {
+        Some((host, port)) => (host.to_string(), port.parse().unwrap_or(0)),
+        None => (addr.to_string(), 0),
+    }
+}
+
+/// The closed pipe ids (revoked), for the pipe list filter.
+fn closed_pipe_ids(
+    store: &iroh_rooms::experimental::store::EventStore,
+    room_id: &IrohRoomId,
+) -> CoreResult<BTreeSet<[u8; 16]>> {
+    let mut ids = BTreeSet::new();
+    for se in store
+        .by_type(room_id, EventType::PipeClosed)
+        .map_err(|e| CoreError::internal(format!("could not read pipe.closed events: {e}")))?
+    {
+        if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
+            if let Content::PipeClosed(c) = ev.content {
+                ids.insert(c.pipe_id);
+            }
+        }
+    }
+    Ok(ids)
+}
+
+// ---------------------------------------------------------------------------
+// The typed dispatch table (the engine's v2 surface)
+// ---------------------------------------------------------------------------
+
+/// One typed operation in, its typed output out, or a typed error. This is
+/// the engine's v2 dispatch seam: the codec hands a decoded [`Call`] here and
+/// gets a `Result<Output, ApiError>` to encode.
+///
+/// The dispatch is **total by construction**: the codec's router already
+/// refused any `op` not in the 33, so the downcast to the concrete input type
+/// cannot fail.
+pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedReply, ApiError> {
+    let t = TypedSupervisor::new(sup);
+    match call {
+        TypedCall::SubjectEnsure(_) => t
+            .subject_ensure()
+            .map(TypedReply::SubjectEnsure)
+            .map_err(core_to_api),
+        TypedCall::RoomCreate(r) => t
+            .room_create(&r)
+            .map(TypedReply::RoomCreate)
+            .map_err(core_to_api),
+        TypedCall::RoomList(_) => t
+            .room_list()
+            .await
+            .map(TypedReply::RoomList)
+            .map_err(core_to_api),
+        TypedCall::RoomActivate(r) => t
+            .room_activate(&r)
+            .await
+            .map(TypedReply::RoomActivate)
+            .map_err(core_to_api),
+        TypedCall::RoomDeactivate(r) => t
+            .room_deactivate(&r)
+            .await
+            .map(TypedReply::RoomDeactivate)
+            .map_err(core_to_api),
+        TypedCall::RoomLeave(r) => t
+            .room_leave(&r)
+            .await
+            .map(TypedReply::RoomLeave)
+            .map_err(core_to_api),
+        TypedCall::RoomTimeline(r) => t
+            .room_timeline(&r)
+            .await
+            .map(TypedReply::RoomTimeline)
+            .map_err(core_to_api),
+        TypedCall::RoomMembers(r) => t
+            .room_members(&r)
+            .await
+            .map(TypedReply::RoomMembers)
+            .map_err(core_to_api),
+        TypedCall::RoomArchive(r) => t
+            .room_archive(&r)
+            .await
+            .map(TypedReply::RoomArchive)
+            .map_err(core_to_api),
+        TypedCall::RoomPeers(r) => t
+            .room_peers(&r)
+            .await
+            .map(TypedReply::RoomPeers)
+            .map_err(core_to_api),
+        TypedCall::MemberRemove(r) => t
+            .member_remove(&r)
+            .await
+            .map(TypedReply::MemberRemove)
+            .map_err(core_to_api),
+        TypedCall::InviteMint(r) => t
+            .invite_mint(&r)
+            .await
+            .map(TypedReply::InviteMint)
+            .map_err(core_to_api),
+        TypedCall::InviteList(r) => t
+            .invite_list(&r)
+            .await
+            .map(TypedReply::InviteList)
+            .map_err(core_to_api),
+        TypedCall::InviteRevoke(r) => t
+            .invite_revoke(&r)
+            .await
+            .map(TypedReply::InviteRevoke)
+            .map_err(core_to_api),
+        TypedCall::InviteRedeem(r) => t
+            .invite_redeem(&r)
+            .await
+            .map(TypedReply::InviteRedeem)
+            .map_err(core_to_api),
+        TypedCall::MessageSend(r) => t
+            .message_send(&r)
+            .await
+            .map(TypedReply::MessageSend)
+            .map_err(core_to_api),
+        TypedCall::StatusPost(r) => t
+            .status_post(&r)
+            .await
+            .map(TypedReply::StatusPost)
+            .map_err(core_to_api),
+        TypedCall::StatusHistory(r) => t
+            .status_history(&r)
+            .await
+            .map(TypedReply::StatusHistory)
+            .map_err(core_to_api),
+        TypedCall::FleetList(_) => t
+            .fleet_list()
+            .await
+            .map(TypedReply::FleetList)
+            .map_err(core_to_api),
+        TypedCall::FileShare(r) => t
+            .file_share(&r)
+            .await
+            .map(TypedReply::FileShare)
+            .map_err(core_to_api),
+        TypedCall::FileList(r) => t
+            .file_list(&r)
+            .await
+            .map(TypedReply::FileList)
+            .map_err(core_to_api),
+        TypedCall::FileFetch(r) => t
+            .file_fetch(&r)
+            .await
+            .map(TypedReply::FileFetch)
+            .map_err(core_to_api),
+        TypedCall::FileRead(r) => t
+            .file_read(&r)
+            .await
+            .map(TypedReply::FileRead)
+            .map_err(core_to_api),
+        TypedCall::TransferCancel(r) => t
+            .transfer_cancel(&r)
+            .await
+            .map(TypedReply::TransferCancel)
+            .map_err(core_to_api),
+        TypedCall::PipePublish(r) => t
+            .pipe_publish(&r)
+            .await
+            .map(TypedReply::PipePublish)
+            .map_err(core_to_api),
+        TypedCall::PipeList(r) => t
+            .pipe_list(&r)
+            .await
+            .map(TypedReply::PipeList)
+            .map_err(core_to_api),
+        TypedCall::PipeConnect(r) => t
+            .pipe_connect(&r)
+            .await
+            .map(TypedReply::PipeConnect)
+            .map_err(core_to_api),
+        TypedCall::PipeRelease(r) => t
+            .pipe_release(&r)
+            .await
+            .map(TypedReply::PipeRelease)
+            .map_err(core_to_api),
+        TypedCall::PipeRevoke(r) => t
+            .pipe_revoke(&r)
+            .await
+            .map(TypedReply::PipeRevoke)
+            .map_err(core_to_api),
+        // Stream operations are connection-scoped; the engine handles them
+        // against the connection's subscription set, not the supervisor.
+        TypedCall::StreamSubscribe(_)
+        | TypedCall::StreamUnsubscribe(_)
+        | TypedCall::StreamResync(_) => Err(ApiError::SubscriptionUnknown {
+            room_id: RoomId::new(""),
+        }),
+        TypedCall::DaemonStop(_) => Ok(TypedReply::DaemonStop(DaemonStopOut { stopping: true })),
+    }
+}
+
+/// A typed call: one of the 33 operations with its concrete input.
+#[derive(Debug)]
+pub enum TypedCall {
+    /// subject.ensure
+    SubjectEnsure(SubjectEnsure),
+    /// daemon.stop
+    DaemonStop(DaemonStop),
+    /// room.create
+    RoomCreate(RoomCreate),
+    /// room.list
+    RoomList(RoomList),
+    /// room.activate
+    RoomActivate(RoomActivate),
+    /// room.deactivate
+    RoomDeactivate(RoomDeactivate),
+    /// room.leave
+    RoomLeave(RoomLeave),
+    /// room.timeline
+    RoomTimeline(RoomTimeline),
+    /// room.members
+    RoomMembers(RoomMembers),
+    /// room.archive
+    RoomArchive(RoomArchive),
+    /// room.peers
+    RoomPeers(RoomPeers),
+    /// member.remove
+    MemberRemove(MemberRemove),
+    /// invite.mint
+    InviteMint(InviteMint),
+    /// invite.list
+    InviteList(InviteList),
+    /// invite.revoke
+    InviteRevoke(InviteRevoke),
+    /// invite.redeem
+    InviteRedeem(InviteRedeem),
+    /// message.send
+    MessageSend(MessageSend),
+    /// status.post
+    StatusPost(StatusPost),
+    /// status.history
+    StatusHistory(StatusHistory),
+    /// fleet.list
+    FleetList(FleetList),
+    /// file.share
+    FileShare(FileShare),
+    /// file.list
+    FileList(FileList),
+    /// file.fetch
+    FileFetch(FileFetch),
+    /// file.read
+    FileRead(FileRead),
+    /// transfer.cancel
+    TransferCancel(TransferCancel),
+    /// pipe.publish
+    PipePublish(PipePublish),
+    /// pipe.list
+    PipeList(PipeList),
+    /// pipe.connect
+    PipeConnect(PipeConnect),
+    /// pipe.release
+    PipeRelease(PipeRelease),
+    /// pipe.revoke
+    PipeRevoke(PipeRevoke),
+    /// stream.subscribe
+    StreamSubscribe(StreamSubscribe),
+    /// stream.unsubscribe
+    StreamUnsubscribe(StreamUnsubscribe),
+    /// stream.resync
+    StreamResync(StreamResync),
+}
+
+/// Resolve a codec-routed `op` and its erased input into a concrete
+/// [`TypedCall`]. The codec guarantees `op` is one of the 33 and the input
+/// decoded into the matching request type, so the downcast is total — a
+/// mismatch is a codec bug, surfaced as `malformed_frame`, never a panic.
+#[must_use]
+pub fn resolve_call(op: &str, input: &dyn std::any::Any) -> Option<TypedCall> {
+    macro_rules! arm {
+        ($path:literal, $ty:ty, $variant:ident) => {
+            if op == <$ty as Operation>::PATH {
+                return input
+                    .downcast_ref::<$ty>()
+                    .cloned()
+                    .map(TypedCall::$variant);
+            }
+        };
+    }
+    arm!("subject.ensure", SubjectEnsure, SubjectEnsure);
+    arm!("daemon.stop", DaemonStop, DaemonStop);
+    arm!("room.create", RoomCreate, RoomCreate);
+    arm!("room.list", RoomList, RoomList);
+    arm!("room.activate", RoomActivate, RoomActivate);
+    arm!("room.deactivate", RoomDeactivate, RoomDeactivate);
+    arm!("room.leave", RoomLeave, RoomLeave);
+    arm!("room.timeline", RoomTimeline, RoomTimeline);
+    arm!("room.members", RoomMembers, RoomMembers);
+    arm!("room.archive", RoomArchive, RoomArchive);
+    arm!("room.peers", RoomPeers, RoomPeers);
+    arm!("member.remove", MemberRemove, MemberRemove);
+    arm!("invite.mint", InviteMint, InviteMint);
+    arm!("invite.list", InviteList, InviteList);
+    arm!("invite.revoke", InviteRevoke, InviteRevoke);
+    arm!("invite.redeem", InviteRedeem, InviteRedeem);
+    arm!("message.send", MessageSend, MessageSend);
+    arm!("status.post", StatusPost, StatusPost);
+    arm!("status.history", StatusHistory, StatusHistory);
+    arm!("fleet.list", FleetList, FleetList);
+    arm!("file.share", FileShare, FileShare);
+    arm!("file.list", FileList, FileList);
+    arm!("file.fetch", FileFetch, FileFetch);
+    arm!("file.read", FileRead, FileRead);
+    arm!("transfer.cancel", TransferCancel, TransferCancel);
+    arm!("pipe.publish", PipePublish, PipePublish);
+    arm!("pipe.list", PipeList, PipeList);
+    arm!("pipe.connect", PipeConnect, PipeConnect);
+    arm!("pipe.release", PipeRelease, PipeRelease);
+    arm!("pipe.revoke", PipeRevoke, PipeRevoke);
+    arm!("stream.subscribe", StreamSubscribe, StreamSubscribe);
+    arm!("stream.unsubscribe", StreamUnsubscribe, StreamUnsubscribe);
+    arm!("stream.resync", StreamResync, StreamResync);
+    let _ = op;
+    None
+}
+
+/// A typed reply: the output paired with the call's operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TypedReply {
+    /// subject.ensure
+    SubjectEnsure(SubjectEnsureOut),
+    /// daemon.stop
+    DaemonStop(DaemonStopOut),
+    /// room.create
+    RoomCreate(RoomCreateOut),
+    /// room.list
+    RoomList(RoomListOut),
+    /// room.activate
+    RoomActivate(RoomActivateOut),
+    /// room.deactivate
+    RoomDeactivate(RoomDeactivateOut),
+    /// room.leave
+    RoomLeave(RoomLeaveOut),
+    /// room.timeline
+    RoomTimeline(RoomTimelineOut),
+    /// room.members
+    RoomMembers(RoomMembersOut),
+    /// room.archive
+    RoomArchive(RoomArchiveOut),
+    /// room.peers
+    RoomPeers(RoomPeersOut),
+    /// member.remove
+    MemberRemove(MemberRemoveOut),
+    /// invite.mint
+    InviteMint(InviteMintOut),
+    /// invite.list
+    InviteList(InviteListOut),
+    /// invite.revoke
+    InviteRevoke(InviteRevokeOut),
+    /// invite.redeem
+    InviteRedeem(InviteRedeemOut),
+    /// message.send
+    MessageSend(MessageSendOut),
+    /// status.post
+    StatusPost(StatusPostOut),
+    /// status.history
+    StatusHistory(StatusHistoryOut),
+    /// fleet.list
+    FleetList(FleetListOut),
+    /// file.share
+    FileShare(FileShareOut),
+    /// file.list
+    FileList(FileListOut),
+    /// file.fetch
+    FileFetch(FileFetchOut),
+    /// file.read
+    FileRead(FileReadOut),
+    /// transfer.cancel
+    TransferCancel(TransferCancelOut),
+    /// pipe.publish
+    PipePublish(PipePublishOut),
+    /// pipe.list
+    PipeList(PipeListOut),
+    /// pipe.connect
+    PipeConnect(PipeConnectOut),
+    /// pipe.release
+    PipeRelease(PipeReleaseOut),
+    /// pipe.revoke
+    PipeRevoke(PipeRevokeOut),
+}
+
+/// Map a core error onto the typed v2 taxonomy at the engine boundary.
+fn core_to_api(err: CoreError) -> ApiError {
+    match err.kind {
+        ErrorKind::IdentityMissing => ApiError::SubjectAbsent,
+        ErrorKind::RoomUnknown | ErrorKind::NotAMember | ErrorKind::FileUnauthorized => {
+            ApiError::RoomNotAvailable {
+                room_id: RoomId::new(""),
+            }
+        }
+        ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
+            room_id: RoomId::new(""),
+        },
+        ErrorKind::BadTicket => ApiError::CapabilityInvalid,
+        ErrorKind::TicketExpired => ApiError::CapabilityExpired {
+            expired_at: proj_epoch(),
+        },
+        ErrorKind::FileUnavailable => ApiError::ProviderUnreachable {
+            file_id: FileId::new(""),
+            providers: Vec::new(),
+        },
+        ErrorKind::HashMismatch => ApiError::DigestMismatch {
+            expected: String::new(),
+            observed: String::new(),
+        },
+        ErrorKind::PipeDenied => ApiError::PolicyRefused {
+            room_id: RoomId::new(""),
+        },
+        ErrorKind::PeerUnreachable => ApiError::PipeUnreachable {
+            pipe_id: PipeId::new(""),
+            link: Link::NotConnected {
+                reason: LinkReason::NoRoute,
+            },
+        },
+        ErrorKind::IdentityExists | ErrorKind::InvalidParams | ErrorKind::Internal => {
+            ApiError::InvalidArgument {
+                field: "in".to_string(),
+                reason: InvalidReason::Format,
+            }
+        }
+    }
+}

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -23,6 +23,11 @@ relay-only-test = ["jeliya-core/relay-only-test"]
 
 [dependencies]
 jeliya-core = { path = "../jeliya-core" }
+# The protocol-v2 codec (#164): the only JSON in the protocol. jeliyad's `/ws`
+# is v2-only through it — the generation gate, bounded envelopes, and
+# exhaustive routing live here, never in the daemon.
+jeliya-codec = { path = "../jeliya-codec" }
+jeliya-api = { path = "../jeliya-api" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time", "sync", "signal"] }
 tokio-tungstenite = "0.26"

--- a/crates/jeliyad/src/lifecycle.rs
+++ b/crates/jeliyad/src/lifecycle.rs
@@ -32,13 +32,20 @@ pub const LOCKFILE_NAME: &str = "daemon.lock";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Portfile {
-    pub schema: u32,
     pub pid: u32,
     pub port: u16,
     pub http: String,
     pub ws: String,
     pub version: String,
+    /// The shared `{protocol, min_protocol, storage_generation, limits}`
+    /// discovery object — identical to Layer-0 health and the ready line.
     pub protocol: u64,
+    pub min_protocol: u64,
+    pub storage_generation: u64,
+    pub limits: jeliya_api::Limits,
+    /// The data dir, kept here (the portfile is 0600, so a caller has already
+    /// proved local read access) but removed from the unauthenticated
+    /// Layer-0 health response.
     pub data_dir: String,
     pub auth_token: String,
     pub started_at_ms: u64,
@@ -93,7 +100,10 @@ pub fn write_portfile(data_dir: &Path, portfile: &Portfile) -> std::io::Result<P
 pub fn read_portfile(data_dir: &Path) -> Option<Portfile> {
     let raw = fs::read_to_string(portfile_path(data_dir)).ok()?;
     let portfile: Portfile = serde_json::from_str(&raw).ok()?;
-    (portfile.schema == 1).then_some(portfile)
+    // The portfile is valid iff it parses and names a live pid/port with the
+    // current discovery object (the retired `schema` field is gone; the
+    // generation axes are the validity signal now).
+    (portfile.pid != 0 && portfile.port != 0).then_some(portfile)
 }
 
 pub fn remove_portfile(data_dir: &Path) {
@@ -227,15 +237,15 @@ async fn health_check(portfile: &Portfile, expect_data_dir: &Path) -> bool {
     if !head.starts_with("HTTP/1.1 200") && !head.starts_with("HTTP/1.0 200") {
         return false;
     }
+    let _ = expect_data_dir;
     let Ok(health) = serde_json::from_str::<serde_json::Value>(body.trim()) else {
         return false;
     };
+    // The answering process is this data dir's daemon iff its pid matches the
+    // portfile read FROM that data dir. The v2 Layer-0 health response no
+    // longer leaks `data_dir` (an unauthenticated endpoint must not expose an
+    // absolute path); pid-plus-the-portfile's own location is the binding.
     health.get("pid").and_then(serde_json::Value::as_u64) == Some(u64::from(portfile.pid))
-        && health
-            .get("data_dir")
-            .and_then(serde_json::Value::as_str)
-            .map(|dir| Path::new(dir) == expect_data_dir)
-            .unwrap_or(false)
 }
 
 /// Tracing to stderr plus a daily-rolling file in `<data_dir>/logs`, filtered

--- a/crates/jeliyad/src/lifecycle.rs
+++ b/crates/jeliyad/src/lifecycle.rs
@@ -38,7 +38,7 @@ pub struct Portfile {
     pub http: String,
     pub ws: String,
     pub version: String,
-    pub protocol: u32,
+    pub protocol: u64,
     pub data_dir: String,
     pub auth_token: String,
     pub started_at_ms: u64,

--- a/crates/jeliyad/src/main.rs
+++ b/crates/jeliyad/src/main.rs
@@ -99,6 +99,12 @@ pub(crate) struct AppState {
     pub(crate) auth_token: Arc<String>,
     /// The actually bound port (`--port 0` resolves here).
     pub(crate) port: u16,
+    /// Outstanding single-use connect tickets (`?ct=`): ticket -> expiry
+    /// (ms since epoch). Minted by `POST /api/session` (token-gated), burned
+    /// on redemption at the upgrade gate. Bounded and short-TTL.
+    pub(crate) connect_tickets: Arc<std::sync::Mutex<std::collections::HashMap<String, u64>>>,
+    /// Live WebSocket connections, for the `max_connections` gate.
+    pub(crate) connections: Arc<std::sync::atomic::AtomicU64>,
 }
 
 #[tokio::main]
@@ -196,22 +202,27 @@ async fn main() {
             shutdown_tx: shutdown_tx.clone(),
         },
     );
+    let engine_limits = engine.limits();
     let state = AppState {
         supervisor,
         data_dir: data_dir.clone(),
         engine,
         auth_token: Arc::new(auth_token.clone()),
         port: addr.port(),
+        connect_tickets: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
     };
 
     let portfile = lifecycle::Portfile {
-        schema: 1,
         pid: std::process::id(),
         port: addr.port(),
         http: format!("http://{addr}/"),
         ws: format!("ws://{addr}/ws"),
         version: env!("CARGO_PKG_VERSION").to_owned(),
         protocol: PROTOCOL_VERSION,
+        min_protocol: jeliya_core::engine::MIN_PROTOCOL_VERSION,
+        storage_generation: jeliya_core::engine::STORAGE_GENERATION,
+        limits: engine_limits,
         data_dir: data_dir.display().to_string(),
         auth_token,
         started_at_ms: jeliya_core::now_ms(),
@@ -237,6 +248,9 @@ async fn main() {
             "ws": portfile.ws,
             "version": portfile.version,
             "protocol": portfile.protocol,
+            "min_protocol": portfile.min_protocol,
+            "storage_generation": portfile.storage_generation,
+            "limits": portfile.limits,
             "data_dir": portfile.data_dir,
             "portfile": portfile_path.display().to_string(),
         })

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -809,16 +809,39 @@ pub async fn serve_ws<S>(
     state: AppState,
     _principal: jeliya_codec::SessionPrincipal,
 ) where
-    S: AsyncRead + AsyncWrite + Unpin,
+    // `Send + 'static` so the single-writer task and the spawned request tasks
+    // can own the socket and engine handles across threads.
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let (mut sink, mut messages) = ws.split();
     let mut push_rx = state.engine.subscribe_pushes();
     let bounds = jeliya_codec::CodecBounds::default();
+
+    // All outbound frames flow through ONE writer task over an mpsc channel,
+    // so a slow request's execution never head-of-line blocks a push, a ping,
+    // or another request's reply. Replies may complete out of order — the
+    // record allows that and the client correlates by `id`.
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Message>(256);
+    let writer = tokio::spawn(async move {
+        while let Some(msg) = out_rx.recv().await {
+            if sink.send(msg).await.is_err() {
+                break;
+            }
+        }
+    });
+
     // This connection's room subscriptions: `stream.subscribe` adds a room
     // with the position the client's stream begins at; `stream.unsubscribe`
     // removes it; pushes are gated on it (no push before subscribe, per the
-    // record's "no global broadcast" rule).
-    let mut subscriptions: std::collections::HashMap<String, u64> =
+    // record's "no global broadcast" rule). Shared with the spawned request
+    // tasks behind a mutex (only ever held for a map op, never across an
+    // engine await).
+    let subscriptions = std::sync::Arc::new(tokio::sync::Mutex::new(
+        std::collections::HashMap::<String, u64>::new(),
+    ));
+    // The last position actually delivered to this connection per room, so a
+    // backpressure lag can name a real resync point for each subscribed room.
+    let mut last_delivered: std::collections::HashMap<String, u64> =
         std::collections::HashMap::new();
 
     // The `hello` frame: exactly one, first, carrying the generation, the
@@ -832,28 +855,36 @@ pub async fn serve_ws<S>(
     };
     match serde_json::to_vec(&hello) {
         Ok(bytes) => {
-            if sink.send(Message::Binary(bytes.into())).await.is_err() {
+            if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
+                writer.abort();
                 return;
             }
         }
-        Err(_) => return,
+        Err(_) => {
+            writer.abort();
+            return;
+        }
     }
+
+    // Track in-flight request tasks so the loop never serializes on a slow
+    // operation; a finished task's result is reaped without blocking.
+    let mut inflight: tokio::task::JoinSet<bool> = tokio::task::JoinSet::new();
 
     loop {
         tokio::select! {
             msg = messages.next() => match msg {
                 Some(Ok(Message::Text(text))) => {
-                    if !handle_frame(&mut sink, &state, text.as_bytes(), &bounds, &mut subscriptions).await {
+                    if !dispatch_inbound(text.as_bytes(), &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
                         break;
                     }
                 }
                 Some(Ok(Message::Binary(bytes))) => {
-                    if !handle_frame(&mut sink, &state, &bytes, &bounds, &mut subscriptions).await {
+                    if !dispatch_inbound(&bytes, &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
                         break;
                     }
                 }
                 Some(Ok(Message::Ping(payload))) => {
-                    if sink.send(Message::Pong(payload)).await.is_err() {
+                    if out_tx.send(Message::Pong(payload)).await.is_err() {
                         break;
                     }
                 }
@@ -866,35 +897,59 @@ pub async fn serve_ws<S>(
                     // for a room the connection has not subscribed to is not
                     // delivered (the record's no-global-broadcast rule), and a
                     // push is never a membership oracle.
-                    let subscribed = push_room_id(&push)
-                        .map(|r| subscriptions.contains_key(r))
-                        .unwrap_or(false);
+                    let room = push_room_id(&push).map(str::to_owned);
+                    let subscribed = {
+                        let subs = subscriptions.lock().await;
+                        room.as_ref().map(|r| subs.contains_key(r)).unwrap_or(false)
+                    };
                     if subscribed {
+                        // Track the last-delivered position per room so a later
+                        // lag can name a real resync point for that room.
+                        if let (Some(r), Some(pos)) = (room.as_ref(), push_pos(&push)) {
+                            last_delivered.insert(r.clone(), pos);
+                        }
                         let bytes = jeliya_codec::push_to_bytes(&push);
-                        if sink.send(Message::Binary(bytes.into())).await.is_err() {
+                        if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
                             break;
                         }
                     }
                 }
                 // A lagged receiver fell behind the push fan-out. v2 never
-                // silently continues: send an explicit gap push naming the
-                // backpressure so the client resyncs from its last position.
+                // silently continues: emit an explicit gap for EACH subscribed
+                // room from its last-delivered position, so the client can
+                // resync each affected room rather than getting one unusable
+                // global frame.
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    let gap = jeliya_api::Push::Gap {
-                        room_id: jeliya_api::RoomId::new(""),
-                        from_pos: 0,
-                        to: jeliya_api::GapTo::Open,
-                        reason: jeliya_api::GapReason::Backpressure,
+                    let rooms: Vec<String> = {
+                        let subs = subscriptions.lock().await;
+                        subs.keys().cloned().collect()
                     };
-                    let bytes = jeliya_codec::push_to_bytes(&gap);
-                    if sink.send(Message::Binary(bytes.into())).await.is_err() {
-                        break;
+                    for room in rooms {
+                        let from_pos = last_delivered.get(&room).copied().unwrap_or(0);
+                        let gap = jeliya_api::Push::Gap {
+                            room_id: jeliya_api::RoomId::new(room),
+                            from_pos,
+                            to: jeliya_api::GapTo::Open,
+                            reason: jeliya_api::GapReason::Backpressure,
+                        };
+                        let bytes = jeliya_codec::push_to_bytes(&gap);
+                        if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
+                            break;
+                        }
                     }
                 }
                 Err(broadcast::error::RecvError::Closed) => break,
             },
+            // Reap finished request tasks without blocking the loop.
+            Some(_) = inflight.join_next() => {}
         }
     }
+
+    // Teardown: stop accepting new work, drain in-flight replies, then drop
+    // the writer task.
+    inflight.abort_all();
+    drop(out_tx);
+    let _ = writer.await;
 }
 
 /// The room a push is scoped to, for subscription gating. `transfer` frames
@@ -908,32 +963,43 @@ fn push_room_id(push: &jeliya_api::Push) -> Option<&str> {
     }
 }
 
+/// The position an event push carries (for last-delivered tracking). Peer,
+/// gap, and transfer pushes carry no event position.
+fn push_pos(push: &jeliya_api::Push) -> Option<u64> {
+    match push {
+        jeliya_api::Push::Event { event, .. } => Some(event.pos),
+        _ => None,
+    }
+}
+
 /// The served `max_subscriptions_per_connection`.
 const MAX_SUBSCRIPTIONS: u64 = 64;
 
 /// `stream.subscribe` — add the room to this connection's subscription set.
 /// Naturally idempotent; exceeding the served limit is
 /// `subscription_limit_reached`, never a silent drop.
-async fn handle_stream_subscribe<S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+async fn handle_stream_subscribe(
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
     state: &AppState,
     request: &jeliya_codec::Request,
-    subscriptions: &mut std::collections::HashMap<String, u64>,
-) -> bool
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
+    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+) -> bool {
     // Extract owned values up front so no `&Request` (non-Sync) is held
     // across an await.
     let id = request.id;
-    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamSubscribe>() {
+    let req = match request
+        .call
+        .input_any()
+        .downcast_ref::<jeliya_api::StreamSubscribe>()
+    {
         Some(r) => r.clone(),
-        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+        None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
     let room_key = req.room_id.to_string();
-    if !subscriptions.contains_key(&room_key) && subscriptions.len() as u64 >= MAX_SUBSCRIPTIONS {
+    let mut subs = subscriptions.lock().await;
+    if !subs.contains_key(&room_key) && subs.len() as u64 >= MAX_SUBSCRIPTIONS {
         return send_api_err(
-            sink,
+            out_tx,
             id,
             jeliya_api::ApiError::SubscriptionLimitReached {
                 limit: MAX_SUBSCRIPTIONS,
@@ -941,16 +1007,25 @@ where
         )
         .await;
     }
-    // Resolve the cursor to a concrete head position. A `start` cursor means
-    // the stream begins at the next committed event; an `at {pos}` cursor
-    // resumes from that position.
+    // Authorize the room before recording any subscription: an unknown,
+    // malformed, or inaccessible room is `room_not_available`, never a dormant
+    // subscription that later springs to life.
     let from_pos = match &req.from {
-        jeliya_api::Cursor::Start => room_head_pos(state, &req.room_id).await,
-        jeliya_api::Cursor::At { pos } => *pos,
+        jeliya_api::Cursor::Start => match room_head_pos(state, &req.room_id).await {
+            Ok(pos) => pos,
+            Err(err) => return send_api_err(out_tx, id, err).await,
+        },
+        jeliya_api::Cursor::At { pos } => {
+            // An explicit position still requires the room to be visible.
+            match authorize_room(state, &req.room_id).await {
+                Ok(()) => *pos,
+                Err(err) => return send_api_err(out_tx, id, err).await,
+            }
+        }
     };
-    subscriptions.insert(room_key, from_pos);
+    subs.insert(room_key, from_pos);
     send_typed(
-        sink,
+        out_tx,
         id,
         &jeliya_api::StreamSubscribeOut {
             room_id: req.room_id,
@@ -961,22 +1036,24 @@ where
 }
 
 /// `stream.unsubscribe` — remove the room from this connection's set.
-async fn handle_stream_unsubscribe<S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+async fn handle_stream_unsubscribe(
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
     request: &jeliya_codec::Request,
-    subscriptions: &mut std::collections::HashMap<String, u64>,
-) -> bool
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
+    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+) -> bool {
     let id = request.id;
-    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamUnsubscribe>() {
+    let req = match request
+        .call
+        .input_any()
+        .downcast_ref::<jeliya_api::StreamUnsubscribe>()
+    {
         Some(r) => r.clone(),
-        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+        None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
-    if subscriptions.remove(&req.room_id.to_string()).is_none() {
+    let mut subs = subscriptions.lock().await;
+    if subs.remove(&req.room_id.to_string()).is_none() {
         return send_api_err(
-            sink,
+            out_tx,
             id,
             jeliya_api::ApiError::SubscriptionUnknown {
                 room_id: req.room_id.clone(),
@@ -985,7 +1062,7 @@ where
         .await;
     }
     send_typed(
-        sink,
+        out_tx,
         id,
         &jeliya_api::StreamUnsubscribeOut {
             room_id: req.room_id,
@@ -997,37 +1074,40 @@ where
 
 /// `stream.resync` — the authoritative recovery: events since `from_pos`, or
 /// `resync_required` naming a position to discard back to.
-async fn handle_stream_resync<S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+async fn handle_stream_resync(
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
     state: &AppState,
     request: &jeliya_codec::Request,
-) -> bool
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
+) -> bool {
     let id = request.id;
-    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamResync>() {
+    let req = match request
+        .call
+        .input_any()
+        .downcast_ref::<jeliya_api::StreamResync>()
+    {
         Some(r) => r.clone(),
-        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+        None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
-    // Read the committed events after from_pos via the engine's typed timeline.
+    // Read the committed events after from_pos via the engine's typed
+    // timeline, starting the page AT from_pos (positions are exclusive on the
+    // low side, so `at {pos: from_pos + 1}` reads strictly after it) rather
+    // than reading the head and filtering — a room longer than one page must
+    // not hide its tail.
     let call = jeliya_core::typed::TypedCall::RoomTimeline(jeliya_api::RoomTimeline {
         room_id: req.room_id.clone(),
         page: jeliya_api::Page {
-            cursor: jeliya_api::Cursor::Start,
+            cursor: jeliya_api::Cursor::At {
+                pos: req.from_pos.saturating_add(1),
+            },
             direction: jeliya_api::Direction::Forward,
             limit: 1024,
         },
     });
     let executed = state.engine.execute(call).await;
     let events: Vec<jeliya_api::Event> = match executed.reply {
-        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => out
-            .events
-            .into_iter()
-            .filter(|e| e.pos > req.from_pos)
-            .collect(),
+        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => out.events,
         Ok(_) => Vec::new(),
-        Err(err) => return send_api_err(sink, id, err).await,
+        Err(err) => return send_api_err(out_tx, id, err).await,
     };
     let next_pos = events.last().map(|e| e.pos).unwrap_or(req.from_pos);
     let truncated = if events.len() >= 1024 {
@@ -1038,7 +1118,7 @@ where
         jeliya_api::Truncated::Complete
     };
     send_typed(
-        sink,
+        out_tx,
         request.id,
         &jeliya_api::StreamResyncOut {
             room_id: req.room_id.clone(),
@@ -1050,9 +1130,25 @@ where
     .await
 }
 
+/// Authorize that the caller can see the room, returning `room_not_available`
+/// when it cannot. A `room.members` read enforces the access boundary.
+async fn authorize_room(state: &AppState, room_id: &jeliya_api::RoomId) -> Result<(), jeliya_api::ApiError> {
+    let call = jeliya_core::typed::TypedCall::RoomMembers(jeliya_api::RoomMembers {
+        room_id: room_id.clone(),
+    });
+    match state.engine.execute(call).await.reply {
+        Ok(_) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
 /// The room's current head position (the next position a `start` cursor
-/// resolves to).
-async fn room_head_pos(state: &AppState, room_id: &jeliya_api::RoomId) -> u64 {
+/// resolves to), or the access error if the room is not visible.
+async fn room_head_pos(
+    state: &AppState,
+    room_id: &jeliya_api::RoomId,
+) -> Result<u64, jeliya_api::ApiError> {
+    authorize_room(state, room_id).await?;
     let call = jeliya_core::typed::TypedCall::RoomTimeline(jeliya_api::RoomTimeline {
         room_id: room_id.clone(),
         page: jeliya_api::Page {
@@ -1063,21 +1159,21 @@ async fn room_head_pos(state: &AppState, room_id: &jeliya_api::RoomId) -> u64 {
     });
     match state.engine.execute(call).await.reply {
         Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => {
-            out.events.last().map(|e| e.pos + 1).unwrap_or(0)
+            Ok(out.events.last().map(|e| e.pos + 1).unwrap_or(0))
         }
-        _ => 0,
+        Ok(_) => Ok(0),
+        Err(err) => Err(err),
     }
 }
 
 /// Encode a typed output as a reply frame and send it.
-async fn send_typed<O, S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+async fn send_typed<O>(
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
     id: u64,
     out: &O,
 ) -> bool
 where
     O: serde::Serialize,
-    S: AsyncRead + AsyncWrite + Unpin,
 {
     let reply = jeliya_codec::Reply {
         id,
@@ -1085,46 +1181,46 @@ where
         out: serde_json::to_value(out).ok(),
         err: None,
     };
-    sink.send(Message::Binary(reply.to_bytes().into())).await.is_ok()
+    out_tx.send(Message::Binary(reply.to_bytes().into()))
+        .await
+        .is_ok()
 }
 
 /// Encode a typed API error as a reply frame and send it.
-async fn send_api_err<S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+async fn send_api_err(
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
     id: u64,
     err: jeliya_api::ApiError,
-) -> bool
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
+) -> bool {
     let reply = jeliya_codec::Reply {
         id,
         ok: false,
         out: None,
         err: Some(err),
     };
-    sink.send(Message::Binary(reply.to_bytes().into())).await.is_ok()
+    out_tx.send(Message::Binary(reply.to_bytes().into()))
+        .await
+        .is_ok()
 }
 
-/// Decode one frame, execute it, and encode the reply. Returns `false` when
-/// the connection must close (a frame over the limit → `4005`, an
-/// unrecoverable `id` → `4007`); `true` to continue serving.
-async fn handle_frame<S>(
-    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
-    state: &AppState,
+/// Decode one inbound frame and route it. Connection-terminating frames (over
+/// the limit → `4005`, unrecoverable id → `4007`) are decided synchronously;
+/// well-formed requests are executed on a spawned task so a slow operation
+/// never head-of-line blocks the push fan-out or other requests. Returns
+/// `false` when the connection must close.
+async fn dispatch_inbound(
     bytes: &[u8],
+    state: &AppState,
     bounds: &jeliya_codec::CodecBounds,
-    subscriptions: &mut std::collections::HashMap<String, u64>,
-) -> bool
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
+    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    inflight: &mut tokio::task::JoinSet<bool>,
+) -> bool {
     use jeliya_codec::CodecError;
     let frame = match jeliya_codec::decode(bytes, bounds) {
         Ok(frame) => frame,
         Err(CodecError::FrameTooLarge { .. }) => {
-            // Over-limit frame: close 4005 unparsed.
-            let _ = sink
+            let _ = out_tx
                 .send(Message::Close(Some(
                     tokio_tungstenite::tungstenite::protocol::CloseFrame {
                         code: 4005.into(),
@@ -1135,8 +1231,7 @@ where
             return false;
         }
         Err(CodecError::UnrecoverableId(_)) => {
-            // No usable correlation id: close 4007.
-            let _ = sink
+            let _ = out_tx
                 .send(Message::Close(Some(
                     tokio_tungstenite::tungstenite::protocol::CloseFrame {
                         code: 4007.into(),
@@ -1147,79 +1242,78 @@ where
             return false;
         }
         Err(CodecError::Malformed { id, error }) => {
-            // A correlatable malformed frame: send the typed error reply so
-            // one bad request never strands the others in flight.
             let reply = jeliya_codec::Reply::from_result::<jeliya_api::RoomList>(id, Err(error));
-            return sink
+            return out_tx
                 .send(Message::Binary(reply.to_bytes().into()))
                 .await
                 .is_ok();
         }
         Err(CodecError::GateRefused(_)) => {
-            // The gate runs pre-upgrade; a post-upgrade gate refusal is a
-            // protocol violation and ends the connection.
             return false;
         }
     };
 
     let jeliya_codec::Frame::Request(request) = frame else {
-        // An inbound non-request frame (a push, or both/neither id/t) has no
-        // place client-to-daemon: correlated malformed reply.
+        // An inbound non-request frame has no place client-to-daemon.
         return true;
     };
 
     // The three stream operations are connection-scoped: they read and mutate
-    // THIS connection's subscription set, never the supervisor. Intercept them
-    // here before the engine's typed dispatch.
+    // THIS connection's subscription set, never the supervisor. They are fast
+    // (map ops plus one engine read), so run them inline.
     match request.call.op {
         "stream.subscribe" => {
-            return handle_stream_subscribe(sink, state, &request, subscriptions).await;
+            return handle_stream_subscribe(out_tx, state, &request, subscriptions).await;
         }
         "stream.unsubscribe" => {
-            return handle_stream_unsubscribe(sink, &request, subscriptions).await;
+            return handle_stream_unsubscribe(out_tx, &request, subscriptions).await;
         }
         "stream.resync" => {
-            return handle_stream_resync(sink, state, &request).await;
+            return handle_stream_resync(out_tx, state, &request).await;
         }
         _ => {}
     }
 
     let Some(call) = jeliya_core::typed::resolve_call(request.call.op, request.call.input_any())
     else {
-        // The codec routed this op but the input did not downcast — a codec
-        // bug, surfaced as malformed rather than a panic.
         let reply = jeliya_codec::Reply::from_result::<jeliya_api::RoomList>(
             request.id,
             Err(jeliya_api::ApiError::MalformedFrame),
         );
-        return sink
+        return out_tx
             .send(Message::Binary(reply.to_bytes().into()))
             .await
             .is_ok();
     };
 
-    let executed = state.engine.execute(call).await;
-    let reply = match executed.reply {
-        Ok(out) => jeliya_codec::Reply {
-            id: request.id,
-            ok: true,
-            out: serde_json::to_value(out).ok(),
-            err: None,
-        },
-        Err(err) => jeliya_codec::Reply {
-            id: request.id,
-            ok: false,
-            out: None,
-            err: Some(err),
-        },
-    };
-    let sent = sink
-        .send(Message::Binary(reply.to_bytes().into()))
-        .await
-        .is_ok();
-    // A `daemon.stop` reply must flush before the host tears down; the engine
-    // already sequenced the delayed signal.
-    sent
+    // Execute on a spawned task so a slow op (file.fetch, pipe.connect) does
+    // not block the loop. `daemon.stop` is sequenced by the engine; its reply
+    // is flushed by the writer before teardown.
+    let id = request.id;
+    let engine = state.engine.clone();
+    let out_tx = out_tx.clone();
+    inflight.spawn(async move {
+        let executed = engine.execute(call).await;
+        let reply = match executed.reply {
+            Ok(out) => jeliya_codec::Reply {
+                id,
+                ok: true,
+                out: serde_json::to_value(out).ok(),
+                err: None,
+            },
+            Err(err) => jeliya_codec::Reply {
+                id,
+                ok: false,
+                out: None,
+                err: Some(err),
+            },
+        };
+        out_tx
+            .send(Message::Binary(reply.to_bytes().into()))
+            .await
+            .is_ok()
+    });
+    true
 }
 
 /// Reject path traversal and produce a clean relative asset key.

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -913,12 +913,29 @@ pub async fn serve_ws<S>(
         std::collections::HashMap::new();
 
     // The `hello` frame: exactly one, first, carrying the generation, the
-    // storage generation, the served limits, and the local subject.
+    // storage generation, the served limits, and the local subject. An
+    // unreadable subject store is `not_ready` — refuse the connection rather
+    // than inviting `subject.ensure` against state that cannot be served.
+    let subject = match state.engine.subject_state() {
+        Ok(s) => s,
+        Err(_) => {
+            let _ = out_tx
+                .send(Message::Close(Some(
+                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: 4003.into(),
+                        reason: "not_ready".into(),
+                    },
+                )))
+                .await;
+            writer.abort();
+            return;
+        }
+    };
     let hello = jeliya_api::Hello {
         protocol: jeliya_core::engine::PROTOCOL_VERSION,
         storage_generation: jeliya_core::engine::STORAGE_GENERATION,
         limits: state.engine.limits(),
-        subject: state.engine.subject_state(),
+        subject,
         resume: jeliya_api::Resume::Fresh,
     };
     match serde_json::to_vec(&hello) {

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -485,9 +485,13 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
                 if let Ok(ws) = websocket.await {
                     // Count the live connection for the `max_connections`
                     // gate; decrement on any exit path.
-                    state.connections.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    state
+                        .connections
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     serve_ws(ws, state.clone(), principal).await;
-                    state.connections.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                    state
+                        .connections
+                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                 }
             });
             response
@@ -904,9 +908,10 @@ pub async fn serve_ws<S>(
     // record's "no global broadcast" rule). Shared with the spawned request
     // tasks behind a mutex (only ever held for a map op, never across an
     // engine await).
-    let subscriptions = std::sync::Arc::new(tokio::sync::Mutex::new(
-        std::collections::HashMap::<String, u64>::new(),
-    ));
+    let subscriptions = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::<
+        String,
+        u64,
+    >::new()));
     // The last position actually delivered to this connection per room, so a
     // backpressure lag can name a real resync point for each subscribed room.
     let mut last_delivered: std::collections::HashMap<String, u64> =
@@ -1237,7 +1242,10 @@ async fn handle_stream_resync(
 
 /// Authorize that the caller can see the room, returning `room_not_available`
 /// when it cannot. A `room.members` read enforces the access boundary.
-async fn authorize_room(state: &AppState, room_id: &jeliya_api::RoomId) -> Result<(), jeliya_api::ApiError> {
+async fn authorize_room(
+    state: &AppState,
+    room_id: &jeliya_api::RoomId,
+) -> Result<(), jeliya_api::ApiError> {
     let call = jeliya_core::typed::TypedCall::RoomMembers(jeliya_api::RoomMembers {
         room_id: room_id.clone(),
     });
@@ -1272,11 +1280,7 @@ async fn room_head_pos(
 }
 
 /// Encode a typed output as a reply frame and send it.
-async fn send_typed<O>(
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
-    id: u64,
-    out: &O,
-) -> bool
+async fn send_typed<O>(out_tx: &tokio::sync::mpsc::Sender<Message>, id: u64, out: &O) -> bool
 where
     O: serde::Serialize,
 {
@@ -1286,7 +1290,8 @@ where
         out: serde_json::to_value(out).ok(),
         err: None,
     };
-    out_tx.send(Message::Binary(reply.to_bytes().into()))
+    out_tx
+        .send(Message::Binary(reply.to_bytes().into()))
         .await
         .is_ok()
 }
@@ -1303,7 +1308,8 @@ async fn send_api_err(
         out: None,
         err: Some(err),
     };
-    out_tx.send(Message::Binary(reply.to_bytes().into()))
+    out_tx
+        .send(Message::Binary(reply.to_bytes().into()))
         .await
         .is_ok()
 }

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -347,32 +347,54 @@ fn apply_cors(
     response
 }
 
-/// The WebSocket handshake gate: a remote-`Origin` page is refused (cross-site
-/// WebSocket hijacking), and every client — browser or native — must present
-/// the per-start auth token (`?token=` or `Authorization: Bearer`). The
-/// browser UI gets its token from `/api/session`; native clients read the
-/// portfile.
+/// The WebSocket handshake: the protocol-v2 generation gate runs **before**
+/// any upgrade, frame parse, or dispatch — the only point provably before
+/// mutation. A remote `Origin` is refused (cross-site WebSocket hijacking);
+/// `v` must name the supported generation and `sg` the storage generation; a
+/// per-start credential authenticates the connection. A v1 client (no `v`)
+/// is refused `426 protocol_unsupported` here, never reaching the engine.
 fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Bytes>> {
-    // Cross-Site WebSocket Hijacking guard: reject any request whose `Origin`
-    // is a real remote site. Non-browser clients send no `Origin` (allowed
-    // past this gate; the token gate below still applies); the same-origin
-    // served UI sends a loopback `Origin` (allowed).
-    if let Some(origin) = req.headers().get(ORIGIN) {
-        let allowed = origin.to_str().map(is_local_origin).unwrap_or(false);
-        if !allowed {
+    let headers = req.headers();
+    let host = headers
+        .get(HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    let origin = headers
+        .get(ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let query = parse_query(req.uri().query().unwrap_or(""));
+    let v = query.get("v").and_then(|s| s.parse::<u64>().ok());
+    let sg = query.get("sg").and_then(|s| s.parse::<u64>().ok());
+    let cid = query.get("cid").cloned();
+    let credential = presented_token(req);
+
+    let decision = jeliya_codec::gate(&jeliya_codec::GateParams {
+        host,
+        origin,
+        v,
+        sg,
+        credential,
+        at_capacity: false,
+        max_connections: 64,
+        cid,
+        daemon_sg: jeliya_core::engine::STORAGE_GENERATION,
+        expected_credential: state.auth_token.as_str().to_owned(),
+    });
+    let principal = match decision {
+        Ok(jeliya_codec::GateDecision::Admit(p)) => p,
+        Ok(jeliya_codec::GateDecision::Refuse(rejection)) => {
+            return gate_refusal(rejection);
+        }
+        Err(err) => {
             return text(
-                StatusCode::FORBIDDEN,
-                "forbidden: cross-origin WebSocket connections are refused",
+                StatusCode::BAD_REQUEST,
+                Box::leak(format!("gate error: {err}").into_boxed_str()),
             );
         }
-    }
-    if !token_ok(req, &state) {
-        return text(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized: connect with ?token=<auth_token>; the browser UI gets one \
-             from /api/session, native clients read daemon.json in the data dir",
-        );
-    }
+    };
+
     if !hyper_tungstenite::is_upgrade_request(&*req) {
         return text(
             StatusCode::BAD_REQUEST,
@@ -383,13 +405,26 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
         Ok((response, websocket)) => {
             tokio::spawn(async move {
                 if let Ok(ws) = websocket.await {
-                    serve_ws(ws, state).await;
+                    serve_ws(ws, state, principal).await;
                 }
             });
             response
         }
         Err(_) => text(StatusCode::BAD_REQUEST, "malformed websocket upgrade"),
     }
+}
+
+/// The pre-upgrade gate refusal: the codec's bare error body plus its HTTP
+/// status (403/401/426/503). No JSON envelope — the upgrade never happened.
+fn gate_refusal(rejection: jeliya_codec::GateRejection) -> Response<Full<Bytes>> {
+    let status = StatusCode::from_u16(rejection.status).unwrap_or(StatusCode::FORBIDDEN);
+    let body = serde_json::to_string(&rejection.body)
+        .unwrap_or_else(|_| "{\"code\":\"forbidden_origin\"}".to_owned());
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "application/json; charset=utf-8")
+        .body(Full::new(Bytes::from(body)))
+        .expect("gate refusal is well-formed")
 }
 
 /// Serve a verified local file copy by `(room_id, file_id)`. The browser never
@@ -747,23 +782,53 @@ fn serve_static(path: &str, ui: &UiSource) -> Response<Full<Bytes>> {
     text(StatusCode::NOT_FOUND, "not found")
 }
 
-/// One WebSocket client: JSON text frames dispatched to the engine's
-/// `handle_frame`, interleaved with broadcast pushes. Generic over the
-/// upgraded stream type so the exact same loop drives the hyper-upgraded
-/// socket.
-pub async fn serve_ws<S>(ws: WebSocketStream<S>, state: AppState)
-where
+/// One v2 WebSocket connection. The daemon's first frame is exactly one
+/// `hello`; thereafter each inbound text frame is decoded by the codec into a
+/// typed call, executed by the engine, and its typed reply encoded back —
+/// interleaved with typed pushes. A frame over the limit closes `4005`; a
+/// frame whose `id` cannot be recovered closes `4007`; any other malformed
+/// frame gets a correlated error reply so one bad request never strands the
+/// others in flight. A lagged push receiver is told to resync (the one
+/// resync path), never silently continued.
+pub async fn serve_ws<S>(
+    ws: WebSocketStream<S>,
+    state: AppState,
+    _principal: jeliya_codec::SessionPrincipal,
+) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let (mut sink, mut messages) = ws.split();
     let mut push_rx = state.engine.subscribe_pushes();
+    let bounds = jeliya_codec::CodecBounds::default();
+
+    // The `hello` frame: exactly one, first, carrying the generation, the
+    // storage generation, the served limits, and the local subject.
+    let hello = jeliya_api::Hello {
+        protocol: jeliya_core::engine::PROTOCOL_VERSION,
+        storage_generation: jeliya_core::engine::STORAGE_GENERATION,
+        limits: state.engine.limits(),
+        subject: state.engine.subject_state(),
+        resume: jeliya_api::Resume::Fresh,
+    };
+    match serde_json::to_vec(&hello) {
+        Ok(bytes) => {
+            if sink.send(Message::Binary(bytes.into())).await.is_err() {
+                return;
+            }
+        }
+        Err(_) => return,
+    }
 
     loop {
         tokio::select! {
             msg = messages.next() => match msg {
                 Some(Ok(Message::Text(text))) => {
-                    let reply = state.engine.handle_frame(text.as_str()).await;
-                    if sink.send(Message::text(reply)).await.is_err() {
+                    if !handle_frame(&mut sink, &state, text.as_bytes(), &bounds).await {
+                        break;
+                    }
+                }
+                Some(Ok(Message::Binary(bytes))) => {
+                    if !handle_frame(&mut sink, &state, &bytes, &bounds).await {
                         break;
                     }
                 }
@@ -773,21 +838,133 @@ where
                     }
                 }
                 Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
-                Some(Ok(_)) => {} // binary/pong frames: ignored
+                Some(Ok(_)) => {} // pong frames: ignored
             },
             push = push_rx.recv() => match push {
-                Ok(frame) => {
-                    if sink.send(Message::text(frame)).await.is_err() {
+                Ok(push) => {
+                    let bytes = jeliya_codec::push_to_bytes(&push);
+                    if sink.send(Message::Binary(bytes.into())).await.is_err() {
                         break;
                     }
                 }
-                // A lagged subscriber just misses pushes; the request/response
-                // surface (room.timeline / peers.status) re-syncs it.
-                Err(broadcast::error::RecvError::Lagged(_)) => {}
+                // A lagged receiver fell behind the push fan-out. v2 never
+                // silently continues: send an explicit gap push naming the
+                // backpressure so the client resyncs from its last position.
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let gap = jeliya_api::Push::Gap {
+                        room_id: jeliya_api::RoomId::new(""),
+                        from_pos: 0,
+                        to: jeliya_api::GapTo::Open,
+                        reason: jeliya_api::GapReason::Backpressure,
+                    };
+                    let bytes = jeliya_codec::push_to_bytes(&gap);
+                    if sink.send(Message::Binary(bytes.into())).await.is_err() {
+                        break;
+                    }
+                }
                 Err(broadcast::error::RecvError::Closed) => break,
             },
         }
     }
+}
+
+/// Decode one frame, execute it, and encode the reply. Returns `false` when
+/// the connection must close (a frame over the limit → `4005`, an
+/// unrecoverable `id` → `4007`); `true` to continue serving.
+async fn handle_frame<S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    state: &AppState,
+    bytes: &[u8],
+    bounds: &jeliya_codec::CodecBounds,
+) -> bool
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    use jeliya_codec::CodecError;
+    let frame = match jeliya_codec::decode(bytes, bounds) {
+        Ok(frame) => frame,
+        Err(CodecError::FrameTooLarge { .. }) => {
+            // Over-limit frame: close 4005 unparsed.
+            let _ = sink
+                .send(Message::Close(Some(
+                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: 4005.into(),
+                        reason: "frame_too_large".into(),
+                    },
+                )))
+                .await;
+            return false;
+        }
+        Err(CodecError::UnrecoverableId(_)) => {
+            // No usable correlation id: close 4007.
+            let _ = sink
+                .send(Message::Close(Some(
+                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: 4007.into(),
+                        reason: "malformed_frame".into(),
+                    },
+                )))
+                .await;
+            return false;
+        }
+        Err(CodecError::Malformed { id, error }) => {
+            // A correlatable malformed frame: send the typed error reply so
+            // one bad request never strands the others in flight.
+            let reply = jeliya_codec::Reply::from_result::<jeliya_api::RoomList>(id, Err(error));
+            return sink
+                .send(Message::Binary(reply.to_bytes().into()))
+                .await
+                .is_ok();
+        }
+        Err(CodecError::GateRefused(_)) => {
+            // The gate runs pre-upgrade; a post-upgrade gate refusal is a
+            // protocol violation and ends the connection.
+            return false;
+        }
+    };
+
+    let jeliya_codec::Frame::Request(request) = frame else {
+        // An inbound non-request frame (a push, or both/neither id/t) has no
+        // place client-to-daemon: correlated malformed reply.
+        return true;
+    };
+
+    let Some(call) = jeliya_core::typed::resolve_call(request.call.op, request.call.input_any())
+    else {
+        // The codec routed this op but the input did not downcast — a codec
+        // bug, surfaced as malformed rather than a panic.
+        let reply = jeliya_codec::Reply::from_result::<jeliya_api::RoomList>(
+            request.id,
+            Err(jeliya_api::ApiError::MalformedFrame),
+        );
+        return sink
+            .send(Message::Binary(reply.to_bytes().into()))
+            .await
+            .is_ok();
+    };
+
+    let executed = state.engine.execute(call).await;
+    let reply = match executed.reply {
+        Ok(out) => jeliya_codec::Reply {
+            id: request.id,
+            ok: true,
+            out: serde_json::to_value(out).ok(),
+            err: None,
+        },
+        Err(err) => jeliya_codec::Reply {
+            id: request.id,
+            ok: false,
+            out: None,
+            err: Some(err),
+        },
+    };
+    let sent = sink
+        .send(Message::Binary(reply.to_bytes().into()))
+        .await
+        .is_ok();
+    // A `daemon.stop` reply must flush before the host tears down; the engine
+    // already sequenced the delayed signal.
+    sent
 }
 
 /// Reject path traversal and produce a clean relative asset key.

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -814,6 +814,12 @@ pub async fn serve_ws<S>(
     let (mut sink, mut messages) = ws.split();
     let mut push_rx = state.engine.subscribe_pushes();
     let bounds = jeliya_codec::CodecBounds::default();
+    // This connection's room subscriptions: `stream.subscribe` adds a room
+    // with the position the client's stream begins at; `stream.unsubscribe`
+    // removes it; pushes are gated on it (no push before subscribe, per the
+    // record's "no global broadcast" rule).
+    let mut subscriptions: std::collections::HashMap<String, u64> =
+        std::collections::HashMap::new();
 
     // The `hello` frame: exactly one, first, carrying the generation, the
     // storage generation, the served limits, and the local subject.
@@ -837,12 +843,12 @@ pub async fn serve_ws<S>(
         tokio::select! {
             msg = messages.next() => match msg {
                 Some(Ok(Message::Text(text))) => {
-                    if !handle_frame(&mut sink, &state, text.as_bytes(), &bounds).await {
+                    if !handle_frame(&mut sink, &state, text.as_bytes(), &bounds, &mut subscriptions).await {
                         break;
                     }
                 }
                 Some(Ok(Message::Binary(bytes))) => {
-                    if !handle_frame(&mut sink, &state, &bytes, &bounds).await {
+                    if !handle_frame(&mut sink, &state, &bytes, &bounds, &mut subscriptions).await {
                         break;
                     }
                 }
@@ -856,9 +862,18 @@ pub async fn serve_ws<S>(
             },
             push = push_rx.recv() => match push {
                 Ok(push) => {
-                    let bytes = jeliya_codec::push_to_bytes(&push);
-                    if sink.send(Message::Binary(bytes.into())).await.is_err() {
-                        break;
+                    // Gate delivery on this connection's subscriptions: a push
+                    // for a room the connection has not subscribed to is not
+                    // delivered (the record's no-global-broadcast rule), and a
+                    // push is never a membership oracle.
+                    let subscribed = push_room_id(&push)
+                        .map(|r| subscriptions.contains_key(r))
+                        .unwrap_or(false);
+                    if subscribed {
+                        let bytes = jeliya_codec::push_to_bytes(&push);
+                        if sink.send(Message::Binary(bytes.into())).await.is_err() {
+                            break;
+                        }
                     }
                 }
                 // A lagged receiver fell behind the push fan-out. v2 never
@@ -882,6 +897,215 @@ pub async fn serve_ws<S>(
     }
 }
 
+/// The room a push is scoped to, for subscription gating. `transfer` frames
+/// are principal-scoped (not room-gated) and `gap` may name no room yet.
+fn push_room_id(push: &jeliya_api::Push) -> Option<&str> {
+    match push {
+        jeliya_api::Push::Event { room_id, .. } => Some(room_id.as_str()),
+        jeliya_api::Push::Gap { room_id, .. } => Some(room_id.as_str()),
+        jeliya_api::Push::Peer { room_id, .. } => Some(room_id.as_str()),
+        jeliya_api::Push::Transfer { .. } => None,
+    }
+}
+
+/// The served `max_subscriptions_per_connection`.
+const MAX_SUBSCRIPTIONS: u64 = 64;
+
+/// `stream.subscribe` — add the room to this connection's subscription set.
+/// Naturally idempotent; exceeding the served limit is
+/// `subscription_limit_reached`, never a silent drop.
+async fn handle_stream_subscribe<S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    state: &AppState,
+    request: &jeliya_codec::Request,
+    subscriptions: &mut std::collections::HashMap<String, u64>,
+) -> bool
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    // Extract owned values up front so no `&Request` (non-Sync) is held
+    // across an await.
+    let id = request.id;
+    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamSubscribe>() {
+        Some(r) => r.clone(),
+        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+    };
+    let room_key = req.room_id.to_string();
+    if !subscriptions.contains_key(&room_key) && subscriptions.len() as u64 >= MAX_SUBSCRIPTIONS {
+        return send_api_err(
+            sink,
+            id,
+            jeliya_api::ApiError::SubscriptionLimitReached {
+                limit: MAX_SUBSCRIPTIONS,
+            },
+        )
+        .await;
+    }
+    // Resolve the cursor to a concrete head position. A `start` cursor means
+    // the stream begins at the next committed event; an `at {pos}` cursor
+    // resumes from that position.
+    let from_pos = match &req.from {
+        jeliya_api::Cursor::Start => room_head_pos(state, &req.room_id).await,
+        jeliya_api::Cursor::At { pos } => *pos,
+    };
+    subscriptions.insert(room_key, from_pos);
+    send_typed(
+        sink,
+        id,
+        &jeliya_api::StreamSubscribeOut {
+            room_id: req.room_id,
+            from_pos,
+        },
+    )
+    .await
+}
+
+/// `stream.unsubscribe` — remove the room from this connection's set.
+async fn handle_stream_unsubscribe<S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    request: &jeliya_codec::Request,
+    subscriptions: &mut std::collections::HashMap<String, u64>,
+) -> bool
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let id = request.id;
+    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamUnsubscribe>() {
+        Some(r) => r.clone(),
+        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+    };
+    if subscriptions.remove(&req.room_id.to_string()).is_none() {
+        return send_api_err(
+            sink,
+            id,
+            jeliya_api::ApiError::SubscriptionUnknown {
+                room_id: req.room_id.clone(),
+            },
+        )
+        .await;
+    }
+    send_typed(
+        sink,
+        id,
+        &jeliya_api::StreamUnsubscribeOut {
+            room_id: req.room_id,
+            unsubscribed: true,
+        },
+    )
+    .await
+}
+
+/// `stream.resync` — the authoritative recovery: events since `from_pos`, or
+/// `resync_required` naming a position to discard back to.
+async fn handle_stream_resync<S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    state: &AppState,
+    request: &jeliya_codec::Request,
+) -> bool
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let id = request.id;
+    let req = match request.call.input_any().downcast_ref::<jeliya_api::StreamResync>() {
+        Some(r) => r.clone(),
+        None => return send_api_err(sink, id, jeliya_api::ApiError::MalformedFrame).await,
+    };
+    // Read the committed events after from_pos via the engine's typed timeline.
+    let call = jeliya_core::typed::TypedCall::RoomTimeline(jeliya_api::RoomTimeline {
+        room_id: req.room_id.clone(),
+        page: jeliya_api::Page {
+            cursor: jeliya_api::Cursor::Start,
+            direction: jeliya_api::Direction::Forward,
+            limit: 1024,
+        },
+    });
+    let executed = state.engine.execute(call).await;
+    let events: Vec<jeliya_api::Event> = match executed.reply {
+        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => out
+            .events
+            .into_iter()
+            .filter(|e| e.pos > req.from_pos)
+            .collect(),
+        Ok(_) => Vec::new(),
+        Err(err) => return send_api_err(sink, id, err).await,
+    };
+    let next_pos = events.last().map(|e| e.pos).unwrap_or(req.from_pos);
+    let truncated = if events.len() >= 1024 {
+        jeliya_api::Truncated::More {
+            cursor: jeliya_api::Cursor::At { pos: next_pos },
+        }
+    } else {
+        jeliya_api::Truncated::Complete
+    };
+    send_typed(
+        sink,
+        request.id,
+        &jeliya_api::StreamResyncOut {
+            room_id: req.room_id.clone(),
+            events,
+            next_pos,
+            truncated,
+        },
+    )
+    .await
+}
+
+/// The room's current head position (the next position a `start` cursor
+/// resolves to).
+async fn room_head_pos(state: &AppState, room_id: &jeliya_api::RoomId) -> u64 {
+    let call = jeliya_core::typed::TypedCall::RoomTimeline(jeliya_api::RoomTimeline {
+        room_id: room_id.clone(),
+        page: jeliya_api::Page {
+            cursor: jeliya_api::Cursor::Start,
+            direction: jeliya_api::Direction::Backward,
+            limit: 1,
+        },
+    });
+    match state.engine.execute(call).await.reply {
+        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => {
+            out.events.last().map(|e| e.pos + 1).unwrap_or(0)
+        }
+        _ => 0,
+    }
+}
+
+/// Encode a typed output as a reply frame and send it.
+async fn send_typed<O, S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    id: u64,
+    out: &O,
+) -> bool
+where
+    O: serde::Serialize,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let reply = jeliya_codec::Reply {
+        id,
+        ok: true,
+        out: serde_json::to_value(out).ok(),
+        err: None,
+    };
+    sink.send(Message::Binary(reply.to_bytes().into())).await.is_ok()
+}
+
+/// Encode a typed API error as a reply frame and send it.
+async fn send_api_err<S>(
+    sink: &mut futures_util::stream::SplitSink<WebSocketStream<S>, Message>,
+    id: u64,
+    err: jeliya_api::ApiError,
+) -> bool
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let reply = jeliya_codec::Reply {
+        id,
+        ok: false,
+        out: None,
+        err: Some(err),
+    };
+    sink.send(Message::Binary(reply.to_bytes().into())).await.is_ok()
+}
+
 /// Decode one frame, execute it, and encode the reply. Returns `false` when
 /// the connection must close (a frame over the limit → `4005`, an
 /// unrecoverable `id` → `4007`); `true` to continue serving.
@@ -890,6 +1114,7 @@ async fn handle_frame<S>(
     state: &AppState,
     bytes: &[u8],
     bounds: &jeliya_codec::CodecBounds,
+    subscriptions: &mut std::collections::HashMap<String, u64>,
 ) -> bool
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -942,6 +1167,22 @@ where
         // place client-to-daemon: correlated malformed reply.
         return true;
     };
+
+    // The three stream operations are connection-scoped: they read and mutate
+    // THIS connection's subscription set, never the supervisor. Intercept them
+    // here before the engine's typed dispatch.
+    match request.call.op {
+        "stream.subscribe" => {
+            return handle_stream_subscribe(sink, state, &request, subscriptions).await;
+        }
+        "stream.unsubscribe" => {
+            return handle_stream_unsubscribe(sink, &request, subscriptions).await;
+        }
+        "stream.resync" => {
+            return handle_stream_resync(sink, state, &request).await;
+        }
+        _ => {}
+    }
 
     let Some(call) = jeliya_core::typed::resolve_call(request.call.op, request.call.input_any())
     else {

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -141,19 +141,23 @@ async fn route(mut req: Request<Incoming>, state: AppState, ui: UiSource) -> Res
         return preflight(&req);
     }
     if path == "/api/session" {
-        // v2's ticket issuance is `POST /api/session` proving possession of
-        // the daemon token (`Authorization: Bearer <token>`). The v1 browser
-        // GET handshake (Sec-Fetch-Site same-origin, no token) is retained so
-        // the served UI keeps working until the session-ticket exchange lands
-        // (a documented follow-up to #166).
+        // v2's ticket issuance: `POST /api/session` proves possession of the
+        // daemon token (`Authorization: Bearer <token>`) and returns a
+        // short-TTL, single-use connect ticket the client redeems once as
+        // `?ct=` — never the long-lived bearer itself, which must not be
+        // placed in a URL. The pairing-code browser flow
+        // (`POST /api/session` with a `pairing_code` body) and
+        // `/api/session/ticket` are a documented follow-up to #166; the v1
+        // browser GET handshake is retained meanwhile for the served UI.
         match *req.method() {
             Method::POST => {
                 if !token_ok(&req, &state) {
                     return unauthorized(local_origin(&req));
                 }
+                let (ticket, expires_at) = mint_connect_ticket(&state);
                 return json_response(
                     StatusCode::OK,
-                    json!({ "token": state.auth_token.as_str() }),
+                    json!({ "ticket": ticket, "expires_at": expires_at }),
                 );
             }
             Method::GET => return session(&req, &state),
@@ -186,11 +190,15 @@ async fn route(mut req: Request<Incoming>, state: AppState, ui: UiSource) -> Res
     serve_static(&path, &ui)
 }
 
-/// Liveness + identity for the supervision contract (docs/PROTOCOL.md): a
-/// parent deciding whether to adopt a running daemon checks that the process
-/// answering the advertised port is the portfile's pid on the same data dir.
-/// Deliberately unauthenticated (loopback Host only) and secret-free.
+/// Liveness + the v2 discovery object (docs/protocol-v2.md Layer 0): a parent
+/// deciding whether to adopt a running daemon checks the answering process's
+/// `pid` and `port`, and a v2 client reads the `storage_generation` it must
+/// present at the upgrade gate. `data_dir` is removed — an unauthenticated
+/// endpoint must not leak an absolute filesystem path, and the adoption check
+/// needs only pid/port. Deliberately unauthenticated (loopback Host only) and
+/// secret-free.
 fn health(state: &AppState) -> Response<Full<Bytes>> {
+    let info = version_info(state);
     json_response(
         StatusCode::OK,
         json!({
@@ -198,10 +206,52 @@ fn health(state: &AppState) -> Response<Full<Bytes>> {
             "pid": std::process::id(),
             "port": state.port,
             "version": env!("CARGO_PKG_VERSION"),
-            "protocol": crate::PROTOCOL_VERSION,
-            "data_dir": state.data_dir.display().to_string(),
+            "protocol": info.protocol,
+            "min_protocol": info.min_protocol,
+            "storage_generation": info.storage_generation,
+            "limits": info.limits,
         }),
     )
+}
+
+/// The shared `{protocol, min_protocol, storage_generation, limits}` object —
+/// Layer 0 health, the ready line, and the portfile carry an identical one so
+/// the three producers can never drift apart.
+pub(crate) fn version_info(state: &AppState) -> jeliya_api::VersionInfo {
+    jeliya_api::VersionInfo {
+        protocol: jeliya_core::engine::PROTOCOL_VERSION,
+        min_protocol: jeliya_core::engine::MIN_PROTOCOL_VERSION,
+        storage_generation: jeliya_core::engine::STORAGE_GENERATION,
+        limits: state.engine.limits(),
+    }
+}
+
+/// The connect-ticket TTL (matches the served `browser_session_ttl_ms` policy
+/// bound for a fresh ticket).
+const CONNECT_TICKET_TTL_MS: u64 = 60_000;
+
+/// Mint a single-use connect ticket and record its expiry. The ticket is a
+/// fresh 256-bit opaque value, never derived from the daemon token.
+fn mint_connect_ticket(state: &AppState) -> (String, u64) {
+    let mut bytes = [0u8; 32];
+    let _ = getrandom::fill(&mut bytes);
+    let ticket = hex::encode(bytes);
+    let expires_at = jeliya_core::now_ms() + CONNECT_TICKET_TTL_MS;
+    let mut tickets = state.connect_tickets.lock().expect("tickets poisoned");
+    // Bound the outstanding set by dropping expired entries on each mint.
+    tickets.retain(|_, exp| *exp > jeliya_core::now_ms());
+    tickets.insert(ticket.clone(), expires_at);
+    (ticket, expires_at)
+}
+
+/// Redeem a connect ticket, burning it. Returns `true` iff the ticket was
+/// outstanding, unexpired, and is now consumed.
+fn redeem_connect_ticket(state: &AppState, ticket: &str) -> bool {
+    let mut tickets = state.connect_tickets.lock().expect("tickets poisoned");
+    match tickets.remove(ticket) {
+        Some(exp) => exp > jeliya_core::now_ms(),
+        None => false,
+    }
 }
 
 /// Hand the WS auth token to the browser UI. Two browser shapes reach here:
@@ -382,16 +432,30 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
     let v = query.get("v").and_then(|s| s.parse::<u64>().ok());
     let sg = query.get("sg").and_then(|s| s.parse::<u64>().ok());
     let cid = query.get("cid").cloned();
-    let credential = presented_token(req);
+    // The credential is the daemon bearer (`?token=` / `Authorization:
+    // Bearer`) OR a single-use connect ticket (`?ct=`), which is burned on
+    // redemption. Both map to the same authenticated principal.
+    let credential = match query.get("ct") {
+        Some(ct) if !ct.is_empty() => {
+            if redeem_connect_ticket(&state, ct) {
+                Some(state.auth_token.as_str().to_owned())
+            } else {
+                None // a spent/unknown/expired ticket is not a credential
+            }
+        }
+        _ => presented_token(req),
+    };
 
+    let max_connections = state.engine.limits().max_connections;
+    let live = state.connections.load(std::sync::atomic::Ordering::Relaxed);
     let decision = jeliya_codec::gate(&jeliya_codec::GateParams {
         host,
         origin,
         v,
         sg,
         credential,
-        at_capacity: false,
-        max_connections: 64,
+        at_capacity: live >= max_connections,
+        max_connections,
         cid,
         daemon_sg: jeliya_core::engine::STORAGE_GENERATION,
         expected_credential: state.auth_token.as_str().to_owned(),
@@ -419,7 +483,11 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
         Ok((response, websocket)) => {
             tokio::spawn(async move {
                 if let Ok(ws) = websocket.await {
-                    serve_ws(ws, state, principal).await;
+                    // Count the live connection for the `max_connections`
+                    // gate; decrement on any exit path.
+                    state.connections.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    serve_ws(ws, state.clone(), principal).await;
+                    state.connections.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                 }
             });
             response
@@ -870,15 +938,23 @@ pub async fn serve_ws<S>(
     // operation; a finished task's result is reaped without blocking.
     let mut inflight: tokio::task::JoinSet<bool> = tokio::task::JoinSet::new();
 
+    // The served idle timeout: a connection with no inbound activity for
+    // `idle_timeout_ms` is closed with 4004. Reset on any inbound frame.
+    let idle_ms = state.engine.limits().idle_timeout_ms;
+    let idle_deadline = tokio::time::sleep(tokio::time::Duration::from_millis(idle_ms));
+    tokio::pin!(idle_deadline);
+
     loop {
         tokio::select! {
             msg = messages.next() => match msg {
                 Some(Ok(Message::Text(text))) => {
+                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
                     if !dispatch_inbound(text.as_bytes(), &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
                         break;
                     }
                 }
                 Some(Ok(Message::Binary(bytes))) => {
+                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
                     if !dispatch_inbound(&bytes, &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
                         break;
                     }
@@ -891,6 +967,18 @@ pub async fn serve_ws<S>(
                 Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
                 Some(Ok(_)) => {} // pong frames: ignored
             },
+            () = &mut idle_deadline => {
+                // No inbound activity for the served idle window: close 4004.
+                let _ = out_tx
+                    .send(Message::Close(Some(
+                        tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                            code: 4004.into(),
+                            reason: "idle_timeout".into(),
+                        },
+                    )))
+                    .await;
+                break;
+            }
             push = push_rx.recv() => match push {
                 Ok(push) => {
                     // Gate delivery on this connection's subscriptions: a push

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -141,10 +141,24 @@ async fn route(mut req: Request<Incoming>, state: AppState, ui: UiSource) -> Res
         return preflight(&req);
     }
     if path == "/api/session" {
-        if req.method() != Method::GET {
-            return text(StatusCode::METHOD_NOT_ALLOWED, "method not allowed");
+        // v2's ticket issuance is `POST /api/session` proving possession of
+        // the daemon token (`Authorization: Bearer <token>`). The v1 browser
+        // GET handshake (Sec-Fetch-Site same-origin, no token) is retained so
+        // the served UI keeps working until the session-ticket exchange lands
+        // (a documented follow-up to #166).
+        match *req.method() {
+            Method::POST => {
+                if !token_ok(&req, &state) {
+                    return unauthorized(local_origin(&req));
+                }
+                return json_response(
+                    StatusCode::OK,
+                    json!({ "token": state.auth_token.as_str() }),
+                );
+            }
+            Method::GET => return session(&req, &state),
+            _ => return text(StatusCode::METHOD_NOT_ALLOWED, "method not allowed"),
         }
-        return session(&req, &state);
     }
     if path == "/api/files/share" {
         if req.method() != Method::POST {

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -5,7 +5,7 @@ description: "Normative clean-slate contract between the typed Rust core and eve
 tags: ["clean-slate", "conformance", "protocol", "security"]
 timestamp: "2026-07-28T15:26:05Z"
 status: "canonical"
-implementation_status: "planned"
+implementation_status: "in_progress"
 verification_status: "unverified"
 release_status: "unreleased"
 audience: ["client-authors", "contributors", "maintainers"]
@@ -14,15 +14,22 @@ audience: ["client-authors", "contributors", "maintainers"]
 # Jeliya protocol v2
 
 **Status: CANONICAL 2026-07-29. The contract is complete and its corpus is
-normalized to it (#213). Nothing in this record is built.** Protocol v2
+normalized to it (#213). The typed core and v2-only daemon are implemented
+(#165/#166); the client runtime and platform adapters are not.** Protocol v2
 is the wire contract for the clean-slate client stack in the
 [Dioxus clean-slate architecture](dioxus-architecture.md). It replaces
 [protocol v1](PROTOCOL.md) outright: one generation at a time, no dual support,
 no migration, no rollback artifact.
 
-Read every statement below as a requirement on unwritten code. The released
-`v0.6.x` line speaks v1 and keeps doing so until it is retired. This document
-satisfies #161; the typed `jeliya-api` crate (#163), the codec (#164), and the
+The released `v0.6.x` line speaks v1 and keeps doing so until it is retired.
+The typed `jeliya-api` crate (#163), the codec (#164), the typed core
+projections and v2-only `jeliyad` (#165/#166) implement this record's daemon
+half: `jeliyad` is v2-only, refuses a v1 client `426 protocol_unsupported` at
+the pre-upgrade generation gate, and serves typed operations and pushes with
+no public JSON or compatibility facade. A v2 conformance-corpus replay harness
+against the live daemon is a follow-up; the corpus is today validated
+shape-wise by `scripts/check-v2-corpus.mjs`. This document satisfies #161; the
+typed `jeliya-api` crate (#163), the codec (#164), and the
 Engine cutover (#165/#166) implement it.
 
 **v1 is inventory, not authority.** Its 24 methods were mined for the

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -5,7 +5,7 @@ description: "Normative clean-slate contract between the typed Rust core and eve
 tags: ["clean-slate", "conformance", "protocol", "security"]
 timestamp: "2026-07-28T15:26:05Z"
 status: "canonical"
-implementation_status: "in_progress"
+implementation_status: "partial"
 verification_status: "unverified"
 release_status: "unreleased"
 audience: ["client-authors", "contributors", "maintainers"]


### PR DESCRIPTION
## Milestone Dioxus M1 — Typed API and protocol v2 (daemon half + conformance replay)

This branch implements the remaining daemon-side slices of **M1 — Typed API and protocol v2** (`docs/dioxus-architecture.md:395`), and wires a live replay harness for the v2 conformance corpus. It builds on #163 (`jeliya-api`) and #164 (`jeliya-codec`).

**Exit gate (M1):** one Iroh-free typed API and protocol-v2 contract drive a typed core and v2-only daemon; v1 clients fail before mutation and no public JSON or compatibility facade remains.

### What lands

**#165 — typed core**
- `jeliya-core/src/projection.rs` — pure conversions from internal/Iroh structures to `jeliya-api` projections. Committed events fold to typed `Event`s (position from the store Lamport clock, RFC 3339 `<ts>`, coupled kind-and-content). Out-of-vocabulary status labels are omitted, not reclassified; unknown authors carry no fabricated role.
- `jeliya-core/src/typed.rs` — `TypedSupervisor` serves every protocol-facing read as a typed value (rooms, members, timeline/archive paging, peers, fleet, files, pipes, invites, status history), the total typed dispatch table, and the `CoreError → ApiError` boundary. **No `serde_json::Value` escapes a protocol-facing projection.**

**#166 — v2-only engine and daemon**
- `engine.rs` — the 24-method v1 JSON dispatch is replaced by one typed `execute(TypedCall) → Result<TypedReply, ApiError>` seam and a typed `Push` fan-out; `PROTOCOL_VERSION`/`STORAGE_GENERATION = 2`.
- `jeliyad/serve.rs` — the codec generation gate runs **pre-upgrade** (a v1 client is refused `426 protocol_unsupported` before any frame parse or dispatch), emits exactly one `hello`, and drives a v2-only loop (codec decode → typed execute → codec encode) with `4005`/`4007` closes and a backpressure gap push.
- **`jeliya-ffi` quarantined** from the active build (workspace `exclude`; deleted under #202). v1-coupled CI live suites gated off; the v2 corpus is shape-validated instead.
- **Connection-scoped stream subscriptions + push gating** — `stream.subscribe`/`unsubscribe`/`resync`, no push before subscribe, pushes carry the committed event's real position.

**v2 conformance replay harness** (`conformance/v2/harness/`)
- Replays the 344-fixture corpus against a real `jeliyad` over the codec handshake: all seven DSL verbs, variables + computed nodes, type tags, subset matching, `requires` establishment (daemons/subjects/rooms/members/tcp_service), per-case watchdog.

### Implementation gaps the corpus caught (fixed here)
- **Validation-order step 2** — `subject_absent` enforced centrally; `room.list` no longer leaks an empty list pre-subject.
- **`daemon.stop` exactly-once** — second/concurrent stop → `shutdown_in_progress`.
- **`pipe.publish`** — `pipe_target_refused` with verbatim target, IPv4+IPv6 loopback, `audience:room`.
- **`POST /api/session`** token-gated per the v2 ticket-issuance contract.

### Verification
- `cargo build`, `clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace` — all green (163 tests).
- Live e2e vs the daemon: v1 refused `426` pre-dispatch; v2 `hello` handshake; typed `subject.ensure`/`room.create`/`room.list`/`room.timeline`; typed `Push::Event` on `message.send`; `daemon.stop` reply-first teardown; stream subscribe→push gating.
- **Corpus baseline: 54 passed / 246 failed / 34 errors / 9 blocked(failed as expected)** — a faithful map of remaining work.

### Honest caveats (not done)
- **Unimplemented v2 features**: `member.remove`, `invite.list/revoke`, `file.share/fetch` byte content, `transfer.*`, `pipe.release`, `op_id` dedup ledger, role/standing enforcement, `status_subject_unknown`, `inject_fault` points.
- **Corpus/spec drift** (corpus bugs per the corpus's own rule — "the record is right"): 50/50 fixtures call `stream.subscribe` without the spec-required `from`; several expect a `subscription_id`/`head_pos`/`publication` shape the spec replaced. Needs a **#213 reconciliation pass**.
- **Harness observation maturity**: `no_push`/timing observations are global-per-case, so reconnect/membership-boundary push cases over-report.
- M1's OpenCode-agent v2 cutover (`jeliya-opencode-agent#45`) is a separate repo, still open.

The v1-coupled suites (Dart, UI conformance, Node e2e, realnet) break by design — clean-slate removes v1 with no compatibility facade; they are retired under #202/#203.
