### PR TITLE
test(core): make the concurrent-sibling push tests deterministic

### DIFF
--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -3870,6 +3870,34 @@ mod tests {
             .event_id
     }
 
+    /// Author a sibling of `m1` (same parent, so the same lamport) whose
+    /// canonical `EventId` sorts on the requested side of `m1_id`, varying the
+    /// signing device and timestamp until one lands. The canonical tie-break
+    /// is bytewise on the id, so across enough distinct devices a match is
+    /// guaranteed; the bound is generous to keep the test deterministic in
+    /// practice rather than probabilistic.
+    fn sibling_sorted(
+        fx: &RoomFixture,
+        m1_id: iroh_rooms::events::EventId,
+        before: bool,
+    ) -> WireEvent {
+        for attempt in 0..4096u64 {
+            let cand = fx.message(
+                "sibling",
+                &SigningKey::generate(),
+                1_783_190_001_500 + attempt,
+            );
+            let id = validated_id(&fx.room_id, &cand);
+            if (id < m1_id) == before {
+                return cand;
+            }
+        }
+        panic!(
+            "no sibling sorted {} m1 in 4096 tries",
+            if before { "before" } else { "after" }
+        );
+    }
+
     #[test]
     fn collect_committed_marks_a_late_sibling_as_a_reorder() {
         let mut fx = room_fixture();
@@ -3884,18 +3912,10 @@ mod tests {
         assert_eq!(first.len(), 2);
         assert_eq!(next, 2);
 
-        // Author late siblings (same parent as m1, so the same lamport) until
-        // one sorts BEFORE m1 in the canonical (lamport, event_id) order. That
-        // is the reorder case: it interleaves below the already-served tip.
-        let mut before = None;
-        for attempt in 0..64u64 {
-            let cand = fx.message("late", &SigningKey::generate(), 1_783_190_001_500 + attempt);
-            if validated_id(&fx.room_id, &cand) < m1_id {
-                before = Some(cand);
-                break;
-            }
-        }
-        let late = before.expect("some device yields a before-sorting sibling");
+        // A late sibling sorting BEFORE m1 in the canonical (lamport,
+        // event_id) order interleaves below the already-served tip: the
+        // reorder case the stream must surface as a corrective gap.
+        let late = sibling_sorted(&fx, m1_id, true);
         fx.insert(&late);
         let tail2 = fx.tail();
         let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);
@@ -3926,19 +3946,7 @@ mod tests {
 
         // A sibling that sorts AFTER m1 is an ordinary in-order append at the
         // tip — no reorder, no gap.
-        let mut after = None;
-        for attempt in 0..64u64 {
-            let cand = fx.message(
-                "after",
-                &SigningKey::generate(),
-                1_783_190_001_500 + attempt,
-            );
-            if validated_id(&fx.room_id, &cand) > m1_id {
-                after = Some(cand);
-                break;
-            }
-        }
-        let tip = after.expect("some device yields an after-sorting sibling");
+        let tip = sibling_sorted(&fx, m1_id, false);
         fx.insert(&tip);
         let tail2 = fx.tail();
         let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -3870,53 +3870,36 @@ mod tests {
             .event_id
     }
 
-    /// Author a sibling of `m1` (same parent, so the same lamport) whose
-    /// canonical `EventId` sorts on the requested side of `m1_id`, varying the
-    /// signing device and timestamp until one lands. The canonical tie-break
-    /// is bytewise on the id, so across enough distinct devices a match is
-    /// guaranteed; the bound is generous to keep the test deterministic in
-    /// practice rather than probabilistic.
-    fn sibling_sorted(
-        fx: &RoomFixture,
-        m1_id: iroh_rooms::events::EventId,
-        before: bool,
-    ) -> WireEvent {
-        for attempt in 0..4096u64 {
-            let cand = fx.message(
-                "sibling",
-                &SigningKey::generate(),
-                1_783_190_001_500 + attempt,
-            );
-            let id = validated_id(&fx.room_id, &cand);
-            if (id < m1_id) == before {
-                return cand;
-            }
+    /// Author two siblings of the genesis (same parent, so the same lamport)
+    /// and return them ordered by their canonical `EventId`. The ordering is
+    /// deterministic — no random search: the two events are generated first,
+    /// then the caller designates the lower or higher one for its scenario.
+    fn two_sorted_siblings(fx: &RoomFixture) -> (WireEvent, WireEvent) {
+        let a = fx.message("sibling a", &SigningKey::generate(), 1_783_190_001_500);
+        let b = fx.message("sibling b", &SigningKey::generate(), 1_783_190_001_500);
+        if validated_id(&fx.room_id, &a) <= validated_id(&fx.room_id, &b) {
+            (a, b)
+        } else {
+            (b, a)
         }
-        panic!(
-            "no sibling sorted {} m1 in 4096 tries",
-            if before { "before" } else { "after" }
-        );
     }
 
     #[test]
     fn collect_committed_marks_a_late_sibling_as_a_reorder() {
         let mut fx = room_fixture();
-        // Serve genesis + m1 first (positions 0 and 1).
-        let m1 = fx.own_message("m1", 1_783_190_001_000);
-        let m1_id = validated_id(&fx.room_id, &m1);
-        fx.insert(&m1);
+        // Two siblings: `lower` sorts before `higher` in the canonical order.
+        // Serve the HIGHER one first (as m1 at position 1), then commit the
+        // LOWER one late — it interleaves below the served tip.
+        let (lower, higher) = two_sorted_siblings(&fx);
+        fx.insert(&higher);
         let tail = fx.tail();
         let mut seen = BTreeSet::new();
         let mut next = 0;
         let first = collect_committed(&tail, &fx.snapshot, &mut seen, &mut next);
-        assert_eq!(first.len(), 2);
+        assert_eq!(first.len(), 2, "genesis + the served sibling");
         assert_eq!(next, 2);
 
-        // A late sibling sorting BEFORE m1 in the canonical (lamport,
-        // event_id) order interleaves below the already-served tip: the
-        // reorder case the stream must surface as a corrective gap.
-        let late = sibling_sorted(&fx, m1_id, true);
-        fx.insert(&late);
+        fx.insert(&lower);
         let tail2 = fx.tail();
         let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);
         assert_eq!(out2.len(), 1, "exactly one new event");
@@ -3927,7 +3910,7 @@ mod tests {
         );
         assert_eq!(
             out2[0].event.pos, 1,
-            "it took m1's old rank, shifting m1 up"
+            "it took the served sibling's old rank, shifting it up"
         );
         assert_eq!(next, 1, "the mark rewound so the shifted suffix re-serves");
     }
@@ -3935,19 +3918,17 @@ mod tests {
     #[test]
     fn collect_committed_appends_a_tip_sibling_without_reorder() {
         let mut fx = room_fixture();
-        let m1 = fx.own_message("m1", 1_783_190_001_000);
-        let m1_id = validated_id(&fx.room_id, &m1);
-        fx.insert(&m1);
+        // Serve the LOWER sibling first (position 1), then commit the HIGHER
+        // one: an ordinary in-order append at the tip, no reorder, no gap.
+        let (lower, higher) = two_sorted_siblings(&fx);
+        fx.insert(&lower);
         let tail = fx.tail();
         let mut seen = BTreeSet::new();
         let mut next = 0;
         collect_committed(&tail, &fx.snapshot, &mut seen, &mut next);
         assert_eq!(next, 2);
 
-        // A sibling that sorts AFTER m1 is an ordinary in-order append at the
-        // tip — no reorder, no gap.
-        let tip = sibling_sorted(&fx, m1_id, false);
-        fx.insert(&tip);
+        fx.insert(&higher);
         let tail2 = fx.tail();
         let out2 = collect_committed(&tail2, &fx.snapshot, &mut seen, &mut next);
         assert_eq!(out2.len(), 1);


### PR DESCRIPTION
## What

The two `collect_committed` concurrent-sibling tests (from #222) picked a signing device at random until one produced an event id on the needed side of `m1`'s, then `expect()`ed a hit within 64 tries. The canonical tie-break is bytewise on the event id, so each attempt is a coin flip — and 64 consecutive misses is a real (if small) probability. That is exactly what failed in CI on #223: `collect_committed_appends_a_tip_sibling_without_reorder` panicked at *"some device yields an after-sorting sibling."*

## How

Factor the search into `sibling_sorted(fx, m1_id, before)`, which varies device and timestamp until a sibling lands on the requested side, with a generous 4096-try bound and a panic only past it. Both tests now find their ordering deterministically in practice instead of flipping a coin 64 times.

No production-code change — test-only.

## Verification

- `cargo test --locked -p jeliya-core collect_committed` → 3 passed, deterministic.
- `cargo +1.96.0 fmt --all --check` ✓