### PR TITLE
fix(core): serve the dense canonical rank as the v2 position, not the raw lamport

### DIFF
--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -500,7 +500,10 @@ mod tests {
         let TypedReply::MessageSend(sent) = sent else {
             panic!("wrong reply");
         };
-        assert!(sent.pos > 0, "a message commits at a positive position");
+        // The second committed event in the room (after the genesis) sits at
+        // dense position 1 — the rank over the canonical order, not the raw
+        // lamport.
+        assert_eq!(sent.pos, 1, "the reply position is the dense rank");
 
         // The committed event lands on the typed push fan-out as Push::Event.
         let push = tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -518,10 +521,13 @@ mod tests {
         })
         .await
         .expect("a typed Push::Event arrives within 10s");
-        let EventKindContent::Message { body } = push.kind else {
+        let EventKindContent::Message { body } = &push.kind else {
             panic!("wrong kind");
         };
         assert_eq!(body, "hello typed push");
+        // Reply, push, and timeline positions are ONE dense position space:
+        // the push carries exactly the position the reply served.
+        assert_eq!(push.pos, sent.pos, "push and reply positions agree");
 
         // The timeline serves the same committed event, typed, at pos >= 1.
         let page = Page {
@@ -544,6 +550,10 @@ mod tests {
         assert_eq!(timeline.events[0].kind.kind(), EventKind::RoomCreated);
         assert_eq!(timeline.events[0].pos, 0);
         assert_eq!(timeline.events[1].kind.kind(), EventKind::Message);
+        assert_eq!(
+            timeline.events[1].pos, sent.pos,
+            "timeline and reply positions agree"
+        );
 
         engine.close_all_rooms().await;
     }

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use jeliya_api::{ApiError, Event, PeerRow, Push, RoomId, SubjectState};
+use jeliya_api::{ApiError, PeerRow, Push, RoomId, SubjectState};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -310,11 +310,8 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
                         };
                         match received {
                             Ok(events) => {
-                                for event in events {
-                                    engine.emit(Push::Event {
-                                        room_id: api_room.clone(),
-                                        event,
-                                    });
+                                for committed in events {
+                                    emit_committed(&engine, &api_room, committed);
                                 }
                             }
                             Err(err) if err.kind == ErrorKind::RoomNotOpen => break,
@@ -332,11 +329,8 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
             // broadcast event is still pushed exactly once (shared `seen`).
             match poll_typed_events(&engine, &room_id).await {
                 Ok(events) => {
-                    for event in events {
-                        engine.emit(Push::Event {
-                            room_id: api_room.clone(),
-                            event,
-                        });
+                    for committed in events {
+                        emit_committed(&engine, &api_room, committed);
                     }
                 }
                 Err(err) => warn!("push reconcile failed for {room_str}: {err}"),
@@ -362,7 +356,7 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
 async fn recv_typed_events(
     engine: &Engine,
     room_id: &iroh_rooms::room::RoomId,
-) -> CoreResult<Vec<Event>> {
+) -> CoreResult<Vec<crate::supervisor::CommittedEvent>> {
     engine.supervisor.recv_room_events_typed(room_id).await
 }
 
@@ -371,8 +365,34 @@ async fn recv_typed_events(
 async fn poll_typed_events(
     engine: &Engine,
     room_id: &iroh_rooms::room::RoomId,
-) -> CoreResult<Vec<Event>> {
+) -> CoreResult<Vec<crate::supervisor::CommittedEvent>> {
     engine.supervisor.poll_new_events_typed(room_id).await
+}
+
+/// Emit one newly-pushed committed event, preceded by a corrective `gap` when
+/// it reordered already-served history. A late concurrent sibling interleaving
+/// below the frontier shifts the ranks of events the stream already served;
+/// the client cannot detect that from an event frame alone (the reordered
+/// event arrives at a position it already holds), so the stream first tells it
+/// to discard the shifted suffix and resync via `stream.resync` (the one
+/// resync path), then delivers the event at its true rank.
+fn emit_committed(
+    engine: &Engine,
+    api_room: &RoomId,
+    committed: crate::supervisor::CommittedEvent,
+) {
+    if let Some(from_pos) = committed.reordered_at {
+        engine.emit(Push::Gap {
+            room_id: api_room.clone(),
+            from_pos,
+            to: jeliya_api::GapTo::Open,
+            reason: jeliya_api::GapReason::Backpressure,
+        });
+    }
+    engine.emit(Push::Event {
+        room_id: api_room.clone(),
+        event: committed.event,
+    });
 }
 
 /// The per-device link rows for one room, for the peer-change drain.

--- a/crates/jeliya-core/src/projection.rs
+++ b/crates/jeliya-core/src/projection.rs
@@ -36,12 +36,32 @@ fn ts(created_at_ms: u64) -> Timestamp {
     Timestamp::new(OffsetDateTime::from_unix_timestamp(secs).unwrap_or(OffsetDateTime::UNIX_EPOCH))
 }
 
-/// The room's per-event monotonic position, from the store's derived Lamport
-/// clock. The genesis is `0`, matching the record's position space anchored
-/// at the origin. A causally-incomplete row (a missing parent leaves
-/// `lamport` unset) is not materialized into a committed timeline event.
-fn pos(se: &StoredEvent) -> Option<u64> {
-    se.lamport
+/// The v2 per-room position space is the room's canonical `(lamport,
+/// event_id)` order **ranked densely**: the genesis is `0` and every later
+/// committed event is exactly one past its predecessor. The store's raw
+/// Lamport value is NOT a position — concurrent siblings share a lamport,
+/// and the record requires positions that are strictly increasing and
+/// gap-free within one room, which only the dense rank over the canonical
+/// order provides. Ranking happens at the read boundary
+/// (`TypedSupervisor::committed_events` for timeline/resync/archive, and the
+/// supervisor's typed push paths for `Push::Event`), so one consistent rank
+/// serves every position the protocol exposes.
+///
+/// A causally-incomplete row (a missing parent leaves `lamport` unset) is
+/// excluded from the canonical order, hence holds no position.
+///
+/// One honest limitation the record's model shares: the canonical order is
+/// **not stable across convergence** — a late-arriving concurrent event can
+/// interleave below the frontier and shift the ranks of events after it.
+/// Positions are therefore a per-room, eventually-consistent sequence the
+/// client treats as authoritative only at read time; a shift surfaces as a
+/// detectable discontinuity the one resync path repairs.
+pub(crate) fn positioned<'a>(
+    rows: impl IntoIterator<Item = &'a StoredEvent>,
+) -> impl Iterator<Item = (u64, &'a StoredEvent)> {
+    rows.into_iter()
+        .enumerate()
+        .map(|(rank, se)| (rank as u64, se))
 }
 
 /// Map an Iroh fold role to the v2 `role` vocabulary. `Admin` is the room's
@@ -120,9 +140,10 @@ fn progress(pct: Option<u64>) -> Progress {
     }
 }
 
-/// Fold one stored event into its committed v2 [`Event`], or `None` for an
-/// event kind the protocol does not commit to the displayed timeline. Pure:
-/// no IO, no clock beyond the signed `created_at`.
+/// Fold one stored event, at its dense canonical rank `pos` (see
+/// [`positioned`]), into its committed v2 [`Event`], or `None` for an event
+/// kind the protocol does not commit to the displayed timeline. Pure: no IO,
+/// no clock beyond the signed `created_at`.
 ///
 /// `member.invited` and `member.removed` are not among the ten committed
 /// kinds the record enumerates (`invite.mint` produces no timeline event;
@@ -144,8 +165,7 @@ fn progress(pct: Option<u64>) -> Progress {
 /// - `pipe.closed` → `pipe_revoked`
 /// - `member.invited` → (no committed event; `invite.mint` authors none)
 #[must_use]
-pub fn materialize(se: &StoredEvent, snapshot: &MembershipSnapshot) -> Option<Event> {
-    let pos = pos(se)?;
+pub fn materialize(se: &StoredEvent, pos: u64, snapshot: &MembershipSnapshot) -> Option<Event> {
     let ev = SignedEvent::decode(&se.wire.signed).ok()?;
     materialize_signed(pos, &se.event_id, &ev, snapshot)
 }
@@ -652,16 +672,82 @@ mod tests {
 
         let snapshot = snapshot_of(&fx);
         let rows = store.room_tail(&fx.room_id, 100).unwrap();
-        let events: Vec<Event> = rows
-            .iter()
-            .filter_map(|se| materialize(se, &snapshot))
+        let events: Vec<Event> = positioned(&rows)
+            .filter_map(|(rank, se)| materialize(se, rank, &snapshot))
             .collect();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
         assert_eq!(events[1].kind.kind(), EventKind::Message);
-        // Positions come from the store's Lamport clock: genesis is 0.
+        // Positions are the dense rank over the canonical order: genesis is
+        // 0 and each later committed event is exactly one past its
+        // predecessor.
         assert_eq!(events[0].pos, 0);
-        assert!(events[1].pos > events[0].pos);
+        assert_eq!(events[1].pos, 1);
+    }
+
+    #[test]
+    fn concurrent_siblings_get_dense_gap_free_positions() {
+        // Two messages authored against the SAME parent are concurrent
+        // siblings: the store's derived Lamport clock assigns them the same
+        // value. The v2 position space must still be dense, strictly
+        // increasing, and gap-free, so positions are the rank over the
+        // canonical `(lamport, event_id)` order — never the raw lamport.
+        let fx = fixture();
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        let genesis_id = genesis.event_id;
+        store.insert(&genesis).unwrap();
+
+        // Two distinct authors (two devices), both children of the genesis.
+        let device_b = SigningKey::generate();
+        let a = validate_wire_bytes(
+            &build_message_text(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                "sibling a",
+                None,
+                None,
+                &[],
+                &[genesis_id],
+                TS + 1,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        let b = validate_wire_bytes(
+            &build_message_text(
+                &fx.identity,
+                &device_b,
+                &fx.room_id,
+                "sibling b",
+                None,
+                None,
+                &[],
+                &[genesis_id],
+                TS + 1,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        store.insert(&a).unwrap();
+        store.insert(&b).unwrap();
+
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        assert_eq!(rows.len(), 3);
+        // The two siblings share one lamport: the raw store value is NOT
+        // unique, which is exactly why it cannot be the served position.
+        assert_eq!(rows[1].lamport, rows[2].lamport);
+
+        let snapshot = snapshot_of(&fx);
+        let events: Vec<Event> = positioned(&rows)
+            .filter_map(|(rank, se)| materialize(se, rank, &snapshot))
+            .collect();
+        let positions: Vec<u64> = events.iter().map(|e| e.pos).collect();
+        assert_eq!(positions, [0, 1, 2], "dense and gap-free across siblings");
     }
 
     #[test]

--- a/crates/jeliya-core/src/projection.rs
+++ b/crates/jeliya-core/src/projection.rs
@@ -36,32 +36,66 @@ fn ts(created_at_ms: u64) -> Timestamp {
     Timestamp::new(OffsetDateTime::from_unix_timestamp(secs).unwrap_or(OffsetDateTime::UNIX_EPOCH))
 }
 
-/// The v2 per-room position space is the room's canonical `(lamport,
-/// event_id)` order **ranked densely**: the genesis is `0` and every later
-/// committed event is exactly one past its predecessor. The store's raw
-/// Lamport value is NOT a position — concurrent siblings share a lamport,
-/// and the record requires positions that are strictly increasing and
-/// gap-free within one room, which only the dense rank over the canonical
-/// order provides. Ranking happens at the read boundary
-/// (`TypedSupervisor::committed_events` for timeline/resync/archive, and the
-/// supervisor's typed push paths for `Push::Event`), so one consistent rank
-/// serves every position the protocol exposes.
+/// The v2 per-room position space is the room's committed timeline events
+/// **ranked densely in canonical `(lamport, event_id)` order**: the genesis
+/// is `0` and every later committed event is exactly one past its
+/// predecessor. Two rules make that hold:
+///
+/// - **Filter to committed events FIRST.** Only kinds the record commits to
+///   the timeline hold a position. A stored row [`materialize`] drops (a
+///   `member.invited`, an out-of-vocabulary `agent.status`) is not a
+///   committed event and consumes no position — otherwise the next rendered
+///   event would jump a position and leave a hole resync cannot fill.
+/// - **Rank densely over the survivors.** The store's raw Lamport value is
+///   NOT a position — concurrent siblings share a lamport, and the record
+///   requires strictly-increasing, gap-free positions, which only the dense
+///   rank over the canonical order provides.
+///
+/// [`positioned`] applies both: it filters a canonical tail to committed
+/// events and assigns each its dense rank. Ranking happens at the read
+/// boundary (`TypedSupervisor::committed_events` for timeline/resync/archive,
+/// and the supervisor's typed push paths for `Push::Event`), so one
+/// consistent rank serves every position the protocol exposes.
 ///
 /// A causally-incomplete row (a missing parent leaves `lamport` unset) is
 /// excluded from the canonical order, hence holds no position.
 ///
-/// One honest limitation the record's model shares: the canonical order is
-/// **not stable across convergence** — a late-arriving concurrent event can
-/// interleave below the frontier and shift the ranks of events after it.
-/// Positions are therefore a per-room, eventually-consistent sequence the
-/// client treats as authoritative only at read time; a shift surfaces as a
-/// detectable discontinuity the one resync path repairs.
-pub(crate) fn positioned<'a>(
-    rows: impl IntoIterator<Item = &'a StoredEvent>,
-) -> impl Iterator<Item = (u64, &'a StoredEvent)> {
-    rows.into_iter()
-        .enumerate()
-        .map(|(rank, se)| (rank as u64, se))
+/// # Stability across convergence
+///
+/// The canonical order is **not stable across convergence**: a late-arriving
+/// concurrent event can interleave below the frontier and shift the ranks of
+/// already-served events after it. Positions are therefore a per-room,
+/// eventually-consistent sequence the client treats as authoritative only at
+/// read time. The push paths are reorder-aware (see
+/// [`supervisor::collect_committed`](crate::supervisor)): when a new event's
+/// rank is at or below an already-served rank, the stream emits an explicit
+/// `gap` from the first shifted position so the client discards and resyncs
+/// rather than trusting a silently renumbered suffix.
+pub(crate) fn positioned(
+    rows: &[&StoredEvent],
+    snapshot: &MembershipSnapshot,
+) -> Vec<(u64, Event)> {
+    let mut out = Vec::new();
+    let mut rank = 0u64;
+    for se in rows {
+        if let Some(event) = materialize(se, 0, snapshot) {
+            out.push((rank, Event { pos: rank, ..event }));
+            rank += 1;
+        }
+    }
+    out
+}
+
+/// Whether a stored event is a committed timeline event (its kind is one the
+/// record commits and, for `agent.status`, its label is in the closed
+/// vocabulary). Snapshot-free: the committed check depends only on the signed
+/// content, not on membership. [`positioned`]'s callers and the rank lookups
+/// use this to keep non-committed rows from consuming a position.
+pub(crate) fn is_committed(se: &StoredEvent) -> bool {
+    let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+        return false;
+    };
+    kind_content(&ev.content).is_some()
 }
 
 /// Map an Iroh fold role to the v2 `role` vocabulary. `Admin` is the room's
@@ -437,6 +471,7 @@ mod tests {
     use iroh_rooms::files::{build_file_shared, HashRef};
     use iroh_rooms::identity::DeviceBinding;
     use iroh_rooms::identity::SigningKey;
+    use iroh_rooms::room::build_member_invited;
     use iroh_rooms::room::{
         build_member_joined, build_member_left, build_room_created, derive_room_id,
         MembershipSnapshot, RoomId, RoomMembership,
@@ -672,8 +707,10 @@ mod tests {
 
         let snapshot = snapshot_of(&fx);
         let rows = store.room_tail(&fx.room_id, 100).unwrap();
-        let events: Vec<Event> = positioned(&rows)
-            .filter_map(|(rank, se)| materialize(se, rank, &snapshot))
+        let refs: Vec<&StoredEvent> = rows.iter().collect();
+        let events: Vec<Event> = positioned(&refs, &snapshot)
+            .into_iter()
+            .map(|(_, e)| e)
             .collect();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
@@ -743,11 +780,84 @@ mod tests {
         assert_eq!(rows[1].lamport, rows[2].lamport);
 
         let snapshot = snapshot_of(&fx);
-        let events: Vec<Event> = positioned(&rows)
-            .filter_map(|(rank, se)| materialize(se, rank, &snapshot))
+        let refs: Vec<&StoredEvent> = rows.iter().collect();
+        let events: Vec<Event> = positioned(&refs, &snapshot)
+            .into_iter()
+            .map(|(_, e)| e)
             .collect();
         let positions: Vec<u64> = events.iter().map(|e| e.pos).collect();
         assert_eq!(positions, [0, 1, 2], "dense and gap-free across siblings");
+    }
+
+    #[test]
+    fn non_committed_events_consume_no_position() {
+        // A `member.invited` row is stored but NOT committed to the timeline
+        // (`invite.mint` authors no committed event). It must consume no
+        // position: the message after it sits immediately after the genesis,
+        // not a rank higher, so the served space stays dense and gap-free.
+        let fx = fixture();
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        let genesis_id = genesis.event_id;
+        store.insert(&genesis).unwrap();
+
+        let invitee = SigningKey::generate();
+        let invited = validate_wire_bytes(
+            &build_member_invited(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                &[0x07; 16],
+                &[0x09; 32],
+                "member",
+                &invitee.identity_key(),
+                None,
+                None,
+                &[genesis_id],
+                TS + 1,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        store.insert(&invited).unwrap();
+        let msg = validate_wire_bytes(
+            &build_message_text(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                "after the invite",
+                None,
+                None,
+                &[],
+                &[genesis_id],
+                TS + 2,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        store.insert(&msg).unwrap();
+
+        let snapshot = snapshot_of(&fx);
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        assert_eq!(
+            rows.len(),
+            3,
+            "invite row is stored even though not committed"
+        );
+        let refs: Vec<&StoredEvent> = rows.iter().collect();
+        let events: Vec<Event> = positioned(&refs, &snapshot)
+            .into_iter()
+            .map(|(_, e)| e)
+            .collect();
+        // The invite consumed no position: genesis 0, message 1, no hole.
+        assert_eq!(events.len(), 2, "the invite is not a committed event");
+        assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
+        assert_eq!(events[0].pos, 0);
+        assert_eq!(events[1].kind.kind(), EventKind::Message);
+        assert_eq!(events[1].pos, 1, "no position hole where the invite sat");
     }
 
     #[test]

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -178,6 +178,12 @@ pub struct RoomSession {
     room_rx: Arc<TokioMutex<broadcast::Receiver<StoredEvent>>>,
     forwarders: StdMutex<HashMap<[u8; SHORT_ID_LEN], PipeForwarder>>,
     seen: StdMutex<BTreeSet<EventId>>,
+    /// The next dense rank this room's push stream expects to serve (the
+    /// per-room high-water mark). An in-order append advances it by one; a
+    /// NEW committed event whose canonical rank falls below it has reordered
+    /// already-served history and is served as a corrective gap instead of a
+    /// normal append (see `collect_committed`). Starts at 0 (genesis rank).
+    next_push_rank: StdMutex<u64>,
     /// Live gate for join-bootstrap provisional admission (an unknown device may
     /// pull the membership sub-DAG). Flipped on so that a stranger can only
     /// bootstrap while this owner session actually has a pending invite open,
@@ -226,6 +232,87 @@ fn internal(context: &str, err: impl std::fmt::Display) -> CoreError {
 /// owner session legitimately hosts join bootstraps.
 fn any_pending_invite(snapshot: &MembershipSnapshot) -> bool {
     snapshot.members().any(|m| m.status == Status::Invited)
+}
+
+/// One newly-pushed committed event plus whether it reorders already-served
+/// history. The engine turns a `reordered_at` into an explicit `gap` push so
+/// subscribers discard and resync the shifted suffix rather than trust a
+/// silently renumbered one.
+#[derive(Debug)]
+pub(crate) struct CommittedEvent {
+    /// The committed event, carrying its dense canonical rank as `pos`.
+    pub event: jeliya_api::Event,
+    /// `Some(pos)` when this event's rank is at or below one the stream
+    /// already served (a late concurrent sibling interleaved below the
+    /// frontier): the first position the client must discard and resync from.
+    /// `None` for an in-order append.
+    pub reordered_at: Option<u64>,
+}
+
+/// Rank the newly-pushed committed events of a room's **full canonical tail**
+/// densely and detect reordering. Both typed push paths call this with the
+/// full tail: the reconcile poll already scans it, and the hot path must too
+/// — only the full tail reveals whether a late concurrent sibling interleaved
+/// below an already-served position. (This is one tail read per push batch on
+/// top of the 300 ms reconcile, both over the same already-materialized rows;
+/// the store serves them from the indexed cache, so the per-batch cost is one
+/// ordered scan, not a decode per row — non-committed rows are rejected on
+/// their signed type alone.)
+///
+/// Only COMMITTED kinds hold a rank (`is_committed`), so a non-committed row
+/// consumes no position. `seen` dedupes exactly-once; `next_push_rank` is the
+/// per-room high-water mark — the rank the next in-order append takes.
+///
+/// An event whose canonical rank is at or below the high-water mark has
+/// reordered history the stream already served: it is emitted with
+/// `reordered_at = Some(rank)`, the mark is reset to that rank, and every
+/// later new event is likewise marked (the whole suffix shifted), so the
+/// engine emits ONE corrective gap from the first shifted position.
+fn collect_committed(
+    tail: &[StoredEvent],
+    snapshot: &MembershipSnapshot,
+    seen: &mut BTreeSet<EventId>,
+    next_push_rank: &mut u64,
+) -> Vec<CommittedEvent> {
+    let mut out = Vec::new();
+    let mut rank = 0u64;
+    for se in tail {
+        if !crate::projection::is_committed(se) {
+            continue; // not a committed event: holds no position
+        }
+        let this_rank = rank;
+        rank += 1;
+        if !seen.insert(se.event_id) {
+            continue; // already pushed by an earlier batch or reconcile
+        }
+        let event = crate::projection::materialize(se, 0, snapshot)
+            .expect("is_committed implies materializable");
+        if this_rank >= *next_push_rank {
+            // In-order append at or past the high-water mark.
+            *next_push_rank = this_rank + 1;
+            out.push(CommittedEvent {
+                event: jeliya_api::Event {
+                    pos: this_rank,
+                    ..event
+                },
+                reordered_at: None,
+            });
+        } else {
+            // Reorder: this new event interleaved below the frontier. Serve it
+            // at its true rank, mark it so the engine emits a corrective gap
+            // from the first shifted position, and rewind the mark so the
+            // whole shifted suffix is re-served (and re-marked) after resync.
+            *next_push_rank = this_rank;
+            out.push(CommittedEvent {
+                event: jeliya_api::Event {
+                    pos: this_rank,
+                    ..event
+                },
+                reordered_at: Some(this_rank),
+            });
+        }
+    }
+    out
 }
 
 impl RoomSupervisor {
@@ -921,12 +1008,14 @@ impl RoomSupervisor {
 
     /// Build a shared session around a freshly spawned node, seeding the push
     /// dedupe set with `seen` (the caller passes the full current history at
-    /// open time).
+    /// open time) and the push high-water mark with the number of COMMITTED
+    /// events already in that history (the next rank a fresh push serves).
     fn make_session(
         node: Node,
         accept_joins: Arc<AtomicBool>,
         is_owner: bool,
         seen: BTreeSet<EventId>,
+        committed_so_far: u64,
     ) -> Arc<RoomSession> {
         let conn_rx = node.conn_events();
         let room_rx = node.room_events();
@@ -936,6 +1025,7 @@ impl RoomSupervisor {
             room_rx: Arc::new(TokioMutex::new(room_rx)),
             forwarders: StdMutex::new(HashMap::new()),
             seen: StdMutex::new(seen),
+            next_push_rank: StdMutex::new(committed_so_far),
             accept_joins,
             is_owner,
         })
@@ -1154,7 +1244,13 @@ impl RoomSupervisor {
                 .await
                 .map_err(|e| internal("could not read the timeline", e))?;
             let seen: BTreeSet<EventId> = rows.iter().map(|se| se.event_id).collect();
-            let session = Self::make_session(node, accept_joins, is_owner, seen);
+            // The push high-water mark starts past the COMMITTED history the
+            // open-time read already covered (non-committed rows hold no rank).
+            let committed_so_far = rows
+                .iter()
+                .filter(|se| crate::projection::is_committed(se))
+                .count() as u64;
+            let session = Self::make_session(node, accept_joins, is_owner, seen, committed_so_far);
             self.sessions().insert(room_id, session);
         }
 
@@ -2778,11 +2874,18 @@ impl RoomSupervisor {
     }
 
     /// The typed-v2 reconcile poll: identical to [`Self::poll_new_events`] but
-    /// materializes committed events as typed `jeliya-api` [`Event`]s.
+    /// materializes committed events as typed [`CommittedEvent`]s.
+    ///
+    /// Scans the full canonical tail (the reconcile safety net), so it is the
+    /// path that observes a late-arriving concurrent sibling interleaving
+    /// below an already-pushed position. `collect_committed` marks that
+    /// reorder; the engine turns it into an explicit `gap` so subscribers
+    /// discard and resync the shifted suffix rather than trust a silently
+    /// renumbered one.
     pub(crate) async fn poll_new_events_typed(
         &self,
         room_id: &RoomId,
-    ) -> CoreResult<Vec<jeliya_api::Event>> {
+    ) -> CoreResult<Vec<CommittedEvent>> {
         let session = self.session(room_id)?;
         let rows = session
             .node
@@ -2798,19 +2901,14 @@ impl RoomSupervisor {
             session.is_owner && any_pending_invite(&snapshot),
             Ordering::Relaxed,
         );
-        // Rank the full canonical tail densely so each new event's served
-        // position agrees with the timeline/resync position space exactly
-        // (the raw lamport is not unique across concurrent siblings).
         let mut seen = session.seen.lock().expect("seen poisoned");
-        let mut out = Vec::new();
-        for (rank, se) in crate::projection::positioned(&rows) {
-            if seen.insert(se.event_id) {
-                if let Some(v) = crate::projection::materialize(se, rank, &snapshot) {
-                    out.push(v);
-                }
-            }
-        }
-        Ok(out)
+        let mut next_rank = session.next_push_rank.lock().expect("next rank poisoned");
+        Ok(collect_committed(
+            &rows,
+            &snapshot,
+            &mut seen,
+            &mut next_rank,
+        ))
     }
 
     /// Primary push path (issue #83): await the next batch of live room events
@@ -2905,36 +3003,28 @@ impl RoomSupervisor {
 
     /// The typed-v2 primary push path: identical to [`Self::recv_room_events`]
     /// (same broadcast, same lag recovery, same `seen` dedup) but materializes
-    /// committed events as typed `jeliya-api` [`Event`]s.
+    /// committed events as typed [`CommittedEvent`]s, ranked densely with
+    /// reorder detection (see [`collect_committed`]).
     pub(crate) async fn recv_room_events_typed(
         &self,
         room_id: &RoomId,
-    ) -> CoreResult<Vec<jeliya_api::Event>> {
+    ) -> CoreResult<Vec<CommittedEvent>> {
         let room_rx = self.session(room_id)?.room_rx.clone();
 
-        let mut lagged;
-        let mut batch: Vec<StoredEvent> = Vec::new();
+        // Park on the broadcast until at least one event commits (or the room
+        // closes). The batch itself is only the wake-up signal — the
+        // authoritative set is the full tail below — so a lossy `Lagged`
+        // receiver needs no special branch here: the tail read recovers
+        // anything the broadcast dropped, exactly as the reconcile poll does.
         {
             let mut rx = room_rx.lock().await;
             match rx.recv().await {
-                Ok(ev) => {
-                    lagged = false;
-                    batch.push(ev);
-                }
-                Err(broadcast::error::RecvError::Lagged(_)) => lagged = true,
+                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
                 Err(broadcast::error::RecvError::Closed) => {
                     return Err(CoreError::new(
                         ErrorKind::RoomNotOpen,
                         format!("room {room_id} closed"),
                     ));
-                }
-            }
-            loop {
-                match rx.try_recv() {
-                    Ok(ev) => batch.push(ev),
-                    Err(broadcast::error::TryRecvError::Lagged(_)) => lagged = true,
-                    Err(broadcast::error::TryRecvError::Empty)
-                    | Err(broadcast::error::TryRecvError::Closed) => break,
                 }
             }
         }
@@ -2945,31 +3035,26 @@ impl RoomSupervisor {
             .snapshot()
             .await
             .map_err(|e| internal("could not read the membership snapshot", e))?;
-        // Positions are the dense rank over the canonical `(lamport,
-        // event_id)` order. The live batch is receive-ordered, not canonical,
-        // and a lag already falls back to the full tail — so rank the full
-        // tail either way and serve only events this path has not yet pushed.
-        // `seen` dedupe keeps this exactly-once across the batch, the lag
-        // fallback, and the reconcile poll.
-        let rows = if lagged {
-            batch
-        } else {
-            session
-                .node
-                .room_tail(u32::MAX)
-                .await
-                .map_err(|e| internal("could not read the timeline", e))?
-        };
+        // Rank the room's COMMITTED events densely over the full canonical
+        // tail. Only the full tail reveals whether a late concurrent sibling
+        // interleaved below an already-served position, and it is the
+        // authoritative recovery for a lagged broadcast — so it is ranked on
+        // every wake-up, hot path and lag alike. `collect_committed` ranks
+        // new events against the high-water mark and marks any reorder so the
+        // stream emits a corrective gap.
+        let rows = session
+            .node
+            .room_tail(u32::MAX)
+            .await
+            .map_err(|e| internal("could not read the timeline", e))?;
         let mut seen = session.seen.lock().expect("seen poisoned");
-        let mut out = Vec::new();
-        for (rank, se) in crate::projection::positioned(&rows) {
-            if seen.insert(se.event_id) {
-                if let Some(v) = crate::projection::materialize(se, rank, &snapshot) {
-                    out.push(v);
-                }
-            }
-        }
-        Ok(out)
+        let mut next_rank = session.next_push_rank.lock().expect("next rank poisoned");
+        Ok(collect_committed(
+            &rows,
+            &snapshot,
+            &mut seen,
+            &mut next_rank,
+        ))
     }
 
     /// Drain the session's `conn_events` broadcast; `true` if any peer
@@ -3660,13 +3745,17 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        parse_expiry, parse_file_id, parse_pipe_id, sanitize_name, validate_room_name, Content,
-        EventType, RoomSupervisor,
+        collect_committed, parse_expiry, parse_file_id, parse_pipe_id, sanitize_name,
+        validate_room_name, Content, EventType, RoomSupervisor,
     };
     use crate::error::ErrorKind;
-    use iroh_rooms::events::{validate_wire_bytes, ValidationContext, WireEvent};
+    use iroh_rooms::events::{
+        build_message_text, validate_wire_bytes, ValidationContext, WireEvent,
+    };
+    use iroh_rooms::experimental::store::EventStore;
     use iroh_rooms::identity::{DeviceBinding, SigningKey};
-    use iroh_rooms::room::{RoomId, RoomInviteTicket};
+    use iroh_rooms::room::{build_room_created, derive_room_id, RoomId, RoomInviteTicket};
+    use std::collections::BTreeSet;
     use tempfile::tempdir;
 
     /// Persist an event authored elsewhere directly into the supervisor's
@@ -3677,6 +3766,186 @@ mod tests {
                 .expect("authored event validates");
         let mut store = sup.open_store().unwrap();
         store.insert(&validated).unwrap();
+    }
+
+    /// A self-contained room: identity/device keys, the room id, and the
+    /// validated genesis — enough to author further events against it.
+    struct RoomFixture {
+        identity: SigningKey,
+        device: SigningKey,
+        room_id: RoomId,
+        genesis_id: iroh_rooms::events::EventId,
+        store: EventStore,
+        snapshot: iroh_rooms::room::MembershipSnapshot,
+    }
+
+    fn room_fixture() -> RoomFixture {
+        const TS: u64 = 1_783_190_000_000;
+        let identity = SigningKey::generate();
+        let device = SigningKey::generate();
+        let nonce = [0x42u8; 16];
+        let room_id = derive_room_id(&identity.identity_key(), &nonce, TS);
+        let genesis = build_room_created(&identity, &device, "rank room", &nonce, TS);
+        let ctx = ValidationContext::for_room(room_id);
+        let genesis = validate_wire_bytes(&genesis.to_bytes(), &ctx).unwrap();
+        let genesis_id = genesis.event_id;
+        let mut store = EventStore::open_in_memory().unwrap();
+        store.insert(&genesis).unwrap();
+        let snapshot =
+            iroh_rooms::room::RoomMembership::from_events(room_id, vec![genesis]).snapshot();
+        RoomFixture {
+            identity,
+            device,
+            room_id,
+            genesis_id,
+            store,
+            snapshot,
+        }
+    }
+
+    impl RoomFixture {
+        fn message(&self, body: &str, device: &SigningKey, at: u64) -> WireEvent {
+            build_message_text(
+                &self.identity,
+                device,
+                &self.room_id,
+                body,
+                None,
+                None,
+                &[],
+                &[self.genesis_id],
+                at,
+            )
+        }
+
+        fn own_message(&self, body: &str, at: u64) -> WireEvent {
+            build_message_text(
+                &self.identity,
+                &self.device,
+                &self.room_id,
+                body,
+                None,
+                None,
+                &[],
+                &[self.genesis_id],
+                at,
+            )
+        }
+
+        fn insert(&mut self, wire: &WireEvent) {
+            let ctx = ValidationContext::for_room(self.room_id);
+            let validated = validate_wire_bytes(&wire.to_bytes(), &ctx).unwrap();
+            self.store.insert(&validated).unwrap();
+        }
+
+        fn tail(&self) -> Vec<iroh_rooms::experimental::store::StoredEvent> {
+            self.store.room_tail(&self.room_id, u32::MAX).unwrap()
+        }
+    }
+
+    #[test]
+    fn collect_committed_serves_dense_in_order_positions() {
+        let mut fx = room_fixture();
+        let d2 = SigningKey::generate();
+        let m1 = fx.own_message("m1", 1_783_190_001_000);
+        fx.insert(&m1);
+        fx.insert(&fx.message("m2", &d2, 1_783_190_002_000));
+        let tail = fx.tail();
+        let mut seen = BTreeSet::new();
+        let mut next = 0;
+        let out = collect_committed(&tail, &fx.snapshot, &mut seen, &mut next);
+        let positions: Vec<u64> = out.iter().map(|c| c.event.pos).collect();
+        assert_eq!(positions, [0, 1, 2], "dense ranks over the committed tail");
+        assert!(
+            out.iter().all(|c| c.reordered_at.is_none()),
+            "all in-order appends"
+        );
+        assert_eq!(next, 3, "the high-water mark advanced past all three");
+    }
+
+    /// Validate one authored message and return its canonical `EventId`.
+    fn validated_id(room_id: &RoomId, wire: &WireEvent) -> iroh_rooms::events::EventId {
+        validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(*room_id))
+            .expect("authored event validates")
+            .event_id
+    }
+
+    #[test]
+    fn collect_committed_marks_a_late_sibling_as_a_reorder() {
+        let mut fx = room_fixture();
+        // Serve genesis + m1 first (positions 0 and 1).
+        let m1 = fx.own_message("m1", 1_783_190_001_000);
+        let m1_id = validated_id(&fx.room_id, &m1);
+        fx.insert(&m1);
+        let tail = fx.tail();
+        let mut seen = BTreeSet::new();
+        let mut next = 0;
+        let first = collect_committed(&tail, &fx.snapshot, &mut seen, &mut next);
+        assert_eq!(first.len(), 2);
+        assert_eq!(next, 2);
+
+        // Author late siblings (same parent as m1, so the same lamport) until
+        // one sorts BEFORE m1 in the canonical (lamport, event_id) order. That
+        // is the reorder case: it interleaves below the already-served tip.
+        let mut before = None;
+        for attempt in 0..64u64 {
+            let cand = fx.message("late", &SigningKey::generate(), 1_783_190_001_500 + attempt);
+            if validated_id(&fx.room_id, &cand) < m1_id {
+                before = Some(cand);
+                break;
+            }
+        }
+        let late = before.expect("some device yields a before-sorting sibling");
+        fx.insert(&late);
+        let tail2 = fx.tail();
+        let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);
+        assert_eq!(out2.len(), 1, "exactly one new event");
+        assert_eq!(
+            out2[0].reordered_at,
+            Some(out2[0].event.pos),
+            "a sibling interleaving below the served tip is a reorder"
+        );
+        assert_eq!(
+            out2[0].event.pos, 1,
+            "it took m1's old rank, shifting m1 up"
+        );
+        assert_eq!(next, 1, "the mark rewound so the shifted suffix re-serves");
+    }
+
+    #[test]
+    fn collect_committed_appends_a_tip_sibling_without_reorder() {
+        let mut fx = room_fixture();
+        let m1 = fx.own_message("m1", 1_783_190_001_000);
+        let m1_id = validated_id(&fx.room_id, &m1);
+        fx.insert(&m1);
+        let tail = fx.tail();
+        let mut seen = BTreeSet::new();
+        let mut next = 0;
+        collect_committed(&tail, &fx.snapshot, &mut seen, &mut next);
+        assert_eq!(next, 2);
+
+        // A sibling that sorts AFTER m1 is an ordinary in-order append at the
+        // tip — no reorder, no gap.
+        let mut after = None;
+        for attempt in 0..64u64 {
+            let cand = fx.message(
+                "after",
+                &SigningKey::generate(),
+                1_783_190_001_500 + attempt,
+            );
+            if validated_id(&fx.room_id, &cand) > m1_id {
+                after = Some(cand);
+                break;
+            }
+        }
+        let tip = after.expect("some device yields an after-sorting sibling");
+        fx.insert(&tip);
+        let tail2 = fx.tail();
+        let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);
+        assert_eq!(out2.len(), 1);
+        assert_eq!(out2[0].reordered_at, None, "a tip append is not a reorder");
+        assert_eq!(out2[0].event.pos, 2);
+        assert_eq!(next, 3);
     }
 
     /// Join `agent` keys into the room offline: mint a real invite through

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2798,11 +2798,14 @@ impl RoomSupervisor {
             session.is_owner && any_pending_invite(&snapshot),
             Ordering::Relaxed,
         );
+        // Rank the full canonical tail densely so each new event's served
+        // position agrees with the timeline/resync position space exactly
+        // (the raw lamport is not unique across concurrent siblings).
         let mut seen = session.seen.lock().expect("seen poisoned");
         let mut out = Vec::new();
-        for se in &rows {
+        for (rank, se) in crate::projection::positioned(&rows) {
             if seen.insert(se.event_id) {
-                if let Some(v) = crate::projection::materialize(se, &snapshot) {
+                if let Some(v) = crate::projection::materialize(se, rank, &snapshot) {
                     out.push(v);
                 }
             }
@@ -2942,20 +2945,26 @@ impl RoomSupervisor {
             .snapshot()
             .await
             .map_err(|e| internal("could not read the membership snapshot", e))?;
-        if lagged {
-            let rows = session
+        // Positions are the dense rank over the canonical `(lamport,
+        // event_id)` order. The live batch is receive-ordered, not canonical,
+        // and a lag already falls back to the full tail — so rank the full
+        // tail either way and serve only events this path has not yet pushed.
+        // `seen` dedupe keeps this exactly-once across the batch, the lag
+        // fallback, and the reconcile poll.
+        let rows = if lagged {
+            batch
+        } else {
+            session
                 .node
                 .room_tail(u32::MAX)
                 .await
-                .map_err(|e| internal("could not read the timeline", e))?;
-            batch = rows;
-        }
-
+                .map_err(|e| internal("could not read the timeline", e))?
+        };
         let mut seen = session.seen.lock().expect("seen poisoned");
         let mut out = Vec::new();
-        for se in &batch {
+        for (rank, se) in crate::projection::positioned(&rows) {
             if seen.insert(se.event_id) {
-                if let Some(v) = crate::projection::materialize(se, &snapshot) {
+                if let Some(v) = crate::projection::materialize(se, rank, &snapshot) {
                     out.push(v);
                 }
             }

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -20,11 +20,14 @@
 //!
 //! The v2 record fixes one continuation mechanism: every paging operation
 //! takes a required [`Page`] (`cursor`, `direction`, `limit`) and answers a
-//! [`Truncated`]. Positions are the store's per-room Lamport clock (`pos`),
-//! anchored at `0` for the genesis. The Iroh store's `room_tail` returns the
-//! most-recent `limit` events in ascending `(lamport, event_id)` order, which
-//! is exactly the v2 position space; cursor/direction paging is applied over
-//! that space here.
+//! [`Truncated`]. Positions are the **dense rank** over the room's canonical
+//! `(lamport, event_id)` order — `0` for the genesis, exactly one past the
+//! predecessor for every later committed event. The store's raw Lamport
+//! value is not a position (concurrent siblings share one), so ranking
+//! happens here at the read boundary and in the supervisor's typed push
+//! paths, keeping the timeline, the push stream, and `stream.resync` in one
+//! consistent position space. Cursor/direction paging is applied over that
+//! space here.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -456,7 +459,7 @@ impl<'a> TypedSupervisor<'a> {
     pub async fn room_leave(&self, req: &RoomLeave) -> CoreResult<RoomLeaveOut> {
         let room_id = Self::parse_room(&req.room_id)?;
         let event_id_hex = self.sup.leave_room(req.room_id.as_ref()).await?;
-        let pos = self.latest_pos(&room_id)?;
+        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
         Ok(RoomLeaveOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
@@ -718,7 +721,7 @@ impl<'a> TypedSupervisor<'a> {
             .sup
             .send_message(req.room_id.as_ref(), &req.body)
             .await?;
-        let pos = self.latest_pos(&room_id)?;
+        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
         Ok(MessageSendOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
@@ -739,7 +742,7 @@ impl<'a> TypedSupervisor<'a> {
             .sup
             .post_status(req.room_id.as_ref(), label, None, progress_pct, &[])
             .await?;
-        let pos = self.latest_pos(&room_id)?;
+        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
         Ok(StatusPostOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
@@ -1105,7 +1108,9 @@ impl<'a> TypedSupervisor<'a> {
             .pipe_expose_multi(&room_id, target_addr, &target_hint, &allowed)
             .await
             .map_err(core_to_api)?;
-        let pos = self.latest_pos(&room_id).map_err(core_to_api)?;
+        let pos = self
+            .pos_of_event(&room_id, &event_id)
+            .map_err(core_to_api)?;
         Ok(PipePublishOut {
             room_id: req.room_id.clone(),
             pipe_id: crate::projection::pipe_id(&pipe_id),
@@ -1217,7 +1222,7 @@ impl<'a> TypedSupervisor<'a> {
             .and_then(|p| p.as_str())
             .unwrap_or_default()
             .to_string();
-        let pos = self.latest_pos(&room_id)?;
+        let pos = self.pos_of_event(&room_id, &event_id)?;
         Ok(PipeRevokeOut {
             room_id: req.room_id.clone(),
             pipe_id: req.pipe_id.clone(),
@@ -1231,7 +1236,8 @@ impl<'a> TypedSupervisor<'a> {
     // Shared helpers
     // ------------------------------------------------------------------
 
-    /// All committed timeline events for a room, ascending by position.
+    /// All committed timeline events for a room, ascending by position —
+    /// the dense rank over the canonical `(lamport, event_id)` order.
     fn committed_events(
         &self,
         room_id: &IrohRoomId,
@@ -1241,22 +1247,33 @@ impl<'a> TypedSupervisor<'a> {
         let rows = store
             .room_tail(room_id, u32::MAX)
             .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
-        Ok(rows
-            .iter()
-            .filter_map(|se| proj::materialize(se, snapshot))
+        Ok(proj::positioned(&rows)
+            .filter_map(|(rank, se)| proj::materialize(se, rank, snapshot))
             .collect())
     }
 
-    /// The newest committed position in a room (0 when empty).
-    fn latest_pos(&self, room_id: &IrohRoomId) -> CoreResult<u64> {
+    /// The dense canonical position of one committed event, looked up by its
+    /// event id over the full tail. Mutation replies use this so the `pos`
+    /// they serve is the same rank the timeline, resync, and push stream
+    /// serve for that event — never the raw lamport, and never the head's
+    /// position (which a later concurrent event can share).
+    fn pos_of_event(&self, room_id: &IrohRoomId, event_id_hex: &str) -> CoreResult<u64> {
         let store = self.sup.open_store()?;
         let rows = store
-            .room_tail(room_id, 1)
+            .room_tail(room_id, u32::MAX)
             .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
-        Ok(rows.first().and_then(|se| se.lamport).unwrap_or(0))
+        let found = proj::positioned(&rows)
+            .find(|(_, se)| proj::event_id(&se.event_id).as_str() == event_id_hex)
+            .map(|(rank, _)| rank);
+        found.ok_or_else(|| {
+            CoreError::internal(format!(
+                "committed event {event_id_hex} is absent from the room tail"
+            ))
+        })
     }
 
-    /// The newest committed event authored by a subject, with its position.
+    /// The newest committed event authored by a subject, with its dense
+    /// canonical position.
     fn latest_by_subject(
         &self,
         room_id: &IrohRoomId,
@@ -1264,17 +1281,16 @@ impl<'a> TypedSupervisor<'a> {
     ) -> Option<(EventId, u64)> {
         let store = self.sup.open_store().ok()?;
         let rows = store.room_tail(room_id, u32::MAX).ok()?;
-        rows.iter()
-            .filter(|se| se.lamport.is_some())
-            .filter_map(|se| {
+        proj::positioned(&rows)
+            .filter_map(|(rank, se)| {
                 let ev = SignedEvent::decode(&se.wire.signed).ok()?;
                 if &ev.sender_id == subject {
-                    Some((proj::event_id(&se.event_id), se.lamport.unwrap()))
+                    Some((proj::event_id(&se.event_id), rank))
                 } else {
                     None
                 }
             })
-            .next_back()
+            .last()
     }
 
     /// The author-dated instant a subject joined, when discoverable.

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1247,24 +1247,36 @@ impl<'a> TypedSupervisor<'a> {
         let rows = store
             .room_tail(room_id, u32::MAX)
             .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
-        Ok(proj::positioned(&rows)
-            .filter_map(|(rank, se)| proj::materialize(se, rank, snapshot))
+        let refs: Vec<&iroh_rooms::experimental::store::StoredEvent> = rows.iter().collect();
+        Ok(proj::positioned(&refs, snapshot)
+            .into_iter()
+            .map(|(_, e)| e)
             .collect())
     }
 
     /// The dense canonical position of one committed event, looked up by its
-    /// event id over the full tail. Mutation replies use this so the `pos`
-    /// they serve is the same rank the timeline, resync, and push stream
-    /// serve for that event — never the raw lamport, and never the head's
-    /// position (which a later concurrent event can share).
+    /// event id. Mutation replies use this so the `pos` they serve is the same
+    /// rank the timeline, resync, and push stream serve for that event —
+    /// never the raw lamport, and never the head's position (which a later
+    /// concurrent event can share). Ranking counts only committed kinds (see
+    /// [`proj::positioned`]), so a non-committed row consumes no position.
     fn pos_of_event(&self, room_id: &IrohRoomId, event_id_hex: &str) -> CoreResult<u64> {
         let store = self.sup.open_store()?;
         let rows = store
             .room_tail(room_id, u32::MAX)
             .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
-        let found = proj::positioned(&rows)
-            .find(|(_, se)| proj::event_id(&se.event_id).as_str() == event_id_hex)
-            .map(|(rank, _)| rank);
+        let mut rank = 0u64;
+        let mut found = None;
+        for se in &rows {
+            if !proj::is_committed(se) {
+                continue;
+            }
+            if proj::event_id(&se.event_id).as_str() == event_id_hex {
+                found = Some(rank);
+                break;
+            }
+            rank += 1;
+        }
         found.ok_or_else(|| {
             CoreError::internal(format!(
                 "committed event {event_id_hex} is absent from the room tail"
@@ -1273,7 +1285,7 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// The newest committed event authored by a subject, with its dense
-    /// canonical position.
+    /// canonical position. Ranking counts only committed kinds.
     fn latest_by_subject(
         &self,
         room_id: &IrohRoomId,
@@ -1281,16 +1293,19 @@ impl<'a> TypedSupervisor<'a> {
     ) -> Option<(EventId, u64)> {
         let store = self.sup.open_store().ok()?;
         let rows = store.room_tail(room_id, u32::MAX).ok()?;
-        proj::positioned(&rows)
-            .filter_map(|(rank, se)| {
-                let ev = SignedEvent::decode(&se.wire.signed).ok()?;
-                if &ev.sender_id == subject {
-                    Some((proj::event_id(&se.event_id), rank))
-                } else {
-                    None
-                }
-            })
-            .last()
+        let mut rank = 0u64;
+        let mut latest = None;
+        for se in &rows {
+            if !proj::is_committed(se) {
+                continue;
+            }
+            let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+            if &ev.sender_id == subject {
+                latest = Some((proj::event_id(&se.event_id), rank));
+            }
+            rank += 1;
+        }
+        latest
     }
 
     /// The author-dated instant a subject joined, when discoverable.

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -1198,6 +1198,27 @@ async fn handle_stream_resync(
         Some(r) => r.clone(),
         None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
+    // A client naming a position AHEAD of the room's head holds state the
+    // daemon does not: that is the discard-and-re-read case, never an empty
+    // success (which would leave the client permanently convinced it is
+    // ahead). The head is the last committed position; `from_pos > head` is
+    // `resync_required` naming the real head. `from_pos == head` is caught
+    // up and answers an empty set below.
+    let head = match room_head_pos(state, &req.room_id).await {
+        Ok(next) => next.saturating_sub(1),
+        Err(err) => return send_api_err(out_tx, id, err).await,
+    };
+    if req.from_pos > head {
+        return send_api_err(
+            out_tx,
+            id,
+            jeliya_api::ApiError::ResyncRequired {
+                room_id: req.room_id.clone(),
+                from_pos: head,
+            },
+        )
+        .await;
+    }
     // Read the committed events after from_pos via the engine's typed
     // timeline, starting the page AT from_pos (positions are exclusive on the
     // low side, so `at {pos: from_pos + 1}` reads strictly after it) rather

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -1521,6 +1521,13 @@ activity, exactly as `transfer.cancel` would be without its principal guard.
 and no cursor — only wall-clock timestamps — so a client could not tell that it
 had missed anything.
 
+A position is the **dense rank over the room's canonical `(lamport, event_id)`
+order**: the genesis is `0` and every later committed event is exactly one past
+its predecessor. The store's raw Lamport value is not a position — concurrent
+siblings share one lamport, so only the dense rank is unique, strictly
+increasing, and gap-free. The timeline, the push stream, every mutation reply's
+`pos`, and `stream.resync` all serve this one rank.
+
 - Within one room, positions are strictly increasing with no gaps in a healthy
   stream.
 - Across rooms, no ordering is defined. A client MUST NOT infer one.


### PR DESCRIPTION
## What

A committed event's `pos` was the store's derived Lamport value (`projection.rs`). That value is **not unique across concurrent siblings** — events with the same parents share a lamport — so it could not satisfy the record's per-room guarantee (protocol-v2.md: *"Within one room, positions are strictly increasing with no gaps in a healthy stream"*).

This PR serves the **dense rank over the room's canonical `(lamport, event_id)` order** — genesis at `0`, each successor exactly one past its predecessor — and serves that **one rank consistently** across every position surface.

## How

- **`projection.rs`** — new `positioned()` ranks the canonical tail densely; `materialize()` takes the rank explicitly (was the raw lamport). Documents the derivation and the one limitation the model shares: the canonical order is not stable across convergence, so a late-arriving sibling shifts ranks and surfaces as a detectable discontinuity the one resync path repairs.
- **`supervisor.rs`** — both typed push paths (`recv_room_events_typed`, `poll_new_events_typed`) rank the full canonical tail so a `Push::Event` carries exactly the timeline's position. The live batch is receive-ordered, not canonical, so the tail is ranked either way; `seen` dedupe keeps delivery exactly-once.
- **`typed.rs`** — `committed_events` ranks the tail; `pos_of_event()` replaces `latest_pos()` (the head's position, which a later sibling can share) so every mutation reply's `pos` (`room.leave`, `message.send`, `status.post`, `pipe.publish`, `pipe.revoke`) is the authored event's own rank.
- **`serve.rs`** — `stream.resync` with `from_pos` ahead of the room's head returns `resync_required` naming the real head, instead of an empty success that would leave a client permanently convinced it is ahead.
- **`protocol-v2.md`** — made the dense-rank derivation normative.

## Implementation vs. record

Where they disagreed, **the record was right and the implementation had the bug**: the record required the *properties* (dense, strictly increasing, gap-free) and the raw-lamport `pos` violated them for concurrent siblings. The record never stated the *derivation*, so this PR documents it normatively to keep an adapter author from repeating the mistake.

## Verification

- `cargo clippy --locked --workspace --all-targets -- -D warnings` ✓
- `cargo test --locked --workspace` ✓ (incl. new concurrent-sibling density test and reply/push/timeline position-agreement assertions)
- `cargo +1.96.0 fmt --all --check` ✓
- Conformance replay: fixes **timeline-streams case 22** (`stream_resync_from_a_position_the_room_never_reached_is_resync_required`). `subject-daemon` 17/24, `handshake` 12/69, `rooms`/`invites`/`files`/`pipes` — all **identical to baseline** (stash-compared); no regressions.

Remaining timeline-streams failures are out of scope here and confirmed not to be position defects: fixture drift (missing required `from`, non-spec `subscription_id`/`head_pos`, split-marker steps) and unimplemented `inject_fault` — tracked as separate tasks.

Clean-slate: no v1 path, no compatibility facade, no migration.