### PR TITLE
feat(core): enforce the authority role at dispatch (validation-order step 6)

### DIFF
--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1583,16 +1583,33 @@ fn closed_pipe_ids(
 /// for `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`;
 /// `None` for every other operation. A malformed room id yields no gate here
 /// — the operation's own `parse_room` reports it.
-fn authority_gated_room(call: &TypedCall) -> Option<(RoomId, IrohRoomId)> {
+/// The room an authority-gated operation targets, for the dispatch-time
+/// validation-order steps 5–6. Returns `Ok(Some((api_room, iroh_room)))` for
+/// `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`;
+/// `Ok(None)` for every other operation. A malformed room id yields no gate
+/// (the operation's own `parse_room` reports it). Step 1 (structure) runs
+/// here for `invite.list`: an out-of-bounds paging `limit` is
+/// `invalid_argument` before the room/role preflight, per the normative
+/// validation order.
+fn authority_gated_room(call: &TypedCall) -> Result<Option<(RoomId, IrohRoomId)>, ApiError> {
     let api_room = match call {
         TypedCall::MemberRemove(r) => &r.room_id,
         TypedCall::InviteMint(r) => &r.room_id,
         TypedCall::InviteRevoke(r) => &r.room_id,
-        TypedCall::InviteList(r) => &r.room_id,
-        _ => return None,
+        TypedCall::InviteList(r) => {
+            // Step 1 first: a structurally invalid page (limit outside
+            // 1..=timeline_page_max) is invalid_argument, never gated by
+            // role. Window::resolve is the one bound check.
+            Window::resolve(&r.page)?;
+            &r.room_id
+        }
+        _ => return Ok(None),
     };
-    let iroh_room = api_room.as_str().trim().parse().ok()?;
-    Some((api_room.clone(), iroh_room))
+    let iroh_room = match api_room.as_str().trim().parse() {
+        Ok(r) => r,
+        Err(_) => return Ok(None),
+    };
+    Ok(Some((api_room.clone(), iroh_room)))
 }
 
 // ---------------------------------------------------------------------------
@@ -1616,20 +1633,27 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
     if !matches!(call, TypedCall::SubjectEnsure(_)) && !t.subject_present()? {
         return Err(ApiError::SubjectAbsent);
     }
-    // Validation-order step 6 (role): the four authority-gated operations
-    // (`member.remove`, `invite.mint`, `invite.revoke`, `invite.list`) refuse
-    // a plain member with `insufficient_standing { required: authority, held
-    // }` before any operation semantics run. Step 5 (standing) is enforced
-    // per-operation where the operation is defined over a live membership;
-    // the role check needs only the membership snapshot. A room the caller
-    // cannot read answers `room_not_available` (step 4 outranks step 6 — the
-    // role check must not be a membership oracle for a foreign room).
-    if let Some((api_room, iroh_room)) = authority_gated_room(&call) {
+    // Validation-order steps 5 and 6 (standing, then role) for the four
+    // authority-gated operations (`member.remove`, `invite.mint`,
+    // `invite.revoke`, `invite.list`). Step 1 (structure) runs first: a
+    // structurally invalid request (a paging `limit` outside
+    // `1..=timeline_page_max`) is `invalid_argument` before any room/role
+    // preflight, so authorization behavior is never exposed for malformed
+    // input. Step 5 (standing) runs before step 6 (role): a former member is
+    // `membership_ended`, never `insufficient_standing` — the role code is
+    // defined only for active members. A room the caller cannot read answers
+    // `room_not_available` (step 4 outranks both), and a room-index failure
+    // is `room_index_unreadable`, never a generic error.
+    if let Some((api_room, iroh_room)) = authority_gated_room(&call)? {
         let snapshot = t
             .sup
             .readable_snapshot(&iroh_room)
             .await
-            .map_err(|e| core_to_api_room(e, &api_room))?;
+            .map_err(|e| match e.kind {
+                ErrorKind::Internal => ApiError::RoomIndexUnreadable,
+                _ => core_to_api_room(e, &api_room),
+            })?;
+        t.require_active_standing(&api_room, &iroh_room, &snapshot)?;
         t.require_role(&api_room, &snapshot, Role::Authority)?;
     }
     match call {
@@ -2134,7 +2158,7 @@ mod tests {
     #[test]
     fn authority_gated_room_covers_exactly_the_four_authority_ops() {
         let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
-        let gated = |call: &TypedCall| authority_gated_room(call).is_some();
+        let gated = |call: &TypedCall| authority_gated_room(call).ok().flatten().is_some();
         assert!(gated(&TypedCall::MemberRemove(MemberRemove {
             room_id: rid(),
             subject_id: SubjectId::new("s"),
@@ -2170,5 +2194,37 @@ mod tests {
             },
             audience: Audience::Room,
         })));
+    }
+
+    /// Validation-order step 1 (structure) precedes the role gate: an
+    /// `invite.list` with a `limit` outside `1..=timeline_page_max` is
+    /// `invalid_argument { field: "in.limit", reason: bound }`, never
+    /// `insufficient_standing` — authorization is not exposed for malformed
+    /// input.
+    #[test]
+    fn invite_list_out_of_bounds_limit_is_invalid_argument_before_role() {
+        let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
+        for limit in [0, limits().timeline_page_max + 1] {
+            let call = TypedCall::InviteList(InviteList {
+                room_id: rid(),
+                page: Page {
+                    cursor: Cursor::Start,
+                    direction: Direction::Forward,
+                    limit,
+                },
+            });
+            let err = authority_gated_room(&call)
+                .expect_err("an out-of-bounds limit is refused at step 1");
+            assert!(
+                matches!(
+                    err,
+                    ApiError::InvalidArgument {
+                        reason: InvalidReason::Bound { .. },
+                        ..
+                    }
+                ),
+                "limit {limit}: got {err:?}"
+            );
+        }
     }
 }

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -520,6 +520,33 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
+    /// Validation-order step 6: the caller's role must meet what the
+    /// operation needs. Authority-gated operations (`invite.mint`,
+    /// `member.remove`, `invite.revoke`, `pipe.publish`, `pipe.revoke`) refuse
+    /// a plain member with `insufficient_standing { required, held }` — the
+    /// role tokens, per the record. Step 5 (standing) runs first; this checks
+    /// role among ACTIVE members.
+    fn require_role(
+        &self,
+        api_room_id: &RoomId,
+        snapshot: &iroh_rooms::room::MembershipSnapshot,
+        required: Role,
+    ) -> Result<(), ApiError> {
+        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
+        let held = snapshot
+            .role(&self_key)
+            .map(proj::role)
+            .unwrap_or(Role::Member);
+        if required == Role::Authority && held != Role::Authority {
+            return Err(ApiError::InsufficientStanding {
+                room_id: api_room_id.clone(),
+                required,
+                held,
+            });
+        }
+        Ok(())
+    }
+
     /// `room.members` — the authoritative signed answer to who belongs. No
     /// presence, no reachability.
     pub async fn room_members(&self, req: &RoomMembers) -> CoreResult<RoomMembersOut> {
@@ -604,7 +631,8 @@ impl<'a> TypedSupervisor<'a> {
     // ------------------------------------------------------------------
 
     /// `invite.mint` — mint one key-bound capability exactly one named
-    /// identity can redeem.
+    /// identity can redeem. Authority-only (validation-order step 6): the
+    /// role gate lives in [`dispatch`], before this body runs.
     pub async fn invite_mint(&self, req: &InviteMint) -> CoreResult<InviteMintOut> {
         if req.role != Role::Member {
             return Err(CoreError::new(
@@ -1550,6 +1578,23 @@ fn closed_pipe_ids(
     Ok(ids)
 }
 
+/// The room an authority-gated operation targets, for the dispatch-time
+/// validation-order step 6 role check. Returns `Some((api_room, iroh_room))`
+/// for `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`;
+/// `None` for every other operation. A malformed room id yields no gate here
+/// — the operation's own `parse_room` reports it.
+fn authority_gated_room(call: &TypedCall) -> Option<(RoomId, IrohRoomId)> {
+    let api_room = match call {
+        TypedCall::MemberRemove(r) => &r.room_id,
+        TypedCall::InviteMint(r) => &r.room_id,
+        TypedCall::InviteRevoke(r) => &r.room_id,
+        TypedCall::InviteList(r) => &r.room_id,
+        _ => return None,
+    };
+    let iroh_room = api_room.as_str().trim().parse().ok()?;
+    Some((api_room.clone(), iroh_room))
+}
+
 // ---------------------------------------------------------------------------
 // The typed dispatch table (the engine's v2 surface)
 // ---------------------------------------------------------------------------
@@ -1570,6 +1615,22 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
     // never a membership oracle.
     if !matches!(call, TypedCall::SubjectEnsure(_)) && !t.subject_present()? {
         return Err(ApiError::SubjectAbsent);
+    }
+    // Validation-order step 6 (role): the four authority-gated operations
+    // (`member.remove`, `invite.mint`, `invite.revoke`, `invite.list`) refuse
+    // a plain member with `insufficient_standing { required: authority, held
+    // }` before any operation semantics run. Step 5 (standing) is enforced
+    // per-operation where the operation is defined over a live membership;
+    // the role check needs only the membership snapshot. A room the caller
+    // cannot read answers `room_not_available` (step 4 outranks step 6 — the
+    // role check must not be a membership oracle for a foreign room).
+    if let Some((api_room, iroh_room)) = authority_gated_room(&call) {
+        let snapshot = t
+            .sup
+            .readable_snapshot(&iroh_room)
+            .await
+            .map_err(|e| core_to_api_room(e, &api_room))?;
+        t.require_role(&api_room, &snapshot, Role::Authority)?;
     }
     match call {
         TypedCall::SubjectEnsure(_) => t
@@ -2060,5 +2121,54 @@ fn core_to_api_ctx(err: CoreError, room_id: Option<RoomId>) -> ApiError {
                 reason: InvalidReason::Format,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dispatch-time role gate targets exactly the four authority
+    /// operations the record names — no more (an open operation must not be
+    /// gated by accident), no fewer.
+    #[test]
+    fn authority_gated_room_covers_exactly_the_four_authority_ops() {
+        let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
+        let gated = |call: &TypedCall| authority_gated_room(call).is_some();
+        assert!(gated(&TypedCall::MemberRemove(MemberRemove {
+            room_id: rid(),
+            subject_id: SubjectId::new("s"),
+        })));
+        assert!(gated(&TypedCall::InviteMint(InviteMint {
+            room_id: rid(),
+            subject_id: SubjectId::new("s"),
+            role: Role::Member,
+            expires_at: proj_epoch(),
+        })));
+        assert!(gated(&TypedCall::InviteRevoke(InviteRevoke {
+            room_id: rid(),
+            invite_id: InviteId::new("i"),
+        })));
+        assert!(gated(&TypedCall::InviteList(InviteList {
+            room_id: rid(),
+            page: Page {
+                cursor: Cursor::Start,
+                direction: Direction::Forward,
+                limit: 1,
+            },
+        })));
+        // Open operations are NOT gated: a plain member runs them.
+        assert!(!gated(&TypedCall::MessageSend(MessageSend {
+            room_id: rid(),
+            body: "hi".into(),
+        })));
+        assert!(!gated(&TypedCall::PipePublish(PipePublish {
+            room_id: rid(),
+            target: Target {
+                host: "127.0.0.1".into(),
+                port: 9,
+            },
+            audience: Audience::Room,
+        })));
     }
 }


### PR DESCRIPTION
## What

Implements validation-order **step 6 (role)** for the four authority-gated operations the record names — `member.remove`, `invite.mint`, `invite.revoke`, `invite.list`. A plain member calling one is refused `insufficient_standing { required: authority, held }`.

The record states this as **one list** deliberately: step 6 is normative for all 33 operations, so a reader who found the rule only under `member.remove` would reasonably conclude the other 32 never raise it — which is how a permission gets implemented as open by accident. `pipe.revoke` is **not** on the list (it is publisher-scoped, answering `pipe_not_publisher`), and this change does not gate it.

## How

- The gate runs **in `dispatch`**, after step 2 (subject) and using the membership snapshot, before any operation semantics — so the typed `insufficient_standing` survives the `ApiError` boundary directly rather than collapsing through the internal `CoreResult` conversion.
- A room the caller cannot read answers `room_not_available` (step 4 outranks step 6 — the role check is never a membership oracle for a foreign room).
- `require_role` checks role among **active** members; step 5 (standing) stays per-operation where the operation is defined over a live membership.
- `authority_gated_room` targets **exactly** the four record-named ops — no more (an open operation must not be gated by accident), no fewer.

## Corpus status (honest)

The corpus's `insufficient_standing` cases are currently **unreachable for an independent reason**: each is blocked by an input-shape fixture drift (`invite.mint` `ttl_ms` vs spec `expires_at`, `pipe.publish` target encoding, `member.remove` unimplemented) that fails validation *before* step 6, and several expect a corpus-specific error shape (`{state: room_authority}`, `required: active`) the record does not define. Those belong to the corpus's #163 reconciliation (task 3), not this change.

This lands the **spec-correct** enforcement so it is in place once the fixtures are re-transcribed. **No conformance case regresses** (the authority flow is unaffected); replay is identical to main's baseline on every file.

## Verification

- `cargo clippy --locked --workspace --all-targets -- -D warnings` ✓
- `cargo test --locked --workspace` ✓ (new test: `authority_gated_room` covers exactly the four ops)
- `cargo +1.96.0 fmt --all --check` ✓
- Conformance replay identical to main's baseline on all seven files.

Clean-slate: no v1 path, no compatibility facade.