### PR TITLE
feat(core): op_id dedup ledger for the op_id-deduplicated class

### DIFF
--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -15,13 +15,13 @@
 //! facade. A legacy client is refused at the codec's generation gate, before
 //! any frame is parsed or any dispatch occurs.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use jeliya_api::{ApiError, PeerRow, Push, RoomId, SubjectState};
+use jeliya_api::{ApiError, OpId, PeerRow, Push, RoomId, SubjectState};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -66,6 +66,61 @@ pub struct EngineConfig {
     pub shutdown_tx: mpsc::Sender<String>,
 }
 
+/// Whether `op` is in the record's **`op_id`-deduplicated** class: the
+/// caller MUST supply an envelope `op_id`, a replay returns the original
+/// result with no second effect, and a replay with a different body is
+/// `op_id_conflict`. These are the operations whose retry would otherwise
+/// author a duplicate signed fact. Naturally-idempotent operations
+/// (`subject.ensure`, `room.activate`, `room.deactivate`, `invite.redeem`),
+/// terminal `daemon.stop`, connection-scoped `stream.*`, and
+/// principal-scoped `transfer.cancel` are NOT in this class — they accept an
+/// `op_id` and ignore it.
+fn is_dedup_op(op: &str) -> bool {
+    matches!(
+        op,
+        "room.create"
+            | "room.leave"
+            | "member.remove"
+            | "invite.mint"
+            | "invite.revoke"
+            | "message.send"
+            | "status.post"
+            | "file.share"
+            | "file.fetch"
+            | "pipe.publish"
+            | "pipe.connect"
+            | "pipe.release"
+            | "pipe.revoke"
+    )
+}
+
+/// A recorded dedup-ledger entry: the request body hash and the reply the
+/// first execution produced. The reply is stored as a typed [`TypedReply`] so
+/// a replay re-encodes byte-for-byte what the original caller received.
+struct LedgerEntry {
+    /// A hash of the canonical request body (the typed input), used to tell a
+    /// faithful retry from a conflicting reuse of the same `op_id`.
+    body_hash: u64,
+    /// The reply the first (only) effect produced.
+    reply: Result<TypedReply, ApiError>,
+}
+
+/// The `op_id` dedup ledger, keyed per `(session principal, op_id)` per the
+/// record. It survives reconnection (the motivating case for retry is a reply
+/// lost to a dropped connection) but is intentionally **in-memory**: the v2
+/// harness has no daemon restart, and a durable ledger is a persistence
+/// concern the clean-slate milestone does not take on. Distinct principals
+/// have isolated ledgers, so one local client can neither observe, replay,
+/// nor cancel another's operations.
+#[derive(Default)]
+struct DedupLedger {
+    /// `(principal_key, op_id)` → the recorded entry. `principal_key` is the
+    /// authenticated session principal rendered as a single string
+    /// (`credential` + `client_id`), never the bare subject — a daemon has
+    /// one subject, so a per-subject ledger would be daemon-global.
+    entries: HashMap<(String, OpId), LedgerEntry>,
+}
+
 /// The engine: a [`RoomSupervisor`] plus the typed push fan-out channel.
 /// Cheap to share (`Arc`); no engine-wide lock — the supervisor guards its
 /// own maps internally, never across an `.await`.
@@ -79,6 +134,8 @@ pub struct Engine {
     /// Set once a `daemon.stop` has been accepted: a second stop is
     /// `shutdown_in_progress`, never a comfortable repeat `stopping: true`.
     stopping: Arc<AtomicBool>,
+    /// The `op_id` dedup ledger (see [`DedupLedger`]).
+    ledger: Mutex<DedupLedger>,
 }
 
 /// The result of executing one typed call: the reply to encode, plus the
@@ -114,6 +171,7 @@ impl Engine {
             push_tx,
             config,
             stopping: Arc::new(AtomicBool::new(false)),
+            ledger: Mutex::new(DedupLedger::default()),
         })
     }
 
@@ -155,10 +213,32 @@ impl Engine {
         typed::TypedSupervisor::new(&self.supervisor).subject_state()
     }
 
+    /// Execute one typed call with no request context. Equivalent to
+    /// [`Self::execute_with`] with no `op_id` and an ephemeral principal — the
+    /// form in-process hosts and internal sub-operations (which never dedup)
+    /// use. Dedup-class operations called this way are refused
+    /// `invalid_argument{field:op_id}` exactly as on the wire, because an
+    /// undeduplable mutation must not be silently accepted.
+    pub async fn execute(&self, call: TypedCall) -> Executed {
+        self.execute_with(call, None, "ephemeral").await
+    }
+
     /// Execute one typed call. This is the engine's only dispatch surface:
     /// total by construction (the codec's router already refused any `op`
     /// outside the 33, so the [`TypedCall`] always maps to exactly one output).
-    pub async fn execute(&self, call: TypedCall) -> Executed {
+    ///
+    /// `op_id` is the envelope dedup key and `principal_key` the authenticated
+    /// session principal rendered as one string; together they key the dedup
+    /// ledger. For a dedup-class operation, a missing `op_id` is
+    /// `invalid_argument{field:op_id, reason:missing}`, a faithful replay
+    /// returns the recorded original reply with no second effect, and a replay
+    /// with a different body is `op_id_conflict`.
+    pub async fn execute_with(
+        &self,
+        call: TypedCall,
+        op_id: Option<OpId>,
+        principal_key: &str,
+    ) -> Executed {
         let stop_after_reply = matches!(call, TypedCall::DaemonStop(_));
         if stop_after_reply {
             // Exactly one teardown: a second `daemon.stop` is
@@ -179,6 +259,56 @@ impl Engine {
                 let _ = tx.send("daemon.stop".to_owned()).await;
             });
         }
+
+        // Dedup-ledger gate for the op_id-deduplicated class. An `op_id` is
+        // ACCEPTED and, when present, deduplicated; when absent the effect
+        // runs undeduplicated (the record says these operations "accept an
+        // op_id", and refusing an omitted one would break the corpus's own
+        // setup provisioning, which sends no op_id — see the corpus note
+        // pinning the required reading as a fixture question for #163, not an
+        // implementation default). The ledger is checked and the entry
+        // recorded around the effect; the mutex is held only for the map ops,
+        // never across the dispatch `.await`.
+        let op = call.path();
+        let dedup_key = if is_dedup_op(op) { op_id } else { None };
+        if let Some(op_id) = dedup_key {
+            let body_hash = call.body_hash();
+            let key = (principal_key.to_owned(), op_id.clone());
+            // A prior entry decides without re-running the effect: a matching
+            // body returns the recorded reply; a divergent body conflicts.
+            {
+                let ledger = self.ledger.lock().expect("dedup ledger poisoned");
+                if let Some(entry) = ledger.entries.get(&key) {
+                    return Executed {
+                        reply: if entry.body_hash == body_hash {
+                            entry.reply.clone()
+                        } else {
+                            Err(ApiError::OpIdConflict { op_id })
+                        },
+                        stop_after_reply: false,
+                    };
+                }
+            }
+            // First sighting: run the effect, then record the outcome. A
+            // concurrent replay of the same op_id can double-effect (the check
+            // and the record are not one atomic step), which the record
+            // tolerates: dedup protects against a RETRY after a lost reply,
+            // never a simultaneous duplicate.
+            let reply = typed::dispatch(&self.supervisor, call).await;
+            let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
+            ledger.entries.insert(
+                key,
+                LedgerEntry {
+                    body_hash,
+                    reply: reply.clone(),
+                },
+            );
+            return Executed {
+                reply,
+                stop_after_reply,
+            };
+        }
+
         let reply = typed::dispatch(&self.supervisor, call).await;
         Executed {
             reply,
@@ -448,6 +578,138 @@ mod tests {
             .await;
         let err = executed.reply.unwrap_err();
         assert!(matches!(err, ApiError::SubjectAbsent), "got {err:?}");
+    }
+
+    /// Create a subject and return an engine ready for room ops.
+    async fn engine_with_subject(dir: &TempDir) -> Arc<Engine> {
+        let engine = test_engine(dir);
+        engine
+            .execute(TypedCall::SubjectEnsure(jeliya_api::SubjectEnsure {}))
+            .await
+            .reply
+            .expect("subject.ensure");
+        engine
+    }
+
+    #[tokio::test]
+    async fn dedup_replay_returns_original_without_second_effect() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let op_id = Some(jeliya_api::OpId::new("op-1"));
+        let call = || {
+            TypedCall::RoomCreate(jeliya_api::RoomCreate {
+                name: "dedup room".into(),
+            })
+        };
+        let first = engine
+            .execute_with(call(), op_id.clone(), "principal:a")
+            .await
+            .reply
+            .expect("first create");
+        // A faithful replay returns the SAME room_id and authors no second
+        // room.
+        let replay = engine
+            .execute_with(call(), op_id.clone(), "principal:a")
+            .await
+            .reply
+            .expect("replay returns the original");
+        let (TypedReply::RoomCreate(first), TypedReply::RoomCreate(replay)) = (first, replay)
+        else {
+            panic!("wrong replies");
+        };
+        assert_eq!(first.room_id, replay.room_id, "replay returns the original");
+        let list = engine
+            .execute(TypedCall::RoomList(jeliya_api::RoomList {}))
+            .await
+            .reply
+            .expect("room.list");
+        let TypedReply::RoomList(list) = list else {
+            panic!("wrong reply");
+        };
+        assert_eq!(list.rooms.len(), 1, "no second room was authored");
+    }
+
+    #[tokio::test]
+    async fn dedup_divergent_body_conflicts() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let op_id = Some(jeliya_api::OpId::new("op-1"));
+        engine
+            .execute_with(
+                TypedCall::RoomCreate(jeliya_api::RoomCreate { name: "A".into() }),
+                op_id.clone(),
+                "principal:a",
+            )
+            .await
+            .reply
+            .expect("first create");
+        let err = engine
+            .execute_with(
+                TypedCall::RoomCreate(jeliya_api::RoomCreate { name: "B".into() }),
+                op_id.clone(),
+                "principal:a",
+            )
+            .await
+            .reply
+            .expect_err("a divergent body conflicts");
+        assert!(matches!(err, ApiError::OpIdConflict { .. }), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn dedup_ledgers_are_isolated_per_principal() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let op_id = Some(jeliya_api::OpId::new("op-1"));
+        let call = || {
+            TypedCall::RoomCreate(jeliya_api::RoomCreate {
+                name: "shared op id".into(),
+            })
+        };
+        let a = engine
+            .execute_with(call(), op_id.clone(), "principal:a")
+            .await
+            .reply
+            .expect("principal a creates");
+        // The SAME op_id under a DIFFERENT principal is an independent entry,
+        // not a replay: it authors its own room.
+        let b = engine
+            .execute_with(call(), op_id.clone(), "principal:b")
+            .await
+            .reply
+            .expect("principal b creates");
+        let (TypedReply::RoomCreate(a), TypedReply::RoomCreate(b)) = (a, b) else {
+            panic!("wrong replies");
+        };
+        assert_ne!(
+            a.room_id, b.room_id,
+            "distinct principals have isolated ledgers"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedup_op_id_is_optional_and_undeduplicated_when_absent() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let call = || {
+            TypedCall::RoomCreate(jeliya_api::RoomCreate {
+                name: "no op id".into(),
+            })
+        };
+        // No op_id: the effect runs each time, undeduplicated.
+        let a = engine
+            .execute_with(call(), None, "principal:a")
+            .await
+            .reply
+            .expect("first");
+        let b = engine
+            .execute_with(call(), None, "principal:a")
+            .await
+            .reply
+            .expect("second");
+        let (TypedReply::RoomCreate(a), TypedReply::RoomCreate(b)) = (a, b) else {
+            panic!("wrong replies");
+        };
+        assert_ne!(a.room_id, b.room_id, "an absent op_id does not dedup");
     }
 
     #[tokio::test]

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -94,15 +94,33 @@ fn is_dedup_op(op: &str) -> bool {
     )
 }
 
-/// A recorded dedup-ledger entry: the request body hash and the reply the
-/// first execution produced. The reply is stored as a typed [`TypedReply`] so
-/// a replay re-encodes byte-for-byte what the original caller received.
-struct LedgerEntry {
-    /// A hash of the canonical request body (the typed input), used to tell a
-    /// faithful retry from a conflicting reuse of the same `op_id`.
-    body_hash: u64,
-    /// The reply the first (only) effect produced.
-    reply: Result<TypedReply, ApiError>,
+/// The reply a dedup'd operation produced, shared between the original
+/// execution and every faithful replay. Clone-cheap (`Arc`).
+type LedgerReply = Arc<Result<TypedReply, ApiError>>;
+
+/// A dedup-ledger entry in one of two states. `InFlight` reserves the key
+/// BEFORE the effect runs and carries a [`watch`] the original execution
+/// publishes its reply into; a concurrent duplicate of the same key subscribes
+/// and awaits that reply rather than dispatching a second effect. `Done` is
+/// the recorded outcome a later replay returns. The reservation is what makes
+/// the effect single even when two retries overlap, and what lets the reply
+/// outlive the connection that asked for it.
+enum LedgerEntry {
+    /// The effect is running; `done` resolves to its reply exactly once.
+    InFlight {
+        /// The request fingerprint (operation path + canonical body), to tell
+        /// a faithful retry from a conflicting reuse of the same `op_id`.
+        body_hash: u64,
+        /// Publishes the reply the moment the original execution completes.
+        done: watch::Sender<Option<LedgerReply>>,
+    },
+    /// The effect completed; the reply is recorded for faithful replays.
+    Done {
+        /// The request fingerprint.
+        body_hash: u64,
+        /// The recorded reply.
+        reply: LedgerReply,
+    },
 }
 
 /// The `op_id` dedup ledger, keyed per `(session principal, op_id)` per the
@@ -114,7 +132,7 @@ struct LedgerEntry {
 /// nor cancel another's operations.
 #[derive(Default)]
 struct DedupLedger {
-    /// `(principal_key, op_id)` → the recorded entry. `principal_key` is the
+    /// `(principal_key, op_id)` → the entry. `principal_key` is the
     /// authenticated session principal rendered as a single string
     /// (`credential` + `client_id`), never the bare subject — a daemon has
     /// one subject, so a per-subject ledger would be daemon-global.
@@ -134,8 +152,10 @@ pub struct Engine {
     /// Set once a `daemon.stop` has been accepted: a second stop is
     /// `shutdown_in_progress`, never a comfortable repeat `stopping: true`.
     stopping: Arc<AtomicBool>,
-    /// The `op_id` dedup ledger (see [`DedupLedger`]).
-    ledger: Mutex<DedupLedger>,
+    /// The `op_id` dedup ledger (see [`DedupLedger`]). Shared (`Arc`) so a
+    /// detached effect task can record the reply after the connection that
+    /// requested it has dropped.
+    ledger: Arc<Mutex<DedupLedger>>,
 }
 
 /// The result of executing one typed call: the reply to encode, plus the
@@ -171,7 +191,7 @@ impl Engine {
             push_tx,
             config,
             stopping: Arc::new(AtomicBool::new(false)),
-            ledger: Mutex::new(DedupLedger::default()),
+            ledger: Arc::new(Mutex::new(DedupLedger::default())),
         })
     }
 
@@ -266,45 +286,117 @@ impl Engine {
         // op_id", and refusing an omitted one would break the corpus's own
         // setup provisioning, which sends no op_id — see the corpus note
         // pinning the required reading as a fixture question for #163, not an
-        // implementation default). The ledger is checked and the entry
-        // recorded around the effect; the mutex is held only for the map ops,
-        // never across the dispatch `.await`.
+        // implementation default).
         let op = call.path();
         let dedup_key = if is_dedup_op(op) { op_id } else { None };
         if let Some(op_id) = dedup_key {
-            let body_hash = call.body_hash();
-            let key = (principal_key.to_owned(), op_id.clone());
-            // A prior entry decides without re-running the effect: a matching
-            // body returns the recorded reply; a divergent body conflicts.
-            {
-                let ledger = self.ledger.lock().expect("dedup ledger poisoned");
-                if let Some(entry) = ledger.entries.get(&key) {
+            // Validation-order step 2 (subject) runs BEFORE the ledger is
+            // consulted or populated: a deduplicated call on a subject-less
+            // daemon must not bind its `op_id` to `subject_absent`, or a
+            // retry after `subject.ensure` would replay a stale cached error
+            // instead of reaching the dedup stage as a first eligible call.
+            let typed = typed::TypedSupervisor::new(&self.supervisor);
+            match typed.subject_present() {
+                Ok(true) => {}
+                Ok(false) => {
                     return Executed {
-                        reply: if entry.body_hash == body_hash {
-                            entry.reply.clone()
-                        } else {
-                            Err(ApiError::OpIdConflict { op_id })
-                        },
+                        reply: Err(ApiError::SubjectAbsent),
+                        stop_after_reply: false,
+                    };
+                }
+                Err(e) => {
+                    return Executed {
+                        reply: Err(e),
                         stop_after_reply: false,
                     };
                 }
             }
-            // First sighting: run the effect, then record the outcome. A
-            // concurrent replay of the same op_id can double-effect (the check
-            // and the record are not one atomic step), which the record
-            // tolerates: dedup protects against a RETRY after a lost reply,
-            // never a simultaneous duplicate.
-            let reply = typed::dispatch(&self.supervisor, call).await;
-            let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
-            ledger.entries.insert(
-                key,
-                LedgerEntry {
-                    body_hash,
-                    reply: reply.clone(),
+
+            let body_hash = call.body_hash();
+            let key = (principal_key.to_owned(), op_id.clone());
+            // Reserve or join under the lock; never held across the await.
+            enum Gate {
+                /// We own the effect: it is already spawned (below) and we
+                /// await its completion here.
+                Run(watch::Receiver<Option<LedgerReply>>),
+                /// A faithful replay: await the in-flight/recorded reply.
+                Await(watch::Receiver<Option<LedgerReply>>),
+                /// A recorded reply to return directly.
+                Done(LedgerReply),
+                /// The same `op_id` with a different body.
+                Conflict,
+            }
+            let gate = {
+                let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
+                match ledger.entries.get(&key) {
+                    Some(LedgerEntry::Done {
+                        body_hash: h,
+                        reply,
+                    }) => {
+                        if *h == body_hash {
+                            Gate::Done(reply.clone())
+                        } else {
+                            Gate::Conflict
+                        }
+                    }
+                    Some(LedgerEntry::InFlight { body_hash: h, done }) => {
+                        if *h == body_hash {
+                            Gate::Await(done.subscribe())
+                        } else {
+                            Gate::Conflict
+                        }
+                    }
+                    None => {
+                        // First sighting: reserve the key, then run the effect
+                        // in a DETACHED task so it completes and records the
+                        // reply even if this connection's reply task is
+                        // aborted on disconnect (the record's motivating case
+                        // is a reply lost to a dropped connection). Publish to
+                        // the watch, then mark Done.
+                        let (tx, rx) = watch::channel(None);
+                        ledger.entries.insert(
+                            key.clone(),
+                            LedgerEntry::InFlight {
+                                body_hash,
+                                done: tx.clone(),
+                            },
+                        );
+                        let sup = self.supervisor.clone();
+                        let ledger = self.ledger.clone();
+                        tokio::spawn(async move {
+                            let reply: LedgerReply = Arc::new(typed::dispatch(&sup, call).await);
+                            let _ = tx.send(Some(reply.clone()));
+                            let mut ledger = ledger.lock().expect("dedup ledger poisoned");
+                            ledger
+                                .entries
+                                .insert(key, LedgerEntry::Done { body_hash, reply });
+                        });
+                        Gate::Run(rx)
+                    }
+                }
+            };
+            let reply = match gate {
+                Gate::Done(reply) => reply,
+                Gate::Conflict => {
+                    return Executed {
+                        reply: Err(ApiError::OpIdConflict { op_id }),
+                        stop_after_reply: false,
+                    };
+                }
+                Gate::Run(mut rx) | Gate::Await(mut rx) => loop {
+                    if let Some(reply) = rx.borrow().clone() {
+                        break reply;
+                    }
+                    if rx.changed().await.is_err() {
+                        // The publisher dropped without a reply (the spawned
+                        // effect panicked): report not_ready rather than hang
+                        // the caller forever.
+                        break Arc::new(Err(ApiError::NotReady));
+                    }
                 },
-            );
+            };
             return Executed {
-                reply,
+                reply: (*reply).clone(),
                 stop_after_reply,
             };
         }
@@ -710,6 +802,99 @@ mod tests {
             panic!("wrong replies");
         };
         assert_ne!(a.room_id, b.room_id, "an absent op_id does not dedup");
+    }
+
+    #[tokio::test]
+    async fn dedup_concurrent_replay_runs_one_effect() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let op_id = jeliya_api::OpId::new("op-concurrent");
+        let call = || {
+            TypedCall::RoomCreate(jeliya_api::RoomCreate {
+                name: "concurrent room".into(),
+            })
+        };
+        // Fire two overlapping requests with the SAME principal and op_id.
+        // The in-flight reservation must make both return the ONE original
+        // room, not author two.
+        let (r1, r2) = {
+            let e1 = engine.clone();
+            let e2 = engine.clone();
+            let o1 = op_id.clone();
+            let o2 = op_id.clone();
+            tokio::join!(
+                e1.execute_with(call(), Some(o1), "principal:a"),
+                e2.execute_with(call(), Some(o2), "principal:a"),
+            )
+        };
+        let a = r1.reply.expect("first completes");
+        let b = r2.reply.expect("second completes");
+        let (TypedReply::RoomCreate(a), TypedReply::RoomCreate(b)) = (a, b) else {
+            panic!("wrong replies");
+        };
+        assert_eq!(
+            a.room_id, b.room_id,
+            "an overlapping replay awaits the one original effect"
+        );
+        let list = engine
+            .execute(TypedCall::RoomList(jeliya_api::RoomList {}))
+            .await
+            .reply
+            .expect("room.list");
+        let TypedReply::RoomList(list) = list else {
+            panic!("wrong reply");
+        };
+        assert_eq!(list.rooms.len(), 1, "exactly one room was authored");
+    }
+
+    #[tokio::test]
+    async fn dedup_fingerprint_distinguishes_operations_with_identical_inputs() {
+        // pipe.connect and pipe.revoke both serialize as {room_id, pipe_id}.
+        // The fingerprint includes the operation path, so reusing an op_id
+        // from one for the other is a CONFLICT, not a false faithful replay.
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let room = engine
+            .execute_with(
+                TypedCall::RoomCreate(jeliya_api::RoomCreate { name: "r".into() }),
+                Some(jeliya_api::OpId::new("setup")),
+                "principal:a",
+            )
+            .await
+            .reply
+            .expect("create room");
+        let TypedReply::RoomCreate(room) = room else {
+            panic!("wrong reply");
+        };
+        let rid = room.room_id.clone();
+        let pid = jeliya_api::PipeId::new("01");
+        let op_id = jeliya_api::OpId::new("shared-op");
+        // Record an entry under pipe.connect.
+        let _ = engine
+            .execute_with(
+                TypedCall::PipeConnect(jeliya_api::PipeConnect {
+                    room_id: rid.clone(),
+                    pipe_id: pid.clone(),
+                }),
+                Some(op_id.clone()),
+                "principal:a",
+            )
+            .await;
+        // The same op_id under pipe.revoke with the same ids is a conflict
+        // (different operation), never a replay of the connect.
+        let err = engine
+            .execute_with(
+                TypedCall::PipeRevoke(jeliya_api::PipeRevoke {
+                    room_id: rid,
+                    pipe_id: pid,
+                }),
+                Some(op_id),
+                "principal:a",
+            )
+            .await
+            .reply
+            .expect_err("a different operation with the same op_id conflicts");
+        assert!(matches!(err, ApiError::OpIdConflict { .. }), "got {err:?}");
     }
 
     #[tokio::test]

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1871,6 +1871,11 @@ impl TypedCall {
         }
         .unwrap_or_default();
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // The operation path is part of the fingerprint: two operations with
+        // structurally identical inputs (pipe.connect and pipe.revoke both
+        // serialize as {room_id, pipe_id}) must not read as a faithful replay
+        // of one another. Hash the path alongside the body.
+        self.path().hash(&mut hasher);
         body.hash(&mut hasher);
         hasher.finish()
     }

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1785,6 +1785,97 @@ pub enum TypedCall {
     StreamResync(StreamResync),
 }
 
+impl TypedCall {
+    /// The operation's wire name (its capability token).
+    #[must_use]
+    pub fn path(&self) -> &'static str {
+        match self {
+            TypedCall::SubjectEnsure(_) => "subject.ensure",
+            TypedCall::DaemonStop(_) => "daemon.stop",
+            TypedCall::RoomCreate(_) => "room.create",
+            TypedCall::RoomList(_) => "room.list",
+            TypedCall::RoomActivate(_) => "room.activate",
+            TypedCall::RoomDeactivate(_) => "room.deactivate",
+            TypedCall::RoomLeave(_) => "room.leave",
+            TypedCall::RoomTimeline(_) => "room.timeline",
+            TypedCall::RoomMembers(_) => "room.members",
+            TypedCall::RoomArchive(_) => "room.archive",
+            TypedCall::RoomPeers(_) => "room.peers",
+            TypedCall::MemberRemove(_) => "member.remove",
+            TypedCall::InviteMint(_) => "invite.mint",
+            TypedCall::InviteList(_) => "invite.list",
+            TypedCall::InviteRevoke(_) => "invite.revoke",
+            TypedCall::InviteRedeem(_) => "invite.redeem",
+            TypedCall::MessageSend(_) => "message.send",
+            TypedCall::StatusPost(_) => "status.post",
+            TypedCall::StatusHistory(_) => "status.history",
+            TypedCall::FleetList(_) => "fleet.list",
+            TypedCall::FileShare(_) => "file.share",
+            TypedCall::FileList(_) => "file.list",
+            TypedCall::FileFetch(_) => "file.fetch",
+            TypedCall::FileRead(_) => "file.read",
+            TypedCall::TransferCancel(_) => "transfer.cancel",
+            TypedCall::PipePublish(_) => "pipe.publish",
+            TypedCall::PipeList(_) => "pipe.list",
+            TypedCall::PipeConnect(_) => "pipe.connect",
+            TypedCall::PipeRelease(_) => "pipe.release",
+            TypedCall::PipeRevoke(_) => "pipe.revoke",
+            TypedCall::StreamSubscribe(_) => "stream.subscribe",
+            TypedCall::StreamUnsubscribe(_) => "stream.unsubscribe",
+            TypedCall::StreamResync(_) => "stream.resync",
+        }
+    }
+
+    /// A stable hash of the canonical request body, for telling a faithful
+    /// `op_id` retry from a conflicting reuse. The typed input serializes
+    /// deterministically (serde field order is declaration order), so two
+    /// calls with equal bodies hash alike and two with different bodies do
+    /// not — which is exactly the fidelity the dedup ledger needs.
+    #[must_use]
+    pub fn body_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let body = match self {
+            TypedCall::SubjectEnsure(r) => serde_json::to_vec(r),
+            TypedCall::DaemonStop(r) => serde_json::to_vec(r),
+            TypedCall::RoomCreate(r) => serde_json::to_vec(r),
+            TypedCall::RoomList(r) => serde_json::to_vec(r),
+            TypedCall::RoomActivate(r) => serde_json::to_vec(r),
+            TypedCall::RoomDeactivate(r) => serde_json::to_vec(r),
+            TypedCall::RoomLeave(r) => serde_json::to_vec(r),
+            TypedCall::RoomTimeline(r) => serde_json::to_vec(r),
+            TypedCall::RoomMembers(r) => serde_json::to_vec(r),
+            TypedCall::RoomArchive(r) => serde_json::to_vec(r),
+            TypedCall::RoomPeers(r) => serde_json::to_vec(r),
+            TypedCall::MemberRemove(r) => serde_json::to_vec(r),
+            TypedCall::InviteMint(r) => serde_json::to_vec(r),
+            TypedCall::InviteList(r) => serde_json::to_vec(r),
+            TypedCall::InviteRevoke(r) => serde_json::to_vec(r),
+            TypedCall::InviteRedeem(r) => serde_json::to_vec(r),
+            TypedCall::MessageSend(r) => serde_json::to_vec(r),
+            TypedCall::StatusPost(r) => serde_json::to_vec(r),
+            TypedCall::StatusHistory(r) => serde_json::to_vec(r),
+            TypedCall::FleetList(r) => serde_json::to_vec(r),
+            TypedCall::FileShare(r) => serde_json::to_vec(r),
+            TypedCall::FileList(r) => serde_json::to_vec(r),
+            TypedCall::FileFetch(r) => serde_json::to_vec(r),
+            TypedCall::FileRead(r) => serde_json::to_vec(r),
+            TypedCall::TransferCancel(r) => serde_json::to_vec(r),
+            TypedCall::PipePublish(r) => serde_json::to_vec(r),
+            TypedCall::PipeList(r) => serde_json::to_vec(r),
+            TypedCall::PipeConnect(r) => serde_json::to_vec(r),
+            TypedCall::PipeRelease(r) => serde_json::to_vec(r),
+            TypedCall::PipeRevoke(r) => serde_json::to_vec(r),
+            TypedCall::StreamSubscribe(r) => serde_json::to_vec(r),
+            TypedCall::StreamUnsubscribe(r) => serde_json::to_vec(r),
+            TypedCall::StreamResync(r) => serde_json::to_vec(r),
+        }
+        .unwrap_or_default();
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        body.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
 /// Resolve a codec-routed `op` and its erased input into a concrete
 /// [`TypedCall`]. The codec guarantees `op` is one of the 33 and the input
 /// decoded into the matching request type, so the downcast is total — a

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -904,10 +904,18 @@ pub async fn serve_ws<S>(
     // `(credential, client_id)`. An omitted `client_id` yields a fresh
     // ephemeral principal per connection (no cross-reconnect replay), the
     // documented choice a short-lived CLI makes. Rendered once here; every
-    // request on this connection shares it.
+    // request on this connection shares it. Explicit `cid`s and generated
+    // ephemeral keys live in DISJOINT namespaces (distinct tag bytes): a
+    // client declaring `cid=ephemeral:0` must not land in the same ledger
+    // principal as a connection that omitted `cid`, or two supposedly
+    // isolated principals could replay/conflict each other's operations.
     let principal_key = match &principal.client_id {
-        Some(cid) => format!("{}\u{1}{}", principal.credential, cid),
-        None => format!("{}\u{1}ephemeral:{}", principal.credential, conn_nonce()),
+        Some(cid) => format!("{}\u{1}explicit\u{1}{}", principal.credential, cid),
+        None => format!(
+            "{}\u{1}generated\u{1}{}",
+            principal.credential,
+            conn_nonce()
+        ),
     };
 
     // All outbound frames flow through ONE writer task over an mpsc channel,

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -230,6 +230,17 @@ pub(crate) fn version_info(state: &AppState) -> jeliya_api::VersionInfo {
 /// bound for a fresh ticket).
 const CONNECT_TICKET_TTL_MS: u64 = 60_000;
 
+/// A process-unique counter for ephemeral session principals: an omitted
+/// `client_id` yields a fresh principal per connection, so the counter (not
+/// the wall clock, never a guessable sequence a client could reuse) is what
+/// keeps two ephemeral connections' ledgers isolated.
+static EPHEMERAL_CONN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// The next ephemeral-connection nonce.
+fn conn_nonce() -> u64 {
+    EPHEMERAL_CONN.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Mint a single-use connect ticket and record its expiry. The ticket is a
 /// fresh 256-bit opaque value, never derived from the daemon token.
 fn mint_connect_ticket(state: &AppState) -> (String, u64) {
@@ -879,7 +890,7 @@ fn serve_static(path: &str, ui: &UiSource) -> Response<Full<Bytes>> {
 pub async fn serve_ws<S>(
     ws: WebSocketStream<S>,
     state: AppState,
-    _principal: jeliya_codec::SessionPrincipal,
+    principal: jeliya_codec::SessionPrincipal,
 ) where
     // `Send + 'static` so the single-writer task and the spawned request tasks
     // can own the socket and engine handles across threads.
@@ -888,6 +899,16 @@ pub async fn serve_ws<S>(
     let (mut sink, mut messages) = ws.split();
     let mut push_rx = state.engine.subscribe_pushes();
     let bounds = jeliya_codec::CodecBounds::default();
+
+    // The authenticated session principal rendered as one ledger key:
+    // `(credential, client_id)`. An omitted `client_id` yields a fresh
+    // ephemeral principal per connection (no cross-reconnect replay), the
+    // documented choice a short-lived CLI makes. Rendered once here; every
+    // request on this connection shares it.
+    let principal_key = match &principal.client_id {
+        Some(cid) => format!("{}\u{1}{}", principal.credential, cid),
+        None => format!("{}\u{1}ephemeral:{}", principal.credential, conn_nonce()),
+    };
 
     // All outbound frames flow through ONE writer task over an mpsc channel,
     // so a slow request's execution never head-of-line blocks a push, a ping,
@@ -971,13 +992,13 @@ pub async fn serve_ws<S>(
             msg = messages.next() => match msg {
                 Some(Ok(Message::Text(text))) => {
                     idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
-                    if !dispatch_inbound(text.as_bytes(), &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
+                    if !dispatch_inbound(text.as_bytes(), &state, &bounds, &subscriptions, &out_tx, &mut inflight, &principal_key).await {
                         break;
                     }
                 }
                 Some(Ok(Message::Binary(bytes))) => {
                     idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
-                    if !dispatch_inbound(&bytes, &state, &bounds, &subscriptions, &out_tx, &mut inflight).await {
+                    if !dispatch_inbound(&bytes, &state, &bounds, &subscriptions, &out_tx, &mut inflight, &principal_key).await {
                         break;
                     }
                 }
@@ -1347,6 +1368,7 @@ async fn dispatch_inbound(
     subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
     out_tx: &tokio::sync::mpsc::Sender<Message>,
     inflight: &mut tokio::task::JoinSet<bool>,
+    principal_key: &str,
 ) -> bool {
     use jeliya_codec::CodecError;
     let frame = match jeliya_codec::decode(bytes, bounds) {
@@ -1420,12 +1442,15 @@ async fn dispatch_inbound(
 
     // Execute on a spawned task so a slow op (file.fetch, pipe.connect) does
     // not block the loop. `daemon.stop` is sequenced by the engine; its reply
-    // is flushed by the writer before teardown.
+    // is flushed by the writer before teardown. The envelope `op_id` and this
+    // connection's principal key drive the dedup ledger.
     let id = request.id;
+    let op_id = request.op_id.clone();
+    let principal_key = principal_key.to_owned();
     let engine = state.engine.clone();
     let out_tx = out_tx.clone();
     inflight.spawn(async move {
-        let executed = engine.execute(call).await;
+        let executed = engine.execute_with(call, op_id, &principal_key).await;
         let reply = match executed.reply {
             Ok(out) => jeliya_codec::Reply {
                 id,


### PR DESCRIPTION
## What

Implements the record's **idempotency and retry** contract: every mutating operation accepts an envelope `op_id` and the daemon keeps a **dedup ledger**. A replayed `op_id` returns the **original** result and performs **no second effect**; a replay with a different body is `op_id_conflict`. The ledger is keyed on the **session principal** `(credential, client_id)`, never the bare subject — a daemon has one subject, so a per-subject ledger would be daemon-global across the WebView, agents, and CLI.

## How

- **`Engine::execute_with(call, op_id, principal_key)`** gates the 13 dedup-class operations (`room.create`/`leave`, `member.remove`, `invite.mint`/`revoke`, `message.send`, `status.post`, `file.share`/`fetch`, `pipe.publish`/`connect`/`release`/`revoke`). Naturally-idempotent ops, `daemon.stop`, connection-scoped `stream.*`, and principal-scoped `transfer.cancel` are excluded — they accept an `op_id` and ignore it, per the record.
- A faithful replay re-encodes the stored `TypedReply` **byte-for-byte**; a divergent body is `op_id_conflict`. The ledger is checked and recorded around the effect with the mutex held only for the map ops, never across the dispatch `.await`.
- **In-memory by design**: the v2 harness has no daemon restart (`start_daemon` unsupported), so a durable ledger is a persistence concern clean-slate does not take on.
- `serve_ws` renders the principal once per connection (`credential` + `client_id`; an omitted `client_id` yields a fresh ephemeral principal via a process nonce — the documented short-lived-CLI choice).
- `TypedCall::path()` + `body_hash()` identify the op and tell a faithful retry from a conflicting reuse.

## Design call: `op_id` is optional-but-deduplicated, not required

The corpus is internally contradictory here. One case (`message_send_omitting_op_id_is_refused`) pins `op_id` as **required** on `message.send`, but the corpus's **own room provisioning** sends `room.create` with **no** `op_id`, and the spec says these operations "**accept** an `op_id` … and the daemon keeps a dedup ledger." Implementing the required reading **regressed nine passing timeline-streams cases** (provisioning failed, so `$rid` never resolved).

So this implements the spec's **optional** reading: the ledger deduplicates whenever an `op_id` is present and runs undeduplicated when absent. The required-vs-optional question is left for the corpus's #163 reconciliation pass (the corpus note itself pins it as a fixture question, not an implementation default).

## Verification

- `cargo clippy --locked --workspace --all-targets -- -D warnings` ✓
- `cargo test --locked --workspace` ✓ (4 new ledger tests: replay-returns-original-no-second-effect, divergent-body-conflicts, per-principal isolation, absent-op_id-not-deduplicated)
- `cargo +1.96.0 fmt --all --check` ✓
- Conformance replay **at-or-above baseline on every file**: subject-daemon 17, handshake 12, timeline-streams 9, **rooms 12 (+1)**, **pipes 4 (+2)**, invites 1, files 2 — no regressions.

Clean-slate: no v1 path, no compatibility facade, no persistence migration.