### PR TITLE
feat(protocol): advance typed API and v2 lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,8 +1942,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "iroh",
  "iroh-rooms-core",
@@ -1952,8 +1952,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-core"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -1966,13 +1966,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-net"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "anyhow",
  "bao-tree",
  "blake3",
  "bytes",
+ "getrandom 0.4.3",
  "hex",
  "iroh",
  "iroh-blobs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.91"
 
 [workspace.dependencies]
-# Pinned to the first upstream main commit carrying the provisional-peer gate
-# and store-insert recovery fixes, including the connection-generation follow-ups.
-# This revision is deliberately untagged: rc.3 predates the fixes, while later
-# main adds CLI-only code Jeliya does not consume. Local working trees may drift.
-iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "a5d98b70d717f35d3ce60953a88e12e646f2e871", features = ["experimental"] }
+# Pinned to the upstream terminal-removal delivery fix, which includes the
+# provisional-peer gate, store-insert recovery, and connection-generation
+# hardening required by Jeliya's live lifecycle tests. This revision is
+# deliberately untagged until the upstream release containing those fixes.
+iroh-rooms = { git = "https://github.com/kortiene/iroh-room", rev = "52a4c89e900c2b065f7112638acedeccab83952f", features = ["experimental"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/conformance/v2/handshake.json
+++ b/conformance/v2/handshake.json
@@ -288,7 +288,7 @@
               ],
               "client": {
                 "state": "declared",
-                "protocol": 1
+                "v": 1
               }
             }
           }
@@ -576,13 +576,19 @@
           }
         },
         {
-          "note": "the connection was never upgraded, so no 4001 close occurs",
-          "assert": [
-            {
-              "observe": "connection_open",
-              "on": "subject:self"
+          "note": "the v1 connection was never upgraded, so no 4001 close occurs; the daemon remains available for a fresh v2 client",
+          "http": {
+            "method": "GET",
+            "path": "/api/health",
+            "headers": {
+              "Host": "127.0.0.1:<port>"
             }
-          ]
+          },
+          "expect": {
+            "ok": true,
+            "protocol": 2,
+            "status": 200
+          }
         }
       ]
     },
@@ -617,7 +623,7 @@
               ],
               "client": {
                 "state": "declared",
-                "protocol": 1
+                "v": 1
               }
             }
           }
@@ -642,7 +648,7 @@
               ],
               "client": {
                 "state": "declared",
-                "protocol": 3
+                "v": 3
               }
             }
           }
@@ -941,7 +947,7 @@
               "daemon": "<daemon_sg>",
               "client": {
                 "state": "declared",
-                "storage_generation": 0
+                "sg": 0
               }
             }
           }
@@ -964,7 +970,7 @@
               "daemon": "<daemon_sg>",
               "client": {
                 "state": "declared",
-                "storage_generation": 99
+                "sg": 99
               }
             }
           }
@@ -1189,7 +1195,7 @@
               ],
               "client": {
                 "state": "declared",
-                "protocol": 1
+                "v": 1
               }
             }
           }
@@ -1241,7 +1247,7 @@
               "daemon": "<uint>",
               "client": {
                 "state": "declared",
-                "storage_generation": 0
+                "sg": 0
               }
             }
           }
@@ -4330,8 +4336,8 @@
     "SPEC GAP 3 — no idle-window value is served, yet 4004 idle_timeout is a defined close code. A conformant client cannot compute a keepalive interval that avoids being closed. `close_code_4004_is_emitted_on_idle_timeout` asserts `limits.idle_timeout_ms` exists and will fail until it does.",
     "SPEC GAP 4 — no code is named for a duplicate in-flight `id`, a missing `id`, or an unknown `op`. The spec fixes `invalid_argument` only for the three codec bounds. For duplicate-id and non-object-`in` the fixtures assert `invalid_argument` (they are decode/validation failures and the generic-code prohibition is stated per-operation, not per-envelope). For an unknown `op` the fixture asserts a distinct `unknown_operation` code, derived from the spec's own reasoning that 'a conformance corpus that can only assert a generic code proves nothing about that operation' — an op outside the 33 is not an argument-bound violation. Both are flagged in the fixtures themselves. #163/#164 must ratify or replace these three names before the corpus freezes.",
     "SPEC GAP 5 — capacity has no position in the gate's fixed five-check order. `max_connections` is served but the order is Host, Origin, v, sg, credential, with no capacity step. `connections_at_the_served_limit_...` pins the refusal code (`resource_exhausted`) without claiming a position, and `a_gate_refused_upgrade_consumes_no_connection_slot` derives the security-relevant half that IS decidable: because the gate runs before the upgrade is performed, a gate-refused request never becomes a connection and so cannot exhaust the table.",
-    "INTERPRETATION — tagged-variant field names. The spec shows the tag pattern three times (`subject: {state:'present', subject_id, device_id}`, `resume: {state:'fresh'}`, `gap.to: {state:'bounded', pos}`): a `state` discriminator with the payload inline. The fixtures apply that pattern to the two gate errors, spelling `protocol_unsupported.client` as `{state:'declared', protocol:N}` / `{state:'absent'}` and `storage_generation_mismatch.client` as `{state:'declared', storage_generation:N}` / `{state:'absent'}`. The spec explicitly names the declared/absent variant only for `protocol_unsupported`; for `storage_generation_mismatch` it lists bare fields `daemon`, `client`, but since `sg` may be absent and no null may carry meaning, `client` must be tagged there too. The tag names and the payload key are #163's to fix; the fixtures assert the shape, not the spelling.",
-    "INTERPRETATION — the pre-upgrade rejection body. 'The v2 error envelope as a JSON body' cannot carry an `id`, because no request envelope exists before the upgrade. The fixtures assert `{ok:false, err:{code,...}}` with `id` explicitly absent, `Content-Type: application/json`, and no `hint`/`message`/`detail`.",
+    "TAGGED-VARIANT FIELD NAMES. The spec and #163's typed contract settle `protocol_unsupported.client` as `{state:'declared', v:N}` / `{state:'absent'}` and `storage_generation_mismatch.client` as `{state:'declared', sg:N}` / `{state:'absent'}`. Both use the same inline `state` discriminator pattern as the other protocol variants; no null carries absence.",
+    "INTERPRETATION — the pre-upgrade rejection body. 'The v2 error envelope as a JSON body' cannot carry an `id`, because no request envelope exists before the upgrade. The fixtures assert the bare `{code,...}` error object with `id`/`ok`/`err` absent, `Content-Type: application/json`, and no `hint`/`message`/`detail`.",
     "INTERPRETATION — an expired connect ticket answers `unauthenticated`, not `capability_expired`. The taxonomy scopes `capability_expired` to an invite ('Invite expired — distinct from invalid and from revoked'), and a connect ticket is a credential, so it fails check 5.",
     "INTERPRETATION — /api/session requires an Origin, where /ws does not. The spec says the ticket endpoint must be gated 'at least as strongly as /ws: exact loopback Origin match'. On /ws, Origin is conditional ('if present'); 'at least as strongly' plus 'exact match' reads as mandatory at /api/session, which is also the only reading that makes the endpoint a real credential boundary for a browser. `gate_check_2_admits_an_absent_origin` pins the /ws side so the two are not conflated — over-applying absence-is-refusal to Origin would lock out every native client.",
     "ORDERING DISCLOSURE, deliberately pinned. Check 4 running before check 5 means an unauthenticated loopback caller learns the daemon's storage generation from a 426 body. That is what the spec's fixed order requires, so `gate_order_storage_precedes_credential` asserts it rather than quietly asserting the safer order. If that disclosure is unintended, the fix is to reorder the spec, and this fixture is the thing that will fail when it is reordered.",

--- a/conformance/v2/pipes.json
+++ b/conformance/v2/pipes.json
@@ -1164,7 +1164,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$foreign_rid",
             "connection_id": "$foreign_cid"
           },
           "on": "subject:C",
@@ -1174,7 +1173,8 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "connection_unknown",
+              "connection_id": "$foreign_cid"
             }
           },
           "op_id": "$op7"
@@ -1182,7 +1182,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$never_existed_rid",
             "connection_id": "$foreign_cid"
           },
           "on": "subject:C",
@@ -1192,7 +1191,8 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "connection_unknown",
+              "connection_id": "$foreign_cid"
             }
           },
           "op_id": "$op8"
@@ -2005,16 +2005,13 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid1"
           },
           "expect": {
             "ok": true,
             "out": {
               "connection_id": "$cid1",
-              "released": {
-                "state": "released"
-              }
+              "released": true
             }
           },
           "on": "subject:B",
@@ -2060,7 +2057,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid2"
           },
           "save": {
@@ -2072,7 +2068,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid2"
           },
           "on": "subject:B",
@@ -2109,7 +2104,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$never_issued_cid"
           },
           "on": "subject:B",
@@ -2136,7 +2130,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$other_rid",
             "connection_id": "$cid_in_rid"
           },
           "on": "subject:B",
@@ -2227,15 +2220,12 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid"
           },
           "expect": {
             "ok": true,
             "out": {
-              "released": {
-                "state": "released"
-              }
+              "released": true
             }
           },
           "on": "subject:B",
@@ -2415,7 +2405,6 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid2"
           },
           "on": "subject:B",
@@ -2491,15 +2480,12 @@
         {
           "call": "pipe.release",
           "in": {
-            "room_id": "$rid",
             "connection_id": "$cid"
           },
           "expect": {
             "ok": true,
             "out": {
-              "released": {
-                "state": "released"
-              }
+              "released": true
             }
           },
           "on": "subject:B",

--- a/conformance/v2/rooms.json
+++ b/conformance/v2/rooms.json
@@ -2928,7 +2928,7 @@
           "call": "member.remove",
           "in": {
             "room_id": "$rid",
-            "subject_id": "$subject_o"
+            "subject_id": "$sc"
           },
           "on": "subject:authority",
           "expect": {
@@ -2944,7 +2944,7 @@
         {
           "assert": [
             {
-              "observe": "no_durable_mutation",
+              "observe": "no_event_authored",
               "scope": "step"
             }
           ],
@@ -2990,15 +2990,15 @@
           "call": "member.remove",
           "in": {
             "room_id": "$rid",
-            "subject_id": "$subject_a"
+            "subject_id": "$self_sid"
           },
           "on": "subject:authority",
           "expect": {
             "ok": false,
             "err": {
-              "code": "sole_authority_cannot_leave",
+              "code": "authority_cannot_be_removed",
               "room_id": "<room_id>",
-              "authority_subject_id": "<string>"
+              "subject_id": "$self_sid"
             }
           },
           "op_id": "$op_id_new"
@@ -3006,7 +3006,7 @@
         {
           "assert": [
             {
-              "observe": "no_durable_mutation",
+              "observe": "no_event_authored",
               "scope": "step"
             }
           ],

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -21,7 +21,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use jeliya_api::{ApiError, OpId, PeerRow, Push, RoomId, SubjectState};
+use jeliya_api::{
+    ApiError, FileRead, FileShare, FileShareOut, OpId, PeerRow, Push, RoomId, SubjectState,
+};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -64,6 +66,21 @@ pub struct EngineConfig {
     /// process-shutdown channel; an in-process host passes a sender whose
     /// receiver performs real engine teardown.
     pub shutdown_tx: mpsc::Sender<String>,
+}
+
+/// A verified local file copy for a host-controlled byte response. The path is
+/// never accepted from a protocol caller; core resolves it from `(room_id,
+/// file_id)` after authorization.
+#[derive(Debug, Clone)]
+pub struct LocalFile {
+    /// Verified local path under the daemon's managed storage.
+    pub path: PathBuf,
+    /// Peer-declared display name.
+    pub name: String,
+    /// Peer-declared, untrusted content type.
+    pub declared_content_type: String,
+    /// Verified byte count.
+    pub bytes: u64,
 }
 
 /// Whether `op` is in the record's **`op_id`-deduplicated** class: the
@@ -184,7 +201,10 @@ impl Engine {
     /// to it besides dispatch — `jeliyad`'s HTTP staging endpoints call the
     /// supervisor directly.
     #[must_use]
-    pub fn with_supervisor(supervisor: Arc<RoomSupervisor>, config: EngineConfig) -> Arc<Self> {
+    pub(crate) fn with_supervisor(
+        supervisor: Arc<RoomSupervisor>,
+        config: EngineConfig,
+    ) -> Arc<Self> {
         let (push_tx, _) = broadcast::channel(1024);
         Arc::new(Self {
             supervisor,
@@ -193,12 +213,6 @@ impl Engine {
             stopping: Arc::new(AtomicBool::new(false)),
             ledger: Arc::new(Mutex::new(DedupLedger::default())),
         })
-    }
-
-    /// The underlying supervisor (for host surfaces that bypass dispatch).
-    #[must_use]
-    pub fn supervisor(&self) -> &Arc<RoomSupervisor> {
-        &self.supervisor
     }
 
     /// The resolved data directory.
@@ -223,6 +237,33 @@ impl Engine {
     #[must_use]
     pub fn limits(&self) -> jeliya_api::Limits {
         typed::limits()
+    }
+
+    /// Complete a host-staged typed file share. Hosts supply a managed path;
+    /// the protocol declaration and result remain `jeliya-api` values.
+    pub async fn share_staged_file(
+        &self,
+        req: &FileShare,
+        staged_path: &Path,
+    ) -> CoreResult<FileShareOut> {
+        typed::TypedSupervisor::new(&self.supervisor)
+            .share_staged_file(req, staged_path)
+            .await
+    }
+
+    /// Resolve a verified local file from a typed protocol address for a
+    /// host-controlled byte response.
+    pub async fn local_file(&self, req: &FileRead) -> CoreResult<LocalFile> {
+        let file = self
+            .supervisor
+            .local_file(req.room_id.as_ref(), req.file_id.as_str())
+            .await?;
+        Ok(LocalFile {
+            path: file.path,
+            name: file.name,
+            declared_content_type: file.mime,
+            bytes: file.bytes,
+        })
     }
 
     /// The `hello` `subject` fact: present with ids, its stated absence, or
@@ -533,7 +574,18 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
                         match received {
                             Ok(events) => {
                                 for committed in events {
-                                    emit_committed(&engine, &api_room, committed);
+                                    let membership_ended =
+                                        emit_committed(&engine, &room_id, &api_room, committed);
+                                    if membership_ended {
+                                        if let Err(err) =
+                                            engine.supervisor.close_room(api_room.as_str()).await
+                                        {
+                                            if err.kind != ErrorKind::RoomNotOpen {
+                                                warn!("could not close removed room {key}: {err}");
+                                            }
+                                        }
+                                        break;
+                                    }
                                 }
                             }
                             Err(err) if err.kind == ErrorKind::RoomNotOpen => break,
@@ -552,7 +604,16 @@ async fn push_loop(engine: Arc<Engine>, mut cancel_rx: watch::Receiver<bool>) {
             match poll_typed_events(&engine, &room_id).await {
                 Ok(events) => {
                     for committed in events {
-                        emit_committed(&engine, &api_room, committed);
+                        let membership_ended =
+                            emit_committed(&engine, &room_id, &api_room, committed);
+                        if membership_ended {
+                            if let Err(err) = sup.close_room(&room_str).await {
+                                if err.kind != ErrorKind::RoomNotOpen {
+                                    warn!("could not close removed room {room_str}: {err}");
+                                }
+                            }
+                            break;
+                        }
                     }
                 }
                 Err(err) => warn!("push reconcile failed for {room_str}: {err}"),
@@ -600,9 +661,21 @@ async fn poll_typed_events(
 /// resync path), then delivers the event at its true rank.
 fn emit_committed(
     engine: &Engine,
+    room_id: &iroh_rooms::room::RoomId,
     api_room: &RoomId,
     committed: crate::supervisor::CommittedEvent,
-) {
+) -> bool {
+    let removes_local_subject = match &committed.event.kind {
+        jeliya_api::EventKindContent::MemberRemoved { subject_id, .. } => engine
+            .supervisor
+            .local_identity_key()
+            .is_ok_and(|local| subject_id.as_str() == local.to_string()),
+        _ => false,
+    };
+    let revoked_pipe = match &committed.event.kind {
+        jeliya_api::EventKindContent::PipeRevoked { pipe_id } => Some(pipe_id.clone()),
+        _ => None,
+    };
     if let Some(from_pos) = committed.reordered_at {
         engine.emit(Push::Gap {
             room_id: api_room.clone(),
@@ -615,6 +688,18 @@ fn emit_committed(
         room_id: api_room.clone(),
         event: committed.event,
     });
+    if let Some(pipe_id) = revoked_pipe {
+        if let Err(error) = engine
+            .supervisor
+            .release_pipe_connections(room_id, pipe_id.as_str())
+        {
+            warn!(
+                "could not release local connections for revoked pipe {}: {error}",
+                pipe_id.as_str()
+            );
+        }
+    }
+    removes_local_subject
 }
 
 /// The per-device link rows for one room, for the peer-change drain.
@@ -1023,5 +1108,166 @@ mod tests {
         );
 
         engine.close_all_rooms().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn member_removal_is_the_removed_members_last_push_and_closes_the_room() {
+        use jeliya_api::*;
+
+        let owner_dir = TempDir::new().expect("owner tempdir");
+        let member_dir = TempDir::new().expect("member tempdir");
+        let owner = engine_with_subject(&owner_dir).await;
+        let member = engine_with_subject(&member_dir).await;
+        let SubjectState::Present {
+            subject_id: member_id,
+            ..
+        } = member.subject_state().unwrap()
+        else {
+            panic!("member subject missing");
+        };
+
+        let created = owner
+            .execute(TypedCall::RoomCreate(RoomCreate {
+                name: "Removal lifecycle".into(),
+            }))
+            .await
+            .reply
+            .expect("owner creates room");
+        let TypedReply::RoomCreate(created) = created else {
+            panic!("wrong reply");
+        };
+        let room_id = created.room_id;
+        owner
+            .execute(TypedCall::RoomActivate(RoomActivate {
+                room_id: room_id.clone(),
+            }))
+            .await
+            .reply
+            .expect("owner activates");
+        let owner_loop = owner.clone().start_push_loop();
+
+        let iroh_room: iroh_rooms::room::RoomId = room_id.as_str().parse().unwrap();
+        let owner_session = owner.supervisor.session(&iroh_room).unwrap();
+        let endpoint = owner_session.node.endpoint_addr().unwrap();
+        let sockets: Vec<String> = endpoint.ip_addrs().map(|addr| addr.to_string()).collect();
+        assert!(
+            !sockets.is_empty(),
+            "loopback endpoint has a socket address"
+        );
+        let owner_addr = format!("{}@{}", endpoint.id, sockets.join(","));
+        drop(owner_session);
+
+        let ticket = owner
+            .supervisor
+            .create_invite(room_id.as_str(), member_id.as_str(), "member", None)
+            .await
+            .expect("owner invites member");
+        member
+            .supervisor
+            .join_room(&ticket, None, &[owner_addr])
+            .await
+            .expect("member redeems");
+        member
+            .execute(TypedCall::RoomActivate(RoomActivate {
+                room_id: room_id.clone(),
+            }))
+            .await
+            .reply
+            .expect("member activates");
+        let member_loop = member.clone().start_push_loop();
+        let mut pushes = member.subscribe_pushes();
+        let member_endpoint = member.supervisor.session(&iroh_room).unwrap().node.id();
+
+        let member_key: iroh_rooms::identity::IdentityKey = member_id.as_str().parse().unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let joined = owner
+                    .supervisor
+                    .snapshot_for(&iroh_room)
+                    .await
+                    .is_ok_and(|snapshot| snapshot.is_active(&member_key));
+                let linked = owner.supervisor.session(&iroh_room).is_ok_and(|session| {
+                    session.node.peer_state(member_endpoint)
+                        == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
+                });
+                if joined && linked {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("owner observes joined member");
+
+        owner
+            .execute(TypedCall::MemberRemove(MemberRemove {
+                room_id: room_id.clone(),
+                subject_id: member_id.clone(),
+            }))
+            .await
+            .reply
+            .expect("authority removes member");
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                match pushes.recv().await {
+                    Ok(Push::Event {
+                        room_id: pushed,
+                        event,
+                    }) if pushed == room_id
+                        && matches!(
+                            event.kind,
+                            EventKindContent::MemberRemoved {
+                                ref subject_id,
+                                ..
+                            } if subject_id == &member_id
+                        ) =>
+                    {
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(error) => panic!("member push stream failed: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("member receives its removal fact");
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while member.supervisor.is_open(&iroh_room) {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("removed member room closes");
+
+        owner
+            .execute(TypedCall::MessageSend(MessageSend {
+                room_id: room_id.clone(),
+                body: "after removal".into(),
+            }))
+            .await
+            .reply
+            .expect("authority can keep authoring");
+        let later_event = tokio::time::timeout(Duration::from_millis(750), async {
+            loop {
+                match pushes.recv().await {
+                    Ok(Push::Event {
+                        room_id: pushed, ..
+                    }) if pushed == room_id => break,
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        })
+        .await;
+        assert!(
+            later_event.is_err(),
+            "no room event is pushed after membership removal"
+        );
+
+        owner_loop.stop();
+        member_loop.stop();
+        owner.close_all_rooms().await;
+        member.close_all_rooms().await;
     }
 }

--- a/crates/jeliya-core/src/lib.rs
+++ b/crates/jeliya-core/src/lib.rs
@@ -2,11 +2,9 @@
 //! `iroh_rooms` SDK (stable tier for authoring/validation, experimental tier
 //! for the online runtime), consumed by the `jeliyad` daemon.
 //!
-//! Modules:
-//! * [`engine`] — the transport-free engine facade: protocol dispatch,
-//!   request/response envelope, and push fan-out per `docs/PROTOCOL.md`,
-//!   shared by every transport (the `jeliyad` WebSocket daemon, the mobile
-//!   FFI shim).
+//! Public modules:
+//! * [`engine`] — the transport-free protocol-v2 facade: typed calls, typed
+//!   replies, and typed push fan-out. Hosts own framing and serialization.
 //! * [`fleet`] — pure agent-liveness derivation (the `agents.fleet` /
 //!   `agent.history` decision table per `docs/agent-orchestration.md` §1.2).
 //! * [`identity`] — create/load the device identity under `--data-dir`
@@ -15,20 +13,21 @@
 //!   overrides. Note: the wire protocol *does* carry a room name
 //!   (`room.created.room_name`), so the local name is an index/override, not
 //!   the source of truth.
-//! * [`materializer`] — pure `StoredEvent -> TimelineEvent` JSON view-models
-//!   per `docs/PROTOCOL.md`.
-//! * [`supervisor`] — `RoomSupervisor`: one experimental `Node` per open room
-//!   (spawned the way the reference CLI spawns its room session), plus the
-//!   offline flows (create/invite/join/reads) mirrored from the CLI.
+//!
+//! The runtime supervisor and the retired v1 JSON materializer are deliberately
+//! private. Protocol callers enter through [`Engine`] and receive
+//! `jeliya-api` values; JSON exists only in host codecs and in the explicitly
+//! out-of-scope daemon-local persistence modules (`identity` and `localstate`).
 
 pub mod engine;
 pub mod error;
 pub mod fleet;
 pub mod identity;
 pub mod localstate;
-pub mod materializer;
-pub mod projection;
-pub mod supervisor;
+#[cfg(test)]
+mod materializer;
+mod projection;
+mod supervisor;
 pub mod typed;
 
 pub use engine::{Engine, EngineConfig, PROTOCOL_VERSION};

--- a/crates/jeliya-core/src/materializer.rs
+++ b/crates/jeliya-core/src/materializer.rs
@@ -18,7 +18,7 @@ use iroh_rooms::room::{MembershipSnapshot, Role};
 /// Map a fold [`Role`] to the protocol's `owner|member|agent` vocabulary.
 /// (The SDK calls the room creator `admin`; the protocol calls it `owner`.)
 #[must_use]
-pub fn role_label(role: Role) -> &'static str {
+pub(crate) fn role_label(role: Role) -> &'static str {
     match role {
         Role::Admin => "owner",
         Role::Member => "member",
@@ -45,7 +45,7 @@ fn sender_role(snapshot: &MembershipSnapshot, sender: &IdentityKey) -> &'static 
 /// The bare 64-hex form of an event id (the protocol strips the `blake3:`
 /// prefix for `event_id`; `room_id` keeps it).
 #[must_use]
-pub fn bare_event_hex(event_id: &EventId) -> String {
+pub(crate) fn bare_event_hex(event_id: &EventId) -> String {
     let s = event_id.to_string();
     match s.strip_prefix("blake3:") {
         Some(hex_part) => hex_part.to_owned(),
@@ -56,21 +56,21 @@ pub fn bare_event_hex(event_id: &EventId) -> String {
 /// The `file_<32-hex>` handle for a 16-byte on-wire short id (mirrors the
 /// reference CLI's `file_handle`).
 #[must_use]
-pub fn file_handle(file_id: &[u8; 16]) -> String {
+pub(crate) fn file_handle(file_id: &[u8; 16]) -> String {
     format!("file_{}", hex::encode(file_id))
 }
 
 /// Fold one stored event into its protocol `TimelineEvent`, or `None` for an
 /// event kind the protocol does not display. Pure: no IO, no clock.
 #[must_use]
-pub fn materialize(se: &StoredEvent, snapshot: &MembershipSnapshot) -> Option<Value> {
+pub(crate) fn materialize(se: &StoredEvent, snapshot: &MembershipSnapshot) -> Option<Value> {
     let ev = SignedEvent::decode(&se.wire.signed).ok()?;
     materialize_signed(&se.room_id, &se.event_id, &ev, snapshot)
 }
 
 /// Fold one decoded signed event into its protocol `TimelineEvent`.
 #[must_use]
-pub fn materialize_signed(
+pub(crate) fn materialize_signed(
     room_id: &RoomId,
     event_id: &EventId,
     ev: &SignedEvent,
@@ -103,7 +103,7 @@ pub fn materialize_signed(
 /// does not name (`member.removed`) — the timestamp is still real, so the row
 /// says *when* without inventing *what*.
 #[must_use]
-pub fn stored_event_recency(se: &StoredEvent) -> Option<(u64, Option<&'static str>)> {
+pub(crate) fn stored_event_recency(se: &StoredEvent) -> Option<(u64, Option<&'static str>)> {
     let ev = SignedEvent::decode(&se.wire.signed).ok()?;
     Some((
         ev.created_at,

--- a/crates/jeliya-core/src/projection.rs
+++ b/crates/jeliya-core/src/projection.rs
@@ -10,9 +10,9 @@
 //! out of scope and stays JSON.
 
 use jeliya_api::{
-    Audience, Author, Cursor, DeviceId, Event, EventId, EventKind, EventKindContent, FileId,
-    InviteId, LastEvent, LastSeen, LatestStatus, Link, LinkReason, Liveness, PipeId, Progress,
-    Role, RoomId, Severity, Standing, StatusLabel, SubjectId, Target, Timestamp, Truncated,
+    Audience, Author, Cursor, Event, EventId, EventKind, EventKindContent, FileId, InviteId,
+    LastEvent, LastSeen, LatestStatus, Liveness, PipeId, Progress, Role, RoomId, Standing,
+    StatusLabel, SubjectId, Target, Timestamp, Truncated,
 };
 use time::OffsetDateTime;
 
@@ -22,7 +22,21 @@ use iroh_rooms::identity::IdentityKey;
 use iroh_rooms::room::{MembershipSnapshot, Role as IrohRole};
 
 use crate::error::{CoreError, CoreResult};
-use crate::materializer::{bare_event_hex, file_handle};
+
+/// The bare 64-hex form of an event id. Protocol v2 strips the SDK's optional
+/// `blake3:` display prefix.
+pub(crate) fn bare_event_hex(event_id: &iroh_rooms::events::EventId) -> String {
+    let displayed = event_id.to_string();
+    displayed
+        .strip_prefix("blake3:")
+        .unwrap_or(&displayed)
+        .to_owned()
+}
+
+/// The protocol file handle for a 16-byte on-wire short id.
+pub(crate) fn file_handle(file_id: &[u8; 16]) -> String {
+    format!("file_{}", hex::encode(file_id))
+}
 
 /// Convert a signed author-dated `created_at` (ms since the Unix epoch, the
 /// non-repudiable author clock) into the wire `<ts>` (RFC 3339, `Z` offset).
@@ -31,9 +45,11 @@ use crate::materializer::{bare_event_hex, file_handle};
 /// clock is never read here. Milliseconds are truncated to whole seconds
 /// because RFC 3339 has no fractional requirement and the `<ts>` grammar is
 /// second-precision.
-fn ts(created_at_ms: u64) -> Timestamp {
-    let secs = i64::try_from(created_at_ms / 1000).unwrap_or(i64::MAX);
-    Timestamp::new(OffsetDateTime::from_unix_timestamp(secs).unwrap_or(OffsetDateTime::UNIX_EPOCH))
+fn ts(created_at_ms: u64) -> Option<Timestamp> {
+    let secs = i64::try_from(created_at_ms / 1000).ok()?;
+    OffsetDateTime::from_unix_timestamp(secs)
+        .ok()
+        .map(Timestamp::new)
 }
 
 /// The v2 per-room position space is the room's committed timeline events
@@ -95,7 +111,7 @@ pub(crate) fn is_committed(se: &StoredEvent) -> bool {
     let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
         return false;
     };
-    kind_content(&ev.content).is_some()
+    ts(ev.created_at).is_some() && kind_content(&ev.content).is_some()
 }
 
 /// Map an Iroh fold role to the v2 `role` vocabulary. `Admin` is the room's
@@ -113,11 +129,11 @@ pub fn role(iroh: IrohRole) -> Role {
 /// Map an on-wire role string (`admin|member|agent`) to the v2 role.
 /// `admin` is `authority`; everything else is `member` (including `agent`,
 /// which is not a role in v2).
-fn role_from_wire(wire: &str) -> Role {
-    if wire == "admin" {
-        Role::Authority
-    } else {
-        Role::Member
+fn role_from_wire(wire: &str) -> Option<Role> {
+    match wire {
+        "admin" => Some(Role::Authority),
+        "member" | "agent" => Some(Role::Member),
+        _ => None,
     }
 }
 
@@ -219,7 +235,7 @@ pub fn materialize_signed(
     Some(Event {
         pos,
         event_id: EventId::new(bare_event_hex(event_id)),
-        at: ts(ev.created_at),
+        at: ts(ev.created_at)?,
         author: author(snapshot, &ev.sender_id),
         kind,
     })
@@ -241,10 +257,9 @@ pub fn stored_event_recency(se: &StoredEvent) -> Option<(u64, Option<EventKind>)
 #[must_use]
 pub fn last_event(recency: Option<(u64, Option<EventKind>)>) -> LastEvent {
     match recency {
-        Some((created_at_ms, Some(kind))) => LastEvent::Present {
-            at: ts(created_at_ms),
-            kind,
-        },
+        Some((created_at_ms, Some(kind))) => {
+            ts(created_at_ms).map_or(LastEvent::Absent, |at| LastEvent::Present { at, kind })
+        }
         _ => LastEvent::Absent,
     }
 }
@@ -271,7 +286,7 @@ fn kind_content(content: &Content) -> Option<EventKindContent> {
         }
         Content::MemberJoined(c) => EventKindContent::MemberJoined {
             subject_id: SubjectId::new(c.device_binding.identity_key.to_string()),
-            role: role_from_wire(&c.role),
+            role: role_from_wire(&c.role)?,
         },
         Content::MemberLeft(c) => EventKindContent::MemberLeft {
             subject_id: SubjectId::new(c.member_id.to_string()),
@@ -288,7 +303,7 @@ fn kind_content(content: &Content) -> Option<EventKindContent> {
         },
         Content::PipeOpened(c) => EventKindContent::PipePublished {
             pipe_id: PipeId::new(hex::encode(c.pipe_id)),
-            target: pipe_target(&c.target_hint),
+            target: pipe_target(&c.target_hint)?,
             audience: pipe_audience(&c.allowed_members),
         },
         Content::PipeClosed(c) => EventKindContent::PipeRevoked {
@@ -305,19 +320,17 @@ fn kind_content(content: &Content) -> Option<EventKindContent> {
 }
 
 /// Parse a pipe `target_hint` (`"host:port"`) into the v2 `target` object.
-/// The hint is authored as a loopback target; a malformed hint falls back to
-/// a loopback placeholder rather than failing the whole event.
-fn pipe_target(hint: &str) -> Target {
-    match hint.rsplit_once(':') {
-        Some((host, port)) => Target {
-            host: host.to_string(),
-            port: port.parse().unwrap_or(0),
-        },
-        None => Target {
-            host: hint.to_string(),
-            port: 0,
-        },
+/// The hint is authored as a loopback target. A malformed or non-loopback
+/// target is omitted rather than projected as a fabricated endpoint.
+fn pipe_target(hint: &str) -> Option<Target> {
+    let addr: std::net::SocketAddr = hint.parse().ok()?;
+    if !addr.ip().is_loopback() || addr.port() == 0 {
+        return None;
     }
+    Some(Target {
+        host: addr.ip().to_string(),
+        port: u64::from(addr.port()),
+    })
 }
 
 /// Map a pipe's allowed-member list to the v2 `audience`. A single allowed
@@ -349,28 +362,11 @@ pub fn standing(removed: bool, left: bool) -> Standing {
     }
 }
 
-/// Build a `Link` from an observed transport state. `direct`/`mixed` are a
-/// direct path, `relay` a relayed one, and anything else is not connected.
-/// `since` is the author-dated instant the link came up when known; the
-/// transport layer does not always date link establishment, so an unknown
-/// since uses the Unix epoch rather than the wall clock.
-#[must_use]
-pub fn link(path: Option<&str>, since_ms: Option<u64>) -> Link {
-    let since = ts(since_ms.unwrap_or(0));
-    match path {
-        Some("direct") | Some("mixed") => Link::Direct { since },
-        Some("relay") => Link::Relay { since },
-        _ => Link::NotConnected {
-            reason: LinkReason::NoRoute,
-        },
-    }
-}
-
 /// A `LastSeen` variant from an optional author-dated instant.
 #[must_use]
 pub fn last_seen(at_ms: Option<u64>) -> LastSeen {
-    match at_ms {
-        Some(ms) => LastSeen::Present { at: ts(ms) },
+    match at_ms.and_then(ts) {
+        Some(at) => LastSeen::Present { at },
         None => LastSeen::Absent,
     }
 }
@@ -380,9 +376,9 @@ pub fn last_seen(at_ms: Option<u64>) -> LastSeen {
 #[must_use]
 pub fn latest_status(label: Option<(&str, u64)>) -> LatestStatus {
     match label {
-        Some((l, ms)) => match status_label(l) {
-            Ok(label) => LatestStatus::Present { label, at: ts(ms) },
-            Err(_) => LatestStatus::Absent,
+        Some((l, ms)) => match (status_label(l), ts(ms)) {
+            (Ok(label), Some(at)) => LatestStatus::Present { label, at },
+            _ => LatestStatus::Absent,
         },
         None => LatestStatus::Absent,
     }
@@ -397,13 +393,6 @@ pub fn liveness(live: crate::fleet::Liveness) -> Liveness {
         crate::fleet::Liveness::Offline => Liveness::Offline,
         crate::fleet::Liveness::Stale => Liveness::Stale,
     }
-}
-
-/// The derived severity for a status label — served, never re-derived by a
-/// client.
-#[must_use]
-pub fn severity(label: StatusLabel) -> Severity {
-    label.severity()
 }
 
 /// A continuation cursor: `More` carrying the position to resume from when a
@@ -430,18 +419,6 @@ pub fn event_id(id: &iroh_rooms::events::EventId) -> EventId {
     EventId::new(bare_event_hex(id))
 }
 
-/// Wrap an Iroh identity key in the opaque v2 `SubjectId`.
-#[must_use]
-pub fn subject_id(key: &IdentityKey) -> SubjectId {
-    SubjectId::new(key.to_string())
-}
-
-/// Wrap a device key string in the opaque v2 `DeviceId`.
-#[must_use]
-pub fn device_id(key: impl Into<String>) -> DeviceId {
-    DeviceId::new(key)
-}
-
 /// Wrap a 16-byte invite short id in the opaque v2 `InviteId` (bare hex).
 #[must_use]
 pub fn invite_id(id: &[u8; 16]) -> InviteId {
@@ -452,12 +429,6 @@ pub fn invite_id(id: &[u8; 16]) -> InviteId {
 #[must_use]
 pub fn pipe_id(id: &[u8; 16]) -> PipeId {
     PipeId::new(hex::encode(id))
-}
-
-/// Wrap a 16-byte file short id in the opaque v2 `FileId` (`file_<hex>`).
-#[must_use]
-pub fn file_id(id: &[u8; 16]) -> FileId {
-    FileId::new(file_handle(id))
 }
 
 #[cfg(test)]
@@ -476,6 +447,7 @@ mod tests {
         build_member_joined, build_member_left, build_room_created, derive_room_id,
         MembershipSnapshot, RoomId, RoomMembership,
     };
+    use jeliya_api::Severity;
 
     const TS: u64 = 1_783_190_000_000;
 

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 use std::time::Duration;
 
 use iroh::TransportAddr;
+#[cfg(test)]
 use serde_json::{json, Value};
 use tokio::sync::{broadcast, Mutex as TokioMutex};
 
@@ -38,25 +39,32 @@ use iroh_rooms::events::{
     EventType, RejectReason, SignedEvent, ValidationContext, WireEvent,
 };
 use iroh_rooms::experimental::pipe_runtime::{is_loopback_target, PipeError, PipeForwarder};
+#[cfg(test)]
+use iroh_rooms::experimental::session::PeerConnState;
 use iroh_rooms::experimental::session::{
     Admission, AdmissionView, AllowlistAdmission, BlobServeConfig, BootstrapProof, ConnEvent,
-    EndpointAddr, EndpointId, JoinBootstrapAdmission, NetConfig, NetMode, Node, PeerConnState,
-    SecretKey, SnapshotAdmission, TracingAudit, DEFAULT_TICK,
+    EndpointAddr, EndpointId, JoinBootstrapAdmission, NetConfig, NetMode, Node, SecretKey,
+    SnapshotAdmission, TracingAudit, DEFAULT_TICK,
 };
 use iroh_rooms::experimental::store::{EventStore, StoreOptions, StoredEvent};
 use iroh_rooms::experimental::sync::{SyncConfig, SyncEngine};
 use iroh_rooms::files::build_file_shared;
 use iroh_rooms::identity::{DeviceBinding, DeviceKey, IdentityKey, SigningKey};
+#[cfg(test)]
+use iroh_rooms::room::Role;
 use iroh_rooms::room::{
-    build_member_invited, build_member_joined, build_member_left, build_room_created,
-    derive_room_id, Ingest, MembershipSnapshot, Role, RoomId, RoomInviteTicket, RoomMembership,
-    Status,
+    build_member_invited, build_member_joined, build_member_left, build_member_removed,
+    build_room_created, derive_room_id, Ingest, MembershipSnapshot, RoomId, RoomInviteTicket,
+    RoomMembership, Status,
 };
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
+#[cfg(test)]
 use crate::fleet::{self, Liveness};
 use crate::identity::SecretKeys;
-use crate::materializer::{self, bare_event_hex, file_handle, role_label};
+#[cfg(test)]
+use crate::materializer::{self, role_label};
+use crate::projection::{bare_event_hex, file_handle};
 use crate::{localstate, now_ms};
 
 /// BLAKE3 KDF domain separator for [`derive_room_device`].
@@ -98,15 +106,16 @@ fn derive_room_device(device: &SigningKey, room_id: &RoomId) -> SigningKey {
 /// per room: a window this size absorbs any realistic skew between peers, and
 /// an event older than 64 causal positions is not this room's "last activity"
 /// under any reading.
+#[cfg(test)]
 const RECENCY_SCAN: u32 = 64;
 
 /// The single event-store database file under the data dir (mirrors the CLI).
-pub const DB_FILE: &str = "rooms.db";
+pub(crate) const DB_FILE: &str = "rooms.db";
 /// Root for the per-room durable blob stores.
 const BLOBS_DIR: &str = "blobs";
 /// Maximum number of bytes accepted for one shared file, exposed so the daemon's
 /// browser-upload endpoint can reject over-limit bodies before staging them.
-pub const FILE_UPLOAD_MAX_BYTES: u64 = MAX_SHARED_FILE_BYTES;
+pub(crate) const FILE_UPLOAD_MAX_BYTES: u64 = MAX_SHARED_FILE_BYTES;
 /// Default downloads directory for `file.fetch` when `save_dir` is omitted.
 const DOWNLOADS_DIR: &str = "downloads";
 /// Room-name cap, mirroring the CLI (spec IR-0102 D7).
@@ -139,11 +148,60 @@ const MEMBERSHIP_EVENT_TYPES: [EventType; 5] = [
 
 /// A verified local file copy that can be served by the loopback HTTP endpoint.
 #[derive(Debug, Clone)]
-pub struct LocalFile {
+pub(crate) struct LocalFile {
     pub path: PathBuf,
     pub name: String,
     pub mime: String,
     pub bytes: u64,
+}
+
+/// The typed facts produced after a staged file has been durably imported and
+/// its signed `file.shared` event has committed. This is runtime plumbing, not
+/// a protocol projection; [`crate::typed`] converts it to `FileShareOut`.
+#[derive(Debug, Clone)]
+pub(crate) struct StagedFileShare {
+    pub file_id: String,
+    pub event_id: String,
+    pub bytes: u64,
+    pub digest: String,
+}
+
+/// Semantic result of `member.remove`; infrastructure failures remain
+/// [`CoreError`]s, while the typed boundary maps these closed outcomes to the
+/// protocol's exact errors.
+pub(crate) enum RemoveMemberOutcome {
+    Removed(String),
+    Authority,
+    Unknown,
+}
+
+/// The verified local result of a completed fetch. The path is host-only
+/// runtime state and never crosses the protocol boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct FetchedFile {
+    #[cfg(test)]
+    pub path: PathBuf,
+    pub bytes: u64,
+    pub provider_device: DeviceKey,
+}
+
+/// One connector-side local pipe connection. Connections are keyed by their
+/// opaque `connection_id`, not by `pipe_id`, so sibling connections to the
+/// same published pipe have independent lifetimes.
+struct LocalPipeConnection {
+    pipe_id: [u8; SHORT_ID_LEN],
+    forwarder: PipeForwarder,
+}
+
+/// Connector-side pipe runtime state guarded by one lock.
+///
+/// Revocation tombstones share the lock with connection insertion so a
+/// `pipe.connect` that finishes its network await after a revoke cannot
+/// resurrect a forwarder for the withdrawn pipe.
+#[derive(Default)]
+struct LocalPipeRegistry {
+    connections: HashMap<String, LocalPipeConnection>,
+    revoked: BTreeSet<[u8; SHORT_ID_LEN]>,
 }
 
 /// One open room: the SDK node (transport + engine + blob serving), the live
@@ -157,7 +215,7 @@ pub struct LocalFile {
 /// `Node` methods take `&self`, so concurrent reads/fetches/publishes share the
 /// one node freely; the mutable session bits sit behind their own small
 /// std mutexes.
-pub struct RoomSession {
+pub(crate) struct RoomSession {
     pub(crate) node: Node,
     conn_rx: StdMutex<broadcast::Receiver<ConnEvent>>,
     /// The node's live `room.event` push stream (issue #83): every event the
@@ -176,7 +234,7 @@ pub struct RoomSession {
     /// unwraps immediately, `Node::shutdown` drops the broadcast senders, and
     /// the parked `recv` wakes with `Closed`.
     room_rx: Arc<TokioMutex<broadcast::Receiver<StoredEvent>>>,
-    forwarders: StdMutex<HashMap<[u8; SHORT_ID_LEN], PipeForwarder>>,
+    forwarders: StdMutex<LocalPipeRegistry>,
     seen: StdMutex<BTreeSet<EventId>>,
     /// The next dense rank this room's push stream expects to serve (the
     /// per-room high-water mark). An in-order append advances it by one; a
@@ -204,7 +262,7 @@ pub struct RoomSession {
 /// room's exclusive blob-store lock; it is deliberately *not* taken by the
 /// message/fetch/share/pipe/peers/push paths (since #84 `file.share` imports
 /// in-session and spawns/tears no node, so it needs no structural lock).
-pub struct RoomSupervisor {
+pub(crate) struct RoomSupervisor {
     data_dir: PathBuf,
     loopback: bool,
     sessions: StdMutex<HashMap<RoomId, Arc<RoomSession>>>,
@@ -317,7 +375,7 @@ fn collect_committed(
 
 impl RoomSupervisor {
     /// Create the supervisor (and the data dir, owner-only).
-    pub fn new(data_dir: PathBuf, loopback: bool) -> CoreResult<Self> {
+    pub(crate) fn new(data_dir: PathBuf, loopback: bool) -> CoreResult<Self> {
         crate::identity::ensure_dir(&data_dir)?;
         Ok(Self {
             data_dir,
@@ -338,43 +396,20 @@ impl RoomSupervisor {
 
     /// The resolved data directory.
     #[must_use]
-    pub fn data_dir(&self) -> &Path {
+    pub(crate) fn data_dir(&self) -> &Path {
         &self.data_dir
-    }
-
-    /// The daemon network mode string for `daemon.status`.
-    #[must_use]
-    pub fn mode(&self) -> &'static str {
-        if self.loopback {
-            "loopback"
-        } else {
-            "real"
-        }
     }
 
     /// Room ids of all open sessions (protocol string form).
     #[must_use]
-    pub fn open_rooms(&self) -> Vec<String> {
+    pub(crate) fn open_rooms(&self) -> Vec<String> {
         self.sessions().keys().map(ToString::to_string).collect()
     }
 
     /// Room ids of all open sessions (typed, for the push loop).
     #[must_use]
-    pub fn open_room_ids(&self) -> Vec<RoomId> {
+    pub(crate) fn open_room_ids(&self) -> Vec<RoomId> {
         self.sessions().keys().copied().collect()
-    }
-
-    /// The `daemon.status` endpoint object (first open session), or `None`
-    /// when no room is open — the daemon has no live node of its own.
-    #[must_use]
-    pub fn status_endpoint(&self) -> Option<Value> {
-        let session = self.sessions().values().next().cloned()?;
-        let node = &session.node;
-        Some(json!({
-            "endpoint_id": node.id().to_string(),
-            "addr": dialable_addr(node),
-            "relay_url": node.relay_url(),
-        }))
     }
 
     // ------------------------------------------------------------------
@@ -1023,7 +1058,7 @@ impl RoomSupervisor {
             node,
             conn_rx: StdMutex::new(conn_rx),
             room_rx: Arc::new(TokioMutex::new(room_rx)),
-            forwarders: StdMutex::new(HashMap::new()),
+            forwarders: StdMutex::new(LocalPipeRegistry::default()),
             seen: StdMutex::new(seen),
             next_push_rank: StdMutex::new(committed_so_far),
             accept_joins,
@@ -1038,12 +1073,15 @@ impl RoomSupervisor {
     /// clone — those ops are all bounded by their own timeouts, so this
     /// terminates. Tears any local pipe forwarders down first.
     async fn reclaim_session(session: Arc<RoomSession>) -> Node {
-        for (_, forwarder) in session
+        let forwarders: Vec<PipeForwarder> = session
             .forwarders
             .lock()
             .expect("forwarders poisoned")
+            .connections
             .drain()
-        {
+            .map(|(_, connection)| connection.forwarder)
+            .collect();
+        for forwarder in forwarders {
             forwarder.shutdown();
         }
         let mut arc = session;
@@ -1064,7 +1102,7 @@ impl RoomSupervisor {
 
     /// `room.create`: author + self-validate + persist the genesis
     /// `room.created` (the creator becomes the room's single immutable owner).
-    pub fn create_room(&self, name: &str) -> CoreResult<String> {
+    pub(crate) fn create_room(&self, name: &str) -> CoreResult<String> {
         validate_room_name(name)?;
         let secret = self.secrets()?;
 
@@ -1110,7 +1148,8 @@ impl RoomSupervisor {
     }
 
     /// `room.list`: every locally known room with name/role/member count/open.
-    pub async fn list_rooms(&self) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn list_rooms(&self) -> CoreResult<Vec<Value>> {
         if !self.db_path().exists() {
             return Ok(Vec::new());
         }
@@ -1210,16 +1249,19 @@ impl RoomSupervisor {
         Ok(rooms)
     }
 
-    /// `room.open`: spawn the room's node session and return the endpoint the
-    /// inviter shares, the member roster, and the folded timeline. Optional
-    /// `peers` (`"<endpoint_id>@<ip:port>"`) merge into the room's persisted
-    /// dial hints before the spawn (loopback mode has no discovery).
-    pub async fn open_room(&self, room_id_str: &str, peers: &[String]) -> CoreResult<Value> {
+    /// Activate a room session without constructing a protocol projection.
+    /// Optional `peers` (`"<endpoint_id>@<ip:port>"`) merge into the room's
+    /// persisted dial hints before the spawn (loopback mode has no discovery).
+    pub(crate) async fn activate_room(
+        &self,
+        room_id_str: &str,
+        peers: &[String],
+    ) -> CoreResult<()> {
         let room_id = parse_room_id(room_id_str)?;
-        // `room.open` is also a read RPC: its response includes the roster and
-        // full local timeline. Authorize before persisting caller-supplied dial
-        // hints or attempting a node spawn, otherwise a foreign room present in
-        // the shared store becomes an existence oracle with a different error.
+        // Activation is also a read boundary. Authorize before persisting
+        // caller-supplied dial hints or attempting a node spawn, otherwise a
+        // foreign room present in the shared store becomes an existence oracle
+        // with a different error.
         self.readable_snapshot(&room_id).await?;
         if !peers.is_empty() {
             parse_peers(peers)?; // validate before persisting
@@ -1253,11 +1295,16 @@ impl RoomSupervisor {
             let session = Self::make_session(node, accept_joins, is_owner, seen, committed_so_far);
             self.sessions().insert(room_id, session);
         }
+        Ok(())
+    }
 
-        // Keep `_structural` held through the reads below so a concurrent
-        // close/share cannot pull the session we just resolved. These reads are
-        // all fast and bounded; the message/fetch/pipe/push paths never take
-        // this lock, so nothing daemon-wide is blocked.
+    /// Retired v1 `room.open` projection retained only for internal regression
+    /// tests. Protocol-v2 calls use [`Self::activate_room`] and build their
+    /// typed answer in `typed.rs`.
+    #[cfg(test)]
+    pub(crate) async fn open_room(&self, room_id_str: &str, peers: &[String]) -> CoreResult<Value> {
+        self.activate_room(room_id_str, peers).await?;
+        let room_id = parse_room_id(room_id_str)?;
         let members = self.members(room_id_str).await?;
         let session = self.session(&room_id)?;
         let rows = session
@@ -1309,7 +1356,7 @@ impl RoomSupervisor {
     }
 
     /// `room.close`: shut the session down without changing membership.
-    pub async fn close_room(&self, room_id_str: &str) -> CoreResult<()> {
+    pub(crate) async fn close_room(&self, room_id_str: &str) -> CoreResult<()> {
         let room_id = parse_room_id(room_id_str)?;
         let _structural = self.structural.lock().await;
         let Some(session) = self.sessions().remove(&room_id) else {
@@ -1396,7 +1443,7 @@ impl RoomSupervisor {
     /// close this daemon's local live session if one is open. The immutable room
     /// owner cannot leave yet: the protocol has no ownership transfer, and an
     /// owner-authored `member.left` would not remove the genesis admin anyway.
-    pub async fn leave_room(&self, room_id_str: &str) -> CoreResult<String> {
+    pub(crate) async fn leave_room(&self, room_id_str: &str) -> CoreResult<String> {
         let room_id = parse_room_id(room_id_str)?;
         let secret = self.secrets()?;
         let self_id = secret.identity.identity_key();
@@ -1517,10 +1564,110 @@ impl RoomSupervisor {
         Ok(bare_event_hex(&event_id))
     }
 
+    /// Author the authority's signed removal of one active member. Repeating a
+    /// removal returns the first committed removal event and authors nothing.
+    pub(crate) async fn remove_member(
+        &self,
+        room_id: &RoomId,
+        subject: &IdentityKey,
+    ) -> CoreResult<RemoveMemberOutcome> {
+        let secret = self.secrets()?;
+        let self_id = secret.identity.identity_key();
+        let _structural = self.structural.lock().await;
+
+        let session = self.session_opt(room_id);
+        let (wire, validated) = {
+            let store = self.open_store()?;
+            let (mut membership, snapshot) = self.fold(&store, room_id)?;
+            if snapshot.admin() != Some(&self_id) {
+                return Err(CoreError::new(
+                    ErrorKind::PipeDenied,
+                    "only the room authority may remove a member",
+                ));
+            }
+            if snapshot.admin() == Some(subject) {
+                return Ok(RemoveMemberOutcome::Authority);
+            }
+            let Some(member) = snapshot.member(subject) else {
+                return Ok(RemoveMemberOutcome::Unknown);
+            };
+            // An invitation or even a malicious removal of a never-joined
+            // identity creates a fold row with no device. Protocol v2 keeps
+            // outstanding invitations separate from membership and must not
+            // let that row become a removable member.
+            if member.device.is_none() {
+                return Ok(RemoveMemberOutcome::Unknown);
+            }
+            if member.status == Status::Removed {
+                return Ok(match current_member_removal(&store, room_id, subject)? {
+                    Some(existing) => RemoveMemberOutcome::Removed(bare_event_hex(&existing)),
+                    None => RemoveMemberOutcome::Unknown,
+                });
+            }
+            if member.status != Status::Active {
+                return Ok(RemoveMemberOutcome::Unknown);
+            }
+
+            let room_device = self.authoring_device_key(&snapshot, &secret, room_id);
+            let heads = Self::authorization_class_heads(&store, room_id, &self_id)?;
+            let binding =
+                DeviceBinding::create(room_id, &secret.identity, room_device.device_key());
+            let wire = build_member_removed(
+                &secret.identity,
+                &room_device,
+                room_id,
+                subject,
+                None,
+                Some(binding),
+                &heads,
+                now_ms(),
+            );
+            let validated =
+                validate_wire_bytes(&wire.to_bytes(), &ValidationContext::for_room(*room_id))
+                    .map_err(|reason| {
+                        CoreError::internal(format!(
+                            "freshly built member.removed failed validation ({})",
+                            reason.code()
+                        ))
+                    })?;
+            match membership.ingest(validated.clone()) {
+                Ingest::Accepted { .. } => {}
+                Ingest::Rejected { reason, .. } => {
+                    return Err(CoreError::internal(format!(
+                        "freshly built member.removed was rejected by the fold ({})",
+                        reason.code()
+                    )))
+                }
+                Ingest::Buffered { .. } => {
+                    return Err(CoreError::internal(
+                        "freshly built member.removed is causally incomplete",
+                    ))
+                }
+            }
+            (wire, validated)
+        };
+
+        let event_id = validated.event_id;
+        if let Some(session) = session {
+            Self::publish_authored(&session.node, room_id, &wire).await?;
+        } else {
+            let mut store = self.open_store()?;
+            store
+                .insert(&validated)
+                .map_err(|e| internal("could not persist the member removal", e))?;
+        }
+        Ok(RemoveMemberOutcome::Removed(bare_event_hex(&event_id)))
+    }
+
     /// `room.timeline`: chronological `TimelineEvent`s from the local log
     /// (an offline read — works whether or not the room is open; a second
     /// read handle on the WAL-mode store sees the engine's committed writes).
-    pub async fn timeline(&self, room_id_str: &str, limit: Option<u32>) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn timeline(
+        &self,
+        room_id_str: &str,
+        limit: Option<u32>,
+    ) -> CoreResult<Vec<Value>> {
         let room_id = parse_room_id(room_id_str)?;
         // Sender roles come from the fast membership snapshot (live snapshot for
         // an open room, cached fold for a closed one) — NOT a full O(history)
@@ -1539,7 +1686,8 @@ impl RoomSupervisor {
 
     /// `room.members`: the folded roster with the display-status refinement
     /// (`active|invited|removed|left`, mirroring the CLI's D5 projection).
-    pub async fn members(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn members(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
         let room_id = parse_room_id(room_id_str)?;
         let snapshot = self.readable_snapshot(&room_id).await?;
         let store = self.open_store()?;
@@ -1563,7 +1711,7 @@ impl RoomSupervisor {
     /// `invite.create`: mint a key-bound invite ticket (owner only). When the
     /// room is open the `member.invited` publishes through the live node (so
     /// it also fans out); otherwise it persists directly, like the CLI.
-    pub async fn create_invite(
+    pub(crate) async fn create_invite(
         &self,
         room_id_str: &str,
         invitee_hex: &str,
@@ -1686,7 +1834,7 @@ impl RoomSupervisor {
     /// `room.join`: redeem a ticket — bootstrap the membership sub-DAG from
     /// the admin over an ephemeral node, author + fold-check + publish the
     /// `member.joined`, and record the room locally (mirrors the CLI join).
-    pub async fn join_room(
+    pub(crate) async fn join_room(
         &self,
         ticket_str: &str,
         display_name: Option<&str>,
@@ -1932,7 +2080,7 @@ impl RoomSupervisor {
 
     /// `message.send` (requires the room to be open — the daemon's live node
     /// persists and fans the frame out).
-    pub async fn send_message(&self, room_id_str: &str, body: &str) -> CoreResult<String> {
+    pub(crate) async fn send_message(&self, room_id_str: &str, body: &str) -> CoreResult<String> {
         if body.is_empty() {
             return Err(CoreError::invalid("message body must not be empty"));
         }
@@ -1975,7 +2123,7 @@ impl RoomSupervisor {
 
     /// `status.post`: author + publish a signed `agent.status` (any active
     /// member may post — the protocol rule).
-    pub async fn post_status(
+    pub(crate) async fn post_status(
         &self,
         room_id_str: &str,
         label: &str,
@@ -2056,13 +2204,13 @@ impl RoomSupervisor {
     /// stale-addr-after-share bug is gone). A concurrent `room.close` still tears
     /// down cleanly — its `reclaim_session` waits for this in-flight share to
     /// finish, exactly as it waits for a `file.fetch`.
-    pub async fn share_file(
+    pub(crate) async fn share_file(
         &self,
         room_id_str: &str,
         path_str: &str,
         name: Option<&str>,
         mime: Option<&str>,
-    ) -> CoreResult<Value> {
+    ) -> CoreResult<StagedFileShare> {
         let room_id = parse_room_id(room_id_str)?;
         let secret = self.secrets()?;
         let sender_id = secret.identity.identity_key();
@@ -2129,6 +2277,7 @@ impl RoomSupervisor {
 
         let room_device = self.authoring_device_key(&snapshot, &secret, &room_id);
         let heads = Self::node_heads(&session.node).await?;
+        let digest = iroh_rooms::files::HashRef::from_bytes(import.hash);
         let wire = build_file_shared(
             &secret.identity,
             &room_device,
@@ -2137,17 +2286,19 @@ impl RoomSupervisor {
             &display_name,
             &mime_type,
             import.size_bytes,
-            iroh_rooms::files::HashRef::from_bytes(import.hash),
+            digest,
             Some("raw"),
             &[room_device.device_key()],
             &heads,
             now_ms(),
         );
         let event_id = Self::publish_authored(&session.node, &room_id, &wire).await?;
-        Ok(json!({
-            "file_id": file_handle(&file_id),
-            "event_id": bare_event_hex(&event_id),
-        }))
+        Ok(StagedFileShare {
+            file_id: file_handle(&file_id),
+            event_id: bare_event_hex(&event_id),
+            bytes: import.size_bytes,
+            digest: digest.to_string(),
+        })
     }
 
     /// `file.list`: the room's `file.shared` references with honest
@@ -2161,7 +2312,8 @@ impl RoomSupervisor {
     /// (PROTOCOL.md honesty rule 1). The file is of course still available to
     /// other members while this session serves it — their own `file.list`
     /// reports this device as their online provider.
-    pub async fn list_files(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn list_files(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
         let room_id = parse_room_id(room_id_str)?;
         self.readable_snapshot(&room_id).await?;
         let store = self.open_store()?;
@@ -2225,12 +2377,12 @@ impl RoomSupervisor {
     /// `file.fetch`: verified retrieval from an asserted provider over the
     /// open session's endpoint, with the honest failure taxonomy — never a
     /// silent partial.
-    pub async fn fetch_file(
+    pub(crate) async fn fetch_file(
         &self,
         room_id_str: &str,
         file_id_str: &str,
         save_dir: Option<&str>,
-    ) -> CoreResult<Value> {
+    ) -> CoreResult<FetchedFile> {
         let room_id = parse_room_id(room_id_str)?;
         let file_id = parse_file_id(file_id_str)?;
         let snapshot = self.readable_snapshot(&room_id).await?;
@@ -2282,14 +2434,16 @@ impl RoomSupervisor {
             Some(list) if !list.is_empty() => list.clone(),
             _ => vec![author_device],
         };
-        let provider_ids: Vec<EndpointId> = provider_devices
+        let provider_ids: Vec<(DeviceKey, EndpointId)> = provider_devices
             .iter()
-            .filter_map(|dev| endpoint_id_of(*dev).ok())
-            .filter(|id| *id != self_device)
+            .filter_map(|dev| endpoint_id_of(*dev).ok().map(|id| (*dev, id)))
+            .filter(|(_, id)| *id != self_device)
             .collect();
         let mut providers: Vec<EndpointAddr> = Vec::with_capacity(provider_ids.len());
-        for id in provider_ids {
+        let mut provider_devices = Vec::with_capacity(provider_ids.len());
+        for (device, id) in provider_ids {
             providers.push(self.enriched_addr(&session.node, &room_id, id).await);
+            provider_devices.push(device);
         }
         if providers.is_empty() {
             return Err(CoreError::new(
@@ -2302,9 +2456,9 @@ impl RoomSupervisor {
         }
 
         let declared = *shared.blob_hash.as_bytes();
-        let mut fetched: Option<Vec<u8>> = None;
+        let mut fetched: Option<(Vec<u8>, DeviceKey)> = None;
         let (mut denied_at_connect, mut attempted) = (0usize, 0usize);
-        for provider in &providers {
+        for (provider, provider_device) in providers.iter().zip(provider_devices) {
             let (outcome, data) = session
                 .node
                 .fetch_file(provider.clone(), declared, declared, FETCH_TIMEOUT)
@@ -2314,7 +2468,7 @@ impl RoomSupervisor {
             use iroh_rooms::experimental::blob::FetchOutcome as O;
             match outcome {
                 O::Fetched => {
-                    fetched = data.map(|b| b.to_vec());
+                    fetched = data.map(|b| (b.to_vec(), provider_device));
                     break;
                 }
                 O::HashMismatch => {
@@ -2336,7 +2490,7 @@ impl RoomSupervisor {
                 }
             }
         }
-        let Some(data) = fetched else {
+        let Some((data, provider_device)) = fetched else {
             if attempted > 0 && denied_at_connect == attempted {
                 return Err(CoreError::new(
                     ErrorKind::FileUnauthorized,
@@ -2375,16 +2529,21 @@ impl RoomSupervisor {
             data.len() as u64,
         )?;
 
-        Ok(json!({
-            "path": target.display().to_string(),
-            "bytes": data.len(),
-            "verified": true,
-        }))
+        Ok(FetchedFile {
+            #[cfg(test)]
+            path: target,
+            bytes: data.len() as u64,
+            provider_device,
+        })
     }
 
     /// A previously verified local copy addressed by protocol identifiers, never
     /// by a browser-supplied filesystem path.
-    pub async fn local_file(&self, room_id_str: &str, file_id_str: &str) -> CoreResult<LocalFile> {
+    pub(crate) async fn local_file(
+        &self,
+        room_id_str: &str,
+        file_id_str: &str,
+    ) -> CoreResult<LocalFile> {
         let room_id = parse_room_id(room_id_str)?;
         self.readable_snapshot(&room_id).await?;
         let file_id = parse_file_id(file_id_str)?;
@@ -2423,7 +2582,8 @@ impl RoomSupervisor {
 
     /// `pipe.expose`: announce + serve a loopback TCP target to exactly one
     /// authorized peer (the runtime rule) through the open session's node.
-    pub async fn pipe_expose(
+    #[cfg(test)]
+    pub(crate) async fn pipe_expose(
         &self,
         room_id_str: &str,
         target_str: &str,
@@ -2554,7 +2714,8 @@ impl RoomSupervisor {
 
     /// `pipe.list`: the room's pipes from the local log, with open/closed
     /// state and whether this daemon currently forwards or serves them.
-    pub async fn pipe_list(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn pipe_list(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
         let room_id = parse_room_id(room_id_str)?;
         self.readable_snapshot(&room_id).await?;
         let store = self.open_store()?;
@@ -2586,7 +2747,9 @@ impl RoomSupervisor {
                 s.forwarders
                     .lock()
                     .expect("forwarders poisoned")
-                    .contains_key(&p.pipe_id)
+                    .connections
+                    .values()
+                    .any(|connection| connection.pipe_id == p.pipe_id)
                     || (is_owner && !is_closed && s.node.live_pipe_sessions_for(p.pipe_id) > 0)
             });
             // Every authorized peer, not just the first — a validated remote
@@ -2607,9 +2770,38 @@ impl RoomSupervisor {
         Ok(pipes)
     }
 
+    /// Whether this daemon currently holds a local connection for one pipe.
+    /// Connector-side forwarders and publisher-side accepted sessions are the
+    /// two runtime forms of the same v2 fact.
+    pub(crate) fn pipe_connection_open(
+        &self,
+        room_id: &RoomId,
+        pipe_id: [u8; SHORT_ID_LEN],
+        owner_id: &IdentityKey,
+    ) -> bool {
+        let Some(session) = self.session_opt(room_id) else {
+            return false;
+        };
+        let connector_open = session
+            .forwarders
+            .lock()
+            .expect("forwarders poisoned")
+            .connections
+            .values()
+            .any(|connection| connection.pipe_id == pipe_id);
+        let local_is_owner = self
+            .local_identity_key()
+            .is_ok_and(|identity| identity == *owner_id);
+        connector_open || (local_is_owner && session.node.live_pipe_sessions_for(pipe_id) > 0)
+    }
+
     /// `pipe.connect`: bind a local loopback forwarder toward the pipe owner
     /// and keep it alive inside the session. Returns the local address.
-    pub async fn pipe_connect(&self, room_id_str: &str, pipe_id_hex: &str) -> CoreResult<String> {
+    pub(crate) async fn pipe_connect(
+        &self,
+        room_id_str: &str,
+        pipe_id_hex: &str,
+    ) -> CoreResult<String> {
         let room_id = parse_room_id(room_id_str)?;
         let pipe_id = parse_pipe_id(pipe_id_hex)?;
         let secret = self.secrets()?;
@@ -2656,20 +2848,90 @@ impl RoomSupervisor {
             }
         };
         let local_addr = forwarder.local_addr().to_string();
-        if let Some(old) = session
-            .forwarders
-            .lock()
-            .expect("forwarders poisoned")
-            .insert(pipe_id, forwarder)
-        {
-            old.shutdown();
+        let mut registry = session.forwarders.lock().expect("forwarders poisoned");
+        if registry.revoked.contains(&pipe_id) {
+            drop(registry);
+            forwarder.shutdown();
+            return Err(CoreError::new(
+                ErrorKind::PipeDenied,
+                format!("pipe {pipe_id_hex} was revoked while the connection opened"),
+            ));
         }
+        if registry.connections.contains_key(&local_addr) {
+            drop(registry);
+            forwarder.shutdown();
+            return Err(CoreError::internal(format!(
+                "local pipe connection id collision at {local_addr}"
+            )));
+        }
+        registry.connections.insert(
+            local_addr.clone(),
+            LocalPipeConnection { pipe_id, forwarder },
+        );
         Ok(local_addr)
+    }
+
+    /// Release exactly one connector-side local connection. The connection id
+    /// is globally opaque to the host, so search only the currently open room
+    /// sessions and never consult signed room state or author an event.
+    pub(crate) fn pipe_release(&self, connection_id: &str) -> bool {
+        let sessions: Vec<Arc<RoomSession>> = self.sessions().values().cloned().collect();
+        for session in sessions {
+            let connection = session
+                .forwarders
+                .lock()
+                .expect("forwarders poisoned")
+                .connections
+                .remove(connection_id);
+            if let Some(connection) = connection {
+                connection.forwarder.shutdown();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Tear down every connector-side local connection for one published pipe.
+    /// Used both by the local revoke path and when a remote `pipe.closed`
+    /// commits through the typed push loop.
+    pub(crate) fn release_pipe_connections(
+        &self,
+        room_id: &RoomId,
+        pipe_id_hex: &str,
+    ) -> CoreResult<usize> {
+        let pipe_id = parse_pipe_id(pipe_id_hex)?;
+        let Some(session) = self.session_opt(room_id) else {
+            return Ok(0);
+        };
+        let forwarders: Vec<PipeForwarder> = {
+            let mut registry = session.forwarders.lock().expect("forwarders poisoned");
+            registry.revoked.insert(pipe_id);
+            let connection_ids: Vec<String> = registry
+                .connections
+                .iter()
+                .filter(|(_, connection)| connection.pipe_id == pipe_id)
+                .map(|(connection_id, _)| connection_id.clone())
+                .collect();
+            connection_ids
+                .iter()
+                .filter_map(|connection_id| registry.connections.remove(connection_id))
+                .map(|connection| connection.forwarder)
+                .collect()
+        };
+        let released = forwarders.len();
+        for forwarder in forwarders {
+            forwarder.shutdown();
+        }
+        Ok(released)
     }
 
     /// `pipe.close`: publish a signed `pipe.closed` (owner or room owner) and
     /// tear down any local forwarder.
-    pub async fn pipe_close(&self, room_id_str: &str, pipe_id_hex: &str) -> CoreResult<Value> {
+    pub(crate) async fn pipe_close(
+        &self,
+        room_id_str: &str,
+        pipe_id_hex: &str,
+    ) -> CoreResult<String> {
         let room_id = parse_room_id(room_id_str)?;
         let pipe_id = parse_pipe_id(pipe_id_hex)?;
         let secret = self.secrets()?;
@@ -2712,18 +2974,11 @@ impl RoomSupervisor {
             .await
             .map_err(|e| internal("could not publish pipe.closed", e))?;
 
-        if let Some(forwarder) = session
-            .forwarders
-            .lock()
-            .expect("forwarders poisoned")
-            .remove(&pipe_id)
-        {
-            forwarder.shutdown();
-        }
+        self.release_pipe_connections(&room_id, pipe_id_hex)?;
         let event_id = self
             .find_pipe_event(&room_id, EventType::PipeClosed, pipe_id)
             .await?;
-        Ok(json!({ "event_id": event_id }))
+        Ok(event_id)
     }
 
     /// Find the freshest persisted pipe event of `ty` for `pipe_id` (the
@@ -2774,7 +3029,8 @@ impl RoomSupervisor {
 
     /// `peers.status`: truthful live peer states + path diagnostics from the
     /// open session's node (never inferred from latency).
-    pub async fn peers_status(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn peers_status(&self, room_id_str: &str) -> CoreResult<Vec<Value>> {
         let room_id = parse_room_id(room_id_str)?;
         self.readable_snapshot(&room_id).await?;
         let session = self.session(&room_id)?;
@@ -2782,6 +3038,7 @@ impl RoomSupervisor {
     }
 
     /// The `PeerStatus` list for one live node.
+    #[cfg(test)]
     async fn peers_of(node: &Node) -> Vec<Value> {
         let paths: HashMap<EndpointId, &'static str> = node
             .peer_paths()
@@ -2828,8 +3085,9 @@ impl RoomSupervisor {
     /// not-yet-pushed validated events (own or remote), each returned exactly
     /// once, as materialized `TimelineEvent`s.
     ///
-    /// Since #83 the primary, sub-second push path is [`Self::recv_room_events`]
-    /// (the node's `room_events` broadcast); this poll stays as the reconcile
+    /// Since #83 the primary, sub-second push path is
+    /// [`Self::recv_room_events_typed`] (the node's `room_events` broadcast);
+    /// this poll stays as the reconcile
     /// safety net that a lossy broadcast (a lagged receiver) cannot let drift,
     /// and it is the sole place that keeps the join-bootstrap `accept_joins`
     /// window tied to live pending-invite state. Both paths dedupe against the
@@ -2842,7 +3100,8 @@ impl RoomSupervisor {
     /// the whole tail and deduping against `seen` guarantees every ingested
     /// event is pushed exactly once regardless of its lamport (PROTOCOL.md
     /// `room.event`). Materialization only runs for genuinely new ids.
-    pub async fn poll_new_events(&self, room_id: &RoomId) -> CoreResult<Vec<Value>> {
+    #[cfg(test)]
+    pub(crate) async fn poll_new_events(&self, room_id: &RoomId) -> CoreResult<Vec<Value>> {
         let session = self.session(room_id)?;
         let rows = session
             .node
@@ -2911,100 +3170,10 @@ impl RoomSupervisor {
         ))
     }
 
-    /// Primary push path (issue #83): await the next batch of live room events
-    /// from the node's `room_events` broadcast, materialized for the daemon to
-    /// fan out as `room.event` with sub-second latency.
-    ///
-    /// Blocks on the broadcast until at least one event arrives, then drains
-    /// every immediately-ready event. Each is deduped against the shared `seen`
-    /// set (exactly-once — the broadcast can coincide with the open-time
-    /// snapshot and with the reconcile poll, which share this set). The
-    /// broadcast is LOSSY: on `Lagged` — the receiver fell behind and the SDK
-    /// dropped events — this resyncs from the full causal tail exactly as the
-    /// reconcile poll does, so no ingested event is ever missed. Returns
-    /// `RoomNotOpen` once the session's broadcast closes (`room.close`), so the
-    /// caller's per-room pump loop exits cleanly.
-    pub async fn recv_room_events(&self, room_id: &RoomId) -> CoreResult<Vec<Value>> {
-        // Clone ONLY the broadcast-receiver handle, not the session. Parking on
-        // `recv().await` below must never pin the session `Arc`: `room.close`'s
-        // `reclaim_session` waits for `Arc::try_unwrap` of the session, and a
-        // quiet room emits no event to unpark us — so a session clone held here
-        // would deadlock close daemon-wide. This independent `Arc` keeps the
-        // receiver's cursor across pump iterations without keeping the node
-        // alive; when close shuts the node down, the broadcast closes and the
-        // parked `recv` wakes with `Closed` (handled below as `RoomNotOpen`).
-        let room_rx = self.session(room_id)?.room_rx.clone();
-
-        // Await the first event; a lagged/closed receiver short-circuits.
-        let mut lagged;
-        let mut batch: Vec<StoredEvent> = Vec::new();
-        {
-            let mut rx = room_rx.lock().await;
-            match rx.recv().await {
-                Ok(ev) => {
-                    lagged = false;
-                    batch.push(ev);
-                }
-                Err(broadcast::error::RecvError::Lagged(_)) => lagged = true,
-                Err(broadcast::error::RecvError::Closed) => {
-                    return Err(CoreError::new(
-                        ErrorKind::RoomNotOpen,
-                        format!("room {room_id} closed"),
-                    ));
-                }
-            }
-            // Drain any further already-ready events in the same wake-up.
-            loop {
-                match rx.try_recv() {
-                    Ok(ev) => batch.push(ev),
-                    Err(broadcast::error::TryRecvError::Lagged(_)) => lagged = true,
-                    Err(broadcast::error::TryRecvError::Empty)
-                    | Err(broadcast::error::TryRecvError::Closed) => break,
-                }
-            }
-        }
-
-        // Re-resolve the session now that we have events to materialize. If the
-        // room was closed while we were parked, this returns `RoomNotOpen` and
-        // the pump exits cleanly — the same signal a `Closed` broadcast gives.
-        // This clone is short-lived and bounded (a snapshot/tail read), so it
-        // never blocks `reclaim_session` the way a clone held across the park
-        // would.
-        let session = self.session(room_id)?;
-        let snapshot = session
-            .node
-            .snapshot()
-            .await
-            .map_err(|e| internal("could not read the membership snapshot", e))?;
-
-        // On lag the batch is incomplete, so recover from the authoritative
-        // full tail — a superset of anything the batch held — deduped against
-        // `seen`, exactly as the reconcile poll recovers.
-        if lagged {
-            let rows = session
-                .node
-                .room_tail(u32::MAX)
-                .await
-                .map_err(|e| internal("could not read the timeline", e))?;
-            batch = rows;
-        }
-
-        let mut seen = session.seen.lock().expect("seen poisoned");
-        let mut out = Vec::new();
-        for se in &batch {
-            if seen.insert(se.event_id) {
-                if let Some(v) = materializer::materialize(se, &snapshot) {
-                    out.push(v);
-                }
-            }
-        }
-        Ok(out)
-    }
-
-    /// The typed-v2 primary push path: identical to [`Self::recv_room_events`]
-    /// (same broadcast, same lag recovery, same `seen` dedup) but materializes
-    /// committed events as typed [`CommittedEvent`]s, ranked densely with
-    /// reorder detection (see [`collect_committed`]).
+    /// The typed-v2 primary push path. It uses the room-event broadcast and
+    /// full-tail lag recovery, then materializes committed events as typed
+    /// [`CommittedEvent`]s ranked densely with reorder detection (see
+    /// [`collect_committed`]).
     pub(crate) async fn recv_room_events_typed(
         &self,
         room_id: &RoomId,
@@ -3059,7 +3228,7 @@ impl RoomSupervisor {
 
     /// Drain the session's `conn_events` broadcast; `true` if any peer
     /// connection transition happened since the last drain.
-    pub fn drain_conn_changes(&self, room_id: &RoomId) -> bool {
+    pub(crate) fn drain_conn_changes(&self, room_id: &RoomId) -> bool {
         let Some(session) = self.session_opt(room_id) else {
             return false;
         };
@@ -3092,7 +3261,8 @@ impl RoomSupervisor {
     /// `working` latest status with no connected peer reports `stale`, never
     /// `working`, and a room without an open session can never read
     /// `online-idle`/`working` (no live peer state exists to support it).
-    pub async fn agents_fleet(&self) -> CoreResult<Value> {
+    #[cfg(test)]
+    pub(crate) async fn agents_fleet(&self) -> CoreResult<Value> {
         let now = crate::now_ms();
         let self_id = self.local_identity_key()?;
         // Candidate rooms: only accepted local creates/joins. A shared SQLite
@@ -3295,7 +3465,8 @@ impl RoomSupervisor {
     /// `identity_id` in `room_id`, chronological — the newest `limit` events
     /// (default 100). The daemon never interpolates, smooths, or fabricates
     /// intermediate points; an identity with no statuses returns `[]`.
-    pub async fn agent_history(
+    #[cfg(test)]
+    pub(crate) async fn agent_history(
         &self,
         room_id_str: &str,
         identity_hex: &str,
@@ -3343,6 +3514,7 @@ impl RoomSupervisor {
 /// A closed-over, store-free candidate for `agents.fleet`'s async aggregation
 /// phase. It deliberately carries neither display name nor timeline rows: both
 /// are read only after the local membership guard accepts the room.
+#[cfg(test)]
 struct RoomScan {
     room_id: RoomId,
     room_str: String,
@@ -3352,6 +3524,7 @@ struct RoomScan {
 /// (from `member.joined` bindings and authored events), its newest
 /// `agent_status`, and the ts of its newest event of any kind. All fields
 /// derive from stored events — nothing is synthesized.
+#[cfg(test)]
 #[derive(Default)]
 struct AgentRoomSignals {
     devices: BTreeSet<DeviceKey>,
@@ -3360,6 +3533,7 @@ struct AgentRoomSignals {
 }
 
 /// The newest `agent_status` posted by an agent (per room).
+#[cfg(test)]
 struct LatestStatus {
     ts: u64,
     label: String,
@@ -3368,6 +3542,7 @@ struct LatestStatus {
 }
 
 /// One agent's cross-room aggregate for `agents.fleet`.
+#[cfg(test)]
 #[derive(Default)]
 struct FleetAgentAgg {
     rooms: Vec<Value>,
@@ -3384,6 +3559,7 @@ struct FleetAgentAgg {
 /// the single identity when there is one, or every identity comma-joined when a
 /// (validated remote) `pipe.opened` declares more than one — never silently
 /// dropping the extras.
+#[cfg(test)]
 fn authorized_peer_value(allowed: &[IdentityKey]) -> Value {
     if allowed.is_empty() {
         Value::Null
@@ -3458,6 +3634,7 @@ fn parse_peers(peers: &[String]) -> CoreResult<Vec<EndpointAddr>> {
 
 /// A dialable `<endpoint_id>@<ip:port,...>` string, or `None` when no socket
 /// address is known yet.
+#[cfg(test)]
 fn dialable_addr(node: &Node) -> Option<String> {
     let addr = node.endpoint_addr().ok()?;
     let socks: Vec<String> = addr.ip_addrs().map(|s| s.to_string()).collect();
@@ -3496,39 +3673,116 @@ pub(crate) fn genesis_name(store: &EventStore, room_id: &RoomId) -> Option<Strin
     }
 }
 
-/// Log-derived departure sets (`member.removed` subjects, `member.left`
-/// subjects) backing the display-status refinement.
+/// Log-derived current departure sets (`member.removed` subjects,
+/// `member.left` subjects) backing the display-status refinement.
+///
+/// A later join clears an older terminal fact, and a later leave/removal
+/// replaces the other departure kind. Keeping only the canonical current
+/// fact prevents an old removal from making a rejoined member look removed
+/// forever.
 pub(crate) fn departure_sets(
     store: &EventStore,
     room_id: &RoomId,
 ) -> CoreResult<(BTreeSet<IdentityKey>, BTreeSet<IdentityKey>)> {
     let mut removed_ids = BTreeSet::new();
-    for se in store
-        .by_type(room_id, EventType::MemberRemoved)
-        .map_err(|e| internal("could not read member.removed events", e))?
-    {
-        if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
-            if let Content::MemberRemoved(c) = ev.content {
-                removed_ids.insert(c.member_id);
-            }
-        }
-    }
     let mut left_ids = BTreeSet::new();
-    for se in store
-        .by_type(room_id, EventType::MemberLeft)
-        .map_err(|e| internal("could not read member.left events", e))?
+    for stored in store
+        .room_tail(room_id, u32::MAX)
+        .map_err(|e| internal("could not read member departure history", e))?
     {
-        if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
-            if let Content::MemberLeft(c) = ev.content {
-                left_ids.insert(c.member_id);
+        if let Ok(event) = SignedEvent::decode(&stored.wire.signed) {
+            match event.content {
+                Content::MemberJoined(_) => {
+                    removed_ids.remove(&event.sender_id);
+                    left_ids.remove(&event.sender_id);
+                }
+                Content::MemberRemoved(c) => {
+                    left_ids.remove(&c.member_id);
+                    removed_ids.insert(c.member_id);
+                }
+                Content::MemberLeft(c) => {
+                    removed_ids.remove(&c.member_id);
+                    left_ids.insert(c.member_id);
+                }
+                _ => {}
             }
         }
     }
     Ok((removed_ids, left_ids))
 }
 
+/// The removal among `subject`'s current causal heads.
+///
+/// Display order is not causal order: concurrent siblings can sort on either
+/// side by event id. A removal remains effective when concurrent with a
+/// join/leave (the upstream fold's Removed-dominates rule), and is superseded
+/// only when another membership fact causally descends from it.
+fn current_member_removal(
+    store: &EventStore,
+    room_id: &RoomId,
+    subject: &IdentityKey,
+) -> CoreResult<Option<EventId>> {
+    let rows = store
+        .room_tail(room_id, u32::MAX)
+        .map_err(|e| internal("could not read member history", e))?;
+    let mut events = BTreeMap::new();
+    let mut touch = BTreeSet::new();
+    let mut removals = BTreeSet::new();
+    for stored in rows {
+        let event = SignedEvent::decode(&stored.wire.signed)
+            .map_err(|e| internal("could not decode member history", e))?;
+        let touches_subject = match &event.content {
+            Content::MemberJoined(join)
+                if event.sender_id == *subject && join.device_binding.identity_key == *subject =>
+            {
+                true
+            }
+            Content::MemberLeft(left) if left.member_id == *subject => true,
+            Content::MemberRemoved(removed) if removed.member_id == *subject => {
+                removals.insert(stored.event_id);
+                true
+            }
+            _ => false,
+        };
+        if touches_subject {
+            touch.insert(stored.event_id);
+        }
+        events.insert(stored.event_id, event);
+    }
+    Ok(removals.into_iter().find(|removal| {
+        !touch
+            .iter()
+            .any(|other| other != removal && event_is_ancestor(&events, *removal, *other))
+    }))
+}
+
+/// Whether `ancestor` is in `descendant`'s transitive `prev_events` closure.
+fn event_is_ancestor(
+    events: &BTreeMap<EventId, SignedEvent>,
+    ancestor: EventId,
+    descendant: EventId,
+) -> bool {
+    let mut pending = events
+        .get(&descendant)
+        .map(|event| event.prev_events.clone())
+        .unwrap_or_default();
+    let mut seen = BTreeSet::new();
+    while let Some(candidate) = pending.pop() {
+        if candidate == ancestor {
+            return true;
+        }
+        if seen.insert(candidate) {
+            if let Some(parent) = events.get(&candidate) {
+                pending.extend(parent.prev_events.iter().copied());
+            }
+        }
+    }
+    false
+}
+
 /// `active | invited | removed | left` (the CLI's D5 display refinement: an
 /// admin removal dominates a concurrent self-leave).
+#[cfg(test)]
 fn status_label(
     status: Status,
     subject: &IdentityKey,
@@ -3616,6 +3870,7 @@ fn find_file_shared(
 }
 
 /// The set of pipe ids with a known `pipe.closed` in the room.
+#[cfg(test)]
 fn closed_pipe_ids(
     store: &EventStore,
     room_id: &RoomId,
@@ -3745,16 +4000,19 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        collect_committed, parse_expiry, parse_file_id, parse_pipe_id, sanitize_name,
-        validate_room_name, Content, EventType, RoomSupervisor,
+        bare_event_hex, collect_committed, parse_expiry, parse_file_id, parse_pipe_id,
+        sanitize_name, validate_room_name, Content, EventType, RemoveMemberOutcome, RoomSupervisor,
     };
     use crate::error::ErrorKind;
     use iroh_rooms::events::{
-        build_message_text, validate_wire_bytes, ValidationContext, WireEvent,
+        build_message_text, validate_wire_bytes, SignedEvent, ValidationContext, WireEvent,
     };
     use iroh_rooms::experimental::store::EventStore;
     use iroh_rooms::identity::{DeviceBinding, SigningKey};
-    use iroh_rooms::room::{build_room_created, derive_room_id, RoomId, RoomInviteTicket};
+    use iroh_rooms::room::{
+        build_member_left, build_member_removed, build_room_created, derive_room_id, RoomId,
+        RoomInviteTicket, Status,
+    };
     use std::collections::BTreeSet;
     use tempfile::tempdir;
 
@@ -5074,6 +5332,154 @@ mod tests {
         assert_eq!(members[0]["status"], "active");
     }
 
+    #[tokio::test]
+    async fn member_remove_is_signed_exact_and_semantically_idempotent_offline() {
+        let dir = tempdir().unwrap();
+        let authority = crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = sup.create_room("Removal Room").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+
+        let member_identity = SigningKey::generate();
+        let member_device = SigningKey::generate();
+        seed_agent_member(&sup, &room_id_str, &member_identity, &member_device).await;
+        let member_id = member_identity.identity_key();
+
+        let RemoveMemberOutcome::Removed(first_id) =
+            sup.remove_member(&room_id, &member_id).await.unwrap()
+        else {
+            panic!("active joined member was not removed");
+        };
+        let stored = sup
+            .open_store()
+            .unwrap()
+            .by_type(&room_id, EventType::MemberRemoved)
+            .unwrap();
+        assert_eq!(stored.len(), 1, "exactly one removal fact was authored");
+        let event = SignedEvent::decode(&stored[0].wire.signed).unwrap();
+        let Content::MemberRemoved(removed) = event.content else {
+            panic!("wrong content");
+        };
+        assert_eq!(removed.member_id, member_id);
+        assert_eq!(removed.removed_by.to_string(), authority.identity_id);
+        assert!(
+            removed.device_binding.is_some(),
+            "the authority/device relationship is self-attested"
+        );
+        assert_eq!(
+            sup.snapshot_for(&room_id).await.unwrap().status(&member_id),
+            Some(iroh_rooms::room::Status::Removed)
+        );
+
+        let RemoveMemberOutcome::Removed(replay_id) =
+            sup.remove_member(&room_id, &member_id).await.unwrap()
+        else {
+            panic!("repeat removal did not return the terminal fact");
+        };
+        assert_eq!(replay_id, first_id);
+        assert_eq!(
+            sup.open_store()
+                .unwrap()
+                .by_type(&room_id, EventType::MemberRemoved)
+                .unwrap()
+                .len(),
+            1,
+            "a fresh semantic repeat authors no second event"
+        );
+
+        let unknown = SigningKey::generate().identity_key();
+        assert!(matches!(
+            sup.remove_member(&room_id, &unknown).await.unwrap(),
+            RemoveMemberOutcome::Unknown
+        ));
+        let authority_id: iroh_rooms::identity::IdentityKey =
+            authority.identity_id.parse().unwrap();
+        assert!(matches!(
+            sup.remove_member(&room_id, &authority_id).await.unwrap(),
+            RemoveMemberOutcome::Authority
+        ));
+    }
+
+    #[tokio::test]
+    async fn concurrent_self_leave_does_not_hide_the_effective_removal() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = sup.create_room("Concurrent Removal").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        let member_identity = SigningKey::generate();
+        let member_device = SigningKey::generate();
+        seed_agent_member(&sup, &room_id_str, &member_identity, &member_device).await;
+        let member_id = member_identity.identity_key();
+
+        let secret = sup.secrets().unwrap();
+        let store = sup.open_store().unwrap();
+        let (_, snapshot) = sup.fold(&store, &room_id).unwrap();
+        let room_device = sup.authoring_device_key(&snapshot, &secret, &room_id);
+        let admin = snapshot.admin().copied().unwrap();
+        let heads = RoomSupervisor::authorization_class_heads(&store, &room_id, &admin).unwrap();
+        drop(store);
+
+        let removal = build_member_removed(
+            &secret.identity,
+            &room_device,
+            &room_id,
+            &member_id,
+            None,
+            Some(DeviceBinding::create(
+                &room_id,
+                &secret.identity,
+                room_device.device_key(),
+            )),
+            &heads,
+            crate::now_ms(),
+        );
+        let removal_id =
+            validate_wire_bytes(&removal.to_bytes(), &ValidationContext::for_room(room_id))
+                .unwrap()
+                .event_id;
+
+        // Force the concurrent leave to sort AFTER the removal in canonical
+        // display order. The old scan-order implementation then cleared the
+        // effective removal even though neither sibling causally supersedes it.
+        let mut ts = crate::now_ms();
+        let leave = loop {
+            let candidate =
+                build_member_left(&member_identity, &member_device, &room_id, None, &heads, ts);
+            let candidate_id =
+                validate_wire_bytes(&candidate.to_bytes(), &ValidationContext::for_room(room_id))
+                    .unwrap()
+                    .event_id;
+            if candidate_id > removal_id {
+                break candidate;
+            }
+            ts += 1;
+        };
+        insert_wire(&sup, &room_id, &removal);
+        insert_wire(&sup, &room_id, &leave);
+
+        assert_eq!(
+            sup.snapshot_for(&room_id).await.unwrap().status(&member_id),
+            Some(Status::Removed),
+            "Removed dominates a concurrent self-leave"
+        );
+        let RemoveMemberOutcome::Removed(replayed) =
+            sup.remove_member(&room_id, &member_id).await.unwrap()
+        else {
+            panic!("the effective concurrent removal was not replayed");
+        };
+        assert_eq!(replayed, bare_event_hex(&removal_id));
+        assert_eq!(
+            sup.open_store()
+                .unwrap()
+                .by_type(&room_id, EventType::MemberRemoved)
+                .unwrap()
+                .len(),
+            1,
+            "semantic replay authors no second removal"
+        );
+    }
+
     /// `docs/room-attention.md` decision 2: recency is the newest signed
     /// event's own `created_at`, projected from the store, per room — and it
     /// agrees with what that room's timeline shows.
@@ -5285,7 +5691,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let foreign_file_id = foreign_file["file_id"].as_str().unwrap().to_owned();
+        let foreign_file_id = foreign_file.file_id;
         let foreign_pipe = foreign
             .pipe_expose(
                 &foreign_room,
@@ -5625,6 +6031,115 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_release_closes_only_one_of_two_connections_to_the_same_pipe() {
+        let owner_dir = tempdir().unwrap();
+        let owner_profile = crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = owner.create_room("Pipe Connections").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        let opened = owner.open_room(&room_id_str, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id_str, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        member
+            .open_room(&room_id_str, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        wait_member_status(&owner, &room_id_str, &member_profile.identity_id, "active").await;
+
+        let member_id: iroh_rooms::identity::IdentityKey =
+            member_profile.identity_id.parse().unwrap();
+        let owner_id: iroh_rooms::identity::IdentityKey =
+            owner_profile.identity_id.parse().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target = listener.local_addr().unwrap();
+        let (pipe_id, _) = owner
+            .pipe_expose_multi(
+                &room_id,
+                target,
+                &target.to_string(),
+                std::slice::from_ref(&member_id),
+            )
+            .await
+            .unwrap();
+        let pipe_id_hex = hex::encode(pipe_id);
+
+        let first = member
+            .pipe_connect(&room_id_str, &pipe_id_hex)
+            .await
+            .unwrap();
+        let second = member
+            .pipe_connect(&room_id_str, &pipe_id_hex)
+            .await
+            .unwrap();
+        assert_ne!(first, second, "each connection has its own local identity");
+        assert!(member.pipe_connection_open(&room_id, pipe_id, &owner_id));
+
+        assert!(member.pipe_release(&first));
+        assert!(
+            member.pipe_connection_open(&room_id, pipe_id, &owner_id),
+            "the sibling connection remains open"
+        );
+        assert!(!member.pipe_release(&first), "a released id is unknown");
+        assert!(member.pipe_release(&second));
+        assert!(
+            !member.pipe_connection_open(&room_id, pipe_id, &owner_id),
+            "the runtime fact clears after the last local connection"
+        );
+
+        let third = member
+            .pipe_connect(&room_id_str, &pipe_id_hex)
+            .await
+            .unwrap();
+        let fourth = member
+            .pipe_connect(&room_id_str, &pipe_id_hex)
+            .await
+            .unwrap();
+        assert_ne!(third, fourth);
+        assert_eq!(
+            member
+                .release_pipe_connections(&room_id, &pipe_id_hex)
+                .unwrap(),
+            2,
+            "a revocation tears down every sibling connection for the pipe"
+        );
+        assert!(!member.pipe_connection_open(&room_id, pipe_id, &owner_id));
+        let err = member
+            .pipe_connect(&room_id_str, &pipe_id_hex)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.kind,
+            ErrorKind::PipeDenied,
+            "a connection finishing after revocation must not resurrect locally"
+        );
+        assert_eq!(
+            member
+                .open_store()
+                .unwrap()
+                .by_type(&room_id, EventType::PipeClosed)
+                .unwrap()
+                .len(),
+            0,
+            "release does not author a pipe revocation"
+        );
+
+        member.close_room(&room_id_str).await.unwrap();
+        owner.close_room(&room_id_str).await.unwrap();
+        drop(listener);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn own_shared_file_list_and_fetch_agree() {
         // Finding #5: file.list must not claim availability that file.fetch
         // cannot honor. A file whose sole provider is this device shows
@@ -5642,7 +6157,7 @@ mod tests {
             .share_file(&room_id, path.to_str().unwrap(), None, None)
             .await
             .unwrap();
-        let file_id = shared["file_id"].as_str().unwrap().to_owned();
+        let file_id = shared.file_id;
 
         let files = sup.list_files(&room_id).await.unwrap();
         let row = files
@@ -5688,7 +6203,7 @@ mod tests {
             .share_file(&room_id, path.to_str().unwrap(), None, None)
             .await
             .unwrap();
-        let file_id = shared["file_id"].as_str().unwrap().to_owned();
+        let file_id = shared.file_id;
 
         let member_dir = tempdir().unwrap();
         let member_profile = crate::identity::create(member_dir.path()).unwrap();
@@ -5723,7 +6238,7 @@ mod tests {
         }
 
         let fetched = member.fetch_file(&room_id, &file_id, None).await.unwrap();
-        assert_eq!(fetched["verified"], true);
+        assert_eq!(fetched.bytes, 14);
 
         member.close_room(&room_id).await.unwrap();
         let member_restarted = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
@@ -5734,16 +6249,13 @@ mod tests {
             .expect("shared file remains listed after restart");
         assert_eq!(row["fetched"], true);
         assert_eq!(row["local_bytes"], 14);
-        assert_eq!(row["local_path"], fetched["path"]);
+        assert_eq!(row["local_path"], fetched.path.display().to_string());
 
         let local = member_restarted
             .local_file(&room_id, &file_id)
             .await
             .unwrap();
-        assert_eq!(
-            local.path.display().to_string(),
-            fetched["path"].as_str().unwrap()
-        );
+        assert_eq!(local.path.display().to_string(), fetched.path);
         assert_eq!(local.name, "report.txt");
         assert_eq!(local.bytes, 14);
 
@@ -5904,7 +6416,7 @@ mod tests {
             .share_file(&room_id, payload.to_str().unwrap(), None, None)
             .await
             .unwrap();
-        let file_id = shared["file_id"].as_str().unwrap().to_string();
+        let file_id = shared.file_id;
 
         // No other peer is online, so an unvalidated destination would return
         // FileUnavailable from the provider loop instead of the real error.

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -30,17 +30,18 @@
 //! space here.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use jeliya_api::*;
 use serde::{Deserialize, Serialize};
 
-use iroh_rooms::events::{Content, EventType, SignedEvent};
+use iroh_rooms::events::{capability_hash, Content, EventType, SignedEvent};
 use iroh_rooms::room::RoomId as IrohRoomId;
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
-use crate::materializer::file_handle;
 use crate::projection as proj;
-use crate::supervisor::RoomSupervisor;
+use crate::projection::file_handle;
+use crate::supervisor::{RemoveMemberOutcome, RoomSupervisor};
 
 /// The daemon's served limits, surfaced in `hello`/`VersionInfo` and enforced
 /// here. Values are the record's served-limits object; the shared-file maximum
@@ -209,21 +210,15 @@ fn page_indexed<T: Clone>(items: Vec<T>, window: Window) -> (Vec<T>, Truncated) 
 }
 
 /// The typed projection facade. Cheap to construct; borrows the supervisor.
-pub struct TypedSupervisor<'a> {
+pub(crate) struct TypedSupervisor<'a> {
     sup: &'a RoomSupervisor,
 }
 
 impl<'a> TypedSupervisor<'a> {
     /// Wrap a supervisor.
     #[must_use]
-    pub fn new(sup: &'a RoomSupervisor) -> Self {
+    pub(crate) fn new(sup: &'a RoomSupervisor) -> Self {
         Self { sup }
-    }
-
-    /// The underlying supervisor (for host surfaces that bypass dispatch).
-    #[must_use]
-    pub fn supervisor(&self) -> &'a RoomSupervisor {
-        self.sup
     }
 
     fn parse_room(room_id: &RoomId) -> CoreResult<IrohRoomId> {
@@ -382,13 +377,8 @@ impl<'a> TypedSupervisor<'a> {
             let store = self.sup.open_store().map_err(core_to_api)?;
             let (removed_ids, left_ids) =
                 crate::supervisor::departure_sets(&store, &room_id).map_err(core_to_api)?;
-            let standing = self_member.map(|m| {
-                proj::standing(
-                    removed_ids.contains(&m.identity)
-                        || matches!(m.status, iroh_rooms::room::Status::Removed),
-                    left_ids.contains(&m.identity),
-                )
-            });
+            let standing = self_member
+                .map(|m| member_standing(m.status, &m.identity, &removed_ids, &left_ids));
             // Recency: the newest committed event's author-dated instant and
             // kind, max by timestamp over the COMPLETE history (never the wall
             // clock, never a bounded window — a clock-ahead peer's older row
@@ -428,7 +418,7 @@ impl<'a> TypedSupervisor<'a> {
         let room_id = Self::parse_room(&req.room_id)?;
         // Activate is also a read boundary: authorize before spawning a node.
         self.sup.readable_snapshot(&room_id).await?;
-        self.sup.open_room(req.room_id.as_ref(), &[]).await?;
+        self.sup.activate_room(req.room_id.as_ref(), &[]).await?;
         let live = self.sup.is_open(&room_id);
         let snapshot = self.sup.snapshot_for(&room_id).await?;
         let self_key = self.sup.local_identity_key()?;
@@ -447,8 +437,25 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.deactivate` — stop live participation without changing membership.
-    pub async fn room_deactivate(&self, req: &RoomDeactivate) -> CoreResult<RoomDeactivateOut> {
-        self.sup.close_room(req.room_id.as_ref()).await?;
+    pub async fn room_deactivate(
+        &self,
+        req: &RoomDeactivate,
+    ) -> Result<RoomDeactivateOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|e| core_to_api_room(e, &req.room_id))?;
+        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
+        match self.sup.close_room(req.room_id.as_ref()).await {
+            Ok(()) => {}
+            // Deactivation is naturally idempotent. A concurrent or repeated
+            // close is success, but only after the standing check above has
+            // proved this is still an active membership.
+            Err(err) if err.kind == ErrorKind::RoomNotOpen => {}
+            Err(err) => return Err(core_to_api_room(err, &req.room_id)),
+        }
         Ok(RoomDeactivateOut {
             room_id: req.room_id.clone(),
             live: false,
@@ -505,11 +512,7 @@ impl<'a> TypedSupervisor<'a> {
         let (removed_ids, left_ids) =
             crate::supervisor::departure_sets(&store, room_id).map_err(core_to_api)?;
         let standing = snapshot.member(&self_key).map_or(Standing::Active, |m| {
-            proj::standing(
-                removed_ids.contains(&m.identity)
-                    || matches!(m.status, iroh_rooms::room::Status::Removed),
-                left_ids.contains(&m.identity),
-            )
+            member_standing(m.status, &m.identity, &removed_ids, &left_ids)
         });
         if standing == Standing::Active {
             return Ok(());
@@ -549,21 +552,23 @@ impl<'a> TypedSupervisor<'a> {
 
     /// `room.members` — the authoritative signed answer to who belongs. No
     /// presence, no reachability.
-    pub async fn room_members(&self, req: &RoomMembers) -> CoreResult<RoomMembersOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let snapshot = self.sup.readable_snapshot(&room_id).await?;
-        let store = self.sup.open_store()?;
-        let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, &room_id)?;
+    pub async fn room_members(&self, req: &RoomMembers) -> Result<RoomMembersOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
+        let store = self.sup.open_store().map_err(core_to_api)?;
+        let (removed_ids, left_ids) =
+            crate::supervisor::departure_sets(&store, &room_id).map_err(core_to_api)?;
         let members = snapshot
             .members()
             .map(|m| MemberRow {
                 subject_id: SubjectId::new(m.identity.to_string()),
                 role: proj::role(m.role),
-                standing: proj::standing(
-                    removed_ids.contains(&m.identity)
-                        || matches!(m.status, iroh_rooms::room::Status::Removed),
-                    left_ids.contains(&m.identity),
-                ),
+                standing: member_standing(m.status, &m.identity, &removed_ids, &left_ids),
                 // The fold does not date joins; joined_at is the join event's
                 // author-dated instant when discoverable, else the genesis.
                 joined_at: self
@@ -615,15 +620,42 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// `member.remove` — room authority removes a member, as a signed fact.
-    /// Not yet backed by the runtime (the MVP supervisor exposes no removal
-    /// flow), so it is refused honestly rather than fabricated.
-    pub async fn member_remove(&self, req: &MemberRemove) -> CoreResult<MemberRemoveOut> {
-        let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "member.remove is not implemented in this build",
-        ))
+    /// `member.remove` — room authority removes a joined member as a signed
+    /// fact. A repeat against the same terminal removal returns that original
+    /// fact without authoring another event.
+    pub async fn member_remove(&self, req: &MemberRemove) -> Result<MemberRemoveOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let subject = Self::parse_subject(&req.subject_id).map_err(core_to_api)?;
+        let outcome = self
+            .sup
+            .remove_member(&room_id, &subject)
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        let event_id = match outcome {
+            RemoveMemberOutcome::Removed(event_id) => event_id,
+            RemoveMemberOutcome::Authority => {
+                return Err(ApiError::AuthorityCannotBeRemoved {
+                    room_id: req.room_id.clone(),
+                    subject_id: req.subject_id.clone(),
+                })
+            }
+            RemoveMemberOutcome::Unknown => {
+                return Err(ApiError::MemberUnknown {
+                    room_id: req.room_id.clone(),
+                    subject_id: req.subject_id.clone(),
+                })
+            }
+        };
+        let pos = self
+            .pos_of_event(&room_id, &event_id)
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        Ok(MemberRemoveOut {
+            room_id: req.room_id.clone(),
+            subject_id: req.subject_id.clone(),
+            event_id: EventId::new(event_id),
+            pos,
+            standing: Standing::Removed,
+        })
     }
 
     // ------------------------------------------------------------------
@@ -707,15 +739,83 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// `invite.list` — enumerate outstanding and recently expired invites.
-    /// The MVP runtime does not maintain a served invite index, so this is
-    /// refused honestly rather than fabricated empty.
-    pub async fn invite_list(&self, req: &InviteList) -> CoreResult<InviteListOut> {
-        let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "invite.list is not implemented in this build",
-        ))
+    /// `invite.list` — fold the accepted invitation and redemption facts into
+    /// an authority-only typed index. Capability secrets and hashes never
+    /// enter the returned rows.
+    pub async fn invite_list(&self, req: &InviteList) -> Result<InviteListOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let store = self
+            .sup
+            .open_store()
+            .map_err(|_| ApiError::InviteIndexUnreadable)?;
+        let stored = store
+            .room_tail(&room_id, u32::MAX)
+            .map_err(|_| ApiError::InviteIndexUnreadable)?;
+
+        // Decode the two membership facts that define this index once. A
+        // corrupt/unrepresentable row makes the index unreadable; silently
+        // skipping it would present a partial answer as complete.
+        let mut joins = Vec::new();
+        for se in stored
+            .iter()
+            .filter(|se| se.event_type == EventType::MemberJoined)
+        {
+            let event = SignedEvent::decode(&se.wire.signed)
+                .map_err(|_| ApiError::InviteIndexUnreadable)?;
+            let Content::MemberJoined(join) = event.content else {
+                return Err(ApiError::InviteIndexUnreadable);
+            };
+            joins.push((event.sender_id, join));
+        }
+
+        let now = crate::now_ms();
+        let mut rows = Vec::new();
+        for se in stored
+            .iter()
+            .filter(|se| se.event_type == EventType::MemberInvited)
+        {
+            let event = SignedEvent::decode(&se.wire.signed)
+                .map_err(|_| ApiError::InviteIndexUnreadable)?;
+            let Content::MemberInvited(invite) = event.content else {
+                return Err(ApiError::InviteIndexUnreadable);
+            };
+            let expires_ms = invite.expires_at.ok_or(ApiError::InviteIndexUnreadable)?;
+            let expires_at =
+                checked_timestamp(expires_ms).ok_or(ApiError::InviteIndexUnreadable)?;
+            let role = match invite.role.as_str() {
+                "admin" => Role::Authority,
+                "member" | "agent" => Role::Member,
+                _ => return Err(ApiError::InviteIndexUnreadable),
+            };
+            let redeemed = joins.iter().any(|(sender, join)| {
+                join.via_invite_id == invite.invite_id
+                    && *sender == invite.invitee_key
+                    && join.device_binding.identity_key == invite.invitee_key
+                    && join.role == invite.role
+                    && capability_hash(&room_id, &join.via_invite_id, &join.capability_secret)
+                        == invite.capability_hash
+            });
+            let redeemability = if redeemed {
+                Redeemability::Redeemed
+            } else if now > expires_ms {
+                Redeemability::Expired
+            } else {
+                Redeemability::Outstanding
+            };
+            rows.push(InviteRow {
+                invite_id: proj::invite_id(&invite.invite_id),
+                subject_id: SubjectId::new(invite.invitee_key.to_string()),
+                role,
+                expires_at,
+                redeemability,
+            });
+        }
+        let (invites, truncated) = page_indexed(rows, Window::resolve(&req.page)?);
+        Ok(InviteListOut {
+            room_id: req.room_id.clone(),
+            invites,
+            truncated,
+        })
     }
 
     /// `invite.revoke` — withdraw an outstanding capability before expiry.
@@ -948,16 +1048,71 @@ impl<'a> TypedSupervisor<'a> {
         ))
     }
 
+    /// Host-side half of `file.share`: the host has already staged the bytes
+    /// under the daemon data directory and supplies the typed declaration.
+    /// The runtime result is converted directly to the protocol-v2 output;
+    /// no JSON projection is built or decoded inside core.
+    pub(crate) async fn share_staged_file(
+        &self,
+        req: &FileShare,
+        path: &Path,
+    ) -> CoreResult<FileShareOut> {
+        let actual_bytes = std::fs::metadata(path)
+            .map_err(|e| CoreError::invalid(format!("cannot read {}: {e}", path.display())))?
+            .len();
+        if actual_bytes != req.declared_bytes {
+            return Err(CoreError::invalid(format!(
+                "declared size {} does not match staged size {actual_bytes}",
+                req.declared_bytes
+            )));
+        }
+        let shared = self
+            .sup
+            .share_file(
+                req.room_id.as_ref(),
+                path.to_string_lossy().as_ref(),
+                Some(&req.name),
+                Some(&req.declared_content_type),
+            )
+            .await?;
+        let room_id = Self::parse_room(&req.room_id)?;
+        let pos = self.pos_of_event(&room_id, &shared.event_id)?;
+        Ok(FileShareOut {
+            room_id: req.room_id.clone(),
+            file_id: FileId::new(shared.file_id),
+            event_id: EventId::new(shared.event_id),
+            pos,
+            bytes: shared.bytes,
+            digest: shared.digest,
+        })
+    }
+
     /// `file.list` — files shared into a room, provider availability as a
     /// protocol fact.
     pub async fn file_list(&self, req: &FileList) -> CoreResult<FileListOut> {
         let room_id = Self::parse_room(&req.room_id)?;
-        self.sup.readable_snapshot(&room_id).await?;
+        let snapshot = self.sup.readable_snapshot(&room_id).await?;
         let store = self.sup.open_store()?;
         let events = store
             .by_type(&room_id, EventType::FileShared)
             .map_err(|e| CoreError::internal(format!("could not read file.shared events: {e}")))?;
         let session = self.sup.session_opt(&room_id);
+        let peer_paths: std::collections::HashMap<_, _> = if let Some(session) = session.as_deref()
+        {
+            session
+                .node
+                .peer_paths()
+                .await
+                .into_iter()
+                .map(|(device, path, _relay)| (device, path.label()))
+                .collect()
+        } else {
+            std::collections::HashMap::new()
+        };
+        let peer_entries: std::collections::HashMap<_, _> = session
+            .as_deref()
+            .map(|session| session.node.peer_entries().into_iter().collect())
+            .unwrap_or_default();
         let room_id_str = room_id.to_string();
         let mut files = Vec::with_capacity(events.len());
         for se in &events {
@@ -971,26 +1126,48 @@ impl<'a> TypedSupervisor<'a> {
                 Some(list) if !list.is_empty() => list.clone(),
                 _ => vec![ev.device_id],
             };
-            let fetchable = session.as_deref().is_some_and(|s| {
-                providers.iter().any(|p| {
-                    crate::supervisor::endpoint_id_of(*p).is_ok_and(|id| {
-                        s.node.peer_state(id)
-                            == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
+            let fetchable = providers.iter().any(|provider| {
+                crate::supervisor::endpoint_id_of(*provider)
+                    .ok()
+                    .and_then(|endpoint| peer_entries.get(&endpoint))
+                    .is_some_and(|entry| {
+                        entry.state == iroh_rooms::experimental::session::PeerConnState::Connected
                     })
-                })
             });
             let file_id = file_handle(&f.file_id);
-            let self_hosted =
-                crate::localstate::fetched_file(self.sup.data_dir(), &room_id_str, &file_id)
+            let local_device =
+                self.sup.local_identity_key().ok().and_then(|identity| {
+                    snapshot.member(&identity).and_then(|member| member.device)
+                });
+            let self_hosted = local_device.is_some_and(|device| providers.contains(&device))
+                || crate::localstate::fetched_file(self.sup.data_dir(), &room_id_str, &file_id)
                     .is_some();
             let provider_rows = providers
                 .iter()
-                .map(|p| PeerRow {
-                    subject_id: SubjectId::new(ev.sender_id.to_string()),
-                    device_id: DeviceId::new(p.to_string()),
-                    link: Link::NotConnected {
-                        reason: LinkReason::NoRoute,
-                    },
+                .filter_map(|provider| {
+                    let subject = snapshot.identity_of_device(provider)?;
+                    let endpoint = crate::supervisor::endpoint_id_of(*provider).ok();
+                    let link = endpoint
+                        .as_ref()
+                        .and_then(|endpoint| peer_entries.get(endpoint))
+                        .map_or(
+                            Link::NotConnected {
+                                reason: LinkReason::NeverDialed,
+                            },
+                            |entry| {
+                                peer_link(
+                                    entry,
+                                    endpoint
+                                        .as_ref()
+                                        .and_then(|endpoint| peer_paths.get(endpoint).copied()),
+                                )
+                            },
+                        );
+                    Some(PeerRow {
+                        subject_id: SubjectId::new(subject.to_string()),
+                        device_id: DeviceId::new(provider.to_string()),
+                        link,
+                    })
                 })
                 .collect();
             files.push(FileRow {
@@ -1020,14 +1197,12 @@ impl<'a> TypedSupervisor<'a> {
     /// the bytes and `file.read` streams them out.
     pub async fn file_fetch(&self, req: &FileFetch) -> CoreResult<FileFetchOut> {
         let room_id = Self::parse_room(&req.room_id)?;
+        let snapshot = self.sup.readable_snapshot(&room_id).await?;
         let result = self
             .sup
             .fetch_file(req.room_id.as_ref(), req.file_id.as_str(), None)
             .await?;
-        let bytes = result
-            .get("bytes")
-            .and_then(|b| b.as_u64())
-            .ok_or_else(|| CoreError::internal("fetch result carried no byte count"))?;
+        let bytes = result.bytes;
         // The verified digest comes from the shared file's declared hash.
         let file_id = Self::parse_file(&req.file_id)?;
         let store = self.sup.open_store()?;
@@ -1041,16 +1216,18 @@ impl<'a> TypedSupervisor<'a> {
                 Content::FileShared(f) if f.file_id == file_id => Some(f.blob_hash.to_string()),
                 _ => None,
             })
-            .unwrap_or_default();
-        let _ = room_id;
+            .ok_or_else(|| CoreError::internal("fetched file has no declared digest"))?;
+        let provider_subject = snapshot
+            .identity_of_device(&result.provider_device)
+            .ok_or_else(|| CoreError::internal("fetched provider device has no bound subject"))?;
         Ok(FileFetchOut {
             room_id: req.room_id.clone(),
             file_id: req.file_id.clone(),
             bytes,
             digest,
             provider: ProviderRef {
-                subject_id: SubjectId::new(""),
-                device_id: DeviceId::new(""),
+                subject_id: SubjectId::new(provider_subject.to_string()),
+                device_id: DeviceId::new(result.provider_device.to_string()),
             },
         })
     }
@@ -1089,6 +1266,12 @@ impl<'a> TypedSupervisor<'a> {
     /// `pipe_target_refused` carrying the rejected target verbatim.
     pub async fn pipe_publish(&self, req: &PipePublish) -> Result<PipePublishOut, ApiError> {
         let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
         // The target must be loopback (IPv4 127.0.0.0/8 or IPv6 ::1) with a
         // port in 1..=65535. Anything else is pipe_target_refused carrying the
         // rejected target verbatim, never the generic policy_refused.
@@ -1111,11 +1294,6 @@ impl<'a> TypedSupervisor<'a> {
         let target_addr = target_addr.expect("parsed above");
 
         // Resolve the audience to a concrete authorized-subject set.
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(core_to_api)?;
         let allowed: Vec<iroh_rooms::identity::IdentityKey> = match &req.audience {
             Audience::Room => snapshot.active_members().map(|m| m.identity).collect(),
             Audience::Subjects { subject_ids } => subject_ids
@@ -1130,7 +1308,7 @@ impl<'a> TypedSupervisor<'a> {
             });
         }
 
-        let target_hint = format!("{}:{}", req.target.host, req.target.port);
+        let target_hint = target_addr.to_string();
         let (pipe_id, event_id) = self
             .sup
             .pipe_expose_multi(&room_id, target_addr, &target_hint, &allowed)
@@ -1156,6 +1334,23 @@ impl<'a> TypedSupervisor<'a> {
         self.sup.readable_snapshot(&room_id).await?;
         let store = self.sup.open_store()?;
         let session = self.sup.session_opt(&room_id);
+        let local_identity = self.sup.local_identity_key().ok();
+        let peer_paths: std::collections::HashMap<_, _> = if let Some(session) = session.as_deref()
+        {
+            session
+                .node
+                .peer_paths()
+                .await
+                .into_iter()
+                .map(|(device, path, _relay)| (device, path.label()))
+                .collect()
+        } else {
+            std::collections::HashMap::new()
+        };
+        let peer_entries: std::collections::HashMap<_, _> = session
+            .as_deref()
+            .map(|session| session.node.peer_entries().into_iter().collect())
+            .unwrap_or_default();
         let closed = closed_pipe_ids(&store, &room_id)?;
         let opened = store
             .by_type(&room_id, EventType::PipeOpened)
@@ -1174,20 +1369,31 @@ impl<'a> TypedSupervisor<'a> {
             if closed.contains(&p.pipe_id) {
                 continue; // revoked pipes are not listed
             }
-            let connected = session.as_deref().is_some_and(|s| {
-                crate::supervisor::endpoint_id_of(p.owner_endpoint).is_ok_and(|id| {
-                    s.node.peer_state(id)
-                        == Some(iroh_rooms::experimental::session::PeerConnState::Connected)
-                })
-            });
-            let link = if connected {
+            let connected = self
+                .sup
+                .pipe_connection_open(&room_id, p.pipe_id, &p.owner_id);
+            let owner_endpoint = crate::supervisor::endpoint_id_of(p.owner_endpoint).ok();
+            let link = if local_identity.as_ref() == Some(&p.owner_id) && session.is_some() {
                 Link::Direct {
-                    since: proj_epoch(),
+                    since: proj_ts(ev.created_at),
                 }
             } else {
-                Link::NotConnected {
-                    reason: LinkReason::NoRoute,
-                }
+                owner_endpoint
+                    .as_ref()
+                    .and_then(|endpoint| peer_entries.get(endpoint))
+                    .map_or(
+                        Link::NotConnected {
+                            reason: LinkReason::NeverDialed,
+                        },
+                        |entry| {
+                            peer_link(
+                                entry,
+                                owner_endpoint
+                                    .as_ref()
+                                    .and_then(|endpoint| peer_paths.get(endpoint).copied()),
+                            )
+                        },
+                    )
             };
             pipes.push((
                 se.lamport.unwrap(),
@@ -1213,11 +1419,19 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `pipe.connect` — connect to a pipe.
-    pub async fn pipe_connect(&self, req: &PipeConnect) -> CoreResult<PipeConnectOut> {
+    pub async fn pipe_connect(&self, req: &PipeConnect) -> Result<PipeConnectOut, ApiError> {
+        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
         let local_addr = self
             .sup
             .pipe_connect(req.room_id.as_ref(), req.pipe_id.as_str())
-            .await?;
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
         let (host, port) = split_host_port(&local_addr);
         Ok(PipeConnectOut {
             room_id: req.room_id.clone(),
@@ -1228,28 +1442,25 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `pipe.release` — release a local connection, named by the connection.
-    pub async fn pipe_release(&self, req: &PipeRelease) -> CoreResult<PipeReleaseOut> {
-        // The runtime names connections by their local addr today; releasing
-        // by connection_id requires a connection index the MVP does not keep.
-        let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "pipe.release by connection_id is not implemented in this build",
-        ))
+    pub async fn pipe_release(&self, req: &PipeRelease) -> Result<PipeReleaseOut, ApiError> {
+        if !self.sup.pipe_release(&req.connection_id) {
+            return Err(ApiError::ConnectionUnknown {
+                connection_id: req.connection_id.clone(),
+            });
+        }
+        Ok(PipeReleaseOut {
+            connection_id: req.connection_id.clone(),
+            released: true,
+        })
     }
 
     /// `pipe.revoke` — withdraw a published pipe as a signed fact.
     pub async fn pipe_revoke(&self, req: &PipeRevoke) -> CoreResult<PipeRevokeOut> {
         let room_id = Self::parse_room(&req.room_id)?;
-        let result = self
+        let event_id = self
             .sup
             .pipe_close(req.room_id.as_ref(), req.pipe_id.as_str())
             .await?;
-        let event_id = result
-            .get("event_id")
-            .and_then(|p| p.as_str())
-            .unwrap_or_default()
-            .to_string();
         let pos = self.pos_of_event(&room_id, &event_id)?;
         Ok(PipeRevokeOut {
             room_id: req.room_id.clone(),
@@ -1372,37 +1583,13 @@ impl<'a> TypedSupervisor<'a> {
             .collect();
         node.peer_entries()
             .into_iter()
-            .map(|(device, entry)| {
-                let connected = matches!(
-                    entry.state,
-                    iroh_rooms::experimental::session::PeerConnState::Connected
-                );
-                let link = if connected {
-                    match paths.get(&device).copied() {
-                        Some("direct") | Some("mixed") => Link::Direct {
-                            since: proj_epoch(),
-                        },
-                        Some("relay") => Link::Relay {
-                            since: proj_epoch(),
-                        },
-                        _ => Link::NotConnected {
-                            reason: LinkReason::NoRoute,
-                        },
-                    }
-                } else {
-                    Link::NotConnected {
-                        reason: LinkReason::NoRoute,
-                    }
-                };
-                PeerRow {
-                    subject_id: entry
-                        .identity
-                        .as_ref()
-                        .map(|id| SubjectId::new(id.to_string()))
-                        .unwrap_or_else(|| SubjectId::new("")),
+            .filter_map(|(device, entry)| {
+                let identity = entry.identity.as_ref()?;
+                Some(PeerRow {
+                    subject_id: SubjectId::new(identity.to_string()),
                     device_id: DeviceId::new(device.to_string()),
-                    link,
-                }
+                    link: peer_link(&entry, paths.get(&device).copied()),
+                })
             })
             .collect()
     }
@@ -1482,12 +1669,23 @@ fn self_key_standing(
     let store = sup.open_store()?;
     let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, room_id)?;
     Ok(snapshot.member(self_key).map_or(Standing::Active, |m| {
-        proj::standing(
-            removed_ids.contains(&m.identity)
-                || matches!(m.status, iroh_rooms::room::Status::Removed),
-            left_ids.contains(&m.identity),
-        )
+        member_standing(m.status, &m.identity, &removed_ids, &left_ids)
     }))
+}
+
+/// Refine the upstream terminal membership status with the signed fact that
+/// caused it. The fold uses `Status::Removed` for both voluntary leave and
+/// administrative removal; the v2 API keeps those lifecycle states distinct.
+fn member_standing(
+    status: iroh_rooms::room::Status,
+    identity: &iroh_rooms::identity::IdentityKey,
+    removed_ids: &BTreeSet<iroh_rooms::identity::IdentityKey>,
+    left_ids: &BTreeSet<iroh_rooms::identity::IdentityKey>,
+) -> Standing {
+    let left = left_ids.contains(identity);
+    let removed = removed_ids.contains(identity)
+        || (!left && matches!(status, iroh_rooms::room::Status::Removed));
+    proj::standing(removed, left)
 }
 
 /// The v2 wire label for a status label (snake_case, matching the Iroh
@@ -1534,10 +1732,15 @@ fn proj_progress(pct: Option<u64>) -> Progress {
 
 /// The wire `<ts>` for an author-dated ms instant.
 fn proj_ts(created_at_ms: u64) -> Timestamp {
-    let secs = i64::try_from(created_at_ms / 1000).unwrap_or(i64::MAX);
-    Timestamp::new(
-        time::OffsetDateTime::from_unix_timestamp(secs).unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
-    )
+    checked_timestamp(created_at_ms).unwrap_or_else(proj_epoch)
+}
+
+/// Convert a millisecond instant only when it is representable on the wire.
+fn checked_timestamp(created_at_ms: u64) -> Option<Timestamp> {
+    let secs = i64::try_from(created_at_ms / 1000).ok()?;
+    time::OffsetDateTime::from_unix_timestamp(secs)
+        .ok()
+        .map(Timestamp::new)
 }
 
 /// The Unix epoch as a `<ts>` (an honest "unknown instant", never the wall
@@ -1549,6 +1752,33 @@ fn proj_epoch() -> Timestamp {
 /// Whether a socket address is loopback (IPv4 127.0.0.0/8 or IPv6 ::1).
 fn is_loopback_addr(addr: &std::net::SocketAddr) -> bool {
     addr.ip().is_loopback()
+}
+
+/// Convert the runtime's observed peer state to the one shared v2 link
+/// vocabulary. The state-change clock is observability data (the `since`
+/// field), not a signed room-event timestamp.
+fn peer_link(entry: &iroh_rooms::experimental::session::PeerEntry, path: Option<&str>) -> Link {
+    use iroh_rooms::experimental::session::{OfflineReason, PeerConnState};
+
+    if entry.state == PeerConnState::Connected {
+        return match path {
+            Some("relay") => Link::Relay {
+                since: proj_ts(entry.last_change_ms),
+            },
+            Some("direct" | "mixed") => Link::Direct {
+                since: proj_ts(entry.last_change_ms),
+            },
+            _ => Link::NotConnected {
+                reason: LinkReason::NoRoute,
+            },
+        };
+    }
+    let reason = match entry.offline_reason {
+        OfflineReason::NeverDialed => LinkReason::NeverDialed,
+        OfflineReason::Unreachable | OfflineReason::TransportError => LinkReason::DialFailed,
+        OfflineReason::LinkDropped | OfflineReason::Deauthorized => LinkReason::Closed,
+    };
+    Link::NotConnected { reason }
 }
 
 /// Split a `"host:port"` loopback address into a `Target`.
@@ -1593,7 +1823,20 @@ fn closed_pipe_ids(
 /// validation order.
 fn authority_gated_room(call: &TypedCall) -> Result<Option<(RoomId, IrohRoomId)>, ApiError> {
     let api_room = match call {
-        TypedCall::MemberRemove(r) => &r.room_id,
+        TypedCall::MemberRemove(r) => {
+            if r.subject_id
+                .as_str()
+                .trim()
+                .parse::<iroh_rooms::identity::IdentityKey>()
+                .is_err()
+            {
+                return Err(ApiError::InvalidArgument {
+                    field: "in.subject_id".into(),
+                    reason: InvalidReason::Format,
+                });
+            }
+            &r.room_id
+        }
         TypedCall::InviteMint(r) => &r.room_id,
         TypedCall::InviteRevoke(r) => &r.room_id,
         TypedCall::InviteList(r) => {
@@ -1623,7 +1866,10 @@ fn authority_gated_room(call: &TypedCall) -> Result<Option<(RoomId, IrohRoomId)>
 /// The dispatch is **total by construction**: the codec's router already
 /// refused any `op` not in the 33, so the downcast to the concrete input type
 /// cannot fail.
-pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedReply, ApiError> {
+pub(crate) async fn dispatch(
+    sup: &RoomSupervisor,
+    call: TypedCall,
+) -> Result<TypedReply, ApiError> {
     let t = TypedSupervisor::new(sup);
     // Validation-order step 2 (subject precondition): every operation except
     // `subject.ensure` — which exists to create the subject — requires a local
@@ -1671,22 +1917,14 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .await
             .map(TypedReply::RoomActivate)
             .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::RoomDeactivate(r) => t
-            .room_deactivate(&r)
-            .await
-            .map(TypedReply::RoomDeactivate)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
+        TypedCall::RoomDeactivate(r) => t.room_deactivate(&r).await.map(TypedReply::RoomDeactivate),
         TypedCall::RoomLeave(r) => t
             .room_leave(&r)
             .await
             .map(TypedReply::RoomLeave)
             .map_err(|e| core_to_api_room(e, &r.room_id)),
         TypedCall::RoomTimeline(r) => t.room_timeline(&r).await.map(TypedReply::RoomTimeline),
-        TypedCall::RoomMembers(r) => t
-            .room_members(&r)
-            .await
-            .map(TypedReply::RoomMembers)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
+        TypedCall::RoomMembers(r) => t.room_members(&r).await.map(TypedReply::RoomMembers),
         TypedCall::RoomArchive(r) => t
             .room_archive(&r)
             .await
@@ -1697,21 +1935,13 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .await
             .map(TypedReply::RoomPeers)
             .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::MemberRemove(r) => t
-            .member_remove(&r)
-            .await
-            .map(TypedReply::MemberRemove)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
+        TypedCall::MemberRemove(r) => t.member_remove(&r).await.map(TypedReply::MemberRemove),
         TypedCall::InviteMint(r) => t
             .invite_mint(&r)
             .await
             .map(TypedReply::InviteMint)
             .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::InviteList(r) => t
-            .invite_list(&r)
-            .await
-            .map(TypedReply::InviteList)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
+        TypedCall::InviteList(r) => t.invite_list(&r).await.map(TypedReply::InviteList),
         TypedCall::InviteRevoke(r) => t
             .invite_revoke(&r)
             .await
@@ -1773,16 +2003,8 @@ pub async fn dispatch(sup: &RoomSupervisor, call: TypedCall) -> Result<TypedRepl
             .await
             .map(TypedReply::PipeList)
             .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::PipeConnect(r) => t
-            .pipe_connect(&r)
-            .await
-            .map(TypedReply::PipeConnect)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::PipeRelease(r) => t
-            .pipe_release(&r)
-            .await
-            .map(TypedReply::PipeRelease)
-            .map_err(core_to_api),
+        TypedCall::PipeConnect(r) => t.pipe_connect(&r).await.map(TypedReply::PipeConnect),
+        TypedCall::PipeRelease(r) => t.pipe_release(&r).await.map(TypedReply::PipeRelease),
         TypedCall::PipeRevoke(r) => t
             .pipe_revoke(&r)
             .await
@@ -2151,6 +2373,7 @@ fn core_to_api_ctx(err: CoreError, room_id: Option<RoomId>) -> ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     /// The dispatch-time role gate targets exactly the four authority
     /// operations the record names — no more (an open operation must not be
@@ -2159,9 +2382,12 @@ mod tests {
     fn authority_gated_room_covers_exactly_the_four_authority_ops() {
         let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
         let gated = |call: &TypedCall| authority_gated_room(call).ok().flatten().is_some();
+        let member_id = iroh_rooms::identity::SigningKey::generate()
+            .identity_key()
+            .to_string();
         assert!(gated(&TypedCall::MemberRemove(MemberRemove {
             room_id: rid(),
-            subject_id: SubjectId::new("s"),
+            subject_id: SubjectId::new(member_id),
         })));
         assert!(gated(&TypedCall::InviteMint(InviteMint {
             room_id: rid(),
@@ -2226,5 +2452,240 @@ mod tests {
                 "limit {limit}: got {err:?}"
             );
         }
+    }
+
+    fn first_page(room_id: &str) -> InviteList {
+        InviteList {
+            room_id: RoomId::new(room_id),
+            page: Page {
+                cursor: Cursor::Start,
+                direction: Direction::Forward,
+                limit: 32,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn invite_list_folds_outstanding_then_redeemed_without_capability_material() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = sup.create_room("Invite Index").unwrap();
+        let room_id: IrohRoomId = room_id_str.parse().unwrap();
+        let invitee_identity = iroh_rooms::identity::SigningKey::generate();
+        let invitee_device = iroh_rooms::identity::SigningKey::generate();
+        let capability = sup
+            .create_invite(
+                &room_id_str,
+                &invitee_identity.identity_key().to_string(),
+                "member",
+                Some("1h"),
+            )
+            .await
+            .unwrap();
+
+        let typed = TypedSupervisor::new(&sup);
+        let outstanding = typed.invite_list(&first_page(&room_id_str)).await.unwrap();
+        assert_eq!(outstanding.invites.len(), 1);
+        assert_eq!(
+            outstanding.invites[0].redeemability,
+            Redeemability::Outstanding
+        );
+        let encoded = serde_json::to_value(&outstanding).unwrap();
+        assert!(
+            encoded["invites"][0].get("capability").is_none(),
+            "the authority index never returns the bearer capability"
+        );
+        assert!(
+            encoded["invites"][0].get("capability_hash").is_none(),
+            "the authority index never returns capability verification material"
+        );
+
+        let ticket: iroh_rooms::room::RoomInviteTicket = capability.parse().unwrap();
+        let mut heads = sup.open_store().unwrap().heads(&room_id).unwrap();
+        heads.truncate(iroh_rooms::events::constants::MAX_PREV_EVENTS);
+        let binding = iroh_rooms::identity::DeviceBinding::create(
+            &room_id,
+            &invitee_identity,
+            invitee_device.device_key(),
+        );
+        let joined = iroh_rooms::room::build_member_joined(
+            &invitee_identity,
+            &invitee_device,
+            &room_id,
+            &ticket.invite_id,
+            &ticket.capability_secret,
+            &ticket.role,
+            binding,
+            None,
+            &heads,
+            crate::now_ms(),
+        );
+        let validated = iroh_rooms::events::validate_wire_bytes(
+            &joined.to_bytes(),
+            &iroh_rooms::events::ValidationContext::for_room(room_id),
+        )
+        .unwrap();
+        sup.open_store().unwrap().insert(&validated).unwrap();
+
+        let redeemed = typed.invite_list(&first_page(&room_id_str)).await.unwrap();
+        assert_eq!(redeemed.invites[0].redeemability, Redeemability::Redeemed);
+    }
+
+    #[tokio::test]
+    async fn room_deactivate_is_naturally_idempotent_for_an_active_member() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Idempotent Deactivate").unwrap();
+        sup.activate_room(&room_id, &[]).await.unwrap();
+        let typed = TypedSupervisor::new(&sup);
+        let req = RoomDeactivate {
+            room_id: RoomId::new(&room_id),
+        };
+
+        let first = typed.room_deactivate(&req).await.unwrap();
+        let second = typed.room_deactivate(&req).await.unwrap();
+
+        assert_eq!(first, second);
+        assert!(!first.live);
+        assert!(sup.open_rooms().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn room_deactivate_rejects_an_ended_membership_before_idempotency() {
+        let owner_dir = tempdir().unwrap();
+        crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id = owner.create_room("Ended Deactivate").unwrap();
+        let opened = owner.open_room(&room_id, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        member.open_room(&room_id, &[]).await.unwrap();
+        member.leave_room(&room_id).await.unwrap();
+
+        let err = TypedSupervisor::new(&member)
+            .room_deactivate(&RoomDeactivate {
+                room_id: RoomId::new(&room_id),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err,
+            ApiError::MembershipEnded {
+                room_id: RoomId::new(&room_id),
+                standing: Standing::Left,
+            }
+        );
+
+        owner.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn member_remove_and_pipe_release_map_semantic_errors_exactly() {
+        let dir = tempdir().unwrap();
+        let profile = crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Exact Errors").unwrap();
+        let typed = TypedSupervisor::new(&sup);
+
+        let authority = typed
+            .member_remove(&MemberRemove {
+                room_id: RoomId::new(&room_id),
+                subject_id: SubjectId::new(&profile.identity_id),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            authority,
+            ApiError::AuthorityCannotBeRemoved { .. }
+        ));
+
+        let unknown_subject = iroh_rooms::identity::SigningKey::generate()
+            .identity_key()
+            .to_string();
+        let unknown = typed
+            .member_remove(&MemberRemove {
+                room_id: RoomId::new(&room_id),
+                subject_id: SubjectId::new(unknown_subject),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(unknown, ApiError::MemberUnknown { .. }));
+
+        let connection_id = "127.0.0.1:65535".to_owned();
+        assert_eq!(
+            typed
+                .pipe_release(&PipeRelease {
+                    connection_id: connection_id.clone(),
+                })
+                .await
+                .unwrap_err(),
+            ApiError::ConnectionUnknown { connection_id }
+        );
+    }
+
+    #[tokio::test]
+    async fn pipe_operations_preflight_room_access_before_runtime_or_policy() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        sup.create_room("Known Room").unwrap();
+        let typed = TypedSupervisor::new(&sup);
+        let unknown_room = RoomId::new(format!("blake3:{}", "de".repeat(32)));
+
+        let publish = typed
+            .pipe_publish(&PipePublish {
+                room_id: unknown_room.clone(),
+                target: Target {
+                    host: "203.0.113.10".into(),
+                    port: 4444,
+                },
+                audience: Audience::Room,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            publish,
+            ApiError::RoomNotAvailable { ref room_id } if room_id == &unknown_room
+        ));
+
+        let connect = typed
+            .pipe_connect(&PipeConnect {
+                room_id: unknown_room.clone(),
+                pipe_id: PipeId::new("ab".repeat(16)),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            connect,
+            ApiError::RoomNotAvailable { ref room_id } if room_id == &unknown_room
+        ));
+    }
+
+    #[test]
+    fn malformed_member_remove_subject_is_structural_before_authorization() {
+        let call = TypedCall::MemberRemove(MemberRemove {
+            room_id: RoomId::new(format!("blake3:{}", "ab".repeat(32))),
+            subject_id: SubjectId::new("not-an-identity"),
+        });
+        assert_eq!(
+            authority_gated_room(&call).unwrap_err(),
+            ApiError::InvalidArgument {
+                field: "in.subject_id".into(),
+                reason: InvalidReason::Format,
+            }
+        );
     }
 }

--- a/crates/jeliyad/src/main.rs
+++ b/crates/jeliyad/src/main.rs
@@ -28,7 +28,6 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use jeliya_core::engine::{Engine, EngineConfig};
-use jeliya_core::supervisor::RoomSupervisor;
 
 #[cfg(feature = "relay-only-test")]
 const RELAY_ONLY_VERIFICATION_MARKER: &str = "jeliya-relay-only-test-build-v1";
@@ -80,18 +79,10 @@ struct Args {
     verification_relay_only_build: bool,
 }
 
-/// Shared server state: the engine (dispatch + push fan-out) plus the
-/// daemon-only surfaces.
-///
-/// The supervisor is shared as a plain `Arc` (no daemon-wide async mutex): its
-/// own internal locks are held only for brief map operations, never across a
-/// network `.await`, so one client's slow request can no longer freeze every
-/// other client or the push loop. The daemon keeps its own handle besides the
-/// engine's because the HTTP staging endpoints (`/api/files/*`) call the
-/// supervisor directly, bypassing dispatch.
+/// Shared server state: the typed engine (dispatch, host file services, and
+/// push fan-out) plus daemon-only transport state.
 #[derive(Clone)]
 pub(crate) struct AppState {
-    pub(crate) supervisor: Arc<RoomSupervisor>,
     pub(crate) data_dir: PathBuf,
     /// Protocol dispatch and the push broadcast (`jeliya_core::engine`).
     pub(crate) engine: Arc<Engine>,
@@ -148,14 +139,6 @@ async fn main() {
     };
     let _instance_guard = lifecycle::acquire_or_adopt(&mut instance_lock, &data_dir).await;
 
-    let supervisor = match RoomSupervisor::new(data_dir.clone(), args.loopback) {
-        Ok(sup) => sup,
-        Err(err) => {
-            error!("could not initialize the data dir: {err}");
-            std::process::exit(1);
-        }
-    };
-
     let auth_token = match lifecycle::generate_token() {
         Ok(token) => token,
         Err(err) => {
@@ -193,18 +176,23 @@ async fn main() {
     }
 
     let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<String>(4);
-    let supervisor = Arc::new(supervisor);
-    let engine = Engine::with_supervisor(
-        supervisor.clone(),
+    let engine = match Engine::new(
+        data_dir.clone(),
+        args.loopback,
         EngineConfig {
             port: addr.port(),
             version: env!("CARGO_PKG_VERSION").to_owned(),
             shutdown_tx: shutdown_tx.clone(),
         },
-    );
+    ) {
+        Ok(engine) => engine,
+        Err(err) => {
+            error!("could not initialize the data dir: {err}");
+            std::process::exit(1);
+        }
+    };
     let engine_limits = engine.limits();
     let state = AppState {
-        supervisor,
         data_dir: data_dir.clone(),
         engine,
         auth_token: Arc::new(auth_token.clone()),

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -24,7 +24,6 @@ use serde_json::{json, Value};
 
 use hyper_util::rt::TokioIo;
 use jeliya_core::error::CoreError;
-use jeliya_core::supervisor::FILE_UPLOAD_MAX_BYTES;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::broadcast;
@@ -519,7 +518,7 @@ fn gate_refusal(rejection: jeliya_codec::GateRejection) -> Response<Full<Bytes>>
         .unwrap_or_else(|_| "{\"code\":\"forbidden_origin\"}".to_owned());
     Response::builder()
         .status(status)
-        .header(CONTENT_TYPE, "application/json; charset=utf-8")
+        .header(CONTENT_TYPE, "application/json")
         .body(Full::new(Bytes::from(body)))
         .expect("gate refusal is well-formed")
 }
@@ -541,7 +540,11 @@ async fn local_file(req: Request<Incoming>, state: AppState) -> Response<Full<By
             &CoreError::invalid("missing file_id for local file"),
         );
     };
-    let file = match state.supervisor.local_file(room_id, file_id).await {
+    let file_req = jeliya_api::FileRead {
+        room_id: jeliya_api::RoomId::new(room_id),
+        file_id: jeliya_api::FileId::new(file_id),
+    };
+    let file = match state.engine.local_file(&file_req).await {
         Ok(file) => file,
         Err(err) => return json_error(StatusCode::BAD_REQUEST, &err),
     };
@@ -569,7 +572,7 @@ async fn local_file(req: Request<Incoming>, state: AppState) -> Response<Full<By
     // and could exfiltrate the auth token. Force a download (attachment),
     // forbid MIME sniffing, and hand the browser only a safe, inert type — the
     // real type travels in the filename the user saved.
-    let content_type = HeaderValue::from_str(&safe_download_mime(&file.mime))
+    let content_type = HeaderValue::from_str(&safe_download_mime(&file.declared_content_type))
         .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream"));
     let content_disposition =
         HeaderValue::from_str(&content_disposition_value(&display_name, "attachment"))
@@ -624,6 +627,7 @@ fn safe_download_mime(mime: &str) -> String {
 /// daemon stages those bytes under its data dir, then uses the normal confined
 /// `file.share` path so protocol authorship and blob import remain centralized.
 async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<Bytes>> {
+    let upload_limit = state.engine.limits().max_shared_file_bytes;
     if let Some(origin) = req.headers().get(ORIGIN) {
         let allowed = origin.to_str().map(is_local_origin).unwrap_or(false);
         if !allowed {
@@ -641,12 +645,12 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
         {
-            Some(n) if n <= FILE_UPLOAD_MAX_BYTES => {}
+            Some(n) if n <= upload_limit => {}
             Some(n) => {
                 return json_error(
                     StatusCode::PAYLOAD_TOO_LARGE,
                     &CoreError::invalid(format!(
-                        "upload is {n} bytes; the share limit is {FILE_UPLOAD_MAX_BYTES} bytes"
+                        "upload is {n} bytes; the share limit is {upload_limit} bytes"
                     )),
                 )
             }
@@ -682,7 +686,7 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
                 .filter(|value| !value.is_empty())
         });
 
-    let body = match read_limited(req.into_body(), FILE_UPLOAD_MAX_BYTES).await {
+    let body = match read_limited(req.into_body(), upload_limit).await {
         Ok(bytes) => bytes,
         Err(err) => return json_error(StatusCode::PAYLOAD_TOO_LARGE, &err),
     };
@@ -701,11 +705,13 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
         );
     }
 
-    let path = stage_path.to_string_lossy().to_string();
-    let result = state
-        .supervisor
-        .share_file(room_id, &path, Some(&display_name), mime.as_deref())
-        .await;
+    let share = jeliya_api::FileShare {
+        room_id: jeliya_api::RoomId::new(room_id),
+        name: display_name,
+        declared_bytes: body.len() as u64,
+        declared_content_type: mime.unwrap_or_else(|| "application/octet-stream".to_owned()),
+    };
+    let result = state.engine.share_staged_file(&share, &stage_path).await;
     let _ = std::fs::remove_file(&stage_path);
     match result {
         Ok(value) => json_ok(value),
@@ -821,7 +827,7 @@ fn unique_stage_name(display_name: &str) -> String {
     format!("{}-{now}-{display_name}", std::process::id())
 }
 
-fn json_ok(result: Value) -> Response<Full<Bytes>> {
+fn json_ok(result: impl serde::Serialize) -> Response<Full<Bytes>> {
     json_response(StatusCode::OK, json!({ "ok": true, "result": result }))
 }
 
@@ -939,12 +945,8 @@ pub async fn serve_ws<S>(
     // engine await).
     let subscriptions = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::<
         String,
-        u64,
+        SubscriptionState,
     >::new()));
-    // The last position actually delivered to this connection per room, so a
-    // backpressure lag can name a real resync point for each subscribed room.
-    let mut last_delivered: std::collections::HashMap<String, u64> =
-        std::collections::HashMap::new();
 
     // The `hello` frame: exactly one, first, carrying the generation, the
     // storage generation, the served limits, and the local subject. An
@@ -1038,15 +1040,20 @@ pub async fn serve_ws<S>(
                     // push is never a membership oracle.
                     let room = push_room_id(&push).map(str::to_owned);
                     let subscribed = {
-                        let subs = subscriptions.lock().await;
-                        room.as_ref().map(|r| subs.contains_key(r)).unwrap_or(false)
+                        let mut subs = subscriptions.lock().await;
+                        room.as_ref()
+                            .and_then(|room| subs.get_mut(room))
+                            .map(|subscription| {
+                                // The position joins the subscription state so
+                                // unsubscribe/resubscribe cannot retain a stale
+                                // high-water mark and skip recovery events.
+                                if let Some(pos) = push_pos(&push) {
+                                    subscription.last_delivered = Some(pos);
+                                }
+                            })
+                            .is_some()
                     };
                     if subscribed {
-                        // Track the last-delivered position per room so a later
-                        // lag can name a real resync point for that room.
-                        if let (Some(r), Some(pos)) = (room.as_ref(), push_pos(&push)) {
-                            last_delivered.insert(r.clone(), pos);
-                        }
                         let bytes = jeliya_codec::push_to_bytes(&push);
                         if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
                             break;
@@ -1059,12 +1066,20 @@ pub async fn serve_ws<S>(
                 // resync each affected room rather than getting one unusable
                 // global frame.
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    let rooms: Vec<String> = {
+                    let rooms: Vec<(String, u64)> = {
                         let subs = subscriptions.lock().await;
-                        subs.keys().cloned().collect()
+                        subs.iter()
+                            .map(|(room, subscription)| {
+                                (
+                                    room.clone(),
+                                    subscription
+                                        .last_delivered
+                                        .unwrap_or(subscription.from_pos),
+                                )
+                            })
+                            .collect()
                     };
-                    for room in rooms {
-                        let from_pos = last_delivered.get(&room).copied().unwrap_or(0);
+                    for (room, from_pos) in rooms {
                         let gap = jeliya_api::Push::Gap {
                             room_id: jeliya_api::RoomId::new(room),
                             from_pos,
@@ -1114,6 +1129,17 @@ fn push_pos(push: &jeliya_api::Push) -> Option<u64> {
 /// The served `max_subscriptions_per_connection`.
 const MAX_SUBSCRIPTIONS: u64 = 64;
 
+/// Per-room delivery baseline for one connection.
+///
+/// Keeping the resolved cursor and delivered high-water mark in the same map
+/// makes unsubscribe remove both atomically; a later subscribe cannot inherit
+/// a stale position from the prior subscription.
+#[derive(Debug, Clone, Copy)]
+struct SubscriptionState {
+    from_pos: u64,
+    last_delivered: Option<u64>,
+}
+
 /// `stream.subscribe` — add the room to this connection's subscription set.
 /// Naturally idempotent; exceeding the served limit is
 /// `subscription_limit_reached`, never a silent drop.
@@ -1121,7 +1147,9 @@ async fn handle_stream_subscribe(
     out_tx: &tokio::sync::mpsc::Sender<Message>,
     state: &AppState,
     request: &jeliya_codec::Request,
-    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+    subscriptions: &std::sync::Arc<
+        tokio::sync::Mutex<std::collections::HashMap<String, SubscriptionState>>,
+    >,
 ) -> bool {
     // Extract owned values up front so no `&Request` (non-Sync) is held
     // across an await.
@@ -1135,8 +1163,22 @@ async fn handle_stream_subscribe(
         None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
     let room_key = req.room_id.to_string();
-    let mut subs = subscriptions.lock().await;
-    if !subs.contains_key(&room_key) && subs.len() as u64 >= MAX_SUBSCRIPTIONS {
+    let existing = {
+        let subs = subscriptions.lock().await;
+        subs.get(&room_key).map(|state| state.from_pos)
+    };
+    if let Some(from_pos) = existing {
+        return send_typed(
+            out_tx,
+            id,
+            &jeliya_api::StreamSubscribeOut {
+                room_id: req.room_id,
+                from_pos,
+            },
+        )
+        .await;
+    }
+    if subscriptions.lock().await.len() as u64 >= MAX_SUBSCRIPTIONS {
         return send_api_err(
             out_tx,
             id,
@@ -1162,7 +1204,33 @@ async fn handle_stream_subscribe(
             }
         }
     };
-    subs.insert(room_key, from_pos);
+    // Another in-flight subscribe can race this one. The first insertion wins
+    // and defines the idempotent result; the second returns that same baseline.
+    let from_pos = {
+        let mut subs = subscriptions.lock().await;
+        if let Some(existing) = subs.get(&room_key) {
+            existing.from_pos
+        } else if subs.len() as u64 >= MAX_SUBSCRIPTIONS {
+            drop(subs);
+            return send_api_err(
+                out_tx,
+                id,
+                jeliya_api::ApiError::SubscriptionLimitReached {
+                    limit: MAX_SUBSCRIPTIONS,
+                },
+            )
+            .await;
+        } else {
+            subs.insert(
+                room_key,
+                SubscriptionState {
+                    from_pos,
+                    last_delivered: None,
+                },
+            );
+            from_pos
+        }
+    };
     send_typed(
         out_tx,
         id,
@@ -1178,7 +1246,9 @@ async fn handle_stream_subscribe(
 async fn handle_stream_unsubscribe(
     out_tx: &tokio::sync::mpsc::Sender<Message>,
     request: &jeliya_codec::Request,
-    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+    subscriptions: &std::sync::Arc<
+        tokio::sync::Mutex<std::collections::HashMap<String, SubscriptionState>>,
+    >,
 ) -> bool {
     let id = request.id;
     let req = match request
@@ -1234,7 +1304,7 @@ async fn handle_stream_resync(
     // `resync_required` naming the real head. `from_pos == head` is caught
     // up and answers an empty set below.
     let head = match room_head_pos(state, &req.room_id).await {
-        Ok(next) => next.saturating_sub(1),
+        Ok(head) => head,
         Err(err) => return send_api_err(out_tx, id, err).await,
     };
     if req.from_pos > head {
@@ -1305,8 +1375,8 @@ async fn authorize_room(
     }
 }
 
-/// The room's current head position (the next position a `start` cursor
-/// resolves to), or the access error if the room is not visible.
+/// The room's last committed position (the concrete lower bound a `start`
+/// subscription resolves to), or the access error if the room is not visible.
 async fn room_head_pos(
     state: &AppState,
     room_id: &jeliya_api::RoomId,
@@ -1321,12 +1391,21 @@ async fn room_head_pos(
         },
     });
     match state.engine.execute(call).await.reply {
-        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => {
-            Ok(out.events.last().map(|e| e.pos + 1).unwrap_or(0))
-        }
+        Ok(jeliya_core::typed::TypedReply::RoomTimeline(out)) => Ok(stream_start_position(
+            out.events.last().map(|event| event.pos),
+        )),
         Ok(_) => Ok(0),
         Err(err) => Err(err),
     }
+}
+
+/// Resolve a `start` cursor to the last position the room already holds.
+///
+/// The first future event is one greater than this baseline. Returning that
+/// next position here would make lag recovery read strictly after it and skip
+/// the first missed event.
+fn stream_start_position(last_committed: Option<u64>) -> u64 {
+    last_committed.unwrap_or(0)
 }
 
 /// Encode a typed output as a reply frame and send it.
@@ -1373,7 +1452,9 @@ async fn dispatch_inbound(
     bytes: &[u8],
     state: &AppState,
     bounds: &jeliya_codec::CodecBounds,
-    subscriptions: &std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
+    subscriptions: &std::sync::Arc<
+        tokio::sync::Mutex<std::collections::HashMap<String, SubscriptionState>>,
+    >,
     out_tx: &tokio::sync::mpsc::Sender<Message>,
     inflight: &mut tokio::task::JoinSet<bool>,
     principal_key: &str,
@@ -1538,7 +1619,28 @@ fn text(status: StatusCode, body: &'static str) -> Response<Full<Bytes>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{constant_time_eq, safe_download_mime};
+    use super::{constant_time_eq, gate_refusal, safe_download_mime, stream_start_position};
+    use hyper::{header::CONTENT_TYPE, StatusCode};
+
+    #[test]
+    fn gate_refusal_is_bare_json_with_the_exact_media_type() {
+        let response = gate_refusal(jeliya_codec::GateRejection {
+            body: jeliya_api::ApiError::ProtocolUnsupported {
+                supported: vec![2],
+                client: jeliya_api::DeclaredVersion::Declared { v: 1 },
+            },
+            status: 426,
+        });
+
+        assert_eq!(response.status(), StatusCode::UPGRADE_REQUIRED);
+        assert_eq!(response.headers()[CONTENT_TYPE], "application/json");
+    }
+
+    #[test]
+    fn stream_start_uses_the_last_held_position_not_the_next_position() {
+        assert_eq!(stream_start_position(Some(41)), 41);
+        assert_eq!(stream_start_position(None), 0);
+    }
 
     #[test]
     fn constant_time_eq_matches_only_identical_bytes() {

--- a/spikes/dioxus-android/Cargo.lock
+++ b/spikes/dioxus-android/Cargo.lock
@@ -1056,6 +1056,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derive_more"
@@ -3208,8 +3211,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "iroh",
  "iroh-rooms-core",
@@ -3218,8 +3221,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-core"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3232,13 +3235,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-rooms-net"
-version = "0.1.0-rc.3"
-source = "git+https://github.com/kortiene/iroh-room?rev=a5d98b70d717f35d3ce60953a88e12e646f2e871#a5d98b70d717f35d3ce60953a88e12e646f2e871"
+version = "0.1.0-rc.4"
+source = "git+https://github.com/kortiene/iroh-room?rev=52a4c89e900c2b065f7112638acedeccab83952f#52a4c89e900c2b065f7112638acedeccab83952f"
 dependencies = [
  "anyhow",
  "bao-tree",
  "blake3",
  "bytes",
+ "getrandom 0.4.3",
  "hex",
  "iroh",
  "iroh-blobs",
@@ -3349,6 +3353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jeliya-api"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "jeliya-core"
 version = "0.6.1"
 dependencies = [
@@ -3359,8 +3372,10 @@ dependencies = [
  "hex",
  "iroh",
  "iroh-rooms",
+ "jeliya-api",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
  "zeroize",


### PR DESCRIPTION
## Summary

- move the legacy `materializer`/`supervisor` JSON projection surfaces behind private or test-only boundaries and route production callers through typed `jeliya-api` values
- implement typed `member.remove`, `invite.list`, and `pipe.release` handling
- harden member-removal replay, room deactivation, pipe release/revocation, and local pipe connect/revoke races
- correct WebSocket gate responses, stream subscription baselines, lag cursor state, and affected v2 corpus expectations
- keep persistence JSON explicitly internal rather than exposing it as a protocol model

## Why

Milestone M1 requires the active Rust and WebSocket surfaces to use the typed v2 contract. The prior implementation still publicly exported raw JSON projection modules, left several typed operations as stubs, and had lifecycle gaps around causal member removal, pipe cleanup, and stream recovery.

## Impact

Production protocol-facing callers now stay on typed `jeliya-api` request, reply, event, and push values. Member removal is signed and idempotent, invite listing folds typed room history, pipe release targets one connection while revocation drains every local connection, and stream recovery starts from the last committed position without skipping the first missed event.

This is an incremental M1 slice and intentionally does **not** close #165 or #166. Remaining acceptance blockers include upstream support for a convergent `invite.revoke` event, cancellable transfer handles for `transfer.cancel`, WebSocket `file.share` byte streaming, complete validation-order/non-fabrication coverage, live lag fault injection, and resolution of the retained v1 `/api/session` compatibility route.

## Validation

- `cargo +1.96.0 fmt --all --check`
- `cargo +1.96.0 build --locked --workspace`
- `cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings`
- `cargo +1.96.0 test --locked --workspace`
- `node scripts/check-v2-corpus.mjs` — 344 cases / 2,195 steps
- `cargo +1.91.0 check --locked --workspace --all-targets`
- `git diff --check`
- targeted live v2 replay — 23/23 cases passed
- live empty-current-head and unreachable-position stream resync probes passed

Refs #165
Refs #166