### PR TITLE
fix(docs): harden the documentation profile gate

### DIFF
--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -1,9 +1,9 @@
 ---
 type: "Policy"
 title: "Jeliya documentation profile"
-description: "Metadata, navigation, linking, and CI rules for the repository's OKF-compatible documentation wiki."
+description: "OKF v0.1 alignment boundary, metadata, navigation, linking, and CI rules for Jeliya's documentation bundle."
 tags: ["documentation", "governance", "okf", "wiki"]
-timestamp: "2026-07-12T12:21:59Z"
+timestamp: "2026-07-31T00:24:07Z"
 status: "canonical"
 implementation_status: "implemented"
 verification_status: "verified"
@@ -14,22 +14,30 @@ audience: ["contributors", "documentation-authors", "maintainers"]
 # Jeliya documentation profile
 
 This document defines the repository's documentation contract. The `docs/`
-directory is the canonical, docs-as-code wiki for Jeliya. Documentation changes
-travel with code changes, use the same review history, and can later be rendered
-by any compatible documentation frontend without creating a second source of
-truth.
+directory is the canonical, docs-as-code wiki for Jeliya and targets the OKF
+v0.1 bundle model through a stricter Jeliya authoring profile. Documentation
+changes travel with code changes, use the same review history, and can later be
+rendered without creating a second source of truth.
 
-The profile is based on the [Open Knowledge Format (OKF) v0.1
-draft](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md).
-The commit is pinned because OKF is still a draft and its reference tooling may
-change independently. Jeliya deliberately narrows the format where predictable
-authoring and CI validation matter more than accepting every YAML or Markdown
-variant.
+The profile targets the Open Knowledge Format (OKF) v0.1 draft at upstream
+commit `ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a`, linked under
+[Citations](#citations). The commit is pinned because OKF is still a draft and
+may change independently. Jeliya deliberately narrows the producer format where
+predictable authoring and CI validation matter more than accepting every YAML
+or Markdown variant.
+
+`scripts/check-docs.mjs` is therefore a gate for documents authored into this
+bundle. It is not a general OKF validator, importer, consumer, or round-trip
+editor. If Jeliya later consumes arbitrary OKF bundles, that separate path must
+follow OKF's permissive consumer rules: tolerate unknown types and fields,
+missing optional metadata and indexes, and broken links. A round-trip editor
+should also preserve unknown metadata.
 
 ## Scope and source of truth
 
 - Every Markdown file under `docs/` is a Jeliya documentation concept except
-  the reserved `index.md` navigation file.
+  an `index.md` or `log.md` reserved by OKF. The profile permits navigation
+  indexes at any directory level, requires `docs/index.md`, and prohibits logs.
 - Root project documents such as `README.md`, `PRODUCT.md`, `DESIGN.md`,
   `CHANGELOG.md`, and `SECURITY.md` remain outside the bundle. The wiki index
   links to them as repository resources instead of duplicating their content.
@@ -38,6 +46,33 @@ variant.
 - A document marked `canonical` is the current source of truth for its stated
   scope. This says nothing by itself about whether the subject is implemented,
   verified, or released; those states have separate required fields.
+
+## OKF v0.1 alignment matrix
+
+The matrix separates OKF's bundle requirements from stricter producer-quality
+rules and states where Jeliya intentionally differs from the draft's soft
+conventions. “Profile extension” means that Jeliya-authored documents face an
+additional constraint; it does not mean a generic OKF consumer may reject an
+otherwise conformant bundle. A green gate proves this profile, not every
+possible OKF producer or consumer behavior.
+
+| OKF section | Responsibility | Jeliya evidence and interpretation | Classification |
+|---|---|---|---|
+| §2, concepts and IDs | Bundle | Each non-reserved Markdown file is one concept; its ID is its `docs/`-relative path without `.md`. | Conformant |
+| §3, bundle structure | Bundle | `docs/` is a hierarchical bundle distributed as a subdirectory of a Git repository. | Conformant |
+| §3.1, reserved files | Producer | `index.md` is navigation, never a concept. Optional `log.md` is omitted because Git is authoritative. | Conformant; no-log rule is a profile restriction |
+| §4, encoding and document shape | Producer | The gate decodes every permitted concept and index as strict UTF-8; every concept requires opening and closing frontmatter delimiters before a Markdown body. | Conformant |
+| §4.1, required `type` | Producer | All concepts require a non-empty controlled `type`; requiring nine additional fields is stricter than OKF's baseline. | Conformant; profile extension |
+| §4.1, optional and extension fields | Producer and future consumer | Jeliya authors exactly the fields defined below and currently omits the optional OKF `resource` field. A future consumer must accept unknown fields and should preserve them when round-tripping. | Profile restriction; consumer work is out of scope |
+| §4.1, YAML | Producer | Double-quoted JSON-compatible strings and flow arrays form a deterministic frontmatter subset. The gate rejects malformed UTF-8, lone surrogates, YAML execution features, nesting, and implicit scalars; it intentionally does not accept arbitrary conformant YAML. | Restricted producer syntax; current authored output is YAML-compatible |
+| §4.2, Markdown body | Producer | CommonMark-compatible bodies use one title H1 and H2 internal sections. OKF's body headings are conventions, not conformance requirements. | Conformant; profile extension |
+| §5, cross-links | Producer and future consumer | Jeliya authors file-relative links, a form OKF supports despite recommending `/`-prefixed bundle-relative links, and rejects broken links before merge. A future consumer must tolerate broken links and support both forms. | Conformant output; intentional difference from soft guidance |
+| §6, indexes | Producer | `docs/index.md` is required and every `index.md` has no frontmatter, one first-position H1, valid links, and no raw HTML. H2 grouping and descriptive list quality remain human-reviewed; the intentionally empty v0.6.1 evidence boundary contains no concepts to enumerate yet. | Progressive-disclosure surface with stricter root-index requirement; full grouping semantics are not machine-verified |
+| §7, logs | Producer | No log is present. Git provides chronological history and attribution. | Conformant optional-feature omission |
+| §8, citations | Producer | Jeliya intentionally maps the conventional numbered final `# Citations` section to descriptive entries under a final `## Citations`, beneath the document's single title H1. This remains a human-reviewed rule; the gate validates link safety, not citation completeness. | Intentional difference from soft guidance |
+| §9, hard conformance | Bundle | The gate verifies strict UTF-8, closed restricted frontmatter, a non-empty controlled `type`, exact reserved-name handling, no logs, and the index checks described above. It does not claim to be a generic YAML/OKF validator or to prove every soft structural convention. | Profile-level evidence toward OKF conformance; remaining semantic review is explicit |
+| §9, permissive consumption | Future consumer | No generic OKF consumer or round-trip editor is implemented. The strict authoring gate must not be reused as one. | Out of scope for the current producer |
+| §11, version declaration | Bundle and future consumer | The target version is pinned in this policy. Jeliya elects not to use the draft's optional root-index frontmatter exception. A future consumer should attempt best-effort handling of unknown declared versions. | Conformant optional-feature omission |
 
 ## Required frontmatter
 
@@ -62,12 +97,18 @@ audience: ["client-authors", "contributors", "maintainers"]
 The repository profile accepts a safe, deterministic YAML subset:
 
 - keys are unquoted ASCII identifiers;
-- string values are double-quoted;
-- `tags` and `audience` are non-empty flow-style arrays of double-quoted
-  strings;
+- string values are JSON-compatible double-quoted strings containing valid
+  Unicode scalar values;
+- `tags` and `audience` are non-empty flow-style arrays of unique,
+  double-quoted lowercase hyphenated tokens;
 - nested mappings, custom tags, anchors, aliases, merge keys, block scalars,
   duplicate keys, and implicit scalar typing are not allowed;
 - unknown fields are rejected until this profile explicitly defines them.
+
+The optional OKF `resource` field is not part of the current producer profile
+because these concepts describe repository knowledge rather than separately
+addressable assets. Add it explicitly if Jeliya gains concepts that need stable
+resource URIs; a future OKF consumer must accept it regardless.
 
 ### Fields
 
@@ -77,7 +118,7 @@ The repository profile accepts a safe, deterministic YAML subset:
 | `title` | Human-readable title. It must match the document's single level-one heading. |
 | `description` | One sentence explaining the document's scope and value. |
 | `tags` | Lowercase topical tokens used for discovery. |
-| `timestamp` | UTC ISO 8601 time of the last meaningful content change. |
+| `timestamp` | A real UTC instant in `YYYY-MM-DDTHH:mm:ss[.sss]Z` form for the last meaningful content change. |
 | `status` | The document lifecycle only: one value from the lifecycle table below. |
 | `implementation_status` | Whether the subject described by the document exists in the current candidate tree. |
 | `verification_status` | Strength and currency of evidence for the subject described by the document. |
@@ -179,9 +220,9 @@ and sanitized evidence location. If any of these are missing, use `partial`,
 - Use file-relative links (`PROTOCOL.md`, `../README.md`, or
   `signing-notarization.md#acceptance-checklist`). Never use a leading slash for
   a repository document.
-- Local paths and heading fragments must resolve. External links must use
-  `https://`; the validator checks their shape but does not make network
-  requests.
+- Local paths and heading fragments must resolve inside the repository without
+  traversing symlinks. External links must be credential-free `https://` URLs;
+  the validator checks their shape but does not make network requests.
 - Moving a document changes its OKF concept ID. Avoid moves without a concrete
   information-architecture benefit, and update every inbound link in the same
   change.
@@ -209,10 +250,18 @@ Run the documentation gate from the repository root:
 node scripts/check-docs.mjs
 ```
 
-The gate validates frontmatter, all four controlled status axes, timestamps,
-unique titles, the single-H1 contract, local paths and fragments, and
-reachability from `docs/index.md`. A documentation change is not complete until
-the gate passes.
+The gate validates strict UTF-8 for every permitted concept and index,
+restricted frontmatter syntax, all four controlled status axes, timestamps,
+unique titles, the single-H1 contract, local paths and fragments, regular-file
+and symlink boundaries, and reachability from `docs/index.md`. It also rejects
+images as navigation edges and accepts inline, full-reference, collapsed, and
+shortcut reference links.
+
+The gate does not prove prose quality, one-sentence descriptions, meaningful
+change dates, the two-document threshold for new types, citation completeness,
+status-evidence sufficiency, or qualitative index grouping. Those remain review
+obligations. A documentation change is not complete until both the machine gate
+and the applicable review obligations pass.
 
 ## Non-goals
 
@@ -220,3 +269,8 @@ This profile does not define a product knowledge runtime, retrieval system,
 vector index, P2P bundle protocol, or agent trust boundary. It structures the
 repository wiki. Jeliya's signed room event log remains the product's source of
 operational truth.
+
+## Citations
+
+- [Open Knowledge Format v0.1 draft, pinned revision](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/ee67a5ca27044ebe7c38385f5b6cffc2305a9c1a/okf/SPEC.md) - Normative bundle, concept, producer, consumer, linking, index, log, citation,
+  conformance, and versioning rules used by this profile.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -356,10 +356,29 @@ function referenceDefinitions(source) {
   return definitions;
 }
 
+function isEscaped(source, index) {
+  let slashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === '\\'; cursor -= 1) {
+    slashes += 1;
+  }
+  return slashes % 2 === 1;
+}
+
+function isImageMarker(source, openBracket) {
+  const marker = openBracket - 1;
+  return marker >= 0 && source[marker] === '!' && !isEscaped(source, marker);
+}
+
 function openingBracket(source, closeBracket) {
+  let nested = 0;
   for (let index = closeBracket - 1; index >= 0 && source[index] !== '\n'; index -= 1) {
-    if (source[index] === ']' && source[index - 1] !== '\\') return -1;
-    if (source[index] === '[' && source[index - 1] !== '\\') return index;
+    if (isEscaped(source, index)) continue;
+    if (source[index] === ']') {
+      nested += 1;
+    } else if (source[index] === '[') {
+      if (nested === 0) return index;
+      nested -= 1;
+    }
   }
   return -1;
 }
@@ -433,7 +452,7 @@ function inlineLinks(source, bodyStartLine) {
       links.push({
         destination,
         line: lineAt(source, index, bodyStartLine),
-        navigation: source[open - 1] !== '!',
+        navigation: !isImageMarker(source, open),
       });
     }
     index = cursor;
@@ -462,6 +481,8 @@ function referenceLinks(source, bodyStartLine, definitions) {
   const occupied = [];
   const pattern = /!?\[([^\]\n]+)\]\[([^\]\n]*)\]/g;
   for (const match of source.matchAll(pattern)) {
+    const open = match.index + (match[0].startsWith('!') ? 1 : 0);
+    if (isEscaped(source, open)) continue;
     if (
       /^ {0,3}\[[^\]]+\]:/.test(
         source.slice(source.lastIndexOf('\n', match.index) + 1),
@@ -479,12 +500,14 @@ function referenceLinks(source, bodyStartLine, definitions) {
     links.push({
       destination: definitions.get(label),
       line,
-      navigation: !match[0].startsWith('!'),
+      navigation: !isImageMarker(source, open),
     });
   }
 
   const shortcutPattern = /!?\[([^\]\n]+)\](?![(:\[])/g;
   for (const match of source.matchAll(shortcutPattern)) {
+    const open = match.index + (match[0].startsWith('!') ? 1 : 0);
+    if (isEscaped(source, open)) continue;
     if (occupied.some(([start, end]) => match.index >= start && match.index < end)) continue;
     if (
       /^ {0,3}\[[^\]]+\]:/.test(
@@ -498,7 +521,7 @@ function referenceLinks(source, bodyStartLine, definitions) {
     links.push({
       destination: definitions.get(label),
       line: lineAt(source, match.index, bodyStartLine),
-      navigation: !match[0].startsWith('!'),
+      navigation: !isImageMarker(source, open),
     });
   }
   return { links, missing };
@@ -773,10 +796,12 @@ function resolveLocalLink(sourcePath, destination) {
   const rawFragment = hash === -1 ? '' : unescaped.slice(hash + 1);
   const query = beforeHash.indexOf('?');
   const rawPath = query === -1 ? beforeHash : beforeHash.slice(0, query);
+  const rawQuery = query === -1 ? '' : beforeHash.slice(query + 1);
   let pathPart;
   let fragment;
   try {
     pathPart = decodeURIComponent(rawPath);
+    decodeURIComponent(rawQuery);
     fragment = decodeURIComponent(rawFragment);
   } catch {
     return { error: 'link contains invalid percent encoding' };

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -11,6 +11,7 @@
 
 import { existsSync, lstatSync, realpathSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, extname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { TextDecoder } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
@@ -75,8 +76,38 @@ function toRepoPath(repoRoot, path) {
   return relative(repoRoot, path).split(sep).join('/');
 }
 
+function isWithin(root, path) {
+  const rel = relative(root, path);
+  return rel === '' || (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`));
+}
+
+function hasSymlinkComponent(root, path) {
+  const rel = relative(root, path);
+  if (!isWithin(root, path)) return false;
+  let current = root;
+  for (const part of rel.split(sep).filter(Boolean)) {
+    current = resolve(current, part);
+    if (lstatSync(current).isSymbolicLink()) return true;
+  }
+  return false;
+}
+
 function issue(file, line, code, message) {
   return { file, line, code, message };
+}
+
+function readUtf8Document(path, file, findings) {
+  const bytes = readFileSync(path);
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    findings.push(
+      issue(file, 1, 'encoding-utf8', 'Markdown document must contain valid UTF-8'),
+    );
+    // Content has no reliable character boundaries, so do not manufacture
+    // secondary metadata, heading, or link findings from lossy replacement.
+    return null;
+  }
 }
 
 function scalarError(value) {
@@ -109,6 +140,7 @@ function parseScalar(raw) {
     throw new Error('invalid double-quoted string');
   }
   if (typeof parsed !== 'string') throw new Error('value must be a string');
+  if (!parsed.isWellFormed()) throw new Error('string must contain valid Unicode scalar values');
   return parsed;
 }
 
@@ -178,6 +210,7 @@ export function parseFrontmatter(source, file = '<document>') {
 
   const data = Object.create(null);
   const errors = [];
+  const seenKeys = new Set();
   for (let index = 1; index < close; index += 1) {
     const rawLine = lines[index];
     const trimmed = rawLine.trim();
@@ -203,12 +236,13 @@ export function parseFrontmatter(source, file = '<document>') {
       );
       continue;
     }
-    if (Object.hasOwn(data, key)) {
+    if (seenKeys.has(key)) {
       errors.push(
         issue(file, index + 1, 'frontmatter-duplicate', `duplicate key: ${key}`),
       );
       continue;
     }
+    seenKeys.add(key);
 
     if (rawValue.trim() === '') {
       errors.push(
@@ -237,14 +271,43 @@ export function parseFrontmatter(source, file = '<document>') {
   };
 }
 
-function markdownFiles(dir) {
+function markdownFiles(dir, repoRoot, findings) {
   const files = [];
   for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
     compareText(a.name, b.name),
   )) {
     const path = resolve(dir, entry.name);
-    if (entry.isDirectory()) files.push(...markdownFiles(path));
-    else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) files.push(path);
+    const file = toRepoPath(repoRoot, path);
+    const lowerName = entry.name.toLowerCase();
+    if ((lowerName === 'index.md' || lowerName === 'log.md') && entry.name !== lowerName) {
+      findings.push(
+        issue(
+          file,
+          1,
+          'reserved-name-case',
+          `reserved documentation filename must use exact lowercase spelling: ${lowerName}`,
+        ),
+      );
+    }
+    if (entry.isSymbolicLink()) {
+      findings.push(
+        issue(file, 1, 'docs-symlink', 'documentation entries must not be symbolic links'),
+      );
+    } else if (entry.isDirectory()) {
+      if (entry.name.toLowerCase().endsWith('.md')) {
+        findings.push(
+          issue(file, 1, 'docs-file-type', 'Markdown documents must be regular files'),
+        );
+      } else {
+        files.push(...markdownFiles(path, repoRoot, findings));
+      }
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      files.push(path);
+    } else if (!entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      findings.push(
+        issue(file, 1, 'docs-file-type', 'Markdown documents must be regular files'),
+      );
+    }
   }
   return files;
 }
@@ -282,28 +345,23 @@ function lineAt(source, index, bodyStartLine) {
   return line;
 }
 
-function referenceDefinitions(source, bodyStartLine) {
+function referenceDefinitions(source) {
   const definitions = new Map();
-  const links = [];
   const pattern = /^ {0,3}\[([^\]\n]+)\]:[ \t]*(?:<([^>\n]+)>|(\S+))/gm;
   for (const match of source.matchAll(pattern)) {
     const label = match[1].trim().replace(/\s+/g, ' ').toLowerCase();
     const destination = match[2] ?? match[3];
-    definitions.set(label, destination);
-    links.push({
-      destination,
-      line: lineAt(source, match.index, bodyStartLine),
-      navigation: false,
-    });
+    if (!definitions.has(label)) definitions.set(label, destination);
   }
-  return { definitions, links };
+  return definitions;
 }
 
-function hasOpeningBracket(source, closeBracket) {
+function openingBracket(source, closeBracket) {
   for (let index = closeBracket - 1; index >= 0 && source[index] !== '\n'; index -= 1) {
-    if (source[index] === '[' && source[index - 1] !== '\\') return true;
+    if (source[index] === ']' && source[index - 1] !== '\\') return -1;
+    if (source[index] === '[' && source[index - 1] !== '\\') return index;
   }
-  return false;
+  return -1;
 }
 
 function destinationFromLinkContents(contents) {
@@ -331,11 +389,12 @@ function destinationFromLinkContents(contents) {
 function inlineLinks(source, bodyStartLine) {
   const links = [];
   for (let index = 0; index < source.length - 1; index += 1) {
+    const open = source[index] === ']' ? openingBracket(source, index) : -1;
     if (
       source[index] !== ']' ||
       source[index + 1] !== '(' ||
       source[index - 1] === '\\' ||
-      !hasOpeningBracket(source, index)
+      open === -1
     ) {
       continue;
     }
@@ -374,7 +433,7 @@ function inlineLinks(source, bodyStartLine) {
       links.push({
         destination,
         line: lineAt(source, index, bodyStartLine),
-        navigation: true,
+        navigation: source[open - 1] !== '!',
       });
     }
     index = cursor;
@@ -384,9 +443,12 @@ function inlineLinks(source, bodyStartLine) {
 
 function automaticLinks(source, bodyStartLine) {
   const links = [];
-  for (const match of source.matchAll(/<([A-Za-z][A-Za-z0-9+.-]*:[^<>\s]+)>/g)) {
+  const pattern = /<([A-Za-z][A-Za-z0-9+.-]*:[^<>\s]+|[^<>\s@]+@[^<>\s@]+)>/g;
+  for (const match of source.matchAll(pattern)) {
     links.push({
-      destination: match[1],
+      destination: match[1].includes('@') && !URI_SCHEME.test(match[1])
+        ? `mailto:${match[1]}`
+        : match[1],
       line: lineAt(source, match.index, bodyStartLine),
       navigation: false,
     });
@@ -397,6 +459,7 @@ function automaticLinks(source, bodyStartLine) {
 function referenceLinks(source, bodyStartLine, definitions) {
   const links = [];
   const missing = [];
+  const occupied = [];
   const pattern = /!?\[([^\]\n]+)\]\[([^\]\n]*)\]/g;
   for (const match of source.matchAll(pattern)) {
     if (
@@ -408,22 +471,45 @@ function referenceLinks(source, bodyStartLine, definitions) {
     }
     const label = (match[2] || match[1]).trim().replace(/\s+/g, ' ').toLowerCase();
     const line = lineAt(source, match.index, bodyStartLine);
+    occupied.push([match.index, match.index + match[0].length]);
     if (!definitions.has(label)) {
       missing.push({ line, label });
       continue;
     }
-    links.push({ destination: definitions.get(label), line, navigation: true });
+    links.push({
+      destination: definitions.get(label),
+      line,
+      navigation: !match[0].startsWith('!'),
+    });
+  }
+
+  const shortcutPattern = /!?\[([^\]\n]+)\](?![(:\[])/g;
+  for (const match of source.matchAll(shortcutPattern)) {
+    if (occupied.some(([start, end]) => match.index >= start && match.index < end)) continue;
+    if (
+      /^ {0,3}\[[^\]]+\]:/.test(
+        source.slice(source.lastIndexOf('\n', match.index) + 1),
+      )
+    ) {
+      continue;
+    }
+    const label = match[1].trim().replace(/\s+/g, ' ').toLowerCase();
+    if (!definitions.has(label)) continue;
+    links.push({
+      destination: definitions.get(label),
+      line: lineAt(source, match.index, bodyStartLine),
+      navigation: !match[0].startsWith('!'),
+    });
   }
   return { links, missing };
 }
 
 function markdownLinks(body, bodyStartLine) {
   const source = maskMarkdownCode(body);
-  const refs = referenceDefinitions(source, bodyStartLine);
-  const usages = referenceLinks(source, bodyStartLine, refs.definitions);
+  const definitions = referenceDefinitions(source);
+  const usages = referenceLinks(source, bodyStartLine, definitions);
   return {
     links: [
-      ...refs.links,
       ...inlineLinks(source, bodyStartLine),
       ...automaticLinks(source, bodyStartLine),
       ...usages.links,
@@ -504,6 +590,7 @@ function levelOneHeadings(frontmatter) {
 
 function validateMetadata(document, findings) {
   const { file, frontmatter, isIndex } = document;
+  if (frontmatter.errors.some((entry) => entry.code === 'frontmatter-unclosed')) return;
   const headings = levelOneHeadings(frontmatter);
   const firstBodyLine = frontmatter.body
     .split('\n')
@@ -666,7 +753,7 @@ function validateMetadata(document, findings) {
 function validateRawHtml(document, findings) {
   const source = maskMarkdownCode(document.frontmatter.body);
   const pattern =
-    /<(?:\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*?)?\/?|![^<>]*|\?[^<>]*\?)>/gi;
+    /<(?:\/?[A-Za-z][A-Za-z0-9-]*(?:\s(?:[^<>"']|"[^"]*"|'[^']*')*?)?\/?|![^<>]*|\?[^<>]*\?)>/gi;
   for (const match of source.matchAll(pattern)) {
     findings.push(
       issue(
@@ -680,26 +767,37 @@ function validateRawHtml(document, findings) {
 }
 
 function resolveLocalLink(sourcePath, destination) {
-  let decoded;
+  const unescaped = destination.replace(/\\([ ()])/g, '$1');
+  const hash = unescaped.indexOf('#');
+  const beforeHash = hash === -1 ? unescaped : unescaped.slice(0, hash);
+  const rawFragment = hash === -1 ? '' : unescaped.slice(hash + 1);
+  const query = beforeHash.indexOf('?');
+  const rawPath = query === -1 ? beforeHash : beforeHash.slice(0, query);
+  let pathPart;
+  let fragment;
   try {
-    decoded = decodeURIComponent(destination.replace(/\\([ ()])/g, '$1'));
+    pathPart = decodeURIComponent(rawPath);
+    fragment = decodeURIComponent(rawFragment);
   } catch {
     return { error: 'link contains invalid percent encoding' };
   }
-  if (decoded.includes('\\')) return { error: 'local links must use forward slashes' };
-  if (decoded.startsWith('/') || decoded.startsWith('//') || isAbsolute(decoded)) {
+  if (pathPart.includes('\\')) return { error: 'local links must use forward slashes' };
+  if (pathPart.startsWith('/') || pathPart.startsWith('//') || isAbsolute(pathPart)) {
     return { error: 'local links must be relative' };
   }
-  const hash = decoded.indexOf('#');
-  const beforeHash = hash === -1 ? decoded : decoded.slice(0, hash);
-  const fragment = hash === -1 ? '' : decoded.slice(hash + 1);
-  const query = beforeHash.indexOf('?');
-  const pathPart = query === -1 ? beforeHash : beforeHash.slice(0, query);
   const target = pathPart === '' ? sourcePath : resolve(dirname(sourcePath), pathPart);
   return { target, fragment };
 }
 
-function validateLinks(document, repoRoot, docsRoot, anchorsCache, graph, findings) {
+function validateLinks(
+  document,
+  repoRoot,
+  docsRoot,
+  anchorsCache,
+  graph,
+  invalidDocuments,
+  findings,
+) {
   const parsed = markdownLinks(document.frontmatter.body, document.frontmatter.bodyStartLine);
   for (const missing of parsed.missingReferences) {
     findings.push(
@@ -770,13 +868,16 @@ function validateLinks(document, repoRoot, docsRoot, anchorsCache, graph, findin
       );
       continue;
     }
-    if (lstatSync(local.target).isSymbolicLink()) {
+    if (
+      lstatSync(local.target).isSymbolicLink() ||
+      hasSymlinkComponent(repoRoot, local.target)
+    ) {
       findings.push(
         issue(
           document.file,
           link.line,
           'link-symlink',
-          `local target must not be a symlink: ${destination}`,
+          `local target path must not contain symbolic links: ${destination}`,
         ),
       );
       continue;
@@ -794,7 +895,11 @@ function validateLinks(document, repoRoot, docsRoot, anchorsCache, graph, findin
       );
       continue;
     }
-    if (local.fragment && extname(local.target).toLowerCase() === '.md') {
+    if (
+      local.fragment &&
+      extname(local.target).toLowerCase() === '.md' &&
+      !invalidDocuments.has(resolve(local.target))
+    ) {
       const expected = local.fragment.toLocaleLowerCase('en-US');
       if (!markdownAnchors(local.target, anchorsCache).has(expected)) {
         findings.push(
@@ -820,6 +925,16 @@ export function validateDocumentation({ repoRoot = DEFAULT_REPO_ROOT, docsDir = 
   const absoluteRoot = resolve(repoRoot);
   const docsRoot = resolve(absoluteRoot, docsDir);
   const findings = [];
+  if (!isWithin(absoluteRoot, docsRoot)) {
+    return [
+      issue(
+        toRepoPath(absoluteRoot, docsRoot),
+        1,
+        'docs-outside-repo',
+        'docs directory must stay inside the repository root',
+      ),
+    ];
+  }
   if (!existsSync(docsRoot)) {
     return [
       issue(
@@ -827,6 +942,36 @@ export function validateDocumentation({ repoRoot = DEFAULT_REPO_ROOT, docsDir = 
         1,
         'docs-missing',
         'docs directory does not exist',
+      ),
+    ];
+  }
+  if (lstatSync(docsRoot).isSymbolicLink()) {
+    return [
+      issue(
+        toRepoPath(absoluteRoot, docsRoot),
+        1,
+        'docs-symlink',
+        'docs directory must not be a symbolic link',
+      ),
+    ];
+  }
+  if (!lstatSync(docsRoot).isDirectory()) {
+    return [
+      issue(
+        toRepoPath(absoluteRoot, docsRoot),
+        1,
+        'docs-file-type',
+        'docs path must be a directory',
+      ),
+    ];
+  }
+  if (!isWithin(realpathSync(absoluteRoot), realpathSync(docsRoot))) {
+    return [
+      issue(
+        toRepoPath(absoluteRoot, docsRoot),
+        1,
+        'docs-outside-repo',
+        'docs directory resolves outside the repository root',
       ),
     ];
   }
@@ -841,9 +986,22 @@ export function validateDocumentation({ repoRoot = DEFAULT_REPO_ROOT, docsDir = 
         'root documentation index is missing',
       ),
     );
+  } else if (
+    lstatSync(rootIndex).isSymbolicLink() ||
+    !lstatSync(rootIndex).isFile() ||
+    hasSymlinkComponent(docsRoot, rootIndex)
+  ) {
+    findings.push(
+      issue(
+        toRepoPath(absoluteRoot, rootIndex),
+        1,
+        'index-file-type',
+        'root documentation index must be a regular non-symlink file',
+      ),
+    );
   }
 
-  const files = markdownFiles(docsRoot);
+  const files = markdownFiles(docsRoot, absoluteRoot, findings);
   for (const path of files) {
     if (path.split(sep).at(-1).toLowerCase() === 'log.md') {
       findings.push(
@@ -860,18 +1018,23 @@ export function validateDocumentation({ repoRoot = DEFAULT_REPO_ROOT, docsDir = 
     .filter((path) => path.split(sep).at(-1).toLowerCase() !== 'log.md')
     .map((path) => {
       const file = toRepoPath(absoluteRoot, path);
-      const source = readFileSync(path, 'utf8');
-      const frontmatter = parseFrontmatter(source, file);
+      const source = readUtf8Document(path, file, findings);
+      const validEncoding = source !== null;
+      const frontmatter = validEncoding
+        ? parseFrontmatter(source, file)
+        : { data: null, body: '', bodyStartLine: 1, errors: [] };
       findings.push(...frontmatter.errors);
       return {
         path,
         file,
         frontmatter,
+        validEncoding,
         isIndex: path.split(sep).at(-1).toLowerCase() === 'index.md',
       };
     });
 
   for (const document of documents) {
+    if (!document.validEncoding) continue;
     validateMetadata(document, findings);
     validateRawHtml(document, findings);
   }
@@ -900,19 +1063,39 @@ export function validateDocumentation({ repoRoot = DEFAULT_REPO_ROOT, docsDir = 
 
   const graph = new Map(documents.map((document) => [document.path, new Set()]));
   const anchorsCache = new Map();
+  const invalidDocuments = new Set(
+    documents.filter((document) => !document.validEncoding).map((document) => document.path),
+  );
   for (const document of documents) {
-    validateLinks(document, absoluteRoot, docsRoot, anchorsCache, graph, findings);
+    if (!document.validEncoding) continue;
+    validateLinks(
+      document,
+      absoluteRoot,
+      docsRoot,
+      anchorsCache,
+      graph,
+      invalidDocuments,
+      findings,
+    );
   }
   const reachable = new Set();
-  const pending = existsSync(rootIndex) ? [rootIndex] : [];
+  const rootIndexDocument = documents.find((document) => document.path === rootIndex);
+  const pending = rootIndexDocument ? [rootIndex] : [];
   while (pending.length > 0) {
     const path = pending.pop();
     if (reachable.has(path)) continue;
     reachable.add(path);
     for (const target of graph.get(path) ?? []) pending.push(target);
   }
+  // An undecodable reachable document may contain links we cannot discover, so
+  // descendants behind it have unknown reachability. An undecodable document
+  // that is itself unreachable cannot hide any path from the root, and definite
+  // orphans must still be reported.
+  const reachableInvalid = documents.some(
+    (document) => !document.validEncoding && reachable.has(document.path),
+  );
   for (const document of documents) {
-    if (!reachable.has(document.path)) {
+    if (!reachable.has(document.path) && !reachableInvalid) {
       findings.push(
         issue(
           document.file,
@@ -946,14 +1129,15 @@ function parseArgs(argv) {
 
 function main() {
   let options;
+  let findings;
   try {
     options = parseArgs(process.argv.slice(2));
+    findings = validateDocumentation(options);
   } catch (error) {
-    console.error(`docs-check: ${error.message}`);
+    console.error(`docs-check: ${error instanceof Error ? error.message : error}`);
     process.exitCode = 2;
     return;
   }
-  const findings = validateDocumentation(options);
   if (findings.length > 0) {
     console.error(`docs-check: ${findings.length} finding(s)\n`);
     for (const finding of findings) {
@@ -965,4 +1149,6 @@ function main() {
   console.log('docs-check: OK — profile, indexes, titles, and local links are valid.');
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) main();
+const isMain =
+  process.argv[1] && realpathSync(resolve(process.argv[1])) === realpathSync(SCRIPT_PATH);
+if (isMain) main();

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import {
   mkdtempSync,
   mkdirSync,
@@ -110,6 +111,242 @@ tags: [docs]
   );
 });
 
+test('restricted frontmatter rejects lone surrogates and tracks duplicate invalid keys', () => {
+  const parsed = parseFrontmatter(`---
+title: "\\ud800"
+title: "Safe title"
+---
+`);
+
+  assert.deepEqual(
+    parsed.errors.map((entry) => entry.code),
+    ['frontmatter-value', 'frontmatter-duplicate'],
+  );
+  assert.equal(parsed.data.title, undefined);
+});
+
+test('OKF baseline requires closed frontmatter and a non-empty type', () => {
+  const unclosed = parseFrontmatter(`---
+type: "Guide"
+`);
+  assert.deepEqual(
+    unclosed.errors.map((entry) => entry.code),
+    ['frontmatter-unclosed'],
+  );
+
+  const unclosedRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Broken](broken.md)\n',
+    'docs/broken.md': '---\ntype: "Guide"\n# Hidden body\n',
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: unclosedRoot }).map((entry) => entry.code),
+    ['frontmatter-unclosed'],
+  );
+
+  const root = repo({
+    'docs/index.md': `# Documentation
+
+- [Empty type](empty-type.md)
+- [Missing type](missing-type.md)
+- [Missing frontmatter](missing-frontmatter.md)
+`,
+    'docs/empty-type.md': `---
+type: ""
+title: "Empty type"
+description: "Invalid OKF type value."
+tags: ["docs"]
+timestamp: "2026-07-18T00:00:00Z"
+status: "canonical"
+implementation_status: "implemented"
+verification_status: "verified"
+release_status: "not-applicable"
+audience: ["contributors"]
+---
+
+# Empty type
+`,
+    'docs/missing-type.md': `---
+title: "Missing type"
+description: "Missing the required OKF type field."
+tags: ["docs"]
+timestamp: "2026-07-18T00:00:00Z"
+status: "canonical"
+implementation_status: "implemented"
+verification_status: "verified"
+release_status: "not-applicable"
+audience: ["contributors"]
+---
+
+# Missing type
+`,
+    'docs/missing-frontmatter.md': '# Missing frontmatter\n',
+  });
+
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: root }).map((entry) => [entry.file, entry.code]),
+    [
+      ['docs/empty-type.md', 'field-type'],
+      ['docs/empty-type.md', 'type-vocabulary'],
+      ['docs/missing-frontmatter.md', 'frontmatter-required'],
+      ['docs/missing-type.md', 'field-required'],
+    ],
+  );
+});
+
+test('documentation decoding accepts Unicode and rejects malformed UTF-8', () => {
+  const validRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md)\n',
+    'docs/guide.md': concept({
+      title: 'Guide',
+      body: 'Jeliya preserves the jeli tradition: jɛliya — a living record.\n',
+    }),
+  });
+  assert.deepEqual(validateDocumentation({ repoRoot: validRoot }), []);
+
+  const invalidConcept = concept({ title: 'Guide' });
+  const afterOpeningDelimiter = invalidConcept.indexOf('\n') + 1;
+  const invalidRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md)\n',
+    'docs/guide.md': Buffer.concat([
+      Buffer.from(invalidConcept.slice(0, afterOpeningDelimiter), 'utf8'),
+      Buffer.from([0xc3, 0x28]),
+      Buffer.from(invalidConcept.slice(afterOpeningDelimiter), 'utf8'),
+    ]),
+    'docs/orphan.md': concept({ title: 'Orphan' }),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: invalidRoot }).map((entry) => entry.code),
+    ['encoding-utf8'],
+  );
+
+  const unrelatedInvalidRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md)\n',
+    'docs/guide.md': concept({ title: 'Guide' }),
+    'docs/bad.md': Buffer.from([0xc3, 0x28]),
+    'docs/orphan.md': concept({ title: 'Orphan' }),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: unrelatedInvalidRoot }).map((entry) => [
+      entry.file,
+      entry.code,
+    ]),
+    [
+      ['docs/bad.md', 'document-orphan'],
+      ['docs/bad.md', 'encoding-utf8'],
+      ['docs/orphan.md', 'document-orphan'],
+    ],
+  );
+
+  const invalidIndexRoot = repo({
+    'docs/index.md': Buffer.from([0xc3, 0x28]),
+    'docs/guide.md': concept({ title: 'Guide' }),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: invalidIndexRoot }).map((entry) => entry.code),
+    ['encoding-utf8'],
+  );
+
+  const linkedInvalidRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md)\n',
+    'docs/guide.md': concept({
+      title: 'Guide',
+      body: '[Malformed target](bad.md#missing-fragment)\n',
+    }),
+    'docs/bad.md': Buffer.from([0xc3, 0x28]),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: linkedInvalidRoot }).map((entry) => entry.code),
+    ['encoding-utf8'],
+  );
+
+  const invalidParent = concept({
+    title: 'Parent',
+    body: '[Child](child.md)\n',
+  });
+  const afterParentDelimiter = invalidParent.indexOf('\n') + 1;
+  const incompleteGraphRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Parent](parent.md)\n',
+    'docs/parent.md': Buffer.concat([
+      Buffer.from(invalidParent.slice(0, afterParentDelimiter), 'utf8'),
+      Buffer.from([0xc3, 0x28]),
+      Buffer.from(invalidParent.slice(afterParentDelimiter), 'utf8'),
+    ]),
+    'docs/child.md': concept({ title: 'Child' }),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: incompleteGraphRoot }).map((entry) => entry.code),
+    ['encoding-utf8'],
+  );
+});
+
+test('Jeliya requires a root index for curated bundle navigation', () => {
+  const root = repo({
+    'docs/guide.md': concept({ title: 'Guide' }),
+  });
+
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: root })
+      .map((entry) => entry.code)
+      .sort(),
+    ['document-orphan', 'index-required'],
+  );
+});
+
+test('documentation roots, indexes, and concepts must be regular in-repo files', () => {
+  const external = mkdtempSync(join(tmpdir(), 'jeliya-docs-root-external-'));
+  tempRoots.push(external);
+  writeFileSync(join(external, 'index.md'), '# External docs\n');
+  const symlinkedRoot = repo({});
+  symlinkSync(external, join(symlinkedRoot, 'docs'));
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: symlinkedRoot }).map((entry) => entry.code),
+    ['docs-symlink'],
+  );
+
+  const symlinkedIndex = repo({
+    'real-index.md': '# Documentation\n',
+  });
+  mkdirSync(join(symlinkedIndex, 'docs'));
+  symlinkSync(join(symlinkedIndex, 'real-index.md'), join(symlinkedIndex, 'docs/index.md'));
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: symlinkedIndex }).map((entry) => entry.code),
+    ['docs-symlink', 'index-file-type'],
+  );
+
+  const directoryIndex = repo({});
+  mkdirSync(join(directoryIndex, 'docs/index.md'), { recursive: true });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: directoryIndex }).map((entry) => entry.code),
+    ['docs-file-type', 'index-file-type'],
+  );
+
+  const outsideRoot = repo({});
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: outsideRoot, docsDir: '../outside' }).map(
+      (entry) => entry.code,
+    ),
+    ['docs-outside-repo'],
+  );
+
+  const reservedCaseRoot = repo({
+    'docs/index.md': '# Documentation\n',
+    'docs/INDEX.MD': '# Wrong case\n',
+    'docs/LOG.MD': '# Wrong case\n',
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: reservedCaseRoot }).map((entry) => [
+      entry.file,
+      entry.code,
+    ]),
+    [
+      ['docs/INDEX.MD', 'document-orphan'],
+      ['docs/INDEX.MD', 'reserved-name-case'],
+      ['docs/LOG.MD', 'log-prohibited'],
+      ['docs/LOG.MD', 'reserved-name-case'],
+    ],
+  );
+});
+
 test('valid profile, nested indexes, references, and fragments pass', () => {
   const root = repo({
     'docs/index.md': `# Documentation
@@ -139,6 +376,34 @@ Recover from a failed node.
   });
 
   assert.deepEqual(validateDocumentation({ repoRoot: root }), []);
+});
+
+test('shortcut references navigate while images never satisfy reachability', () => {
+  const shortcutRoot = repo({
+    'docs/index.md': `# Documentation
+
+[Guide]
+
+[Guide]: guide.md
+`,
+    'docs/guide.md': concept({ title: 'Guide' }),
+  });
+  assert.deepEqual(validateDocumentation({ repoRoot: shortcutRoot }), []);
+
+  for (const body of [
+    '![Guide](guide.md)',
+    '![Guide][guide]\n\n[guide]: guide.md',
+    '[text] ordinary prose ](guide.md)',
+  ]) {
+    const imageRoot = repo({
+      'docs/index.md': `# Documentation\n\n${body}\n`,
+      'docs/guide.md': concept({ title: 'Guide' }),
+    });
+    assert.deepEqual(
+      validateDocumentation({ repoRoot: imageRoot }).map((entry) => entry.code),
+      ['document-orphan'],
+    );
+  }
 });
 
 test('index pages need no concept frontmatter and code examples are not links', () => {
@@ -213,6 +478,13 @@ test('broken files, fragments, relative-link policy, and references are reported
     findings.map((entry) => entry.code).sort(),
     ['anchor-broken', 'link-broken', 'link-format', 'link-outside-repo', 'reference-missing'],
   );
+
+  const encodedDelimiterRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md)\n- [Encoded](encoded%23name.md)\n',
+    'docs/guide.md': concept({ title: 'Guide' }),
+    'docs/encoded#name.md': concept({ title: 'Encoded' }),
+  });
+  assert.deepEqual(validateDocumentation({ repoRoot: encodedDelimiterRoot }), []);
 });
 
 test('local links cannot traverse a symlink outside the repository', () => {
@@ -230,7 +502,7 @@ test('local links cannot traverse a symlink outside the repository', () => {
 
   assert.deepEqual(
     validateDocumentation({ repoRoot: root }).map((entry) => entry.code),
-    ['link-outside-repo'],
+    ['docs-symlink', 'link-symlink'],
   );
 });
 
@@ -247,13 +519,14 @@ test('only credential-free HTTPS external links are accepted', () => {
 [opaque](https:example.com)
 [credentials](https://user:secret@example.com)
 <http://example.com/autolink>
+<docs@example.com>
 `,
     }),
   });
 
   const findings = validateDocumentation({ repoRoot: root });
-  assert.equal(findings.filter((entry) => entry.code === 'link-external').length, 6);
-  assert.equal(findings.length, 6);
+  assert.equal(findings.filter((entry) => entry.code === 'link-external').length, 7);
+  assert.equal(findings.length, 7);
 });
 
 test('unknown fields, invalid tokens, and repeated discovery tokens are rejected', () => {
@@ -346,6 +619,7 @@ title: "Not a concept"
       body: `<!-- comments are allowed -->
 
 <script>alert('no')</script>
+<x a="<">
 
 \`<span>code is allowed</span>\`
 `,
@@ -355,7 +629,7 @@ title: "Not a concept"
 
   assert.deepEqual(
     validateDocumentation({ repoRoot: root }).map((entry) => entry.code),
-    ['raw-html', 'raw-html', 'index-frontmatter', 'log-prohibited'],
+    ['raw-html', 'raw-html', 'raw-html', 'index-frontmatter', 'log-prohibited'],
   );
 });
 
@@ -374,6 +648,20 @@ test('duplicate titles and documents absent from every index are reported', () =
       ['docs/b.md', 'title-duplicate'],
     ],
   );
+});
+
+test('CLI runs through a symlink and reports argument errors without a stack trace', () => {
+  const root = repo({});
+  const link = join(root, 'check-docs-link.mjs');
+  symlinkSync(new URL('./check-docs.mjs', import.meta.url), link);
+
+  const invocation = spawnSync(process.execPath, [link, '--bad'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  assert.equal(invocation.status, 2);
+  assert.match(invocation.stderr, /^docs-check: unknown or incomplete argument: --bad\n$/);
+  assert.doesNotMatch(invocation.stderr, /\n\s+at /);
 });
 
 test('developer documentation matches the MSRV and complete CI job matrix', () => {

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -393,6 +393,7 @@ test('shortcut references navigate while images never satisfy reachability', () 
   for (const body of [
     '![Guide](guide.md)',
     '![Guide][guide]\n\n[guide]: guide.md',
+    '\\[Guide]\n\n[Guide]: guide.md',
     '[text] ordinary prose ](guide.md)',
   ]) {
     const imageRoot = repo({
@@ -403,6 +404,17 @@ test('shortcut references navigate while images never satisfy reachability', () 
       validateDocumentation({ repoRoot: imageRoot }).map((entry) => entry.code),
       ['document-orphan'],
     );
+  }
+
+  for (const body of [
+    '[Nested [label]](guide.md)',
+    '\\![Guide](guide.md)',
+  ]) {
+    const linkedRoot = repo({
+      'docs/index.md': `# Documentation\n\n${body}\n`,
+      'docs/guide.md': concept({ title: 'Guide' }),
+    });
+    assert.deepEqual(validateDocumentation({ repoRoot: linkedRoot }), []);
   }
 });
 
@@ -485,6 +497,15 @@ test('broken files, fragments, relative-link policy, and references are reported
     'docs/encoded#name.md': concept({ title: 'Encoded' }),
   });
   assert.deepEqual(validateDocumentation({ repoRoot: encodedDelimiterRoot }), []);
+
+  const malformedQueryRoot = repo({
+    'docs/index.md': '# Documentation\n\n- [Guide](guide.md?q=%ZZ)\n',
+    'docs/guide.md': concept({ title: 'Guide' }),
+  });
+  assert.deepEqual(
+    validateDocumentation({ repoRoot: malformedQueryRoot }).map((entry) => entry.code),
+    ['document-orphan', 'link-format'],
+  );
 });
 
 test('local links cannot traverse a symlink outside the repository', () => {


### PR DESCRIPTION
## What

- Align `docs/PROFILE.md` with the exact OKF v0.1 producer boundary the repository enforces, including explicit human-review obligations.
- Reject malformed UTF-8, lone surrogates, duplicate/unsafe frontmatter keys, symlinked or out-of-root documentation trees, wrong-case reserved files, raw HTML edge cases, and unsafe local/external links.
- Make reachability understand inline/full/collapsed/shortcut references while ensuring images never satisfy navigation.
- Preserve definite orphan findings around malformed documents and make CLI invocation through symlinks execute normally.
- Add focused regression coverage for every hardened boundary.

## Verification

- `node --test scripts/check-docs.test.mjs` — 22/22 passed
- `node scripts/check-docs.mjs` — passed against the repository docs
- `node --check scripts/check-docs.mjs scripts/check-docs.test.mjs` — passed
- CI-adjacent script subset (docs, secret-storage, release/installers/receipt/finalize) — 60/60 passed
- `git diff --check` — passed
