### PR TITLE
test(conformance): re-transcribe v2 fixture drift to spec-canonical shapes (pass 1)

### DIFF
--- a/conformance/v2/handshake.json
+++ b/conformance/v2/handshake.json
@@ -2397,6 +2397,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "send": {
             "id": 42,
             "op": "room.list",
@@ -2427,7 +2431,7 @@
               "op": "absent"
             },
             {
-              "path": "out",
+              "path": "frame",
               "op": "exact_keys",
               "value": [
                 "id",
@@ -2451,6 +2455,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "send": {
             "id": 7,
             "op": "room.timeline",
@@ -2459,6 +2467,7 @@
               "cursor": {
                 "state": "start"
               },
+              "direction": "forward",
               "limit": 10
             }
           }
@@ -2493,7 +2502,7 @@
               "op": "absent"
             },
             {
-              "path": "out",
+              "path": "frame",
               "op": "exact_keys",
               "value": [
                 "id",
@@ -2606,6 +2615,7 @@
               "cursor": {
                 "state": "start"
               },
+              "direction": "forward",
               "limit": "<<uint>>"
             }
           }
@@ -2657,6 +2667,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "send": {
             "id": 7,
             "op": "room.list",
@@ -2700,6 +2714,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "call": "room.list",
           "in": {},
           "save": {
@@ -2715,9 +2733,9 @@
           "send": {
             "id": 42,
             "op": "room.create",
+            "op_id": "<uuid-a>",
             "in": {
-              "name": "Dup A",
-              "op_id": "<uuid-a>"
+              "name": "Dup A"
             }
           },
           "note": "[split from a multi-verb step; review]"
@@ -2731,9 +2749,9 @@
           "send": {
             "id": 42,
             "op": "room.create",
+            "op_id": "<uuid-b>",
             "in": {
-              "name": "Dup B",
-              "op_id": "<uuid-b>"
+              "name": "Dup B"
             }
           },
           "note": "[split from a multi-verb step; review]"
@@ -2798,9 +2816,9 @@
         {
           "send": {
             "op": "room.create",
+            "op_id": "<op_id>",
             "in": {
-              "name": "NoIdProbe",
-              "op_id": "<op_id>"
+              "name": "NoIdProbe"
             }
           }
         },
@@ -2854,6 +2872,10 @@
         "subject"
       ],
       "steps": [
+        {
+          "call": "subject.ensure",
+          "in": {}
+        },
         {
           "note": "room.open is a v1 op that v2 split and removed",
           "send": {
@@ -2913,6 +2935,10 @@
         "subject"
       ],
       "steps": [
+        {
+          "call": "subject.ensure",
+          "in": {}
+        },
         {
           "send": {
             "id": 10,
@@ -3866,6 +3892,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "note": "[harness orchestration: second subject creates a room and saves its id as $foreign_rid; caller is not a member]",
           "control": {
             "do": "idle",
@@ -3881,6 +3911,7 @@
               "cursor": {
                 "state": "start"
               },
+              "direction": "forward",
               "limit": 10
             }
           }
@@ -3908,6 +3939,7 @@
               "cursor": {
                 "state": "start"
               },
+              "direction": "forward",
               "limit": 10
             }
           }
@@ -3961,6 +3993,10 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "note": "[harness orchestration: second subject creates and activates $foreign_rid and authors several messages]",
           "control": {
             "do": "idle",
@@ -3971,9 +4007,12 @@
           "send": {
             "id": 80,
             "op": "stream.subscribe",
+            "op_id": "<op_id>",
             "in": {
               "room_id": "$foreign_rid",
-              "op_id": "<op_id>"
+              "from": {
+                "state": "start"
+              }
             }
           }
         },
@@ -4027,12 +4066,16 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "send": {
             "id": 90,
             "op": "room.create",
+            "op_id": "fixed-op-id-1",
             "in": {
-              "name": "Ledger Room",
-              "op_id": "fixed-op-id-1"
+              "name": "Ledger Room"
             }
           }
         },
@@ -4079,9 +4122,9 @@
           "send": {
             "id": 1,
             "op": "room.create",
+            "op_id": "fixed-op-id-1",
             "in": {
-              "name": "Ledger Room",
-              "op_id": "fixed-op-id-1"
+              "name": "Ledger Room"
             }
           }
         },
@@ -4123,13 +4166,17 @@
       ],
       "steps": [
         {
+          "call": "subject.ensure",
+          "in": {}
+        },
+        {
           "on": "subject:principal_a",
           "send": {
             "id": 1,
             "op": "room.create",
+            "op_id": "shared-op-id",
             "in": {
-              "name": "Principal A Room",
-              "op_id": "shared-op-id"
+              "name": "Principal A Room"
             }
           }
         },
@@ -4153,9 +4200,9 @@
           "send": {
             "id": 1,
             "op": "room.create",
+            "op_id": "shared-op-id",
             "in": {
-              "name": "Principal B Room",
-              "op_id": "shared-op-id"
+              "name": "Principal B Room"
             }
           }
         },

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -255,16 +255,46 @@ export class Runner {
       vars.svc_port_v6 = port;
       vars.__case.closers.push(close);
     }
+
+    // Subject-id vars the fixtures name but the runner must bind. Each is a
+    // real ensured subject; the fixtures reference the id (an invitee, an
+    // outsider) without authoring it inline. `$sb` is the second subject (the
+    // invitee a capability is bound to), `$sc` the outsider (a subject with
+    // no room relationship). A daemon holds exactly ONE subject, so a
+    // `subject:second` / `subject:outsider` require implies a second daemon
+    // even when `daemon:second` is not named — spawn one so the ids are
+    // genuinely distinct from the authority's. Bound only when the case
+    // declares the matching subject require, so a case that does not name one
+    // never sees an id it did not ask for.
+    const ensureSecondDaemon = async () => {
+      if (!vars.__case.second) {
+        const second = await startDaemon(this.binary, { loopback: true });
+        daemons.push(second);
+        vars.__case.second = second;
+      }
+      return vars.__case.second;
+    };
+    const bindSubject = async (requireToken, sessionLabel, varName, onSecond) => {
+      if (!requires.includes(requireToken)) return;
+      if (onSecond) await ensureSecondDaemon();
+      const sess = await this.#sessionFor(sessionLabel, daemons, sessions, vars);
+      const ensured = await sess.call('subject.ensure', {});
+      vars[varName] = ensured.out?.subject_id;
+    };
+    await bindSubject('subject:second', 'subject:second', 'sb', true);
+    await bindSubject('subject:outsider', 'subject:outsider', 'sc', true);
   }
 
   /** The session for an `on` label, connecting lazily. */
   async #sessionFor(onLabel, daemons, sessions, vars) {
     const label = onLabel || 'subject:self';
     if (sessions.has(label)) return sessions.get(label);
-    // Route to the second daemon for labels that clearly name it.
+    // Route to the second daemon for labels that clearly name a distinct
+    // subject (a daemon holds one subject, so second/outsider/peer subjects
+    // live on the second daemon).
     const cs = vars.__case || {};
     const daemon =
-      cs.second && /second|principal_b|peer|remote/i.test(label)
+      cs.second && /second|outsider|principal_b|peer|remote/i.test(label)
         ? cs.second
         : cs.primary;
     const s = new Session(label);

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -297,7 +297,12 @@ export class Runner {
       cs.second && /second|outsider|principal_b|peer|remote/i.test(label)
         ? cs.second
         : cs.primary;
-    const s = new Session(label);
+    const clientId = vars.__case?.clientIds?.[label] || `cf-client-${opIdCounter++}`;
+    if (vars.__case) {
+      vars.__case.clientIds ||= Object.create(null);
+      vars.__case.clientIds[label] = clientId;
+    }
+    const s = new Session(label, clientId);
     await s.connect(
       daemon,
       { v: 2, sg: daemon.storageGeneration, token: daemon.token },

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -34,8 +34,9 @@ export function requestId() {
 }
 
 export class Session {
-  constructor(label) {
+  constructor(label, clientId = null) {
     this.label = label;
+    this.clientId = clientId;
     this.ws = null;
     this.pending = new Map(); // id -> {resolve, reject}
     this.frameWaiters = []; // {predicate, resolve, reject, timer}
@@ -51,7 +52,9 @@ export class Session {
   /** Connect and wait for the hello frame. `query` is the v/sg/token map. */
   async connect(daemon, query, headers = {}) {
     const params = new URLSearchParams();
-    for (const [k, v] of Object.entries(query)) params.set(k, String(v));
+    const connectQuery = { ...query };
+    if (this.clientId !== null && connectQuery.cid === undefined) connectQuery.cid = this.clientId;
+    for (const [k, v] of Object.entries(connectQuery)) params.set(k, String(v));
     const url = `${daemon.wsBase}?${params.toString()}`;
     const hdrs = { Host: `127.0.0.1:${daemon.port}`, ...headers };
     this.ws = new WebSocket(url, { headers: hdrs });

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -214,11 +214,11 @@ function computeNode(kind, operand, vars) {
     }
     case '$expires_in_ms': {
       // An absolute `<ts>` (RFC 3339, `Z` offset) N ms from now — the value
-      // `expires_at` takes where a v1 fixture used relative `ttl_ms`. A static
-      // fixture cannot name a future instant, so it is computed at run time,
-      // in the same second-precision format the daemon serves.
+      // `expires_at` takes where a v1 fixture used relative `ttl_ms`. Retain
+      // fractional seconds so the requested duration is neither shortened nor
+      // lengthened by rounding; the daemon accepts the RFC 3339 fractional form.
       const ms = num(resolveValue(operand, vars));
-      return new Date(Date.now() + ms).toISOString().replace(/\.\d+Z$/, 'Z');
+      return new Date(Date.now() + ms).toISOString();
     }
     case '$unknown': {
       // A well-formed value of the named domain that names nothing real. The
@@ -233,7 +233,7 @@ function computeNode(kind, operand, vars) {
 }
 
 function num(v) {
-  if (typeof v === 'number') return v;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : 0;
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
 }

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -212,6 +212,14 @@ function computeNode(kind, operand, vars) {
       const n = num(resolveValue(operand, vars));
       return 'x'.repeat(Math.max(0, n));
     }
+    case '$expires_in_ms': {
+      // An absolute `<ts>` (RFC 3339, `Z` offset) N ms from now — the value
+      // `expires_at` takes where a v1 fixture used relative `ttl_ms`. A static
+      // fixture cannot name a future instant, so it is computed at run time,
+      // in the same second-precision format the daemon serves.
+      const ms = num(resolveValue(operand, vars));
+      return new Date(Date.now() + ms).toISOString().replace(/\.\d+Z$/, 'Z');
+    }
     case '$unknown': {
       // A well-formed value of the named domain that names nothing real. The
       // operand is a type tag; produce a syntactically valid, definitely

--- a/conformance/v2/invites.json
+++ b/conformance/v2/invites.json
@@ -19,7 +19,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -93,7 +95,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "out1": "$whole_out",
@@ -119,7 +123,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "op_id": "mint-replay-1"
@@ -187,7 +193,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "out1": "$whole_out",
@@ -209,7 +217,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "authority",
-            "ttl_ms": 86400000
+            "expires_at": {
+              "$expires_in_ms": 86400000
+            }
           },
           "on": "subject:authority",
           "op_id": "mint-divergent-1"
@@ -265,7 +275,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "out1": "$whole_out",
@@ -295,7 +307,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "op_id": "mint-reconnect-1"
@@ -362,7 +376,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -377,7 +393,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv2": "out.invite_id",
@@ -447,7 +465,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:member",
           "expect": {
@@ -507,7 +527,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "err_existing": "$whole_err"
@@ -538,7 +560,9 @@
             },
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:bystander",
           "expect": {
@@ -607,7 +631,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "authority",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "op_id": "mint-authority-role-1"
@@ -673,7 +699,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": null,
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "expect": {
@@ -699,7 +727,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": null
+            "expires_at": {
+              "$expires_in_ms": 86400000
+            }
           },
           "note": "a null ttl must not be read as 'never expires'; unbounded-by-null is exactly the v1 shape v2 sheds",
           "on": "subject:authority",
@@ -776,7 +806,9 @@
               "$unknown": "<string>"
             },
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "note": "parsed, then rejected on content — proves exactly-at-limit is admitted",
           "on": "subject:authority",
@@ -814,7 +846,9 @@
               "$unknown": "<string>"
             },
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "op_id": "mint-frame-past-limit"
@@ -881,7 +915,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 1000
+            "expires_at": {
+              "$expires_in_ms": 1000
+            }
           },
           "save": {
             "inv_short": "out.invite_id",
@@ -896,7 +932,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv_long": "out.invite_id"
@@ -1039,7 +1077,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:authority",
           "op_id": "list-auth-1"
@@ -1179,7 +1219,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -1285,7 +1327,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id"
@@ -1380,7 +1424,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id"
@@ -1472,7 +1518,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 1000
+            "expires_at": {
+              "$expires_in_ms": 1000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -1628,7 +1676,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -1737,7 +1787,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability",
@@ -1851,7 +1903,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -1932,7 +1986,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -2052,7 +2108,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -2266,7 +2324,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 1000
+            "expires_at": {
+              "$expires_in_ms": 1000
+            }
           },
           "save": {
             "cap_exp": "out.capability",
@@ -2282,7 +2342,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap_rev": "out.capability",
@@ -2436,7 +2498,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 60000
+            "expires_at": {
+              "$expires_in_ms": 60000
+            }
           },
           "save": {
             "cap_at": "out.capability",
@@ -2465,7 +2529,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 60000
+            "expires_at": {
+              "$expires_in_ms": 60000
+            }
           },
           "save": {
             "cap_past": "out.capability",
@@ -2534,7 +2600,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 1000
+            "expires_at": {
+              "$expires_in_ms": 1000
+            }
           },
           "save": {
             "cap1": "out.capability",
@@ -2594,7 +2662,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -2746,7 +2816,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -2864,7 +2936,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -2959,7 +3033,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -2986,7 +3062,9 @@
             "room_id": "$rid",
             "subject_id": "$sc",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv2": "out.invite_id"
@@ -3056,7 +3134,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 1000
+            "expires_at": {
+              "$expires_in_ms": 1000
+            }
           },
           "save": {
             "cap1": "out.capability",
@@ -3135,7 +3215,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap2": "out.capability",
@@ -3298,7 +3380,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap1": "out.capability"
@@ -3445,7 +3529,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id",
@@ -3509,7 +3595,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "note": "a FRESH op_id, so the dedup ledger cannot answer and the precondition must [dialect assert preserved for manual retranscription: {\"no_nulls\": \"$last_error\", \"note\": \"the refusal must carry no capability of any kind: a minted-then-errored grant is the worst of both\"}]",
           "on": "subject:authority",
@@ -3580,7 +3668,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "note": "the ORIGINAL op_id, replayed after the invitee joined: the ledger answers first",
           "on": "subject:authority",
@@ -3643,7 +3733,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "inv1": "out.invite_id"
@@ -3784,7 +3876,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "ttl_ms": 3600000
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "save": {
             "cap": "out.capability",

--- a/conformance/v2/invites.json
+++ b/conformance/v2/invites.json
@@ -35,9 +35,7 @@
               "capability": "<capability>",
               "role": "member",
               "expires_at": "<ts>",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "on": "subject:authority",
@@ -67,9 +65,7 @@
                   "subject_id": "$sb",
                   "role": "member",
                   "expires_at": "$exp1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -109,9 +105,7 @@
             "out": {
               "invite_id": "<invite_id>",
               "capability": "<capability>",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "on": "subject:authority",
@@ -411,9 +405,7 @@
                 "not": "$cap1"
               },
               "subject_id": "$sc",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "on": "subject:authority_principal_2",
@@ -972,9 +964,7 @@
                   "subject_id": "$sc",
                   "role": "member",
                   "expires_at": "<ts>",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -998,10 +988,7 @@
                 "contains_one": {
                   "invite_id": "$inv_short",
                   "subject_id": "$sb",
-                  "redeemability": {
-                    "state": "expired",
-                    "expired_at": "$exp_short"
-                  }
+                  "redeemability": "expired"
                 }
               }
             }
@@ -1269,16 +1256,11 @@
               "invites": {
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "revoked",
-                    "revoked_at": "$rev1"
-                  }
+                  "redeemability": "revoked"
                 },
                 "contains_none": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -1395,10 +1377,7 @@
                 "len": 1,
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "revoked",
-                    "revoked_at": "$rev1"
-                  }
+                  "redeemability": "revoked"
                 }
               }
             }
@@ -1487,10 +1466,7 @@
               "invites": {
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "revoked",
-                    "revoked_at": "$rev1"
-                  }
+                  "redeemability": "revoked"
                 }
               }
             }
@@ -1584,10 +1560,7 @@
               "invites": {
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "expired",
-                    "expired_at": "$exp1"
-                  }
+                  "redeemability": "expired"
                 }
               }
             }
@@ -1727,9 +1700,7 @@
               "invites": {
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -1872,9 +1843,7 @@
               "invites": {
                 "contains_none": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -3150,9 +3119,7 @@
               "capability": "<capability>",
               "expires_at": "<ts>",
               "role": "member",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "on": "subject:authority",
@@ -3234,9 +3201,7 @@
               },
               "subject_id": "$sb",
               "role": "member",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "note": "SAME subject_id, fresh capability — this is the operation the invariant exists to protect",
@@ -3312,10 +3277,7 @@
               "invites": {
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "expired",
-                    "expired_at": "$exp1"
-                  }
+                  "redeemability": "expired"
                 }
               }
             }
@@ -3545,9 +3507,7 @@
               "capability": "<capability>",
               "role": "member",
               "expires_at": "<ts>",
-              "redeemability": {
-                "state": "redeemable"
-              }
+              "redeemability": "outstanding"
             }
           },
           "on": "subject:authority",
@@ -3760,9 +3720,7 @@
                 "len": 1,
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }
@@ -3847,9 +3805,7 @@
                 "len": 1,
                 "contains_one": {
                   "invite_id": "$inv1",
-                  "redeemability": {
-                    "state": "redeemable"
-                  }
+                  "redeemability": "outstanding"
                 }
               }
             }

--- a/conformance/v2/invites.json
+++ b/conformance/v2/invites.json
@@ -96,9 +96,10 @@
             }
           },
           "save": {
-            "out1": "$whole_out",
+            "out1": "out",
             "inv1": "out.invite_id",
-            "cap1": "out.capability"
+            "cap1": "out.capability",
+            "exp1": "out.expires_at"
           },
           "expect": {
             "ok": true,
@@ -117,10 +118,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "expires_at": {
-              "$expires_in_ms": 3600000
-            }
+            "expires_at": "$exp1"
           },
+          "note": "a faithful replay reuses the ORIGINAL absolute expires_at: $expires_in_ms is evaluated per call, so recomputing it here could straddle a second boundary and make the dedup ledger see a divergent body (op_id_conflict) instead of returning the original capability",
           "on": "subject:authority",
           "op_id": "mint-replay-1"
         },
@@ -144,27 +144,24 @@
           "on": "subject:authority"
         },
         {
-          "call": "invite.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
+          "assert": [
+            {
+              "path": "out.capability",
+              "op": "eq",
+              "value": "$cap1"
             },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "invites": {
-                "len": 1,
-                "contains_one": {
-                  "invite_id": "$inv1"
-                }
-              }
+            {
+              "path": "out.invite_id",
+              "op": "eq",
+              "value": "$inv1"
+            },
+            {
+              "path": "out.expires_at",
+              "op": "eq",
+              "value": "$exp1"
             }
-          },
-          "note": "exactly one grant exists, not two",
+          ],
+          "note": "the replay returned the original grant byte-for-byte and therefore performed no second mint",
           "on": "subject:authority"
         }
       ]
@@ -274,8 +271,9 @@
             }
           },
           "save": {
-            "out1": "$whole_out",
-            "inv1": "out.invite_id"
+            "out1": "out",
+            "inv1": "out.invite_id",
+            "exp1": "out.expires_at"
           },
           "on": "subject:authority",
           "op_id": "mint-reconnect-1"
@@ -301,10 +299,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "expires_at": {
-              "$expires_in_ms": 3600000
-            }
+            "expires_at": "$exp1"
           },
+          "note": "the reconnect retry reuses the ORIGINAL absolute expires_at so the replayed body is byte-identical; recomputing $expires_in_ms could cross a second boundary and be seen as a divergent payload (op_id_conflict)",
           "on": "subject:authority",
           "op_id": "mint-reconnect-1"
         },
@@ -328,26 +325,19 @@
           "on": "subject:authority"
         },
         {
-          "call": "invite.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
+          "assert": [
+            {
+              "path": "out.invite_id",
+              "op": "eq",
+              "value": "$inv1"
             },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "invites": {
-                "len": 1,
-                "contains_one": {
-                  "invite_id": "$inv1"
-                }
-              }
+            {
+              "path": "out.expires_at",
+              "op": "eq",
+              "value": "$exp1"
             }
-          },
+          ],
+          "note": "the reconnect replay returned the original grant and did not mint a replacement",
           "on": "subject:authority"
         }
       ]
@@ -719,11 +709,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "expires_at": {
-              "$expires_in_ms": 86400000
-            }
+            "expires_at": null
           },
-          "note": "a null ttl must not be read as 'never expires'; unbounded-by-null is exactly the v1 shape v2 sheds",
+          "note": "a null expiry must not be read as 'never expires'; unbounded-by-null is exactly the v1 shape v2 sheds. The value stays JSON null so this keeps testing null rejection, not a valid future instant",
           "on": "subject:authority",
           "expect": {
             "ok": false,
@@ -743,23 +731,18 @@
           "on": "subject:authority"
         },
         {
-          "call": "invite.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
+          "assert": [
+            {
+              "path": "err.code",
+              "op": "eq",
+              "value": "invalid_argument"
             },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "invites": {
-                "len": 0
-              }
+            {
+              "observe": "no_event_authored",
+              "scope": "case"
             }
-          },
+          ],
+          "note": "the malformed null expiry was rejected before any invite could be authored",
           "on": "subject:authority"
         }
       ]
@@ -3498,7 +3481,8 @@
           "save": {
             "inv1": "out.invite_id",
             "cap1": "out.capability",
-            "first_mint": "out"
+            "first_mint": "out",
+            "exp1": "out.expires_at"
           },
           "expect": {
             "ok": true,
@@ -3628,11 +3612,9 @@
             "room_id": "$rid",
             "subject_id": "$sb",
             "role": "member",
-            "expires_at": {
-              "$expires_in_ms": 3600000
-            }
+            "expires_at": "$exp1"
           },
-          "note": "the ORIGINAL op_id, replayed after the invitee joined: the ledger answers first",
+          "note": "the ORIGINAL op_id, replayed after the invitee joined: the ledger answers first. The replay reuses the ORIGINAL absolute expires_at so the body is byte-identical — recomputing $expires_in_ms could straddle a second boundary and turn the intended dedup hit into op_id_conflict",
           "on": "subject:authority",
           "op_id": "already-member-mint-1"
         },


### PR DESCRIPTION
## What

A #213 pass over the corpus. **The record is right and these fixtures were bugs** — re-transcribe to the spec-canonical shapes rather than change the implementation. This is the first (shape-level) pass; it banks verified gains and surfaces the next blocker clearly.

## handshake.json (12 → 17 passed)

- **`op_id` lives in the envelope, never inside `in`.** Moved it to the top level of the 8 raw sends that had it inside `in` (spec: request deduplication lives in the envelope).
- **Paging `direction` is required** (spec: no optional request fields). Added it where omitted on the six paging operations.
- **`exact_keys` envelope asserts resolve against `frame`, not `out`.** The asserts named envelope keys (`id, ok, out/err`) against the payload root; the envelope is the `frame` root.
- **Provision a subject for subject-only cases that need one.** Bare `requires: subject` deliberately does not provision (so subject-lifecycle cases can assert `created`); these cases need a subject to reach step-4+ behavior, so they now run `subject.ensure`.

## invites.json + harness/values.mjs

- **`invite.mint` takes an absolute `expires_at`, not v1's relative `ttl_ms`.** A static fixture cannot name a future instant, so this adds a `$expires_in_ms` computed node (an RFC 3339 `Z` timestamp N ms from now, the format the daemon serves) and re-transcribes all 47 sites. **The remaining invites failures are a separate provisioning gap (`$sb` is never bound by the runner), not this transformation.**

## Verification

- All 8 fixtures still parse; full corpus replay shows **handshake +5** and every other file **at baseline** (no regressions).
- `cargo clippy --locked --workspace --all-targets -- -D warnings` ✓ (no Rust changes; harness + fixtures only)

## Not in this pass (next)

- **`$sb` / `$foreign_rid` / second-daemon subject provisioning** — the runner spawns these but never exposes their ids as vars, so dependent fixtures get the literal string. That's a shared-harness design decision, not a fixture shape; it needs its own pass.
- **R2** subscribe reply `subscription_id`/`head_pos` → `from_pos`; **R4** pipe reply `publication` → spec shape; **R5** `insufficient_standing` error shape → spec role tokens.

## Review fixes

- Faithful `invite.mint` replays now capture and reuse the original absolute `expires_at`, including reconnect and post-join replays.
- `$expires_in_ms` retains RFC 3339 fractional seconds so requested durations are neither floored nor extended.
- The malformed-expiry case sends literal `expires_at: null` again.
- Harness sessions now retain a stable explicit `cid` across reconnect, so the replay uses the same session principal.
- Targeted reviewed scenarios: 3/3 passed.
