### PR TITLE
feat(core): centralize v2 validation order and remove fabricated projections

### DIFF
--- a/conformance/v2/subject-daemon.json
+++ b/conformance/v2/subject-daemon.json
@@ -2000,7 +2000,7 @@
       "name": "subject_absent_outranks_room_not_available_and_is_not_a_membership_oracle",
       "kind": "authorization",
       "operation": "room.timeline",
-      "intent": "The non-oracle property applied to the subject precondition. A subject-less caller MUST NOT be able to use error-code selection as a room probe: a well-formed unknown room id, a well-formed id the daemon might hold, and a malformed id all return the identical subject_absent object with identical fields and indistinguishable timing. Catches an implementation that validates or looks up the room first and thereby leaks room_not_available versus invalid_argument to an unauthenticated-by-subject caller.",
+      "intent": "The non-oracle property applied to the subject precondition. A subject-less caller MUST NOT be able to use error-code selection as a ROOM probe: a well-formed unknown room id, a well-formed id the daemon might hold, and a malformed id all return the identical subject_absent object with identical fields and indistinguishable timing. Catches an implementation that looks the room up first and thereby leaks room_not_available to an unauthenticated-by-subject caller. It does NOT assert that structural refusal is preempted: the validation-order table runs structural decode and bounds as step 1 and the subject precondition as step 2, and the record explains why that costs the property nothing. A step-1 refusal names only a value the caller sent and a limit hello already served, so the final step asserts invalid_argument and the room-lookup steps assert subject_absent — which is the distinction the property actually turns on.",
       "requires": [
         "daemon:fresh",
         "subject:none",
@@ -2121,14 +2121,44 @@
             "limit": 999999999,
             "direction": "forward"
           },
-          "note": "An over-limit page size also does not preempt the precondition.",
+          "note": "An over-limit page size is refused at step 1, AHEAD of the subject precondition. This step previously asserted subject_absent, which contradicted the validation-order table it was meant to cover: that table runs structural decode and bounds as step 1 and the subject precondition as step 2, and the record states outright that putting format and bounds first 'does not weaken the non-oracle property' because 'step 1 discloses only the value formats this record publishes, never any daemon state'. timeline_page_max is served in hello to this very connection before any subject exists, so refusing against it reveals nothing the client was not already told. The oracle this case exists to catch is a room LOOKUP preempting the precondition, which the three room_id spellings above still prove; a bound check on a value the caller sent is not one.",
           "on": "subject:A",
           "expect": {
             "ok": false,
             "err": {
-              "code": "subject_absent"
+              "code": "invalid_argument",
+              "field": "in.limit"
             }
           }
+        },
+        {
+          "note": "The bound arm carries min and max; the served maximum itself is pinned by the hello-limits case, so this one asserts the arm rather than restating a number.",
+          "assert": [
+            {
+              "path": "err.reason.state",
+              "op": "eq",
+              "value": "bound"
+            },
+            {
+              "path": "err.reason.min",
+              "op": "eq",
+              "value": 1
+            },
+            {
+              "path": "err.reason.max",
+              "op": "gte",
+              "value": 1
+            },
+            {
+              "path": "err.hint",
+              "op": "absent"
+            },
+            {
+              "path": "err",
+              "op": "no_nulls"
+            }
+          ],
+          "on": "subject:A"
         },
         {
           "note": "Timing is asserted as a repeated-sample distribution comparison, never as a single measurement, because 'indistinguishable timing' is normative and a single sample cannot establish it.",

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -240,12 +240,14 @@ impl Engine {
     }
 
     /// Complete a host-staged typed file share. Hosts supply a managed path;
-    /// the protocol declaration and result remain `jeliya-api` values.
+    /// the protocol declaration and result remain `jeliya-api` values, and so
+    /// does the refusal — a size disagreement is `declared_size_mismatch`
+    /// carrying both counts, never a prose error the host must re-classify.
     pub async fn share_staged_file(
         &self,
         req: &FileShare,
         staged_path: &Path,
-    ) -> CoreResult<FileShareOut> {
+    ) -> Result<FileShareOut, ApiError> {
         typed::TypedSupervisor::new(&self.supervisor)
             .share_staged_file(req, staged_path)
             .await
@@ -331,11 +333,23 @@ impl Engine {
         let op = call.path();
         let dedup_key = if is_dedup_op(op) { op_id } else { None };
         if let Some(op_id) = dedup_key {
-            // Validation-order step 2 (subject) runs BEFORE the ledger is
-            // consulted or populated: a deduplicated call on a subject-less
-            // daemon must not bind its `op_id` to `subject_absent`, or a
-            // retry after `subject.ensure` would replay a stale cached error
-            // instead of reaching the dedup stage as a first eligible call.
+            // Validation-order steps 1 and 2 run BEFORE the ledger is consulted
+            // or populated, because the record puts dedup at step 3.
+            //
+            // Both matter for the same reason: a refusal from an earlier stage
+            // must not be recorded against the `op_id`, or a client that fixes
+            // the request and retries with the same key gets `op_id_conflict`
+            // instead of its effect. `member.remove` is the reachable case —
+            // it deduplicates and carries a step-1 subject-id format check —
+            // and a subject-less daemon is the case for step 2, where a retry
+            // after `subject.ensure` must reach the ledger as a first eligible
+            // call rather than replay a cached `subject_absent`.
+            if let Err(err) = typed::validate_structure(&call) {
+                return Executed {
+                    reply: Err(err),
+                    stop_after_reply: false,
+                };
+            }
             let typed = typed::TypedSupervisor::new(&self.supervisor);
             match typed.subject_present() {
                 Ok(true) => {}
@@ -703,14 +717,19 @@ fn emit_committed(
 }
 
 /// The per-device link rows for one room, for the peer-change drain.
+///
+/// It goes through [`typed::dispatch`] rather than the projection body, so the
+/// push path is gated by the same validation pipeline a client read is: a room
+/// whose membership has ended stops producing peer frames at exactly the point
+/// it stops answering `room.peers`, rather than at whatever the push loop
+/// happens to check.
 async fn typed_peer_rows(engine: &Engine, room_id: &iroh_rooms::room::RoomId) -> Vec<PeerRow> {
-    let typed = typed::TypedSupervisor::new(&engine.supervisor);
-    let req = jeliya_api::RoomPeers {
+    let call = TypedCall::RoomPeers(jeliya_api::RoomPeers {
         room_id: RoomId::new(room_id.to_string()),
-    };
-    match typed.room_peers(&req).await {
-        Ok(out) => out.peers,
-        Err(_) => Vec::new(),
+    });
+    match typed::dispatch(&engine.supervisor, call).await {
+        Ok(TypedReply::RoomPeers(out)) => out.peers,
+        _ => Vec::new(),
     }
 }
 

--- a/crates/jeliya-core/src/error.rs
+++ b/crates/jeliya-core/src/error.rs
@@ -97,6 +97,16 @@ pub struct CoreError {
     pub message: String,
     /// Next-action line (IR-0303 convention) or `None`.
     pub hint: Option<String>,
+    /// One **machine-readable** value the typed v2 layer lifts into a typed
+    /// error field, distinct from [`Self::message`], which is prose the wire
+    /// never carries.
+    ///
+    /// It exists because some v2 error codes fix a typed field the runtime is
+    /// the only thing that knows: today the sole use is the **observed**
+    /// digest on a `hash_mismatch`, which `digest_mismatch { expected,
+    /// observed }` requires and which would otherwise be served as an empty
+    /// string — a schema satisfied and a fact invented.
+    pub detail: Option<String>,
 }
 
 impl CoreError {
@@ -106,6 +116,7 @@ impl CoreError {
             kind,
             message: message.into(),
             hint: kind.default_hint().map(str::to_owned),
+            detail: None,
         }
     }
 
@@ -113,6 +124,14 @@ impl CoreError {
     #[must_use]
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
+        self
+    }
+
+    /// Attach the machine-readable value the typed layer lifts into a typed
+    /// error field. See [`CoreError::detail`].
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
         self
     }
 

--- a/crates/jeliya-core/src/projection.rs
+++ b/crates/jeliya-core/src/projection.rs
@@ -9,6 +9,8 @@
 //! has a bug. Internal persistence JSON (`localstate.rs`, `identity.rs`) is
 //! out of scope and stays JSON.
 
+use std::collections::BTreeSet;
+
 use jeliya_api::{
     Audience, Author, Cursor, Event, EventId, EventKind, EventKindContent, FileId, InviteId,
     LastEvent, LastSeen, LatestStatus, Liveness, PipeId, Progress, Role, RoomId, Standing,
@@ -19,7 +21,7 @@ use time::OffsetDateTime;
 use iroh_rooms::events::{Content, SignedEvent};
 use iroh_rooms::experimental::store::StoredEvent;
 use iroh_rooms::identity::IdentityKey;
-use iroh_rooms::room::{MembershipSnapshot, Role as IrohRole};
+use iroh_rooms::room::{MembershipSnapshot, Role as IrohRole, Status as IrohStatus};
 
 use crate::error::{CoreError, CoreResult};
 
@@ -39,17 +41,99 @@ pub(crate) fn file_handle(file_id: &[u8; 16]) -> String {
 }
 
 /// Convert a signed author-dated `created_at` (ms since the Unix epoch, the
-/// non-repudiable author clock) into the wire `<ts>` (RFC 3339, `Z` offset).
+/// non-repudiable author clock) into the wire `<ts>` (RFC 3339, `Z` offset),
+/// or `None` when the instant is not representable on the wire.
 ///
 /// The signed timestamp is the only clock a projection may serve; the wall
 /// clock is never read here. Milliseconds are truncated to whole seconds
 /// because RFC 3339 has no fractional requirement and the `<ts>` grammar is
 /// second-precision.
-fn ts(created_at_ms: u64) -> Option<Timestamp> {
+///
+/// **There is no epoch fallback.** An unrepresentable instant is a missing
+/// fact, and the record forbids turning a missing fact into a known one: an
+/// event carrying one is not a committed event at all (see [`is_committed`]),
+/// and a projection that needs one and cannot have it answers its exact typed
+/// error rather than serving `1970-01-01T00:00:00Z` as though it were signed.
+pub(crate) fn ts(created_at_ms: u64) -> Option<Timestamp> {
     let secs = i64::try_from(created_at_ms / 1000).ok()?;
     OffsetDateTime::from_unix_timestamp(secs)
         .ok()
         .map(Timestamp::new)
+}
+
+/// [`ts`] retaining the sub-second part, for a `<ts>` the **caller supplied**
+/// rather than an author dated.
+///
+/// An invite's `expires_at` is chosen by the client, signed verbatim, and then
+/// echoed by `invite.mint` and served again by `invite.list`. Truncating it to
+/// whole seconds would make the daemon answer with an instant the caller did
+/// not name — and a faithful `op_id` retry that resent the reply's value would
+/// then carry a different body than the original request. RFC 3339 permits the
+/// fractional part, so the value round-trips exactly.
+pub(crate) fn ts_millis(at_ms: u64) -> Option<Timestamp> {
+    let nanos = i128::from(at_ms).checked_mul(1_000_000)?;
+    OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .ok()
+        .map(Timestamp::new)
+}
+
+/// The signed departure facts a room's history carries.
+///
+/// The upstream fold collapses a voluntary leave and an administrative removal
+/// into one `Status::Removed`; protocol v2 keeps `left` and `removed` distinct,
+/// so the two sets are folded from the signed `member.left` / `member.removed`
+/// content and consulted wherever a `standing` is served. Carrying them as one
+/// value is what lets **every** standing answer — the caller's own, a roster
+/// row's, and a committed event's `author.standing` — come from one derivation
+/// instead of three, one of which used to be the constant `active`.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Departures {
+    /// Subjects an authority removed.
+    pub removed: BTreeSet<IdentityKey>,
+    /// Subjects that left voluntarily.
+    pub left: BTreeSet<IdentityKey>,
+}
+
+impl Departures {
+    /// Fold the departure facts out of a room's canonical tail. Pure: it reads
+    /// only signed content, so the push paths (which already hold the tail) can
+    /// build it without a second store handle.
+    pub(crate) fn from_rows<'a>(rows: impl IntoIterator<Item = &'a StoredEvent>) -> Self {
+        let mut out = Self::default();
+        for stored in rows {
+            let Ok(event) = SignedEvent::decode(&stored.wire.signed) else {
+                continue;
+            };
+            match event.content {
+                // A re-join supersedes both prior terminal facts.
+                Content::MemberJoined(_) => {
+                    out.removed.remove(&event.sender_id);
+                    out.left.remove(&event.sender_id);
+                }
+                Content::MemberRemoved(c) => {
+                    out.left.remove(&c.member_id);
+                    out.removed.insert(c.member_id);
+                }
+                Content::MemberLeft(c) => {
+                    out.removed.remove(&c.member_id);
+                    out.left.insert(c.member_id);
+                }
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// The v2 `standing` for one subject, refining the fold's terminal status
+    /// with the signed fact that caused it. An administrative removal dominates
+    /// a concurrent self-leave.
+    #[must_use]
+    pub(crate) fn standing_of(&self, status: IrohStatus, identity: &IdentityKey) -> Standing {
+        let left = self.left.contains(identity);
+        let removed =
+            self.removed.contains(identity) || (!left && matches!(status, IrohStatus::Removed));
+        standing(removed, left)
+    }
 }
 
 /// The v2 per-room position space is the room's committed timeline events
@@ -90,11 +174,12 @@ fn ts(created_at_ms: u64) -> Option<Timestamp> {
 pub(crate) fn positioned(
     rows: &[&StoredEvent],
     snapshot: &MembershipSnapshot,
+    departures: &Departures,
 ) -> Vec<(u64, Event)> {
     let mut out = Vec::new();
     let mut rank = 0u64;
     for se in rows {
-        if let Some(event) = materialize(se, 0, snapshot) {
+        if let Some(event) = materialize(se, 0, snapshot, departures) {
             out.push((rank, Event { pos: rank, ..event }));
             rank += 1;
         }
@@ -142,16 +227,18 @@ fn role_from_wire(wire: &str) -> Option<Role> {
 /// cannot resolve carries **no attribution** (`Unresolved`) — the record
 /// removes v1's fabricated default role, so an unknown author is stated
 /// honestly rather than invented as a `member`.
-fn author(snapshot: &MembershipSnapshot, sender: &IdentityKey) -> Author {
+///
+/// `standing` is the **same derivation `room.members` serves**, folded from the
+/// signed departure facts. An earlier revision hardcoded `active` here, which
+/// told a client that a removed member's messages were authored by someone who
+/// still belongs — attribution a UI uses to decide how much to trust something,
+/// invented. One derivation, both places.
+fn author(snapshot: &MembershipSnapshot, departures: &Departures, sender: &IdentityKey) -> Author {
     match snapshot.member(sender) {
         Some(member) => Author::Resolved {
             subject_id: SubjectId::new(sender.to_string()),
             role: role(member.role),
-            // The fold's member row carries the standing; a member in the set
-            // is active unless a departure event set it aside. The snapshot's
-            // status refinement is applied by the caller for roster rows; for
-            // authorship the fold's membership fact is what we serve.
-            standing: Standing::Active,
+            standing: departures.standing_of(member.status, &member.identity),
         },
         None => Author::Unresolved,
     }
@@ -178,15 +265,22 @@ fn status_label(label: &str) -> CoreResult<StatusLabel> {
     })
 }
 
-/// Map an on-wire progress percent to the v2 `progress` variant. Absent is
-/// the no-progress arm; a reported percent is bounded to `0..=100` by the
-/// content validator, so it always fits the `Reported` arm's `u8`.
-fn progress(pct: Option<u64>) -> Progress {
+/// Map an on-wire progress percent to the v2 `progress` variant. Absent is the
+/// no-progress arm; a reported percent must be in the record's inclusive
+/// `0..=100`.
+///
+/// A percent outside that range is **refused, never clamped**: saturating an
+/// out-of-range value to `100` would report a task as complete on the strength
+/// of a number the author never signed. The row carrying it is therefore not a
+/// committed event (see [`kind_content`]), the same answer an out-of-vocabulary
+/// label gets.
+pub(crate) fn progress(pct: Option<u64>) -> Option<Progress> {
     match pct {
-        Some(p) => Progress::Reported {
-            percent: u8::try_from(p.min(100)).unwrap_or(100),
-        },
-        None => Progress::Absent,
+        Some(p) => u8::try_from(p)
+            .ok()
+            .filter(|percent| *percent <= 100)
+            .map(|percent| Progress::Reported { percent }),
+        None => Some(Progress::Absent),
     }
 }
 
@@ -215,9 +309,14 @@ fn progress(pct: Option<u64>) -> Progress {
 /// - `pipe.closed` → `pipe_revoked`
 /// - `member.invited` → (no committed event; `invite.mint` authors none)
 #[must_use]
-pub fn materialize(se: &StoredEvent, pos: u64, snapshot: &MembershipSnapshot) -> Option<Event> {
+pub(crate) fn materialize(
+    se: &StoredEvent,
+    pos: u64,
+    snapshot: &MembershipSnapshot,
+    departures: &Departures,
+) -> Option<Event> {
     let ev = SignedEvent::decode(&se.wire.signed).ok()?;
-    materialize_signed(pos, &se.event_id, &ev, snapshot)
+    materialize_signed(pos, &se.event_id, &ev, snapshot, departures)
 }
 
 /// Fold one decoded signed event plus its position into a committed v2
@@ -225,42 +324,67 @@ pub fn materialize(se: &StoredEvent, pos: u64, snapshot: &MembershipSnapshot) ->
 /// (`member.invited`), and for an `agent.status` whose label is outside the
 /// closed vocabulary (refused, never reclassified).
 #[must_use]
-pub fn materialize_signed(
+pub(crate) fn materialize_signed(
     pos: u64,
     event_id: &iroh_rooms::events::EventId,
     ev: &SignedEvent,
     snapshot: &MembershipSnapshot,
+    departures: &Departures,
 ) -> Option<Event> {
     let kind = kind_content(&ev.content)?;
     Some(Event {
         pos,
         event_id: EventId::new(bare_event_hex(event_id)),
         at: ts(ev.created_at)?,
-        author: author(snapshot, &ev.sender_id),
+        author: author(snapshot, departures, &ev.sender_id),
         kind,
     })
 }
 
-/// The `created_at` and committed [`EventKind`] of a stored event, for the
-/// `room.list` `last_event` recency projection. The kind is `None` for an
-/// event with no committed kind (`member.invited`) — the timestamp is still
-/// real, so the row says *when* without inventing *what*.
-#[must_use]
-pub fn stored_event_recency(se: &StoredEvent) -> Option<(u64, Option<EventKind>)> {
-    let ev = SignedEvent::decode(&se.wire.signed).ok()?;
-    Some((ev.created_at, kind_content(&ev.content).map(|k| k.kind())))
+/// One committed event's recency evidence, for the `room.list` `last_event`
+/// projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Recency {
+    /// The signed `created_at` in **milliseconds**. Ordering is compared on
+    /// this, not on [`Self::at`]: the wire `<ts>` is second-precision, so
+    /// comparing the converted value would tie every pair of events authored
+    /// within the same second and let the id tiebreak pick the older one.
+    pub created_at_ms: u64,
+    /// The same instant in its wire form.
+    pub at: Timestamp,
+    /// The committed kind.
+    pub kind: EventKind,
 }
 
-/// Build the `last_event` variant for a room row: the newest committed
-/// event's author-dated instant and kind, or `Absent` when the room has no
-/// committed event.
+/// The recency evidence of a stored event — `None` for a row that is not a
+/// committed event at all (`member.invited`, an out-of-vocabulary status, an
+/// out-of-range progress) or whose instant is not representable on the wire.
+///
+/// It returns evidence only when **every** part is real. An earlier revision
+/// returned `(ts, None)` for a non-committed row, and because the caller took
+/// the max over *every* row and then dropped a kindless winner, a room whose
+/// newest row was an invitation reported `last_event: absent` while holding a
+/// timeline full of messages. The recency projection is defined over committed
+/// events, so a non-committed row must not win the max in the first place.
 #[must_use]
-pub fn last_event(recency: Option<(u64, Option<EventKind>)>) -> LastEvent {
+pub(crate) fn stored_event_recency(se: &StoredEvent) -> Option<Recency> {
+    let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+    Some(Recency {
+        created_at_ms: ev.created_at,
+        at: ts(ev.created_at)?,
+        kind: kind_content(&ev.content)?.kind(),
+    })
+}
+
+/// Build the `last_event` variant for a room row: the newest committed event's
+/// author-dated instant and kind, or `Absent` when the room has no committed
+/// event. `Absent` means exactly "no committed event", never "we had one and
+/// could not describe it".
+#[must_use]
+pub(crate) fn last_event(recency: Option<Recency>) -> LastEvent {
     match recency {
-        Some((created_at_ms, Some(kind))) => {
-            ts(created_at_ms).map_or(LastEvent::Absent, |at| LastEvent::Present { at, kind })
-        }
-        _ => LastEvent::Absent,
+        Some(Recency { at, kind, .. }) => LastEvent::Present { at, kind },
+        None => LastEvent::Absent,
     }
 }
 
@@ -275,13 +399,14 @@ fn kind_content(content: &Content) -> Option<EventKindContent> {
             body: c.body.clone(),
         },
         Content::AgentStatus(c) => {
-            // An out-of-vocabulary label must not become a fabricated known
+            // An out-of-vocabulary label — or a progress percent outside the
+            // record's inclusive `0..=100` — must not become a fabricated known
             // state: the event is omitted from the committed timeline rather
-            // than reclassified.
+            // than reclassified or clamped.
             let label = status_label(&c.status).ok()?;
             EventKindContent::AgentStatus {
                 label,
-                progress: progress(c.progress_pct),
+                progress: progress(c.progress_pct)?,
             }
         }
         Content::MemberJoined(c) => EventKindContent::MemberJoined {
@@ -320,13 +445,15 @@ fn kind_content(content: &Content) -> Option<EventKindContent> {
 }
 
 /// Parse a pipe `target_hint` (`"host:port"`) into the v2 `target` object.
-/// The hint is authored as a loopback target. A malformed or non-loopback
-/// target is omitted rather than projected as a fabricated endpoint.
+///
+/// The target is projected **verbatim**, including a non-loopback host. The
+/// loopback policy is a *publish-side* refusal this daemon applies before
+/// authoring (`pipe_target_refused`); a target another peer signed is a fact
+/// about that peer's pipe, and suppressing it would hide from the operator
+/// exactly the pipe worth seeing. Only a hint that is not an address at all
+/// leaves the event unrepresentable, and such an event holds no position.
 fn pipe_target(hint: &str) -> Option<Target> {
     let addr: std::net::SocketAddr = hint.parse().ok()?;
-    if !addr.ip().is_loopback() || addr.port() == 0 {
-        return None;
-    }
     Some(Target {
         host: addr.ip().to_string(),
         port: u64::from(addr.port()),
@@ -442,12 +569,14 @@ mod tests {
     use iroh_rooms::files::{build_file_shared, HashRef};
     use iroh_rooms::identity::DeviceBinding;
     use iroh_rooms::identity::SigningKey;
+    use iroh_rooms::pipes::{build_pipe_closed, build_pipe_opened};
     use iroh_rooms::room::build_member_invited;
     use iroh_rooms::room::{
-        build_member_joined, build_member_left, build_room_created, derive_room_id,
-        MembershipSnapshot, RoomId, RoomMembership,
+        build_member_joined, build_member_left, build_member_removed, build_room_created,
+        derive_room_id, MembershipSnapshot, RoomId, RoomMembership,
     };
     use jeliya_api::Severity;
+    use serde_json::{json, Value};
 
     const TS: u64 = 1_783_190_000_000;
 
@@ -483,6 +612,10 @@ mod tests {
     }
 
     fn mat(fx: &Fixture, wire: &WireEvent, pos: u64) -> Event {
+        mat_with(fx, wire, pos, &Departures::default())
+    }
+
+    fn mat_with(fx: &Fixture, wire: &WireEvent, pos: u64, departures: &Departures) -> Event {
         let snapshot = snapshot_of(fx);
         let ev = decode(wire);
         let ctx = ValidationContext::for_room(fx.room_id);
@@ -490,15 +623,283 @@ mod tests {
             .map_or(iroh_rooms::events::EventId::from_bytes([0x0f; 32]), |v| {
                 v.event_id
             });
-        materialize_signed(pos, &event_id, &ev, &snapshot).expect("materializes")
+        materialize_signed(pos, &event_id, &ev, &snapshot, departures).expect("materializes")
     }
+
+    // ------------------------------------------------------------------
+    // Every currently representable committed event, as a table
+    // ------------------------------------------------------------------
+
+    /// One authored event per committed kind this build can represent, with
+    /// the **encoded** `{kind, content}` the record fixes for it.
+    ///
+    /// The record closes `kind` at ten. Nine are exercised here as real signed
+    /// events folded through [`materialize_signed`] and compared to a
+    /// hand-written expectation transcribed from `docs/protocol-v2.md`'s
+    /// committed-event table — not from this module's output.
+    ///
+    /// **`invite_revoked` is the tenth and is absent, irreducibly.** The active
+    /// Iroh Room SDK has no convergent signed invite-revocation content, so
+    /// there is no event to author and none to project; a locally synthesized
+    /// tombstone would be a "committed" fact no peer converges on.
+    /// [`no_kind_is_silently_uncovered`] asserts that gap explicitly rather
+    /// than letting nine-of-ten read as complete coverage.
+    fn committed_event_table(fx: &Fixture) -> Vec<(EventKind, WireEvent, Value)> {
+        let joiner_identity = SigningKey::generate();
+        let joiner_device = SigningKey::generate();
+        let joiner = joiner_identity.identity_key();
+        let binding =
+            DeviceBinding::create(&fx.room_id, &joiner_identity, joiner_device.device_key());
+        let removed_subject = SigningKey::generate().identity_key();
+        let peer = SigningKey::generate().identity_key();
+
+        vec![
+            (
+                EventKind::RoomCreated,
+                fx.genesis.clone(),
+                json!({ "kind": "room_created", "content": { "name": "Build Iroh Rooms MVP" } }),
+            ),
+            (
+                EventKind::Message,
+                build_message_text(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    "hello",
+                    None,
+                    None,
+                    &[],
+                    &[],
+                    TS + 1,
+                ),
+                json!({ "kind": "message", "content": { "body": "hello" } }),
+            ),
+            (
+                EventKind::AgentStatus,
+                build_agent_status(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    "working",
+                    None,
+                    &[],
+                    Some(60),
+                    &[],
+                    TS + 1,
+                ),
+                json!({
+                    "kind": "agent_status",
+                    "content": {
+                        "label": "working",
+                        "progress": { "state": "reported", "percent": 60 },
+                    },
+                }),
+            ),
+            (
+                EventKind::MemberJoined,
+                build_member_joined(
+                    &joiner_identity,
+                    &joiner_device,
+                    &fx.room_id,
+                    &[0x01; 16],
+                    &[0x03; 16],
+                    "member",
+                    binding,
+                    None,
+                    &[],
+                    TS + 2,
+                ),
+                json!({
+                    "kind": "member_joined",
+                    "content": { "subject_id": joiner.to_string(), "role": "member" },
+                }),
+            ),
+            (
+                EventKind::MemberLeft,
+                build_member_left(&fx.identity, &fx.device, &fx.room_id, None, &[], TS + 3),
+                json!({
+                    "kind": "member_left",
+                    "content": { "subject_id": fx.identity.identity_key().to_string() },
+                }),
+            ),
+            (
+                EventKind::MemberRemoved,
+                build_member_removed(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    &removed_subject,
+                    None,
+                    None,
+                    &[],
+                    TS + 4,
+                ),
+                json!({
+                    "kind": "member_removed",
+                    "content": {
+                        "subject_id": removed_subject.to_string(),
+                        "by": fx.identity.identity_key().to_string(),
+                    },
+                }),
+            ),
+            (
+                EventKind::FileShared,
+                build_file_shared(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    [0x11; 16],
+                    "PRD.pdf",
+                    "application/pdf",
+                    123,
+                    HashRef::from_bytes([0xcc; 32]),
+                    Some("raw"),
+                    &[fx.device.device_key()],
+                    &[],
+                    TS + 5,
+                ),
+                json!({
+                    "kind": "file_shared",
+                    "content": {
+                        "file_id": format!("file_{}", "11".repeat(16)),
+                        "name": "PRD.pdf",
+                        "bytes": 123,
+                        "digest": HashRef::from_bytes([0xcc; 32]).to_string(),
+                    },
+                }),
+            ),
+            (
+                EventKind::PipePublished,
+                build_pipe_opened(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    [0xef; 16],
+                    &fx.device.device_key(),
+                    "dev",
+                    "127.0.0.1:3000",
+                    "iroh-rooms/pipe/1",
+                    &[peer],
+                    None,
+                    &[],
+                    TS + 6,
+                ),
+                json!({
+                    "kind": "pipe_published",
+                    "content": {
+                        "pipe_id": "ef".repeat(16),
+                        "target": { "host": "127.0.0.1", "port": 3000 },
+                        "audience": { "state": "subjects", "subject_ids": [peer.to_string()] },
+                    },
+                }),
+            ),
+            (
+                EventKind::PipeRevoked,
+                build_pipe_closed(
+                    &fx.identity,
+                    &fx.device,
+                    &fx.room_id,
+                    [0xef; 16],
+                    Some("closed"),
+                    &[],
+                    TS + 7,
+                ),
+                json!({
+                    "kind": "pipe_revoked",
+                    "content": { "pipe_id": "ef".repeat(16) },
+                }),
+            ),
+        ]
+    }
+
+    /// Every representable committed kind encodes to exactly the `{kind,
+    /// content}` the record fixes for it — same discriminant spelling, same
+    /// field set, no extra keys, and no JSON `null` anywhere.
+    #[test]
+    fn every_representable_event_encodes_to_its_record_shape() {
+        let fx = fixture();
+        for (kind, wire, expected) in committed_event_table(&fx) {
+            let event = mat(&fx, &wire, 7);
+            assert_eq!(event.kind.kind(), kind, "kind discriminant");
+            let encoded = serde_json::to_value(&event).expect("an event serializes");
+
+            // The common header the record fixes on every committed event.
+            let obj = encoded.as_object().expect("an event is an object");
+            let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            assert_eq!(
+                keys,
+                ["at", "author", "content", "event_id", "kind", "pos"],
+                "{kind:?} carries exactly the record's event fields"
+            );
+            assert_eq!(
+                obj["pos"],
+                json!(7),
+                "{kind:?} serves the rank it was given"
+            );
+
+            // The kind-and-content pair, transcribed from the record.
+            let expected = expected.as_object().expect("expectation is an object");
+            assert_eq!(obj["kind"], expected["kind"], "{kind:?} wire spelling");
+            assert_eq!(obj["content"], expected["content"], "{kind:?} content");
+
+            assert_no_nulls(&encoded, &format!("{kind:?}"));
+        }
+    }
+
+    /// The nine kinds above are the nine this build can represent, and
+    /// `invite_revoked` is the tenth. The gap is asserted so nine-of-ten can
+    /// never read as coverage.
+    #[test]
+    fn no_kind_is_silently_uncovered() {
+        let fx = fixture();
+        let covered: std::collections::HashSet<EventKind> = committed_event_table(&fx)
+            .into_iter()
+            .map(|(kind, _, _)| kind)
+            .collect();
+        // The record's ten, in its own order.
+        let all = [
+            EventKind::RoomCreated,
+            EventKind::Message,
+            EventKind::AgentStatus,
+            EventKind::MemberJoined,
+            EventKind::MemberLeft,
+            EventKind::MemberRemoved,
+            EventKind::InviteRevoked,
+            EventKind::FileShared,
+            EventKind::PipePublished,
+            EventKind::PipeRevoked,
+        ];
+        assert_eq!(all.len(), 10, "the record closes `kind` at ten");
+        let uncovered: Vec<EventKind> = all
+            .into_iter()
+            .filter(|kind| !covered.contains(kind))
+            .collect();
+        assert_eq!(
+            uncovered,
+            vec![EventKind::InviteRevoked],
+            "exactly one kind is unrepresentable, and it is the upstream-blocked one"
+        );
+    }
+
+    fn assert_no_nulls(value: &Value, label: &str) {
+        match value {
+            Value::Null => panic!("{label} encodes a JSON null"),
+            Value::Object(map) => map.values().for_each(|v| assert_no_nulls(v, label)),
+            Value::Array(items) => items.iter().for_each(|v| assert_no_nulls(v, label)),
+            _ => {}
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Attribution
+    // ------------------------------------------------------------------
 
     #[test]
     fn room_created_has_authority_author_and_typed_content() {
         let fx = fixture();
         let e = mat(&fx, &fx.genesis, 0);
         assert_eq!(e.pos, 0);
-        assert!(matches!(e.kind, EventKindContent::RoomCreated { .. }));
         assert_eq!(e.kind.kind(), EventKind::RoomCreated);
         match e.author {
             Author::Resolved { role, standing, .. } => {
@@ -507,56 +908,122 @@ mod tests {
             }
             Author::Unresolved => panic!("genesis author must resolve"),
         }
-        if let EventKindContent::RoomCreated { name } = e.kind {
-            assert_eq!(name, "Build Iroh Rooms MVP");
-        }
     }
 
     #[test]
-    fn message_carries_typed_body() {
+    fn unresolved_author_carries_no_attribution() {
         let fx = fixture();
+        let stranger_identity = SigningKey::generate();
+        let stranger_device = SigningKey::generate();
+        let wire = build_message_text(
+            &stranger_identity,
+            &stranger_device,
+            &fx.room_id,
+            "hi",
+            None,
+            None,
+            &[],
+            &[],
+            TS,
+        );
+        let e = mat(&fx, &wire, 1);
+        assert_eq!(e.author, Author::Unresolved);
+    }
+
+    /// **The author's `standing` is derived, not assumed.** An earlier
+    /// revision hardcoded `active` on every resolved author, which told a
+    /// client that a departed member's messages were authored by someone who
+    /// still belongs. Attribution a UI uses to decide how much to trust
+    /// something must not be invented.
+    #[test]
+    fn a_resolved_authors_standing_is_the_signed_departure_fact() {
+        let fx = fixture();
+        let author_key = fx.identity.identity_key();
         let wire = build_message_text(
             &fx.identity,
             &fx.device,
             &fx.room_id,
-            "hello",
+            "before leaving",
             None,
             None,
             &[],
             &[],
             TS + 1,
         );
-        let e = mat(&fx, &wire, 1);
-        match e.kind {
-            EventKindContent::Message { body } => assert_eq!(body, "hello"),
-            other => panic!("wrong kind: {other:?}"),
+
+        for (departures, expected) in [
+            (Departures::default(), Standing::Active),
+            (
+                Departures {
+                    left: BTreeSet::from([author_key]),
+                    ..Departures::default()
+                },
+                Standing::Left,
+            ),
+            (
+                Departures {
+                    removed: BTreeSet::from([author_key]),
+                    ..Departures::default()
+                },
+                Standing::Removed,
+            ),
+            (
+                // A removal dominates a concurrent self-leave.
+                Departures {
+                    removed: BTreeSet::from([author_key]),
+                    left: BTreeSet::from([author_key]),
+                },
+                Standing::Removed,
+            ),
+        ] {
+            let e = mat_with(&fx, &wire, 1, &departures);
+            let Author::Resolved { standing, .. } = e.author else {
+                panic!("the author resolves");
+            };
+            assert_eq!(standing, expected, "departures {departures:?}");
         }
     }
 
+    /// `Departures` folds `member.left` / `member.removed` out of a real tail,
+    /// and a re-join supersedes both.
     #[test]
-    fn agent_status_maps_typed_label_and_progress() {
+    fn departures_fold_from_the_canonical_tail() {
         let fx = fixture();
-        let wire = build_agent_status(
-            &fx.identity,
-            &fx.device,
-            &fx.room_id,
-            "working",
-            None,
-            &[],
-            Some(60),
-            &[],
-            TS + 1,
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        store.insert(&genesis).unwrap();
+        let left = validate_wire_bytes(
+            &build_member_left(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                None,
+                &[genesis.event_id],
+                TS + 1,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        store.insert(&left).unwrap();
+
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        let departures = Departures::from_rows(rows.iter());
+        assert!(departures.left.contains(&fx.identity.identity_key()));
+        assert!(departures.removed.is_empty());
+        assert_eq!(
+            departures.standing_of(
+                iroh_rooms::room::Status::Active,
+                &fx.identity.identity_key()
+            ),
+            Standing::Left
         );
-        let e = mat(&fx, &wire, 1);
-        match e.kind {
-            EventKindContent::AgentStatus { label, progress } => {
-                assert_eq!(label, StatusLabel::Working);
-                assert_eq!(progress, Progress::Reported { percent: 60 });
-                assert_eq!(label.severity(), Severity::Ok);
-            }
-            other => panic!("wrong kind: {other:?}"),
-        }
     }
+
+    // ------------------------------------------------------------------
+    // Refusals: an unknown or out-of-range fact never becomes a known one
+    // ------------------------------------------------------------------
 
     #[test]
     fn out_of_vocabulary_status_label_is_omitted_not_reclassified() {
@@ -576,85 +1043,166 @@ mod tests {
         let ev = decode(&wire);
         let id = iroh_rooms::events::EventId::from_bytes([0x01; 32]);
         assert!(
-            materialize_signed(1, &id, &ev, &snapshot).is_none(),
+            materialize_signed(1, &id, &ev, &snapshot, &Departures::default()).is_none(),
             "an unrecognized label must not become a fabricated known state"
         );
     }
 
+    /// A progress percent outside the record's inclusive `0..=100` is
+    /// **refused, never clamped**. Saturating it to `100` would report a task
+    /// as complete on the strength of a number the author never signed.
     #[test]
-    fn member_joined_and_left_map_subject_ids() {
-        let fx = fixture();
-        let joiner_identity = SigningKey::generate();
-        let joiner_device = SigningKey::generate();
-        let binding =
-            DeviceBinding::create(&fx.room_id, &joiner_identity, joiner_device.device_key());
-        let joined = build_member_joined(
-            &joiner_identity,
-            &joiner_device,
-            &fx.room_id,
-            &[0x01; 16],
-            &[0x03; 16],
-            "member",
-            binding,
-            None,
-            &[],
-            TS + 2,
+    fn an_out_of_range_progress_percent_is_refused_not_clamped() {
+        assert_eq!(progress(None), Some(Progress::Absent));
+        assert_eq!(progress(Some(0)), Some(Progress::Reported { percent: 0 }));
+        assert_eq!(
+            progress(Some(100)),
+            Some(Progress::Reported { percent: 100 })
         );
-        let e = mat(&fx, &joined, 1);
-        match e.kind {
-            EventKindContent::MemberJoined { subject_id, role } => {
-                assert_eq!(
-                    subject_id.as_str(),
-                    joiner_identity.identity_key().to_string()
-                );
-                assert_eq!(role, Role::Member);
-            }
-            other => panic!("wrong kind: {other:?}"),
-        }
-
-        let left = build_member_left(&fx.identity, &fx.device, &fx.room_id, None, &[], TS + 3);
-        let e = mat(&fx, &left, 2);
-        match e.kind {
-            EventKindContent::MemberLeft { subject_id } => {
-                assert_eq!(subject_id.as_str(), fx.identity.identity_key().to_string());
-            }
-            other => panic!("wrong kind: {other:?}"),
+        for out_of_range in [101_u64, 255, 256, u64::MAX] {
+            assert_eq!(
+                progress(Some(out_of_range)),
+                None,
+                "percent {out_of_range} is not representable"
+            );
         }
     }
 
+    /// An unrepresentable instant leaves the row uncommitted rather than
+    /// dating it to the Unix epoch.
     #[test]
-    fn file_shared_maps_typed_file_fields() {
+    fn an_unrepresentable_instant_has_no_wire_form() {
+        assert!(ts(0).is_some(), "the epoch itself is representable");
+        assert!(ts(TS).is_some());
+        assert!(
+            ts(u64::MAX).is_none(),
+            "an instant past the wire domain has no `<ts>`"
+        );
+    }
+
+    /// A `member.invited` authors no committed event, so it holds no position
+    /// and cannot win the recency projection.
+    #[test]
+    fn member_invited_is_not_a_committed_event() {
         let fx = fixture();
-        let wire = build_file_shared(
+        let invitee = SigningKey::generate();
+        let wire = build_member_invited(
             &fx.identity,
             &fx.device,
             &fx.room_id,
-            [0x11; 16],
-            "PRD.pdf",
-            "application/pdf",
-            123,
-            HashRef::from_bytes([0xcc; 32]),
-            Some("raw"),
-            &[fx.device.device_key()],
+            &[0x07; 16],
+            &[0x09; 32],
+            "member",
+            &invitee.identity_key(),
+            None,
+            None,
             &[],
             TS + 1,
         );
-        let e = mat(&fx, &wire, 1);
-        match e.kind {
-            EventKindContent::FileShared {
-                file_id,
-                name,
-                bytes,
-                digest,
-            } => {
-                assert!(file_id.as_str().starts_with("file_"));
-                assert_eq!(name, "PRD.pdf");
-                assert_eq!(bytes, 123);
-                assert!(!digest.is_empty());
-            }
-            other => panic!("wrong kind: {other:?}"),
-        }
+        let snapshot = snapshot_of(&fx);
+        let ev = decode(&wire);
+        let id = iroh_rooms::events::EventId::from_bytes([0x05; 32]);
+        assert!(
+            materialize_signed(1, &id, &ev, &snapshot, &Departures::default()).is_none(),
+            "invite.mint authors no committed timeline event"
+        );
     }
+
+    /// `last_event` is `absent` **only** when the room has no committed event,
+    /// never as a stand-in for one that could not be described.
+    #[test]
+    fn last_event_is_absent_only_for_a_room_with_no_committed_event() {
+        assert_eq!(last_event(None), LastEvent::Absent);
+        let at = ts(TS).unwrap();
+        assert_eq!(
+            last_event(Some(Recency {
+                created_at_ms: TS,
+                at,
+                kind: EventKind::Message,
+            })),
+            LastEvent::Present {
+                at,
+                kind: EventKind::Message
+            }
+        );
+    }
+
+    /// Recency is ordered on the **signed millisecond**, not the
+    /// second-precision wire form. Two events authored inside one second would
+    /// otherwise tie, and the id tiebreak would pick whichever hashed lower —
+    /// reporting a room's newest event as an older one at random.
+    #[test]
+    fn recency_orders_within_a_single_second() {
+        let fx = fixture();
+        let a = stored_event_recency_of(&fx, TS + 100);
+        let b = stored_event_recency_of(&fx, TS + 900);
+        assert_eq!(
+            a.at, b.at,
+            "both truncate to the same wire instant, which is why the raw ms matters"
+        );
+        assert!(
+            b.created_at_ms > a.created_at_ms,
+            "the raw signed instants still order"
+        );
+    }
+
+    fn stored_event_recency_of(fx: &Fixture, created_at: u64) -> Recency {
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        let genesis_id = genesis.event_id;
+        store.insert(&genesis).unwrap();
+        let msg = validate_wire_bytes(
+            &build_message_text(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                "timed",
+                None,
+                None,
+                &[],
+                &[genesis_id],
+                created_at,
+            )
+            .to_bytes(),
+            &ctx,
+        )
+        .unwrap();
+        store.insert(&msg).unwrap();
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        rows.iter()
+            .filter_map(stored_event_recency)
+            .find(|r| r.kind == EventKind::Message)
+            .expect("the message is a committed event")
+    }
+
+    /// A pipe target another peer signed is projected **verbatim**, including
+    /// a non-loopback host: the loopback rule is this daemon's publish-side
+    /// policy, and suppressing a peer's target would hide the pipe most worth
+    /// seeing. Only a hint that is not an address at all is unrepresentable.
+    #[test]
+    fn a_signed_pipe_target_is_projected_verbatim() {
+        assert_eq!(
+            pipe_target("127.0.0.1:3000"),
+            Some(Target {
+                host: "127.0.0.1".into(),
+                port: 3000
+            })
+        );
+        assert_eq!(
+            pipe_target("192.168.1.10:22"),
+            Some(Target {
+                host: "192.168.1.10".into(),
+                port: 22
+            }),
+            "a peer's non-loopback target is a fact, not something to hide"
+        );
+        assert_eq!(pipe_target("not-an-address"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Positions
+    // ------------------------------------------------------------------
 
     #[test]
     fn store_roundtrip_materializes_committed_events() {
@@ -680,16 +1228,14 @@ mod tests {
         let snapshot = snapshot_of(&fx);
         let rows = store.room_tail(&fx.room_id, 100).unwrap();
         let refs: Vec<&StoredEvent> = rows.iter().collect();
-        let events: Vec<Event> = positioned(&refs, &snapshot)
+        let departures = Departures::from_rows(rows.iter());
+        let events: Vec<Event> = positioned(&refs, &snapshot, &departures)
             .into_iter()
             .map(|(_, e)| e)
             .collect();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
         assert_eq!(events[1].kind.kind(), EventKind::Message);
-        // Positions are the dense rank over the canonical order: genesis is
-        // 0 and each later committed event is exactly one past its
-        // predecessor.
         assert_eq!(events[0].pos, 0);
         assert_eq!(events[1].pos, 1);
     }
@@ -708,7 +1254,6 @@ mod tests {
         let genesis_id = genesis.event_id;
         store.insert(&genesis).unwrap();
 
-        // Two distinct authors (two devices), both children of the genesis.
         let device_b = SigningKey::generate();
         let a = validate_wire_bytes(
             &build_message_text(
@@ -747,13 +1292,12 @@ mod tests {
 
         let rows = store.room_tail(&fx.room_id, 100).unwrap();
         assert_eq!(rows.len(), 3);
-        // The two siblings share one lamport: the raw store value is NOT
-        // unique, which is exactly why it cannot be the served position.
         assert_eq!(rows[1].lamport, rows[2].lamport);
 
         let snapshot = snapshot_of(&fx);
         let refs: Vec<&StoredEvent> = rows.iter().collect();
-        let events: Vec<Event> = positioned(&refs, &snapshot)
+        let departures = Departures::from_rows(rows.iter());
+        let events: Vec<Event> = positioned(&refs, &snapshot, &departures)
             .into_iter()
             .map(|(_, e)| e)
             .collect();
@@ -820,38 +1364,104 @@ mod tests {
             "invite row is stored even though not committed"
         );
         let refs: Vec<&StoredEvent> = rows.iter().collect();
-        let events: Vec<Event> = positioned(&refs, &snapshot)
+        let departures = Departures::from_rows(rows.iter());
+        let events: Vec<Event> = positioned(&refs, &snapshot, &departures)
             .into_iter()
             .map(|(_, e)| e)
             .collect();
-        // The invite consumed no position: genesis 0, message 1, no hole.
         assert_eq!(events.len(), 2, "the invite is not a committed event");
-        assert_eq!(events[0].kind.kind(), EventKind::RoomCreated);
         assert_eq!(events[0].pos, 0);
-        assert_eq!(events[1].kind.kind(), EventKind::Message);
         assert_eq!(events[1].pos, 1, "no position hole where the invite sat");
     }
 
+    /// `is_committed` and `materialize` agree exactly: every push path relies
+    /// on "is_committed implies materializable", so a divergence would panic
+    /// the push loop rather than merely mis-serve a row.
     #[test]
-    fn unresolved_author_carries_no_attribution() {
+    fn is_committed_implies_materializable() {
         let fx = fixture();
-        let stranger_identity = SigningKey::generate();
-        let stranger_device = SigningKey::generate();
-        let wire = build_message_text(
-            &stranger_identity,
-            &stranger_device,
-            &fx.room_id,
-            "hi",
-            None,
-            None,
-            &[],
-            &[],
-            TS,
-        );
+        let mut store = EventStore::open_in_memory().unwrap();
+        let ctx = ValidationContext::for_room(fx.room_id);
+        let genesis = validate_wire_bytes(&fx.genesis.to_bytes(), &ctx).unwrap();
+        let genesis_id = genesis.event_id;
+        store.insert(&genesis).unwrap();
+        // A committed message, an uncommitted invite, and an out-of-vocabulary
+        // status in one tail.
+        for wire in [
+            build_message_text(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                "committed",
+                None,
+                None,
+                &[],
+                &[genesis_id],
+                TS + 1,
+            ),
+            build_member_invited(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                &[0x07; 16],
+                &[0x09; 32],
+                "member",
+                &SigningKey::generate().identity_key(),
+                None,
+                None,
+                &[genesis_id],
+                TS + 2,
+            ),
+            build_agent_status(
+                &fx.identity,
+                &fx.device,
+                &fx.room_id,
+                "running_tests",
+                None,
+                &[],
+                None,
+                &[genesis_id],
+                TS + 3,
+            ),
+        ] {
+            let validated = validate_wire_bytes(&wire.to_bytes(), &ctx).unwrap();
+            store.insert(&validated).unwrap();
+        }
+
         let snapshot = snapshot_of(&fx);
-        let ev = decode(&wire);
-        let id = iroh_rooms::events::EventId::from_bytes([0x02; 32]);
-        let e = materialize_signed(1, &id, &ev, &snapshot).unwrap();
-        assert_eq!(e.author, Author::Unresolved);
+        let rows = store.room_tail(&fx.room_id, 100).unwrap();
+        let departures = Departures::from_rows(rows.iter());
+        for se in &rows {
+            assert_eq!(
+                is_committed(se),
+                materialize(se, 0, &snapshot, &departures).is_some(),
+                "is_committed and materialize must never disagree"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_status_maps_typed_label_and_progress() {
+        let fx = fixture();
+        let wire = build_agent_status(
+            &fx.identity,
+            &fx.device,
+            &fx.room_id,
+            "working",
+            None,
+            &[],
+            Some(60),
+            &[],
+            TS + 1,
+        );
+        let e = mat(&fx, &wire, 1);
+        match e.kind {
+            EventKindContent::AgentStatus { label, progress } => {
+                assert_eq!(label, StatusLabel::Working);
+                assert_eq!(progress, Progress::Reported { percent: 60 });
+                assert_eq!(label.severity(), Severity::Ok);
+            }
+            other => panic!("wrong kind: {other:?}"),
+        }
     }
 }

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -332,6 +332,10 @@ fn collect_committed(
     seen: &mut BTreeSet<EventId>,
     next_push_rank: &mut u64,
 ) -> Vec<CommittedEvent> {
+    // The pushed event's `author.standing` is the same derivation `room.members`
+    // and `room.timeline` serve, so it is folded from the same tail rather than
+    // assumed active. One pre-pass over rows already in hand.
+    let departures = crate::projection::Departures::from_rows(tail.iter());
     let mut out = Vec::new();
     let mut rank = 0u64;
     for se in tail {
@@ -343,7 +347,7 @@ fn collect_committed(
         if !seen.insert(se.event_id) {
             continue; // already pushed by an earlier batch or reconcile
         }
-        let event = crate::projection::materialize(se, 0, snapshot)
+        let event = crate::projection::materialize(se, 0, snapshot, &departures)
             .expect("is_committed implies materializable");
         if this_rank >= *next_push_rank {
             // In-order append at or past the high-water mark.
@@ -1198,9 +1202,15 @@ impl RoomSupervisor {
             let self_member = snapshot.member(&self_key);
             let role = snapshot.role(&self_key).map(role_label);
             let store = self.open_store()?;
-            let (removed_ids, left_ids) = departure_sets(&store, &room_id)?;
-            let status = self_member
-                .map(|member| status_label(member.status, &self_key, &removed_ids, &left_ids));
+            let departures = departure_sets(&store, &room_id)?;
+            let status = self_member.map(|member| {
+                status_label(
+                    member.status,
+                    &self_key,
+                    &departures.removed,
+                    &departures.left,
+                )
+            });
             // Recency projection (docs/room-attention.md decision 2): the
             // `created_at` the newest signed event's author actually signed —
             // never the wall clock, never render time. One bounded store read
@@ -1691,14 +1701,19 @@ impl RoomSupervisor {
         let room_id = parse_room_id(room_id_str)?;
         let snapshot = self.readable_snapshot(&room_id).await?;
         let store = self.open_store()?;
-        let (removed_ids, left_ids) = departure_sets(&store, &room_id)?;
+        let departures = departure_sets(&store, &room_id)?;
         Ok(snapshot
             .members()
             .map(|m| {
                 json!({
                     "identity_id": m.identity.to_string(),
                     "role": role_label(m.role),
-                    "status": status_label(m.status, &m.identity, &removed_ids, &left_ids),
+                    "status": status_label(
+                        m.status,
+                        &m.identity,
+                        &departures.removed,
+                        &departures.left,
+                    ),
                 })
             })
             .collect())
@@ -1711,12 +1726,45 @@ impl RoomSupervisor {
     /// `invite.create`: mint a key-bound invite ticket (owner only). When the
     /// room is open the `member.invited` publishes through the live node (so
     /// it also fans out); otherwise it persists directly, like the CLI.
+    /// [`Self::create_invite_at`] with a **relative** expiry spec
+    /// (`<int>{s|m|h|d}`), resolved against this call's clock.
+    ///
+    /// Test-only: protocol v2's `invite.mint` carries an absolute `<ts>`, so
+    /// the daemon path takes [`Self::create_invite_at`]. The relative form
+    /// survives because it is how the lifecycle tests express "an hour from
+    /// now" without pinning a clock.
+    #[cfg(test)]
     pub(crate) async fn create_invite(
         &self,
         room_id_str: &str,
         invitee_hex: &str,
         role: &str,
         expiry: Option<&str>,
+    ) -> CoreResult<String> {
+        let absolute = match expiry {
+            Some(spec) => Some(parse_expiry(spec, now_ms())?),
+            None => None,
+        };
+        self.create_invite_at(room_id_str, invitee_hex, role, absolute)
+            .await
+    }
+
+    /// Mint a key-bound invite ticket with an **absolute** expiry in ms since
+    /// the epoch, which is what protocol v2's `invite.mint` carries.
+    ///
+    /// The absolute form exists so the expiry the caller asked for is the
+    /// expiry the capability is signed with, exactly. Converting to a relative
+    /// spec and re-resolving it here against a later clock shifted the signed
+    /// instant off the requested one, so `invite.mint`'s reply, the
+    /// `invite.list` row, and the capability itself could all disagree — and a
+    /// faithful `op_id` retry that resent the reply's value became an
+    /// `op_id_conflict`.
+    pub(crate) async fn create_invite_at(
+        &self,
+        room_id_str: &str,
+        invitee_hex: &str,
+        role: &str,
+        expires_at_ms: Option<u64>,
     ) -> CoreResult<String> {
         let room_id = parse_room_id(room_id_str)?;
         if role != "member" && role != "agent" {
@@ -1740,9 +1788,13 @@ impl RoomSupervisor {
         getrandom::fill(secret_bytes.as_mut_slice())
             .map_err(|e| internal("OS CSPRNG unavailable", e))?;
         let cap_hash = capability_hash(&room_id, &invite_id, &secret_bytes);
-        let expires_at = expiry
-            .map(|spec| parse_expiry(spec, created_at))
-            .transpose()?;
+        // The absolute instant the caller named, signed verbatim.
+        let expires_at = expires_at_ms;
+        if expires_at.is_some_and(|at| at <= created_at) {
+            return Err(CoreError::invalid(
+                "expiry must be in the future at the moment the capability is signed",
+            ));
+        }
 
         let is_open = self.is_open(&room_id);
         // The whole store-backed authoring path lives in one sync scope so no
@@ -2472,14 +2524,25 @@ impl RoomSupervisor {
                     break;
                 }
                 O::HashMismatch => {
-                    return Err(CoreError::new(
+                    // The upstream mismatch arm still hands back the bytes it
+                    // rejected, so the digest they actually hash to is
+                    // computable here rather than unknowable. It travels as
+                    // the error's machine-readable detail so `file.fetch` can
+                    // serve `digest_mismatch { expected, observed }` with both
+                    // halves real, instead of an empty `observed`.
+                    let observed = data.map(|bytes| blake3::hash(&bytes).to_hex().to_string());
+                    let error = CoreError::new(
                         ErrorKind::HashMismatch,
                         format!(
                             "integrity check FAILED: fetched bytes do not hash to the declared \
                              {}; refusing to save",
                             shared.blob_hash
                         ),
-                    ));
+                    );
+                    return Err(match observed {
+                        Some(observed) => error.with_detail(observed),
+                        None => error,
+                    });
                 }
                 O::DeniedAtConnect => {
                     denied_at_connect += 1;
@@ -3683,32 +3746,11 @@ pub(crate) fn genesis_name(store: &EventStore, room_id: &RoomId) -> Option<Strin
 pub(crate) fn departure_sets(
     store: &EventStore,
     room_id: &RoomId,
-) -> CoreResult<(BTreeSet<IdentityKey>, BTreeSet<IdentityKey>)> {
-    let mut removed_ids = BTreeSet::new();
-    let mut left_ids = BTreeSet::new();
-    for stored in store
+) -> CoreResult<crate::projection::Departures> {
+    let rows = store
         .room_tail(room_id, u32::MAX)
-        .map_err(|e| internal("could not read member departure history", e))?
-    {
-        if let Ok(event) = SignedEvent::decode(&stored.wire.signed) {
-            match event.content {
-                Content::MemberJoined(_) => {
-                    removed_ids.remove(&event.sender_id);
-                    left_ids.remove(&event.sender_id);
-                }
-                Content::MemberRemoved(c) => {
-                    left_ids.remove(&c.member_id);
-                    removed_ids.insert(c.member_id);
-                }
-                Content::MemberLeft(c) => {
-                    removed_ids.remove(&c.member_id);
-                    left_ids.insert(c.member_id);
-                }
-                _ => {}
-            }
-        }
-    }
-    Ok((removed_ids, left_ids))
+        .map_err(|e| internal("could not read member departure history", e))?;
+    Ok(crate::projection::Departures::from_rows(rows.iter()))
 }
 
 /// The removal among `subject`'s current causal heads.
@@ -3912,6 +3954,7 @@ fn open_pipe(
 
 /// Parse an expiry spec (`<int>{s|m|h|d}`, bare integer = seconds) into an
 /// absolute ms timestamp anchored at `now`.
+#[cfg(test)]
 fn parse_expiry(spec: &str, now: u64) -> CoreResult<u64> {
     let spec = spec.trim();
     if spec.is_empty() {

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2988,8 +2988,16 @@ impl RoomSupervisor {
         Ok(released)
     }
 
-    /// `pipe.close`: publish a signed `pipe.closed` (owner or room owner) and
-    /// tear down any local forwarder.
+    /// `pipe.close`: publish a signed `pipe.closed` and tear down any local
+    /// forwarder.
+    ///
+    /// **The publisher, and only the publisher.** The record makes revocation a
+    /// relation, not a role: "`pipe.revoke` is **not** on this list. It is
+    /// restricted to the pipe's publisher, which is a narrower relation than
+    /// role and answers `pipe_not_publisher`" (`docs/protocol-v2.md`). An
+    /// earlier revision also admitted the room's administrator, which let one
+    /// subject destroy another subject's published tunnel — a role bypassing a
+    /// relation the record deliberately made narrower than any role.
     pub(crate) async fn pipe_close(
         &self,
         room_id_str: &str,
@@ -3007,18 +3015,18 @@ impl RoomSupervisor {
         // Sync scope: no !Sync store borrow crosses the pipe_close await.
         {
             let store = self.open_store()?;
-            let opened = open_pipe(&store, &room_id, pipe_id)?;
-            let is_admin = snapshot.admin() == Some(&self_id);
-            let is_owner = opened.as_ref().is_some_and(|o| o.owner_id == self_id);
-            if opened.is_none() {
+            // Unknown-pipe first, so a pipe this daemon has never seen stays
+            // `pipe_unknown` rather than being reported as an authorization
+            // refusal that would confirm it exists.
+            let Some(opened) = open_pipe(&store, &room_id, pipe_id)? else {
                 return Err(CoreError::invalid(format!(
                     "no pipe {pipe_id_hex} known in room {room_id}"
                 )));
-            }
-            if !is_admin && !is_owner {
+            };
+            if opened.owner_id != self_id {
                 return Err(CoreError::new(
                     ErrorKind::PipeDenied,
-                    "only the pipe owner or the room owner can close a pipe",
+                    "only the pipe's publisher can close it",
                 ));
             }
         }
@@ -6071,6 +6079,94 @@ mod tests {
         assert_eq!(err.kind, ErrorKind::NotAMember);
 
         owner.close_room(&room_id).await.unwrap();
+    }
+
+    /// Revocation is a **relation**, not a role: the record restricts
+    /// `pipe.revoke` to the pipe's publisher, "a narrower relation than role",
+    /// and answers `pipe_not_publisher`. An earlier revision authorized
+    /// `is_admin || is_owner`, so the room's authority could destroy a tunnel
+    /// another member published — a role bypassing a relation the record
+    /// deliberately made narrower than any role. The authority here is even
+    /// inside the pipe's audience, and still may not close it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_close_refuses_a_room_authority_that_did_not_publish() {
+        let owner_dir = tempdir().unwrap();
+        let owner_profile = crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = owner.create_room("Publisher Only").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        let opened = owner.open_room(&room_id_str, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id_str, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        member
+            .open_room(&room_id_str, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        wait_member_status(&owner, &room_id_str, &member_profile.identity_id, "active").await;
+
+        // The MEMBER publishes, authorizing the room's owner as its audience.
+        let owner_id: iroh_rooms::identity::IdentityKey =
+            owner_profile.identity_id.parse().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target = listener.local_addr().unwrap();
+        let (pipe_id, _) = member
+            .pipe_expose_multi(
+                &room_id,
+                target,
+                &target.to_string(),
+                std::slice::from_ref(&owner_id),
+            )
+            .await
+            .unwrap();
+        let pipe_id_hex = hex::encode(pipe_id);
+
+        // Wait for the announcement to reach the owner's log, so the refusal
+        // below is the authorization one and not "no such pipe".
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let pipes = owner.pipe_list(&room_id_str).await.unwrap();
+            if pipes
+                .iter()
+                .any(|p| p["pipe_id"].as_str() == Some(pipe_id_hex.as_str()))
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for the member's pipe.opened to reach the owner"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        // The room's authority, inside the audience, is still not the publisher.
+        let err = owner
+            .pipe_close(&room_id_str, &pipe_id_hex)
+            .await
+            .expect_err("a room authority that did not publish cannot revoke");
+        assert_eq!(
+            err.kind,
+            ErrorKind::PipeDenied,
+            "the authority earns the publisher-only refusal, which typed maps to \
+             pipe_not_publisher, never a silent success"
+        );
+
+        // The publisher itself can, so the refusal is about the relation and
+        // not about the pipe being unclosable.
+        member.pipe_close(&room_id_str, &pipe_id_hex).await.unwrap();
+
+        member.close_room(&room_id_str).await.unwrap();
+        owner.close_room(&room_id_str).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -16,11 +16,41 @@
 //!   `identity.rs` are untouched; only the protocol-facing projections move
 //!   to typed shapes.
 //!
+//! # The validation pipeline
+//!
+//! [`dispatch`] runs the record's **normative validation order** once, for
+//! every operation, rather than leaving each body to re-implement it:
+//!
+//! | Stage | Runs for | Refusal |
+//! |---|---|---|
+//! | 1 structural | every operation ([`validate_structure`]) | `invalid_argument` |
+//! | 2 subject | every operation except `subject.ensure` | `subject_absent` |
+//! | 3 dedup | the `op_id`-deduplicated class (the engine's ledger) | the original reply |
+//! | 4 room index | every operation whose `in` carries `room_id` ([`request_room`]) | `room_not_available` |
+//! | 5 standing | as step 4, minus `room.archive` ([`standing_exempt`]) | `membership_ended` |
+//! | 6 role | the four operations in [`requires_authority`] | `insufficient_standing` |
+//! | 7 semantics | the operation body | the operation's own codes |
+//!
+//! Steps 4–6 produce one [`RoomContext`] — the room, its snapshot, the
+//! caller's resolved role and standing, and the room's departure facts — which
+//! is handed to the body. A body therefore never re-derives an authorization
+//! answer the pipeline already settled, which is what keeps the gate from
+//! being a rule with a quiet per-operation carve-out. `room.list` and the
+//! three `stream.*` operations are the only room-shaped reads that do not take
+//! one: `room.list` carries no `room_id` (it enumerates every room, including
+//! left ones), and `stream.*` is connection-scoped and authorized by its host.
+//!
 //! # Paging and positions
 //!
 //! The v2 record fixes one continuation mechanism: every paging operation
 //! takes a required [`Page`] (`cursor`, `direction`, `limit`) and answers a
-//! [`Truncated`]. Positions are the **dense rank** over the room's canonical
+//! [`Truncated`]. `cursor` and `direction` are closed wire types, so the codec
+//! refuses a malformed one at step 1 before this layer sees it; `limit` is
+//! bounded against a **served** limit only the daemon knows, so its step-1
+//! bound check lives in [`validate_structure`] — ahead of the subject, room,
+//! standing, role, and storage stages for all six paging operations.
+//!
+//! Positions are the **dense rank** over the room's canonical
 //! `(lamport, event_id)` order — `0` for the genesis, exactly one past the
 //! predecessor for every later committed event. The store's raw Lamport
 //! value is not a position (concurrent siblings share one), so ranking
@@ -28,6 +58,15 @@
 //! paths, keeping the timeline, the push stream, and `stream.resync` in one
 //! consistent position space. Cursor/direction paging is applied over that
 //! space here.
+//!
+//! # Honesty
+//!
+//! No projection in this module invents a fact it does not hold. There is no
+//! epoch timestamp for an unreadable instant, no default `member` role, no
+//! default `active` standing, and no empty identifier in an error. Where a
+//! fact is missing the answer is the operation's exact typed code — most often
+//! `membership_unresolved` for a caller or member the fold cannot resolve, and
+//! the `*_index_unreadable` code for a row a projection cannot compose.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -36,11 +75,10 @@ use jeliya_api::*;
 use serde::{Deserialize, Serialize};
 
 use iroh_rooms::events::{capability_hash, Content, EventType, SignedEvent};
-use iroh_rooms::room::RoomId as IrohRoomId;
+use iroh_rooms::room::{MembershipSnapshot, RoomId as IrohRoomId};
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
-use crate::projection as proj;
-use crate::projection::file_handle;
+use crate::projection::{self as proj, file_handle, Departures};
 use crate::supervisor::{RemoveMemberOutcome, RoomSupervisor};
 
 /// The daemon's served limits, surfaced in `hello`/`VersionInfo` and enforced
@@ -113,7 +151,13 @@ impl Window {
                 reason: InvalidReason::Bound { min: 1, max },
             });
         }
-        let limit = usize::try_from(page.limit).unwrap_or(usize::MAX);
+        // The bound above already proved `limit <= timeline_page_max`, which
+        // fits `usize` on every supported target, so this conversion cannot
+        // saturate a caller's page size into a different one.
+        let limit = usize::try_from(page.limit).map_err(|_| ApiError::InvalidArgument {
+            field: "in.limit".into(),
+            reason: InvalidReason::Bound { min: 1, max },
+        })?;
         let forward = matches!(page.direction, Direction::Forward);
         Ok(Self {
             from,
@@ -209,6 +253,30 @@ fn page_indexed<T: Clone>(items: Vec<T>, window: Window) -> (Vec<T>, Truncated) 
     }
 }
 
+/// What validation-order steps 4–6 resolved for one room-bearing operation:
+/// the room the caller named, its membership fold, the caller's **resolved**
+/// role and standing, and the room's signed departure facts.
+///
+/// Every field is a fact the pipeline established before step 7 ran. A body
+/// that takes a `RoomContext` therefore cannot reach a state where it must
+/// guess the caller's role or standing — the case the record removes the
+/// fabricated `member` and `active` defaults for — because a caller the fold
+/// could not resolve never produced one.
+pub(crate) struct RoomContext {
+    /// The parsed room id.
+    room_id: IrohRoomId,
+    /// The membership fold at read time.
+    snapshot: MembershipSnapshot,
+    /// The caller's resolved role.
+    role: Role,
+    /// The caller's resolved standing.
+    standing: Standing,
+    /// The room's signed departure facts (`left` vs `removed`).
+    departures: Departures,
+    /// The caller's own subject, as the fold resolved it.
+    self_key: iroh_rooms::identity::IdentityKey,
+}
+
 /// The typed projection facade. Cheap to construct; borrows the supervisor.
 pub(crate) struct TypedSupervisor<'a> {
     sup: &'a RoomSupervisor,
@@ -221,10 +289,23 @@ impl<'a> TypedSupervisor<'a> {
         Self { sup }
     }
 
-    fn parse_room(room_id: &RoomId) -> CoreResult<IrohRoomId> {
-        room_id.as_str().trim().parse().map_err(|e| {
-            CoreError::invalid(format!("invalid room_id (expected blake3:<hex>): {e}"))
-        })
+    /// Parse a `<room_id>` for the room-index stage.
+    ///
+    /// The record defines every identifier as an **opaque string with no
+    /// published format**, so a `room_id` this daemon cannot parse is not a
+    /// malformed argument — it is a room that is not available, and it answers
+    /// exactly what an unknown-or-unauthorized room answers. Refusing it as
+    /// `invalid_argument` instead would hand a caller a second, distinguishable
+    /// answer for "no such room", which is the membership oracle
+    /// `room_not_available` exists as one code to prevent.
+    fn parse_room(api_room: &RoomId) -> Result<IrohRoomId, ApiError> {
+        api_room
+            .as_str()
+            .trim()
+            .parse()
+            .map_err(|_| ApiError::RoomNotAvailable {
+                room_id: api_room.clone(),
+            })
     }
 
     fn parse_subject(subject_id: &SubjectId) -> CoreResult<iroh_rooms::identity::IdentityKey> {
@@ -240,6 +321,82 @@ impl<'a> TypedSupervisor<'a> {
             .map_err(|_| CoreError::invalid(format!("invalid file_id {trimmed:?}")))?;
         <[u8; 16]>::try_from(bytes.as_slice())
             .map_err(|_| CoreError::invalid(format!("invalid file_id {trimmed:?}")))
+    }
+
+    /// Validation-order steps 4, 5, and 6 for one room-bearing operation, in
+    /// that order and in one place.
+    ///
+    /// - **4 room index** — an unparseable, unknown, or unreadable-to-this-
+    ///   caller room is `room_not_available` echoing the id the caller sent;
+    ///   an index this daemon cannot read at all is `room_index_unreadable`.
+    /// - **5 standing** — a `left` or `removed` caller is `membership_ended`,
+    ///   *except* for the operations defined over a former membership.
+    /// - **6 role** — the four authority operations refuse a plain member with
+    ///   `insufficient_standing { required, held }`.
+    ///
+    /// The caller's role and standing are **resolved, never defaulted**: a
+    /// caller the fold has no row for is `membership_unresolved`, because the
+    /// alternative — assuming `member`/`active` — is a fabricated
+    /// authorization answer, and the fail-closed direction of that assumption
+    /// does not make it true.
+    async fn room_context(
+        &self,
+        api_room: &RoomId,
+        standing_exempt: bool,
+        authority: bool,
+    ) -> Result<RoomContext, ApiError> {
+        // Step 4.
+        let room_id = Self::parse_room(api_room)?;
+        let snapshot = self
+            .sup
+            .readable_snapshot(&room_id)
+            .await
+            .map_err(|error| match error.kind {
+                ErrorKind::Internal => ApiError::RoomIndexUnreadable,
+                _ => core_to_api_room(error, api_room),
+            })?;
+        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
+        let store = self
+            .sup
+            .open_store()
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
+        let departures = crate::supervisor::departure_sets(&store, &room_id)
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
+        drop(store);
+
+        // The caller's own membership facts, resolved from the signed fold.
+        let member = snapshot
+            .member(&self_key)
+            .ok_or_else(|| ApiError::MembershipUnresolved {
+                room_id: api_room.clone(),
+                subject_id: SubjectId::new(self_key.to_string()),
+            })?;
+        let role = proj::role(member.role);
+        let standing = departures.standing_of(member.status, &member.identity);
+
+        // Step 5.
+        if !standing_exempt && standing != Standing::Active {
+            return Err(ApiError::MembershipEnded {
+                room_id: api_room.clone(),
+                standing,
+            });
+        }
+        // Step 6.
+        if authority && role != Role::Authority {
+            return Err(ApiError::InsufficientStanding {
+                room_id: api_room.clone(),
+                required: Role::Authority,
+                held: role,
+            });
+        }
+        Ok(RoomContext {
+            room_id,
+            snapshot,
+            role,
+            standing,
+            departures,
+            self_key,
+        })
     }
 
     // ------------------------------------------------------------------
@@ -293,39 +450,55 @@ impl<'a> TypedSupervisor<'a> {
 
     /// `room.create` — bring a room into existence with the caller as its
     /// authority; works with no network.
-    pub fn room_create(&self, req: &RoomCreate) -> CoreResult<RoomCreateOut> {
+    ///
+    /// A name outside `1..=128` bytes after trimming, or one with no
+    /// non-whitespace character, is `room_name_invalid` carrying the same
+    /// closed `reason` variant `invalid_argument` uses — a `bound` arm for
+    /// length and a `format` arm for whitespace-only, per the record's stated
+    /// bounds.
+    pub async fn room_create(&self, req: &RoomCreate) -> Result<RoomCreateOut, ApiError> {
         let name = req.name.trim();
-        if name.is_empty() || name.len() > 128 {
-            return Err(CoreError::new(
-                ErrorKind::InvalidParams,
-                "room name must be 1..=128 bytes with at least one non-whitespace",
-            ));
+        if name.is_empty() {
+            // Empty-after-trimming covers both "no characters at all" and
+            // "whitespace only"; the record spells the latter as `format`.
+            return Err(ApiError::RoomNameInvalid {
+                reason: if req.name.is_empty() {
+                    InvalidReason::Bound { min: 1, max: 128 }
+                } else {
+                    InvalidReason::Format
+                },
+            });
         }
-        let room_id_str = self.sup.create_room(name)?;
-        let room_id: IrohRoomId = room_id_str
-            .parse()
-            .map_err(|e| CoreError::internal(format!("fresh room id does not parse: {e}")))?;
-        // The genesis is the room's origin event at pos 0, authored now.
-        let store = self.sup.open_store()?;
-        let rows = store
-            .room_tail(&room_id, 1)
-            .map_err(|e| CoreError::internal(format!("could not read the genesis: {e}")))?;
-        let (event_id, created_at) = rows
-            .first()
-            .and_then(|se| {
-                SignedEvent::decode(&se.wire.signed)
-                    .ok()
-                    .map(|ev| (se.event_id, ev.created_at))
+        if name.len() > 128 {
+            return Err(ApiError::RoomNameInvalid {
+                reason: InvalidReason::Bound { min: 1, max: 128 },
+            });
+        }
+        let room_id_str = self.sup.create_room(name).map_err(core_to_api)?;
+        let api_room = RoomId::new(room_id_str);
+        let room_id = Self::parse_room(&api_room)?;
+        // The genesis is the room's origin event at pos 0, found **by kind**
+        // rather than as the one-row tail. `created_at` is the instant its
+        // author signed — read back from the persisted event, never the wall
+        // clock, and never an epoch stand-in if it will not convert.
+        let store = self.sup.open_store().map_err(core_to_api)?;
+        let (event_id, created_at) = store
+            .by_type(&room_id, EventType::RoomCreated)
+            .map_err(|_| ApiError::RoomIndexUnreadable)?
+            .iter()
+            .find_map(|se| {
+                let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+                Some((se.event_id, proj::ts(ev.created_at)?))
             })
-            .ok_or_else(|| CoreError::internal("the genesis did not persist"))?;
+            .ok_or(ApiError::RoomIndexUnreadable)?;
         Ok(RoomCreateOut {
-            room_id: RoomId::new(room_id_str),
+            room_id: api_room,
             name: name.to_string(),
             role: Role::Authority,
             standing: Standing::Active,
             event_id: proj::event_id(&event_id),
             pos: 0,
-            created_at: proj_ts(created_at),
+            created_at,
         })
     }
 
@@ -333,16 +506,17 @@ impl<'a> TypedSupervisor<'a> {
     /// recency and capabilities, from local evidence with zero network
     /// activity.
     pub async fn room_list(&self) -> Result<RoomListOut, ApiError> {
+        // A subject with no room store genuinely holds no rooms, and the empty
+        // list means exactly that. A subject-less daemon is a different fact
+        // and answers `subject_absent` — the record removes v1's pre-identity
+        // `room.list` carve-out precisely because one precondition answered two
+        // ways let an empty list stand in for a missing subject. The pipeline's
+        // step 2 already refuses that case; this arm keeps the answer the same
+        // for a direct caller rather than reintroducing the carve-out below it.
         if !self.sup.db_path().exists() {
             return Ok(RoomListOut { rooms: Vec::new() });
         }
-        let self_key = match self.sup.local_identity_key() {
-            Ok(key) => key,
-            Err(e) if e.kind == ErrorKind::IdentityMissing => {
-                return Ok(RoomListOut { rooms: Vec::new() })
-            }
-            Err(e) => return Err(core_to_api(e)),
-        };
+        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
         let room_ids: Vec<IrohRoomId> = crate::localstate::load(self.sup.data_dir())
             .map_err(|_| ApiError::RoomIndexUnreadable)?
             .rooms
@@ -369,38 +543,61 @@ impl<'a> TypedSupervisor<'a> {
                     crate::localstate::local_name(self.sup.data_dir(), &room_id.to_string())
                 })
             };
-            let self_member = snapshot.member(&self_key);
-            let role = snapshot
-                .role(&self_key)
-                .map(proj::role)
-                .unwrap_or(Role::Member);
+            // The caller's own role and standing come from the fold, never a
+            // default. A row in the local index whose fold has no membership
+            // for this caller cannot be described truthfully, so it answers
+            // `membership_unresolved` rather than a row claiming `member` /
+            // `active`.
+            let api_room = proj::room_id(&room_id);
             let store = self.sup.open_store().map_err(core_to_api)?;
-            let (removed_ids, left_ids) =
-                crate::supervisor::departure_sets(&store, &room_id).map_err(core_to_api)?;
-            let standing = self_member
-                .map(|m| member_standing(m.status, &m.identity, &removed_ids, &left_ids));
-            // Recency: the newest committed event's author-dated instant and
+            let departures = crate::supervisor::departure_sets(&store, &room_id)
+                .map_err(|_| ApiError::RoomIndexUnreadable)?;
+            let member =
+                snapshot
+                    .member(&self_key)
+                    .ok_or_else(|| ApiError::MembershipUnresolved {
+                        room_id: api_room.clone(),
+                        subject_id: SubjectId::new(self_key.to_string()),
+                    })?;
+            let role = proj::role(member.role);
+            let standing = departures.standing_of(member.status, &member.identity);
+            // Recency: the newest COMMITTED event's author-dated instant and
             // kind, max by timestamp over the COMPLETE history (never the wall
             // clock, never a bounded window — a clock-ahead peer's older row
             // with the greatest signed instant must not fall out and move the
-            // projection backward).
+            // projection backward). Non-committed rows are excluded from the
+            // max, not merely dropped after winning it: an invitation is not a
+            // timeline event, and letting one win would report `absent` for a
+            // room whose timeline is full.
             let recency = store
                 .room_tail(&room_id, u32::MAX)
                 .map_err(|_| ApiError::RoomIndexUnreadable)?
                 .iter()
-                .filter_map(|se| {
-                    proj::stored_event_recency(se).map(|(ts, kind)| (ts, se.event_id, kind))
+                .filter_map(|se| proj::stored_event_recency(se).map(|r| (r, se.event_id)))
+                // Ordered on the signed millisecond, not the second-precision
+                // wire form, so two events in the same second still order.
+                // `event_id` breaks a true tie so the answer is deterministic.
+                .max_by(|a, b| {
+                    a.0.created_at_ms
+                        .cmp(&b.0.created_at_ms)
+                        .then_with(|| a.1.cmp(&b.1))
                 })
-                .max_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)))
-                .map(|(ts, _, kind)| (ts, kind));
+                .map(|(recency, _)| recency);
             let last_event = proj::last_event(recency);
             let live = self.sup.is_open(&room_id);
-            let standing = standing.unwrap_or(Standing::Active);
-            let member_count = snapshot.members().count() as u64;
+            // The same signed-membership set `room.members` serves, so the
+            // count and the roster can never disagree. An outstanding
+            // invitation is not a member.
+            let member_count = snapshot.members().filter(|m| m.device.is_some()).count() as u64;
             let capabilities = room_capabilities(standing, role, live);
+            // `name` is a required `<string>`: a room whose genesis name is
+            // unreadable and that carries no local override cannot produce a
+            // truthful row, and `""` would render as an unnamed room that does
+            // not exist. That is an unreadable index entry, and it says so.
+            let name = name.ok_or(ApiError::RoomIndexUnreadable)?;
             rooms.push(RoomRow {
-                room_id: proj::room_id(&room_id),
-                name: name.unwrap_or_default(),
+                room_id: api_room,
+                name,
                 standing,
                 live,
                 role,
@@ -413,46 +610,46 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.activate` — make a room live on this device; returns reachability
-    /// and capabilities, **not history**.
-    pub async fn room_activate(&self, req: &RoomActivate) -> CoreResult<RoomActivateOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        // Activate is also a read boundary: authorize before spawning a node.
-        self.sup.readable_snapshot(&room_id).await?;
-        self.sup.activate_room(req.room_id.as_ref(), &[]).await?;
-        let live = self.sup.is_open(&room_id);
-        let snapshot = self.sup.snapshot_for(&room_id).await?;
-        let self_key = self.sup.local_identity_key()?;
-        let role = snapshot
-            .role(&self_key)
-            .map(proj::role)
-            .unwrap_or(Role::Member);
-        let standing = self_key_standing(self.sup, &room_id, &snapshot, &self_key)?;
-        let reachability = self.reachability(&room_id).await;
+    /// and capabilities, **not history**. Naturally idempotent.
+    pub async fn room_activate(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomActivate,
+    ) -> Result<RoomActivateOut, ApiError> {
+        self.sup
+            .activate_room(req.room_id.as_ref(), &[])
+            .await
+            .map_err(|error| match error.kind {
+                // A room the caller may act in that will not come live is a
+                // transport fact, and it has its own code.
+                ErrorKind::Internal | ErrorKind::PeerUnreachable => {
+                    ApiError::TransportUnavailable {
+                        room_id: req.room_id.clone(),
+                    }
+                }
+                _ => core_to_api_room(error, &req.room_id),
+            })?;
+        let live = self.sup.is_open(&ctx.room_id);
+        let reachability = self.reachability(&ctx.room_id).await;
         Ok(RoomActivateOut {
             room_id: req.room_id.clone(),
             live,
             reachability,
-            capabilities: room_capabilities(standing, role, live),
+            capabilities: room_capabilities(ctx.standing, ctx.role, live),
         })
     }
 
     /// `room.deactivate` — stop live participation without changing membership.
     pub async fn room_deactivate(
         &self,
+        _ctx: &RoomContext,
         req: &RoomDeactivate,
     ) -> Result<RoomDeactivateOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(|e| core_to_api_room(e, &req.room_id))?;
-        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
         match self.sup.close_room(req.room_id.as_ref()).await {
             Ok(()) => {}
             // Deactivation is naturally idempotent. A concurrent or repeated
-            // close is success, but only after the standing check above has
-            // proved this is still an active membership.
+            // close is success, but only after the pipeline's standing stage
+            // has proved this is still an active membership.
             Err(err) if err.kind == ErrorKind::RoomNotOpen => {}
             Err(err) => return Err(core_to_api_room(err, &req.room_id)),
         }
@@ -463,10 +660,26 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.leave` — author a signed departure every member converges on.
-    pub async fn room_leave(&self, req: &RoomLeave) -> CoreResult<RoomLeaveOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let event_id_hex = self.sup.leave_room(req.room_id.as_ref()).await?;
-        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
+    pub async fn room_leave(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomLeave,
+    ) -> Result<RoomLeaveOut, ApiError> {
+        let event_id_hex = self
+            .sup
+            .leave_room(req.room_id.as_ref())
+            .await
+            .map_err(|error| match error.kind {
+                // The creator is permanently the sole authority and cannot
+                // leave; that refusal has its own code, not a generic one.
+                ErrorKind::PipeDenied | ErrorKind::NotAMember if ctx.role == Role::Authority => {
+                    ApiError::SoleAuthorityCannotLeave {
+                        room_id: req.room_id.clone(),
+                    }
+                }
+                _ => core_to_api_room(error, &req.room_id),
+            })?;
+        let pos = self.pos_of_event(&ctx.room_id, &event_id_hex)?;
         Ok(RoomLeaveOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
@@ -476,19 +689,15 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.timeline` — read committed history identically whether or not
-    /// the room is live. A left or removed caller is `membership_ended` — only
-    /// `room.archive` and `room.list` are defined over a former membership.
-    pub async fn room_timeline(&self, req: &RoomTimeline) -> Result<RoomTimelineOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(|e| core_to_api_room(e, &req.room_id))?;
-        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
-        let events = self
-            .committed_events(&room_id, &snapshot)
-            .map_err(|e| core_to_api_room(e, &req.room_id))?;
+    /// the room is live. A left or removed caller is `membership_ended` at the
+    /// pipeline's standing stage — only `room.archive` and `room.list` are
+    /// defined over a former membership.
+    pub fn room_timeline(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomTimeline,
+    ) -> Result<RoomTimelineOut, ApiError> {
+        let events = self.committed_events(ctx)?;
         let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
         Ok(RoomTimelineOut {
             room_id: req.room_id.clone(),
@@ -497,85 +706,44 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// Validation-order step 5: the caller's standing must be `active`. A
-    /// `left` or `removed` standing is `membership_ended` carrying the ended
-    /// standing, for the operations defined over a live membership
-    /// (everything except `room.archive` and `room.list`).
-    fn require_active_standing(
-        &self,
-        api_room_id: &RoomId,
-        room_id: &IrohRoomId,
-        snapshot: &iroh_rooms::room::MembershipSnapshot,
-    ) -> Result<(), ApiError> {
-        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
-        let store = self.sup.open_store().map_err(core_to_api)?;
-        let (removed_ids, left_ids) =
-            crate::supervisor::departure_sets(&store, room_id).map_err(core_to_api)?;
-        let standing = snapshot.member(&self_key).map_or(Standing::Active, |m| {
-            member_standing(m.status, &m.identity, &removed_ids, &left_ids)
-        });
-        if standing == Standing::Active {
-            return Ok(());
-        }
-        Err(ApiError::MembershipEnded {
-            room_id: api_room_id.clone(),
-            standing,
-        })
-    }
-
-    /// Validation-order step 6: the caller's role must meet what the
-    /// operation needs. Authority-gated operations (`invite.mint`,
-    /// `member.remove`, `invite.revoke`, `pipe.publish`, `pipe.revoke`) refuse
-    /// a plain member with `insufficient_standing { required, held }` — the
-    /// role tokens, per the record. Step 5 (standing) runs first; this checks
-    /// role among ACTIVE members.
-    fn require_role(
-        &self,
-        api_room_id: &RoomId,
-        snapshot: &iroh_rooms::room::MembershipSnapshot,
-        required: Role,
-    ) -> Result<(), ApiError> {
-        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
-        let held = snapshot
-            .role(&self_key)
-            .map(proj::role)
-            .unwrap_or(Role::Member);
-        if required == Role::Authority && held != Role::Authority {
-            return Err(ApiError::InsufficientStanding {
-                room_id: api_room_id.clone(),
-                required,
-                held,
-            });
-        }
-        Ok(())
-    }
-
     /// `room.members` — the authoritative signed answer to who belongs. No
     /// presence, no reachability.
-    pub async fn room_members(&self, req: &RoomMembers) -> Result<RoomMembersOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(|error| core_to_api_room(error, &req.room_id))?;
-        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
-        let store = self.sup.open_store().map_err(core_to_api)?;
-        let (removed_ids, left_ids) =
-            crate::supervisor::departure_sets(&store, &room_id).map_err(core_to_api)?;
-        let members = snapshot
-            .members()
-            .map(|m| MemberRow {
+    ///
+    /// `joined_at` is the join event's author-dated instant. A member whose
+    /// join this daemon cannot date is `membership_unresolved` naming that
+    /// member: the record removes compatibility-nullability, and the epoch is
+    /// not a truthful stand-in for an instant nobody signed.
+    pub fn room_members(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomMembers,
+    ) -> Result<RoomMembersOut, ApiError> {
+        let mut members = Vec::new();
+        // The roster is **signed membership**, not the fold's every-known-row
+        // set. The upstream snapshot also yields an `Invited` row for an
+        // identity that was offered a capability and has not redeemed it; that
+        // identity is not a member, has no join to date, and belongs to
+        // `invite.list`. A joined identity carries a device binding, and keeps
+        // it after leaving or being removed, so the binding is exactly the
+        // "did this subject ever join" test — the same one the room read
+        // boundary uses. Including an invited row here would either date it to
+        // a fabricated instant or, as an earlier revision did, fail the whole
+        // roster with `membership_unresolved` the moment any invite is
+        // outstanding.
+        for m in ctx.snapshot.members().filter(|m| m.device.is_some()) {
+            let joined_at = self.joined_at(&ctx.room_id, &m.identity).ok_or_else(|| {
+                ApiError::MembershipUnresolved {
+                    room_id: req.room_id.clone(),
+                    subject_id: SubjectId::new(m.identity.to_string()),
+                }
+            })?;
+            members.push(MemberRow {
                 subject_id: SubjectId::new(m.identity.to_string()),
                 role: proj::role(m.role),
-                standing: member_standing(m.status, &m.identity, &removed_ids, &left_ids),
-                // The fold does not date joins; joined_at is the join event's
-                // author-dated instant when discoverable, else the genesis.
-                joined_at: self
-                    .joined_at(&room_id, &m.identity)
-                    .unwrap_or_else(proj_epoch),
-            })
-            .collect();
+                standing: ctx.departures.standing_of(m.status, &m.identity),
+                joined_at,
+            });
+        }
         Ok(RoomMembersOut {
             room_id: req.room_id.clone(),
             members,
@@ -583,36 +751,44 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `room.archive` — open a left or removed room as a local read-only
-    /// archive; normatively zero network activity.
-    pub async fn room_archive(&self, req: &RoomArchive) -> CoreResult<RoomArchiveOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let snapshot = self.sup.readable_snapshot(&room_id).await?;
-        let self_key = self.sup.local_identity_key()?;
-        let standing = self_key_standing(self.sup, &room_id, &snapshot, &self_key)?;
-        if standing == Standing::Active {
-            return Err(CoreError::new(
-                ErrorKind::InvalidParams,
-                "room.archive on a room the caller still belongs to",
-            ));
+    /// archive; normatively zero network activity and zero durable mutation.
+    /// Exempt from the pipeline's standing stage, so it checks the converse
+    /// here: an active membership is `room_still_active`.
+    pub fn room_archive(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomArchive,
+    ) -> Result<RoomArchiveOut, ApiError> {
+        if ctx.standing == Standing::Active {
+            return Err(ApiError::RoomStillActive {
+                room_id: req.room_id.clone(),
+            });
         }
-        let events = self.committed_events(&room_id, &snapshot)?;
-        let (page, truncated) =
-            page_events(events, Window::resolve(&req.page).map_err(api_to_core)?);
+        let events = self.committed_events(ctx)?;
+        let (page, truncated) = page_events(events, Window::resolve(&req.page)?);
         Ok(RoomArchiveOut {
             room_id: req.room_id.clone(),
-            standing,
+            standing: ctx.standing,
             events: page,
             truncated,
         })
     }
 
-    /// `room.peers` — observed transport facts for one live room.
-    pub async fn room_peers(&self, req: &RoomPeers) -> CoreResult<RoomPeersOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        self.sup.readable_snapshot(&room_id).await?;
-        let session = self.sup.session(&room_id)?;
+    /// `room.peers` — observed transport facts for one live room. Requires
+    /// liveness, so a non-live room is `room_not_live`.
+    pub async fn room_peers(
+        &self,
+        ctx: &RoomContext,
+        req: &RoomPeers,
+    ) -> Result<RoomPeersOut, ApiError> {
+        let session = self
+            .sup
+            .session(&ctx.room_id)
+            .map_err(|_| ApiError::RoomNotLive {
+                room_id: req.room_id.clone(),
+            })?;
         let peers = self.peer_rows(&session.node).await;
-        let reachability = reachability_from_peers(&peers, self.sup.is_open(&room_id));
+        let reachability = reachability_from_peers(&peers, self.sup.is_open(&ctx.room_id));
         Ok(RoomPeersOut {
             room_id: req.room_id.clone(),
             reachability,
@@ -623,8 +799,12 @@ impl<'a> TypedSupervisor<'a> {
     /// `member.remove` — room authority removes a joined member as a signed
     /// fact. A repeat against the same terminal removal returns that original
     /// fact without authoring another event.
-    pub async fn member_remove(&self, req: &MemberRemove) -> Result<MemberRemoveOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+    pub async fn member_remove(
+        &self,
+        ctx: &RoomContext,
+        req: &MemberRemove,
+    ) -> Result<MemberRemoveOut, ApiError> {
+        let room_id = ctx.room_id;
         let subject = Self::parse_subject(&req.subject_id).map_err(core_to_api)?;
         let outcome = self
             .sup
@@ -646,9 +826,7 @@ impl<'a> TypedSupervisor<'a> {
                 })
             }
         };
-        let pos = self
-            .pos_of_event(&room_id, &event_id)
-            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        let pos = self.pos_of_event(&room_id, &event_id)?;
         Ok(MemberRemoveOut {
             room_id: req.room_id.clone(),
             subject_id: req.subject_id.clone(),
@@ -663,87 +841,174 @@ impl<'a> TypedSupervisor<'a> {
     // ------------------------------------------------------------------
 
     /// `invite.mint` — mint one key-bound capability exactly one named
-    /// identity can redeem. Authority-only (validation-order step 6): the
-    /// role gate lives in [`dispatch`], before this body runs.
-    pub async fn invite_mint(&self, req: &InviteMint) -> CoreResult<InviteMintOut> {
+    /// identity can redeem. Authority-only: the role gate is validation-order
+    /// step 6, applied by [`dispatch`] before this body runs.
+    pub async fn invite_mint(
+        &self,
+        ctx: &RoomContext,
+        req: &InviteMint,
+    ) -> Result<InviteMintOut, ApiError> {
+        // `role` accepts `member` only today; `authority` is
+        // `role_not_grantable` carrying the role that was requested.
         if req.role != Role::Member {
-            return Err(CoreError::new(
-                ErrorKind::InvalidParams,
-                "invite.mint may only grant the member role today",
-            ));
+            return Err(ApiError::RoleNotGrantable {
+                requested: req.role,
+            });
         }
         // v2 `expires_at` is an absolute instant; the supervisor takes a
         // relative spec. Convert absolute -> seconds-from-now. A past or
         // already-expiring expiry is refused rather than minting a capability
         // that is born expired yet labelled `outstanding` — the reply's
-        // redeemability must agree with the capability's signed expiry.
-        let expires_ms = req.expires_at.into_inner().unix_timestamp().max(0) as u64 * 1000;
-        let now = crate::now_ms();
-        if expires_ms <= now {
-            return Err(CoreError::new(
-                ErrorKind::InvalidParams,
-                "invite.mint expiry is not in the future",
-            ));
+        // redeemability must agree with the capability's signed expiry. The
+        // taxonomy has no expiry-specific code, so it is the step-1 bound it
+        // actually is, naming the field and the instant it must exceed.
+        //
+        // The bound arm's `min`/`max` are **both** whole seconds since the
+        // epoch, the same domain the refused `<ts>` sits in. An earlier
+        // revision paired a seconds `min` with a milliseconds `max`, so a
+        // client reading the pair saw a window ~1000x too wide and could not
+        // tell which unit either number was in.
+        //
+        // The instant is handed to the runtime **absolutely**, not as a
+        // relative spec it would re-resolve against a later clock: the expiry
+        // the caller asked for must be the expiry the capability is signed
+        // with, or the reply, the `invite.list` row, and the capability itself
+        // can all name different instants.
+        const TS_MAX_SECS: u64 = u32::MAX as u64;
+        let now_ms = crate::now_ms();
+        // Milliseconds, not whole seconds: the instant is the caller's, and it
+        // is signed verbatim so the reply, the `invite.list` row, and the
+        // capability all name the one instant that was asked for.
+        let expires_ms =
+            u64::try_from(req.expires_at.into_inner().unix_timestamp_nanos() / 1_000_000)
+                .unwrap_or(0);
+        if expires_ms <= now_ms {
+            return Err(ApiError::InvalidArgument {
+                field: "in.expires_at".into(),
+                reason: InvalidReason::Bound {
+                    min: now_ms / 1000 + 1,
+                    max: TS_MAX_SECS,
+                },
+            });
         }
-        let spec = format!("{}s", (expires_ms - now) / 1000);
         let ticket = self
             .sup
-            .create_invite(
+            .create_invite_at(
                 req.room_id.as_ref(),
                 req.subject_id.as_str(),
                 "member",
-                Some(&spec),
+                Some(expires_ms),
             )
-            .await?;
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
         // The ticket is the capability string; its id is derivable from the
         // ticket itself for the reply.
-        let parsed: iroh_rooms::room::RoomInviteTicket = ticket.trim().parse().map_err(|e| {
-            CoreError::internal(format!("freshly minted ticket does not parse: {e}"))
-        })?;
+        let parsed: iroh_rooms::room::RoomInviteTicket = ticket
+            .trim()
+            .parse()
+            .map_err(|_| ApiError::InviteIndexUnreadable)?;
+        // `expires_at` is the instant the capability was **signed** with, read
+        // back off the minted ticket — not the instant the caller asked for.
+        // The two differ: the request is converted to a whole-second relative
+        // spec the supervisor then applies to its own clock, so echoing the
+        // request would promise an expiry the capability does not carry and
+        // would disagree with the `invite.list` row for the same invite, which
+        // serves the signed value.
+        let expires_at = parsed
+            .expires_at
+            .and_then(proj::ts_millis)
+            .ok_or(ApiError::InviteIndexUnreadable)?;
+        let _ = ctx;
         Ok(InviteMintOut {
             invite_id: proj::invite_id(&parsed.invite_id),
             room_id: req.room_id.clone(),
             subject_id: req.subject_id.clone(),
             role: req.role,
-            expires_at: req.expires_at,
+            expires_at,
             capability: ticket,
             redeemability: Redeemability::Outstanding,
         })
     }
 
     /// `invite.redeem` — convert a capability into signed membership.
-    pub async fn invite_redeem(&self, req: &InviteRedeem) -> CoreResult<InviteRedeemOut> {
-        let room_id_str = self.sup.join_room(&req.capability, None, &[]).await?;
-        let room_id: IrohRoomId = room_id_str
-            .parse()
-            .map_err(|e| CoreError::internal(format!("joined room id does not parse: {e}")))?;
-        let snapshot = self.sup.snapshot_for(&room_id).await?;
-        let self_key = self.sup.local_identity_key()?;
-        let role = snapshot
-            .role(&self_key)
-            .map(proj::role)
-            .unwrap_or(Role::Member);
-        // The member_joined event is the newest committed event by this
-        // subject; find its id and position.
-        let (event_id, pos) = self
-            .latest_by_subject(&room_id, &self_key)
-            .unwrap_or_else(|| (EventId::new(""), 0));
+    ///
+    /// The only operation a non-member can reach, so **every** capability
+    /// failure is one of the four fieldless-or-instant redemption-side codes
+    /// and never a room-scoped one: `room_not_available` here would name a
+    /// room to a caller who is not in it, which is exactly the probe the
+    /// non-oracle property forbids.
+    ///
+    /// `joined` reports whether *this* call authored the membership. It is read
+    /// from the store — the signed `member_joined` for this subject and its
+    /// dense position — rather than asserted, because without it a replay is
+    /// byte-identical to a fresh join.
+    pub async fn invite_redeem(&self, req: &InviteRedeem) -> Result<InviteRedeemOut, ApiError> {
+        // The absolute expiry the capability itself carries, so an expired one
+        // reports the instant it expired rather than the epoch.
+        let ticket: Option<iroh_rooms::room::RoomInviteTicket> = req.capability.trim().parse().ok();
+        let expired_at = ticket
+            .as_ref()
+            .and_then(|t| t.expires_at)
+            .and_then(proj::ts_millis);
+        let joined_before = ticket
+            .as_ref()
+            .and_then(|t| self.membership_event(&t.room_id));
+
+        let room_id_str = self
+            .sup
+            .join_room(&req.capability, None, &[])
+            .await
+            .map_err(|error| redemption_error(error, expired_at))?;
+        let api_room = RoomId::new(room_id_str);
+        let room_id = Self::parse_room(&api_room).map_err(|_| ApiError::CapabilityInvalid)?;
+        let snapshot = self
+            .sup
+            .snapshot_for(&room_id)
+            .await
+            .map_err(|_| ApiError::CapabilityInvalid)?;
+        let self_key = self.sup.local_identity_key().map_err(core_to_api)?;
+        let subject_id = SubjectId::new(self_key.to_string());
+        // Role and standing come from the fold, never a default: a redeemer the
+        // fold cannot resolve is `membership_unresolved`, not a fabricated
+        // active member.
+        let member = snapshot
+            .member(&self_key)
+            .ok_or_else(|| ApiError::MembershipUnresolved {
+                room_id: api_room.clone(),
+                subject_id: subject_id.clone(),
+            })?;
+        let store = self.sup.open_store().map_err(core_to_api)?;
+        let departures = crate::supervisor::departure_sets(&store, &room_id)
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
+        drop(store);
+        let (event_id, pos) =
+            self.membership_event(&room_id)
+                .ok_or_else(|| ApiError::MembershipUnresolved {
+                    room_id: api_room.clone(),
+                    subject_id: subject_id.clone(),
+                })?;
         Ok(InviteRedeemOut {
-            room_id: RoomId::new(room_id_str),
-            subject_id: SubjectId::new(self_key.to_string()),
-            role,
-            standing: Standing::Active,
+            room_id: api_room,
+            subject_id,
+            role: proj::role(member.role),
+            standing: departures.standing_of(member.status, &member.identity),
             event_id,
             pos,
-            joined: true,
+            // `false` when the membership event already existed before this
+            // call reached the runtime.
+            joined: joined_before.is_none(),
         })
     }
 
     /// `invite.list` — fold the accepted invitation and redemption facts into
     /// an authority-only typed index. Capability secrets and hashes never
     /// enter the returned rows.
-    pub async fn invite_list(&self, req: &InviteList) -> Result<InviteListOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
+    pub fn invite_list(
+        &self,
+        ctx: &RoomContext,
+        req: &InviteList,
+    ) -> Result<InviteListOut, ApiError> {
+        let room_id = ctx.room_id;
         let store = self
             .sup
             .open_store()
@@ -780,8 +1045,9 @@ impl<'a> TypedSupervisor<'a> {
                 return Err(ApiError::InviteIndexUnreadable);
             };
             let expires_ms = invite.expires_at.ok_or(ApiError::InviteIndexUnreadable)?;
-            let expires_at =
-                checked_timestamp(expires_ms).ok_or(ApiError::InviteIndexUnreadable)?;
+            // The same millisecond-fidelity conversion `invite.mint` serves,
+            // so the two answers about one invite's expiry cannot disagree.
+            let expires_at = proj::ts_millis(expires_ms).ok_or(ApiError::InviteIndexUnreadable)?;
             let role = match invite.role.as_str() {
                 "admin" => Role::Authority,
                 "member" | "agent" => Role::Member,
@@ -819,13 +1085,19 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `invite.revoke` — withdraw an outstanding capability before expiry.
-    /// Not yet backed by the runtime.
-    pub async fn invite_revoke(&self, req: &InviteRevoke) -> CoreResult<InviteRevokeOut> {
+    ///
+    /// **Not implemented in this build.** The active Iroh Room SDK has no
+    /// convergent signed invite-revocation event, and a local store tombstone
+    /// would be a withdrawal no peer converges on — a fact this daemon would
+    /// assert and no other member could see. It is refused rather than faked;
+    /// see the acceptance matrix on #165 for the upstream blocker.
+    pub async fn invite_revoke(
+        &self,
+        _ctx: &RoomContext,
+        req: &InviteRevoke,
+    ) -> Result<InviteRevokeOut, ApiError> {
         let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "invite.revoke is not implemented in this build",
-        ))
+        Err(ApiError::NotReady)
     }
 
     // ------------------------------------------------------------------
@@ -833,34 +1105,53 @@ impl<'a> TypedSupervisor<'a> {
     // ------------------------------------------------------------------
 
     /// `message.send` — author a message.
-    pub async fn message_send(&self, req: &MessageSend) -> CoreResult<MessageSendOut> {
+    ///
+    /// `at` is the instant the event's author **signed**, read back from the
+    /// committed event, not the wall clock at reply time: the record defines
+    /// `<ts>` on a committed fact as the non-repudiable author date, and the
+    /// two are not the same number.
+    pub async fn message_send(
+        &self,
+        ctx: &RoomContext,
+        req: &MessageSend,
+    ) -> Result<MessageSendOut, ApiError> {
+        let limit = limits().max_message_body_bytes;
         let body_len = req.body.len() as u64;
-        if req.body.is_empty() || body_len > limits().max_message_body_bytes {
-            return Err(CoreError::new(
-                ErrorKind::InvalidParams,
-                format!(
-                    "message body must be 1..={} bytes",
-                    limits().max_message_body_bytes
-                ),
-            ));
+        if body_len > limit {
+            return Err(ApiError::MessageTooLarge {
+                declared_bytes: body_len,
+                limit_bytes: limit,
+            });
         }
-        let room_id = Self::parse_room(&req.room_id)?;
+        if req.body.is_empty() {
+            // An empty body carries no message. The record states no minimum,
+            // so this is the step-1 bound it is, never `message_too_large`.
+            return Err(ApiError::InvalidArgument {
+                field: "in.body".into(),
+                reason: InvalidReason::Bound { min: 1, max: limit },
+            });
+        }
         let event_id_hex = self
             .sup
             .send_message(req.room_id.as_ref(), &req.body)
-            .await?;
-        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        let (pos, at) = self.committed_pos_and_instant(&ctx.room_id, &event_id_hex)?;
         Ok(MessageSendOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
             pos,
-            at: proj_ts(crate::now_ms()),
+            at,
         })
     }
 
-    /// `status.post` — author an agent status (any active member).
-    pub async fn status_post(&self, req: &StatusPost) -> CoreResult<StatusPostOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
+    /// `status.post` — author an agent status. Open to any active member:
+    /// member and agent are a classification, not a permission.
+    pub async fn status_post(
+        &self,
+        ctx: &RoomContext,
+        req: &StatusPost,
+    ) -> Result<StatusPostOut, ApiError> {
         let label = status_label_wire(req.label);
         let progress_pct = match req.progress {
             Progress::Reported { percent } => Some(u64::from(percent)),
@@ -869,28 +1160,40 @@ impl<'a> TypedSupervisor<'a> {
         let event_id_hex = self
             .sup
             .post_status(req.room_id.as_ref(), label, None, progress_pct, &[])
-            .await?;
-        let pos = self.pos_of_event(&room_id, &event_id_hex)?;
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        let (pos, at) = self.committed_pos_and_instant(&ctx.room_id, &event_id_hex)?;
         Ok(StatusPostOut {
             room_id: req.room_id.clone(),
             event_id: EventId::new(event_id_hex),
             pos,
-            at: proj_ts(crate::now_ms()),
+            at,
             severity: req.label.severity(),
         })
     }
 
     /// `status.history` — read one subject's status history, one entry per
-    /// real posted event, chronological.
-    pub async fn status_history(&self, req: &StatusHistory) -> CoreResult<StatusHistoryOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let identity = Self::parse_subject(&req.subject_id)?;
-        self.sup.readable_snapshot(&room_id).await?;
-        let store = self.sup.open_store()?;
+    /// real posted event, chronological. The daemon MUST NOT interpolate,
+    /// smooth, or fabricate a point.
+    ///
+    /// An entry is served **iff** its event is a committed one: an
+    /// out-of-vocabulary label, an out-of-range progress percent, or an
+    /// unrepresentable instant leaves the row uncommitted, and it is omitted
+    /// here exactly as it is from `room.timeline`. One rule, both projections
+    /// — a row that is a status entry in one and not an event in the other
+    /// would be two answers to one question.
+    pub fn status_history(
+        &self,
+        ctx: &RoomContext,
+        req: &StatusHistory,
+    ) -> Result<StatusHistoryOut, ApiError> {
+        let identity = Self::parse_subject(&req.subject_id).map_err(core_to_api)?;
+        let store = self.sup.open_store().map_err(core_to_api)?;
         let rows = store
-            .room_tail(&room_id, u32::MAX)
-            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+            .room_tail(&ctx.room_id, u32::MAX)
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
         let mut entries = Vec::new();
+        let mut authored_any = false;
         for se in &rows {
             if se.event_type != EventType::AgentStatus {
                 continue;
@@ -901,22 +1204,31 @@ impl<'a> TypedSupervisor<'a> {
             if ev.sender_id != identity {
                 continue;
             }
+            authored_any = true;
             let Content::AgentStatus(c) = ev.content else {
                 continue;
             };
-            let Ok(label) = status_label_parse(&c.status) else {
-                continue; // out-of-vocabulary labels are not reclassified
+            let (Ok(label), Some(at), Some(progress)) = (
+                status_label_parse(&c.status),
+                proj::ts(ev.created_at),
+                proj::progress(c.progress_pct),
+            ) else {
+                continue; // not a committed event; not a status entry either
             };
             entries.push(StatusEntry {
-                at: proj_ts(ev.created_at),
+                at,
                 label,
                 severity: label.severity(),
-                progress: proj_progress(c.progress_pct),
+                progress,
             });
         }
-        // Paging over the chronological entries.
-        let window = Window::resolve(&req.page).map_err(api_to_core)?;
-        let (page, truncated) = page_indexed(entries, window);
+        if !authored_any {
+            return Err(ApiError::StatusSubjectUnknown {
+                room_id: req.room_id.clone(),
+                subject_id: req.subject_id.clone(),
+            });
+        }
+        let (page, truncated) = page_indexed(entries, Window::resolve(&req.page)?);
         Ok(StatusHistoryOut {
             room_id: req.room_id.clone(),
             subject_id: req.subject_id.clone(),
@@ -925,11 +1237,14 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// `fleet.list` — the agent fleet projection, no tallies.
-    pub async fn fleet_list(&self) -> CoreResult<FleetListOut> {
+    /// `fleet.list` — the agent fleet projection, no tallies. Scope is the
+    /// caller's authorized room set; a room the caller cannot see contributes
+    /// nothing and its absence is indistinguishable from it not existing.
+    pub async fn fleet_list(&self) -> Result<FleetListOut, ApiError> {
         let now = crate::now_ms();
-        let self_id = self.sup.local_identity_key()?;
-        let known: BTreeSet<String> = crate::localstate::load(self.sup.data_dir())?
+        let self_id = self.sup.local_identity_key().map_err(core_to_api)?;
+        let known: BTreeSet<String> = crate::localstate::load(self.sup.data_dir())
+            .map_err(|_| ApiError::FleetProjectionUnavailable)?
             .rooms
             .keys()
             .cloned()
@@ -957,10 +1272,13 @@ impl<'a> TypedSupervisor<'a> {
                 continue;
             }
             let rows = {
-                let store = self.sup.open_store()?;
+                let store = self
+                    .sup
+                    .open_store()
+                    .map_err(|_| ApiError::FleetProjectionUnavailable)?;
                 store
                     .room_tail(&room_id, u32::MAX)
-                    .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?
+                    .map_err(|_| ApiError::FleetProjectionUnavailable)?
             };
             let mut signals: AgentSignalsMap = BTreeMap::new();
             for se in &rows {
@@ -1035,17 +1353,20 @@ impl<'a> TypedSupervisor<'a> {
     // Files
     // ------------------------------------------------------------------
 
-    /// `file.share` — share bytes into a room. The v2 surface declares the
-    /// name/size/type; the daemon stages the bytes itself.
-    pub async fn file_share(&self, req: &FileShare) -> CoreResult<FileShareOut> {
-        // The v1 staging endpoint supplies bytes by path; the v2 WS op is the
-        // typed declaration. Until the byte-stream staging is wired into the
-        // codec, this is refused honestly rather than fabricating an event.
+    /// `file.share` — share bytes into a room.
+    ///
+    /// **Not implemented on the typed WS surface in this build.** The record
+    /// streams the bytes alongside the declaration, and that framing is not
+    /// wired to the codec yet; the host-staged half below is what carries a
+    /// real share today. It is refused rather than fabricating an event for
+    /// bytes nobody sent.
+    pub async fn file_share(
+        &self,
+        _ctx: &RoomContext,
+        req: &FileShare,
+    ) -> Result<FileShareOut, ApiError> {
         let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "file.share byte staging is not wired to the typed surface in this build",
-        ))
+        Err(ApiError::NotReady)
     }
 
     /// Host-side half of `file.share`: the host has already staged the bytes
@@ -1056,15 +1377,27 @@ impl<'a> TypedSupervisor<'a> {
         &self,
         req: &FileShare,
         path: &Path,
-    ) -> CoreResult<FileShareOut> {
+    ) -> Result<FileShareOut, ApiError> {
         let actual_bytes = std::fs::metadata(path)
-            .map_err(|e| CoreError::invalid(format!("cannot read {}: {e}", path.display())))?
+            .map_err(|_| ApiError::FileIndexUnreadable)?
             .len();
         if actual_bytes != req.declared_bytes {
-            return Err(CoreError::invalid(format!(
-                "declared size {} does not match staged size {actual_bytes}",
-                req.declared_bytes
-            )));
+            // A stream that does not match its declaration is a size
+            // disagreement, never `digest_mismatch` — accusing an honest peer
+            // of corruption for a size mismatch is the false accusation the
+            // size policy forbids.
+            return Err(ApiError::DeclaredSizeMismatch {
+                declared_bytes: req.declared_bytes,
+                observed_bytes: actual_bytes,
+            });
+        }
+        let limit = limits().max_shared_file_bytes;
+        if actual_bytes > limit {
+            return Err(ApiError::FileTooLarge {
+                declared_bytes: actual_bytes,
+                limit_bytes: limit,
+                enforced_at: EnforcedAt::StageStream,
+            });
         }
         let shared = self
             .sup
@@ -1074,7 +1407,8 @@ impl<'a> TypedSupervisor<'a> {
                 Some(&req.name),
                 Some(&req.declared_content_type),
             )
-            .await?;
+            .await
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
         let room_id = Self::parse_room(&req.room_id)?;
         let pos = self.pos_of_event(&room_id, &shared.event_id)?;
         Ok(FileShareOut {
@@ -1088,14 +1422,21 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `file.list` — files shared into a room, provider availability as a
-    /// protocol fact.
-    pub async fn file_list(&self, req: &FileList) -> CoreResult<FileListOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let snapshot = self.sup.readable_snapshot(&room_id).await?;
-        let store = self.sup.open_store()?;
+    /// protocol fact rather than an inference from membership display state.
+    pub async fn file_list(
+        &self,
+        ctx: &RoomContext,
+        req: &FileList,
+    ) -> Result<FileListOut, ApiError> {
+        let room_id = ctx.room_id;
+        let snapshot = &ctx.snapshot;
+        let store = self
+            .sup
+            .open_store()
+            .map_err(|_| ApiError::FileIndexUnreadable)?;
         let events = store
             .by_type(&room_id, EventType::FileShared)
-            .map_err(|e| CoreError::internal(format!("could not read file.shared events: {e}")))?;
+            .map_err(|_| ApiError::FileIndexUnreadable)?;
         let session = self.sup.session_opt(&room_id);
         let peer_paths: std::collections::HashMap<_, _> = if let Some(session) = session.as_deref()
         {
@@ -1135,41 +1476,17 @@ impl<'a> TypedSupervisor<'a> {
                     })
             });
             let file_id = file_handle(&f.file_id);
-            let local_device =
-                self.sup.local_identity_key().ok().and_then(|identity| {
-                    snapshot.member(&identity).and_then(|member| member.device)
-                });
+            let local_device = snapshot
+                .member(&ctx.self_key)
+                .and_then(|member| member.device);
             let self_hosted = local_device.is_some_and(|device| providers.contains(&device))
                 || crate::localstate::fetched_file(self.sup.data_dir(), &room_id_str, &file_id)
                     .is_some();
-            let provider_rows = providers
-                .iter()
-                .filter_map(|provider| {
-                    let subject = snapshot.identity_of_device(provider)?;
-                    let endpoint = crate::supervisor::endpoint_id_of(*provider).ok();
-                    let link = endpoint
-                        .as_ref()
-                        .and_then(|endpoint| peer_entries.get(endpoint))
-                        .map_or(
-                            Link::NotConnected {
-                                reason: LinkReason::NeverDialed,
-                            },
-                            |entry| {
-                                peer_link(
-                                    entry,
-                                    endpoint
-                                        .as_ref()
-                                        .and_then(|endpoint| peer_paths.get(endpoint).copied()),
-                                )
-                            },
-                        );
-                    Some(PeerRow {
-                        subject_id: SubjectId::new(subject.to_string()),
-                        device_id: DeviceId::new(provider.to_string()),
-                        link,
-                    })
-                })
-                .collect();
+            let provider_rows = provider_rows(&providers, snapshot, &peer_entries, &peer_paths);
+            // `shared_at` is the sharer's signed instant. A row whose instant
+            // will not convert is an unreadable index entry, not a row dated
+            // to the epoch.
+            let shared_at = proj::ts(ev.created_at).ok_or(ApiError::FileIndexUnreadable)?;
             files.push(FileRow {
                 file_id: FileId::new(file_id),
                 name: f.name.clone(),
@@ -1177,15 +1494,14 @@ impl<'a> TypedSupervisor<'a> {
                 digest: f.blob_hash.to_string(),
                 declared_content_type: f.mime_type.clone(),
                 shared_by: SubjectId::new(ev.sender_id.to_string()),
-                shared_at: proj_ts(ev.created_at),
+                shared_at,
                 providers: provider_rows,
                 fetchable,
                 self_hosted,
             });
         }
         // Paging over the file rows (position = index within the file index).
-        let window = Window::resolve(&req.page).map_err(api_to_core)?;
-        let (page, truncated) = page_indexed(files, window);
+        let (page, truncated) = page_indexed(files, Window::resolve(&req.page)?);
         Ok(FileListOut {
             room_id: req.room_id.clone(),
             files: page,
@@ -1194,36 +1510,74 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `file.fetch` — fetch a file's bytes from a provider; the daemon holds
-    /// the bytes and `file.read` streams them out.
-    pub async fn file_fetch(&self, req: &FileFetch) -> CoreResult<FileFetchOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        let snapshot = self.sup.readable_snapshot(&room_id).await?;
-        let result = self
+    /// the bytes and `file.read` streams them out. Requires liveness.
+    ///
+    /// `provider_unreachable` carries the **attempted** provider rows — the
+    /// same `{subject_id, device_id, link}` evidence `file.list` serves — so a
+    /// client can say *why* each attempt failed. An error whose typed field is
+    /// an empty array is prose wearing a schema's clothes.
+    pub async fn file_fetch(
+        &self,
+        ctx: &RoomContext,
+        req: &FileFetch,
+    ) -> Result<FileFetchOut, ApiError> {
+        let room_id = ctx.room_id;
+        let file_id = Self::parse_file(&req.file_id).map_err(|_| ApiError::FileUnknown {
+            file_id: req.file_id.clone(),
+        })?;
+        // The signed share is read first: it is what names the digest to verify
+        // against and the providers an unreachable fetch must report.
+        let shared = {
+            let store = self
+                .sup
+                .open_store()
+                .map_err(|_| ApiError::FileIndexUnreadable)?;
+            store
+                .by_type(&room_id, EventType::FileShared)
+                .map_err(|_| ApiError::FileIndexUnreadable)?
+                .iter()
+                .filter_map(|se| {
+                    let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+                    match ev.content {
+                        Content::FileShared(f) if f.file_id == file_id => Some((f, ev.device_id)),
+                        _ => None,
+                    }
+                })
+                .next()
+        };
+        let Some((shared, author_device)) = shared else {
+            return Err(ApiError::FileUnknown {
+                file_id: req.file_id.clone(),
+            });
+        };
+        let digest = shared.blob_hash.to_string();
+
+        let result = match self
             .sup
             .fetch_file(req.room_id.as_ref(), req.file_id.as_str(), None)
-            .await?;
-        let bytes = result.bytes;
-        // The verified digest comes from the shared file's declared hash.
-        let file_id = Self::parse_file(&req.file_id)?;
-        let store = self.sup.open_store()?;
-        let events = store
-            .by_type(&room_id, EventType::FileShared)
-            .map_err(|e| CoreError::internal(format!("could not read file.shared events: {e}")))?;
-        let digest = events
-            .iter()
-            .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
-            .find_map(|ev| match ev.content {
-                Content::FileShared(f) if f.file_id == file_id => Some(f.blob_hash.to_string()),
-                _ => None,
-            })
-            .ok_or_else(|| CoreError::internal("fetched file has no declared digest"))?;
-        let provider_subject = snapshot
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                return Err(self
+                    .fetch_error(ctx, req, error, &shared, author_device, &digest)
+                    .await)
+            }
+        };
+        // A provider device the fold cannot bind to a subject leaves the reply
+        // with no truthful `provider.subject_id`. It is a fold this daemon
+        // could not complete, not a named subject whose membership is
+        // unresolved: `<subject_id>` and `<device_id>` are distinct opaque
+        // domains, so putting the device key in a subject field would hand the
+        // client an identifier that resolves in neither.
+        let provider_subject = ctx
+            .snapshot
             .identity_of_device(&result.provider_device)
-            .ok_or_else(|| CoreError::internal("fetched provider device has no bound subject"))?;
+            .ok_or(ApiError::RoomIndexUnreadable)?;
         Ok(FileFetchOut {
             room_id: req.room_id.clone(),
             file_id: req.file_id.clone(),
-            bytes,
+            bytes: result.bytes,
             digest,
             provider: ProviderRef {
                 subject_id: SubjectId::new(provider_subject.to_string()),
@@ -1233,11 +1587,48 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `file.read` — stream locally held bytes out (the header; bytes follow).
-    pub async fn file_read(&self, req: &FileRead) -> CoreResult<FileReadOut> {
+    ///
+    /// "No such file in this room" and "its bytes are not held here" are two
+    /// different facts with two different codes. The supervisor answers both
+    /// with one internal kind, so the signed share is resolved here first:
+    /// answering `file_not_fetched` for a file that was never shared would
+    /// assert it exists and merely awaits a fetch.
+    pub async fn file_read(
+        &self,
+        ctx: &RoomContext,
+        req: &FileRead,
+    ) -> Result<FileReadOut, ApiError> {
+        let unknown = || ApiError::FileUnknown {
+            file_id: req.file_id.clone(),
+        };
+        let file_id = Self::parse_file(&req.file_id).map_err(|_| unknown())?;
+        {
+            let store = self
+                .sup
+                .open_store()
+                .map_err(|_| ApiError::FileIndexUnreadable)?;
+            let shared = store
+                .by_type(&ctx.room_id, EventType::FileShared)
+                .map_err(|_| ApiError::FileIndexUnreadable)?
+                .iter()
+                .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+                .any(|ev| matches!(ev.content, Content::FileShared(f) if f.file_id == file_id));
+            if !shared {
+                return Err(unknown());
+            }
+        }
         let local = self
             .sup
             .local_file(req.room_id.as_ref(), req.file_id.as_str())
-            .await?;
+            .await
+            .map_err(|error| match error.kind {
+                // The share exists, so the only remaining cause is that this
+                // daemon holds no bytes for it.
+                ErrorKind::FileUnavailable => ApiError::FileNotFetched {
+                    file_id: req.file_id.clone(),
+                },
+                _ => core_to_api_room(error, &req.room_id),
+            })?;
         Ok(FileReadOut {
             room_id: req.room_id.clone(),
             file_id: req.file_id.clone(),
@@ -1246,14 +1637,23 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// `transfer.cancel` — cancel a transfer by the op_id that started it.
-    /// Transfers are not yet tracked by op_id in this build.
-    pub async fn transfer_cancel(&self, req: &TransferCancel) -> CoreResult<TransferCancelOut> {
-        let _ = req;
-        Err(CoreError::new(
-            ErrorKind::InvalidParams,
-            "transfer.cancel is not implemented in this build",
-        ))
+    /// `transfer.cancel` — cancel a transfer by the `op_id` that started it.
+    ///
+    /// This build tracks no transfers by `op_id` (that needs upstream progress
+    /// and cancellation handles), so **no** `transfer_op_id` names an in-flight
+    /// transfer for this principal — which is exactly what
+    /// `transfer_unknown { transfer_op_id }` states, and it is the operation's
+    /// own distinctive code. It is a true statement about this daemon rather
+    /// than a stand-in code: a `cancelled` outcome would claim an effect that
+    /// did not happen, and the record's non-oracle rule already makes
+    /// `transfer_unknown` the answer for a transfer the caller may not see.
+    pub async fn transfer_cancel(
+        &self,
+        req: &TransferCancel,
+    ) -> Result<TransferCancelOut, ApiError> {
+        Err(ApiError::TransferUnknown {
+            transfer_op_id: req.transfer_op_id.clone(),
+        })
     }
 
     // ------------------------------------------------------------------
@@ -1264,14 +1664,13 @@ impl<'a> TypedSupervisor<'a> {
     /// authorizes every active member; `audience: subjects` authorizes the
     /// named list. A non-loopback target or an out-of-range port is
     /// `pipe_target_refused` carrying the rejected target verbatim.
-    pub async fn pipe_publish(&self, req: &PipePublish) -> Result<PipePublishOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(|error| core_to_api_room(error, &req.room_id))?;
-        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
+    pub async fn pipe_publish(
+        &self,
+        ctx: &RoomContext,
+        req: &PipePublish,
+    ) -> Result<PipePublishOut, ApiError> {
+        let room_id = ctx.room_id;
+        let snapshot = &ctx.snapshot;
         // The target must be loopback (IPv4 127.0.0.0/8 or IPv6 ::1) with a
         // port in 1..=65535. Anything else is pipe_target_refused carrying the
         // rejected target verbatim, never the generic policy_refused.
@@ -1313,10 +1712,8 @@ impl<'a> TypedSupervisor<'a> {
             .sup
             .pipe_expose_multi(&room_id, target_addr, &target_hint, &allowed)
             .await
-            .map_err(core_to_api)?;
-        let pos = self
-            .pos_of_event(&room_id, &event_id)
-            .map_err(core_to_api)?;
+            .map_err(|error| core_to_api_room(error, &req.room_id))?;
+        let pos = self.pos_of_event(&room_id, &event_id)?;
         Ok(PipePublishOut {
             room_id: req.room_id.clone(),
             pipe_id: crate::projection::pipe_id(&pipe_id),
@@ -1329,12 +1726,18 @@ impl<'a> TypedSupervisor<'a> {
 
     /// `pipe.list` — pipes in a room, with publisher reachability and local
     /// connection as two separately named facts.
-    pub async fn pipe_list(&self, req: &PipeList) -> CoreResult<PipeListOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
-        self.sup.readable_snapshot(&room_id).await?;
-        let store = self.sup.open_store()?;
+    pub async fn pipe_list(
+        &self,
+        ctx: &RoomContext,
+        req: &PipeList,
+    ) -> Result<PipeListOut, ApiError> {
+        let room_id = ctx.room_id;
+        let store = self
+            .sup
+            .open_store()
+            .map_err(|_| ApiError::PipeIndexUnreadable)?;
         let session = self.sup.session_opt(&room_id);
-        let local_identity = self.sup.local_identity_key().ok();
+        let local_identity = Some(ctx.self_key);
         let peer_paths: std::collections::HashMap<_, _> = if let Some(session) = session.as_deref()
         {
             session
@@ -1351,10 +1754,11 @@ impl<'a> TypedSupervisor<'a> {
             .as_deref()
             .map(|session| session.node.peer_entries().into_iter().collect())
             .unwrap_or_default();
-        let closed = closed_pipe_ids(&store, &room_id)?;
+        let closed =
+            closed_pipe_ids(&store, &room_id).map_err(|_| ApiError::PipeIndexUnreadable)?;
         let opened = store
             .by_type(&room_id, EventType::PipeOpened)
-            .map_err(|e| CoreError::internal(format!("could not read pipe.opened events: {e}")))?;
+            .map_err(|_| ApiError::PipeIndexUnreadable)?;
         let mut pipes = Vec::new();
         for se in opened {
             if se.lamport.is_none() {
@@ -1369,13 +1773,17 @@ impl<'a> TypedSupervisor<'a> {
             if closed.contains(&p.pipe_id) {
                 continue; // revoked pipes are not listed
             }
+            // The publisher's signed instant. A pipe whose announcement will not
+            // convert to a wire instant is an unreadable index row, never one
+            // dated to the epoch.
+            let published_at = proj::ts(ev.created_at).ok_or(ApiError::PipeIndexUnreadable)?;
             let connected = self
                 .sup
                 .pipe_connection_open(&room_id, p.pipe_id, &p.owner_id);
             let owner_endpoint = crate::supervisor::endpoint_id_of(p.owner_endpoint).ok();
             let link = if local_identity.as_ref() == Some(&p.owner_id) && session.is_some() {
                 Link::Direct {
-                    since: proj_ts(ev.created_at),
+                    since: published_at,
                 }
             } else {
                 owner_endpoint
@@ -1401,7 +1809,7 @@ impl<'a> TypedSupervisor<'a> {
                     pipe_id: proj::pipe_id(&p.pipe_id),
                     published_by: SubjectId::new(p.owner_id.to_string()),
                     device_id: DeviceId::new(p.owner_endpoint.to_string()),
-                    published_at: proj_ts(ev.created_at),
+                    published_at,
                     link,
                     connected,
                 },
@@ -1409,8 +1817,7 @@ impl<'a> TypedSupervisor<'a> {
         }
         pipes.sort_by_key(|(pos, _)| *pos);
         let all: Vec<PipeRow> = pipes.into_iter().map(|(_, p)| p).collect();
-        let window = Window::resolve(&req.page).map_err(api_to_core)?;
-        let (page, truncated) = page_indexed(all, window);
+        let (page, truncated) = page_indexed(all, Window::resolve(&req.page)?);
         Ok(PipeListOut {
             room_id: req.room_id.clone(),
             pipes: page,
@@ -1418,26 +1825,36 @@ impl<'a> TypedSupervisor<'a> {
         })
     }
 
-    /// `pipe.connect` — connect to a pipe.
-    pub async fn pipe_connect(&self, req: &PipeConnect) -> Result<PipeConnectOut, ApiError> {
-        let room_id = Self::parse_room(&req.room_id).map_err(core_to_api)?;
-        let snapshot = self
-            .sup
-            .readable_snapshot(&room_id)
-            .await
-            .map_err(|error| core_to_api_room(error, &req.room_id))?;
-        self.require_active_standing(&req.room_id, &room_id, &snapshot)?;
-        let local_addr = self
+    /// `pipe.connect` — connect to a pipe. Requires liveness. A caller outside
+    /// the pipe's audience answers `pipe_unknown`, indistinguishable from no
+    /// such pipe.
+    pub async fn pipe_connect(
+        &self,
+        ctx: &RoomContext,
+        req: &PipeConnect,
+    ) -> Result<PipeConnectOut, ApiError> {
+        let local_addr = match self
             .sup
             .pipe_connect(req.room_id.as_ref(), req.pipe_id.as_str())
             .await
-            .map_err(|error| core_to_api_room(error, &req.room_id))?;
-        let (host, port) = split_host_port(&local_addr);
+        {
+            Ok(addr) => addr,
+            Err(error) => return Err(self.pipe_connect_error(ctx, req, error).await),
+        };
+        // The local endpoint is one this daemon just bound, so it parses as a
+        // socket address by construction; a value that does not is a runtime
+        // inconsistency, not a `port: 0` to be served as though real.
+        let local = parse_target(&local_addr).ok_or_else(|| ApiError::PipeUnreachable {
+            pipe_id: req.pipe_id.clone(),
+            link: Link::NotConnected {
+                reason: LinkReason::NoRoute,
+            },
+        })?;
         Ok(PipeConnectOut {
             room_id: req.room_id.clone(),
             pipe_id: req.pipe_id.clone(),
-            connection_id: local_addr.clone(),
-            local: Target { host, port },
+            connection_id: local_addr,
+            local,
         })
     }
 
@@ -1455,19 +1872,37 @@ impl<'a> TypedSupervisor<'a> {
     }
 
     /// `pipe.revoke` — withdraw a published pipe as a signed fact.
-    pub async fn pipe_revoke(&self, req: &PipeRevoke) -> CoreResult<PipeRevokeOut> {
-        let room_id = Self::parse_room(&req.room_id)?;
+    ///
+    /// Restricted to the pipe's **publisher**, which is a narrower relation
+    /// than role: an authority that did not publish a pipe cannot revoke it
+    /// either, and that refusal is `pipe_not_publisher`, not
+    /// `insufficient_standing`. `revoked_at` is the withdrawal event's signed
+    /// instant, not the wall clock at reply time.
+    pub async fn pipe_revoke(
+        &self,
+        ctx: &RoomContext,
+        req: &PipeRevoke,
+    ) -> Result<PipeRevokeOut, ApiError> {
         let event_id = self
             .sup
             .pipe_close(req.room_id.as_ref(), req.pipe_id.as_str())
-            .await?;
-        let pos = self.pos_of_event(&room_id, &event_id)?;
+            .await
+            .map_err(|error| match error.kind {
+                ErrorKind::PipeDenied => ApiError::PipeNotPublisher {
+                    pipe_id: req.pipe_id.clone(),
+                },
+                ErrorKind::InvalidParams => ApiError::PipeUnknown {
+                    pipe_id: req.pipe_id.clone(),
+                },
+                _ => core_to_api_room(error, &req.room_id),
+            })?;
+        let (pos, revoked_at) = self.committed_pos_and_instant(&ctx.room_id, &event_id)?;
         Ok(PipeRevokeOut {
             room_id: req.room_id.clone(),
             pipe_id: req.pipe_id.clone(),
             event_id: EventId::new(event_id),
             pos,
-            revoked_at: proj_ts(crate::now_ms()),
+            revoked_at,
         })
     }
 
@@ -1477,77 +1912,94 @@ impl<'a> TypedSupervisor<'a> {
 
     /// All committed timeline events for a room, ascending by position —
     /// the dense rank over the canonical `(lamport, event_id)` order.
-    fn committed_events(
-        &self,
-        room_id: &IrohRoomId,
-        snapshot: &iroh_rooms::room::MembershipSnapshot,
-    ) -> CoreResult<Vec<Event>> {
-        let store = self.sup.open_store()?;
+    fn committed_events(&self, ctx: &RoomContext) -> Result<Vec<Event>, ApiError> {
+        let store = self.sup.open_store().map_err(core_to_api)?;
         let rows = store
-            .room_tail(room_id, u32::MAX)
-            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+            .room_tail(&ctx.room_id, u32::MAX)
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
         let refs: Vec<&iroh_rooms::experimental::store::StoredEvent> = rows.iter().collect();
-        Ok(proj::positioned(&refs, snapshot)
+        Ok(proj::positioned(&refs, &ctx.snapshot, &ctx.departures)
             .into_iter()
             .map(|(_, e)| e)
             .collect())
     }
 
-    /// The dense canonical position of one committed event, looked up by its
-    /// event id. Mutation replies use this so the `pos` they serve is the same
-    /// rank the timeline, resync, and push stream serve for that event —
-    /// never the raw lamport, and never the head's position (which a later
-    /// concurrent event can share). Ranking counts only committed kinds (see
-    /// [`proj::positioned`]), so a non-committed row consumes no position.
-    fn pos_of_event(&self, room_id: &IrohRoomId, event_id_hex: &str) -> CoreResult<u64> {
-        let store = self.sup.open_store()?;
+    /// The dense canonical position **and the author-signed instant** of one
+    /// committed event, looked up by its event id.
+    ///
+    /// Mutation replies use this so the `pos` they serve is the same rank the
+    /// timeline, resync, and push stream serve for that event — never the raw
+    /// lamport, and never the head's position (which a later concurrent event
+    /// can share) — and so the `at` / `revoked_at` they serve is the instant the
+    /// author signed rather than the wall clock at reply time. Ranking counts
+    /// only committed kinds (see [`proj::positioned`]), so a non-committed row
+    /// consumes no position.
+    fn committed_pos_and_instant(
+        &self,
+        room_id: &IrohRoomId,
+        event_id_hex: &str,
+    ) -> Result<(u64, Timestamp), ApiError> {
+        let store = self.sup.open_store().map_err(core_to_api)?;
         let rows = store
             .room_tail(room_id, u32::MAX)
-            .map_err(|e| CoreError::internal(format!("could not read the timeline: {e}")))?;
+            .map_err(|_| ApiError::RoomIndexUnreadable)?;
         let mut rank = 0u64;
-        let mut found = None;
         for se in &rows {
             if !proj::is_committed(se) {
                 continue;
             }
             if proj::event_id(&se.event_id).as_str() == event_id_hex {
-                found = Some(rank);
-                break;
+                // `is_committed` already proved both halves convert.
+                let at = SignedEvent::decode(&se.wire.signed)
+                    .ok()
+                    .and_then(|ev| proj::ts(ev.created_at))
+                    .ok_or(ApiError::RoomIndexUnreadable)?;
+                return Ok((rank, at));
             }
             rank += 1;
         }
-        found.ok_or_else(|| {
-            CoreError::internal(format!(
-                "committed event {event_id_hex} is absent from the room tail"
-            ))
-        })
+        Err(ApiError::RoomIndexUnreadable)
     }
 
-    /// The newest committed event authored by a subject, with its dense
-    /// canonical position. Ranking counts only committed kinds.
-    fn latest_by_subject(
-        &self,
-        room_id: &IrohRoomId,
-        subject: &iroh_rooms::identity::IdentityKey,
-    ) -> Option<(EventId, u64)> {
+    /// [`Self::committed_pos_and_instant`] when only the position is wanted.
+    fn pos_of_event(&self, room_id: &IrohRoomId, event_id_hex: &str) -> Result<u64, ApiError> {
+        self.committed_pos_and_instant(room_id, event_id_hex)
+            .map(|(pos, _)| pos)
+    }
+
+    /// The local subject's `member_joined` event in a room, with its dense
+    /// canonical position — the event `invite.redeem` reports. Looking for the
+    /// *membership* event specifically (not merely the newest event this
+    /// subject authored) is what lets `joined` tell a fresh join from a replay.
+    fn membership_event(&self, room_id: &IrohRoomId) -> Option<(EventId, u64)> {
+        let self_key = self.sup.local_identity_key().ok()?;
         let store = self.sup.open_store().ok()?;
         let rows = store.room_tail(room_id, u32::MAX).ok()?;
         let mut rank = 0u64;
-        let mut latest = None;
         for se in &rows {
             if !proj::is_committed(se) {
                 continue;
             }
-            let ev = SignedEvent::decode(&se.wire.signed).ok()?;
-            if &ev.sender_id == subject {
-                latest = Some((proj::event_id(&se.event_id), rank));
+            if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
+                let is_join = match &ev.content {
+                    Content::MemberJoined(c) => c.device_binding.identity_key == self_key,
+                    // The authority never authors a join: its membership is the
+                    // genesis it signed.
+                    Content::RoomCreated(_) => ev.sender_id == self_key,
+                    _ => false,
+                };
+                if is_join {
+                    return Some((proj::event_id(&se.event_id), rank));
+                }
             }
             rank += 1;
         }
-        latest
+        None
     }
 
-    /// The author-dated instant a subject joined, when discoverable.
+    /// The author-dated instant a subject joined, when discoverable. `None`
+    /// when this daemon holds no dating evidence — the caller answers
+    /// `membership_unresolved` rather than dating the row to the epoch.
     fn joined_at(
         &self,
         room_id: &IrohRoomId,
@@ -1556,21 +2008,179 @@ impl<'a> TypedSupervisor<'a> {
         let store = self.sup.open_store().ok()?;
         let rows = store.by_type(room_id, EventType::MemberJoined).ok()?;
         for se in rows {
-            let ev = SignedEvent::decode(&se.wire.signed).ok()?;
+            let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
+                continue;
+            };
             if let Content::MemberJoined(c) = &ev.content {
                 if &c.device_binding.identity_key == subject {
-                    return Some(proj_ts(ev.created_at));
+                    return proj::ts(ev.created_at);
                 }
             }
         }
-        // The authority's join is the genesis.
-        let genesis = store.room_tail(room_id, 1).ok()?;
-        let first = genesis.first()?;
-        let ev = SignedEvent::decode(&first.wire.signed).ok()?;
+        // The authority authors no join: its membership is the genesis it
+        // signed, so that event's instant is its `joined_at`.
+        //
+        // The genesis is found **by kind**, not as `room_tail(room_id, 1)`.
+        // That call returns the newest row, not the origin, so on any room with
+        // more than one event it dated the authority from whatever happened
+        // last — an outstanding invitation was enough to move the roster's
+        // `joined_at` forward on every read.
+        let ev = genesis_event(&store, room_id)?;
         if &ev.sender_id == subject {
-            return Some(proj_ts(ev.created_at));
+            return proj::ts(ev.created_at);
         }
         None
+    }
+
+    /// The exact refusal a failed `file.fetch` earns, with the **attempted**
+    /// provider evidence the record's `provider_unreachable` requires.
+    async fn fetch_error(
+        &self,
+        ctx: &RoomContext,
+        req: &FileFetch,
+        error: CoreError,
+        shared: &iroh_rooms::files::FileShared,
+        author_device: iroh_rooms::identity::DeviceKey,
+        digest: &str,
+    ) -> ApiError {
+        match error.kind {
+            ErrorKind::FileUnavailable | ErrorKind::FileUnauthorized => {
+                // The record requires the **attempted** set, not the candidate
+                // set: "a client can say *why* each one failed instead of only
+                // that the fetch did". The runtime narrows the candidates the
+                // same two ways before dialing — it drops a device whose
+                // endpoint will not resolve, and it never dials itself — so
+                // both filters are applied here or the error would name a
+                // provider no attempt was ever made against.
+                let self_device = self
+                    .sup
+                    .local_identity_key()
+                    .ok()
+                    .and_then(|identity| ctx.snapshot.member(&identity))
+                    .and_then(|member| member.device)
+                    .and_then(|device| crate::supervisor::endpoint_id_of(device).ok());
+                let candidates: Vec<iroh_rooms::identity::DeviceKey> = match &shared.providers {
+                    Some(list) if !list.is_empty() => list.clone(),
+                    _ => vec![author_device],
+                };
+                let providers: Vec<iroh_rooms::identity::DeviceKey> = candidates
+                    .into_iter()
+                    .filter(|device| match crate::supervisor::endpoint_id_of(*device) {
+                        Ok(endpoint) => Some(endpoint) != self_device,
+                        Err(_) => false,
+                    })
+                    .collect();
+                let (peer_entries, peer_paths) = self.peer_evidence(&ctx.room_id).await;
+                let attempted =
+                    provider_rows(&providers, &ctx.snapshot, &peer_entries, &peer_paths)
+                        .into_iter()
+                        .map(|row| AttemptedProvider {
+                            subject_id: row.subject_id,
+                            device_id: row.device_id,
+                            link: row.link,
+                        })
+                        .collect();
+                ApiError::ProviderUnreachable {
+                    file_id: req.file_id.clone(),
+                    providers: attempted,
+                }
+            }
+            // Both halves are real: `expected` is the digest the share signed,
+            // and `observed` is the digest the rejected bytes actually hash to,
+            // recomputed by the supervisor from the bytes the upstream mismatch
+            // arm hands back. An earlier revision served `observed: ""`, which
+            // satisfied the schema and invented the fact. A mismatch this
+            // daemon somehow cannot describe is not reported as a digest
+            // comparison at all.
+            ErrorKind::HashMismatch => match &error.detail {
+                Some(observed) => ApiError::DigestMismatch {
+                    expected: digest.to_owned(),
+                    observed: observed.clone(),
+                },
+                None => ApiError::FileIndexUnreadable,
+            },
+            ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
+                room_id: req.room_id.clone(),
+            },
+            _ => core_to_api_room(error, &req.room_id),
+        }
+    }
+
+    /// The exact refusal a failed `pipe.connect` earns, naming the pipe the
+    /// caller asked for and the link this daemon actually observed.
+    async fn pipe_connect_error(
+        &self,
+        ctx: &RoomContext,
+        req: &PipeConnect,
+        error: CoreError,
+    ) -> ApiError {
+        match error.kind {
+            ErrorKind::PeerUnreachable => ApiError::PipeUnreachable {
+                pipe_id: req.pipe_id.clone(),
+                link: self.pipe_owner_link(ctx, &req.pipe_id).await,
+            },
+            ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
+                room_id: req.room_id.clone(),
+            },
+            // "No such pipe", "you are outside its audience", and "it was
+            // withdrawn while you connected" are all `pipe_unknown` to a caller
+            // that may not distinguish them.
+            ErrorKind::InvalidParams | ErrorKind::PipeDenied => ApiError::PipeUnknown {
+                pipe_id: req.pipe_id.clone(),
+            },
+            _ => core_to_api_room(error, &req.room_id),
+        }
+    }
+
+    /// The observed link to a pipe's publisher device, for
+    /// `pipe_unreachable.link`.
+    async fn pipe_owner_link(&self, ctx: &RoomContext, pipe_id: &PipeId) -> Link {
+        let never = Link::NotConnected {
+            reason: LinkReason::NeverDialed,
+        };
+        let Ok(raw) = hex::decode(pipe_id.as_str()) else {
+            return never;
+        };
+        let Ok(raw) = <[u8; 16]>::try_from(raw.as_slice()) else {
+            return never;
+        };
+        let Some(session) = self.sup.session_opt(&ctx.room_id) else {
+            return never;
+        };
+        let Some(opened) = session.node.pipe_opened(raw).await else {
+            return never;
+        };
+        let (peer_entries, peer_paths) = self.peer_evidence(&ctx.room_id).await;
+        provider_rows(
+            &[opened.owner_endpoint],
+            &ctx.snapshot,
+            &peer_entries,
+            &peer_paths,
+        )
+        .into_iter()
+        .next()
+        .map_or(never, |row| row.link)
+    }
+
+    /// This daemon's observed per-device transport evidence for one room.
+    async fn peer_evidence(&self, room_id: &IrohRoomId) -> (PeerEntryMap, PeerPathMap) {
+        let session = self.sup.session_opt(room_id);
+        let paths: PeerPathMap = if let Some(session) = session.as_deref() {
+            session
+                .node
+                .peer_paths()
+                .await
+                .into_iter()
+                .map(|(device, path, _relay)| (device, path.label()))
+                .collect()
+        } else {
+            std::collections::HashMap::new()
+        };
+        let entries: PeerEntryMap = session
+            .as_deref()
+            .map(|session| session.node.peer_entries().into_iter().collect())
+            .unwrap_or_default();
+        (entries, paths)
     }
 
     /// The per-device link rows for one live node.
@@ -1613,33 +2223,85 @@ impl<'a> TypedSupervisor<'a> {
 // Free helpers
 // ---------------------------------------------------------------------------
 
-/// The capabilities a caller holds in a room, derived from standing/role/live.
+/// The operations that need an **open room session** in this build.
+///
+/// The record names three that require liveness — `file.fetch`,
+/// `pipe.connect`, and `room.peers` — because authoring is a local CRDT write
+/// that converges later. This daemon's authoring path publishes through a live
+/// node instead, so `message.send`, `status.post`, `file.share`,
+/// `pipe.publish`, and `pipe.revoke` are additionally refused `room_not_live`
+/// on a quiescent room.
+///
+/// That divergence is a **runtime gap, recorded here rather than papered
+/// over**: `capabilities` is normatively "would not be refused *at the instant
+/// the reply was composed*", so it must describe what this daemon actually
+/// serves. Advertising `message.send` on a non-live room because the record
+/// says it should work is exactly the drift the array exists to prevent — the
+/// fix is to make offline authoring work, not to claim it already does.
+const LIVENESS_GATED: [CapabilityToken; 8] = [
+    // The record's three.
+    CapabilityToken::RoomPeers,
+    CapabilityToken::FileFetch,
+    CapabilityToken::PipeConnect,
+    // This build's five additional authoring refusals.
+    CapabilityToken::MessageSend,
+    CapabilityToken::StatusPost,
+    CapabilityToken::FileShare,
+    CapabilityToken::PipePublish,
+    CapabilityToken::PipeRevoke,
+];
+
+/// The room-scoped operations a caller may invoke **right now**, as the
+/// record's operation-name capability tokens.
+///
+/// A token is present *iff* the operation would not be refused on membership,
+/// standing, lifecycle, or **liveness** grounds at the instant the reply was
+/// composed. Three corrections over an earlier revision, each observable by a
+/// client that tried the advertised token:
+///
+/// - **`invite.list` is authority-only.** The invite index is the authority's
+///   own record of what it issued; offering the token to a plain member
+///   advertised a read that answers `insufficient_standing`.
+/// - **`pipe.revoke` is not authority-gated.** It is restricted to the pipe's
+///   publisher — a narrower relation than role, refused with
+///   `pipe_not_publisher` — so an ordinary member that published a pipe may
+///   revoke it and an authority that did not, may not.
+/// - **`room.archive` belongs to a *former* membership, and only that.** It
+///   answers `room_still_active` for an active member, so advertising it there
+///   promised a read that cannot succeed; conversely `room.timeline` and
+///   `room.members` answer `membership_ended` once a membership has ended, so
+///   advertising them there promised the same.
+///
+/// `room.activate` and `room.deactivate` are naturally idempotent and never
+/// refused on liveness in either direction, so both are present for any active
+/// member. Only room-scoped tokens appear: `room.list`, `fleet.list`,
+/// `subject.ensure`, `daemon.stop`, `invite.redeem`, `transfer.cancel`, and
+/// `pipe.release` are not answers about *this* room.
 fn room_capabilities(standing: Standing, role: Role, live: bool) -> Vec<CapabilityToken> {
     use CapabilityToken::*;
-    let mut caps = vec![RoomTimeline, RoomMembers, RoomList, RoomArchive];
-    if standing == Standing::Active {
-        caps.extend([RoomLeave, InviteList, FileList, PipeList, StatusHistory]);
-        if live {
-            caps.extend([
-                RoomDeactivate,
-                RoomPeers,
-                MessageSend,
-                StatusPost,
-                FileShare,
-                FileFetch,
-                FileRead,
-                PipePublish,
-                PipeConnect,
-                StreamSubscribe,
-                StreamUnsubscribe,
-                StreamResync,
-            ]);
-        } else {
-            caps.push(RoomActivate);
-        }
-        if role == Role::Authority {
-            caps.extend([InviteMint, InviteRevoke, MemberRemove, PipeRevoke]);
-        }
+    if standing != Standing::Active {
+        // A former membership reaches exactly one room-scoped operation.
+        return vec![RoomArchive];
+    }
+    let mut caps = vec![
+        RoomActivate,
+        RoomDeactivate,
+        RoomLeave,
+        RoomTimeline,
+        RoomMembers,
+        StatusHistory,
+        FileList,
+        FileRead,
+        PipeList,
+        StreamSubscribe,
+        StreamUnsubscribe,
+        StreamResync,
+    ];
+    if live {
+        caps.extend(LIVENESS_GATED);
+    }
+    if role == Role::Authority {
+        caps.extend([InviteMint, InviteList, InviteRevoke, MemberRemove]);
     }
     caps
 }
@@ -1659,33 +2321,55 @@ fn reachability_from_peers(peers: &[PeerRow], live: bool) -> Reachability {
     }
 }
 
-/// The caller's own standing in a room.
-fn self_key_standing(
-    sup: &RoomSupervisor,
-    room_id: &IrohRoomId,
-    snapshot: &iroh_rooms::room::MembershipSnapshot,
-    self_key: &iroh_rooms::identity::IdentityKey,
-) -> CoreResult<Standing> {
-    let store = sup.open_store()?;
-    let (removed_ids, left_ids) = crate::supervisor::departure_sets(&store, room_id)?;
-    Ok(snapshot.member(self_key).map_or(Standing::Active, |m| {
-        member_standing(m.status, &m.identity, &removed_ids, &left_ids)
-    }))
-}
+/// This daemon's observed peer connection entries for one room, keyed by the
+/// P2P endpoint the device binds.
+type PeerEntryMap = std::collections::HashMap<
+    iroh_rooms::experimental::session::EndpointId,
+    iroh_rooms::experimental::session::PeerEntry,
+>;
 
-/// Refine the upstream terminal membership status with the signed fact that
-/// caused it. The fold uses `Status::Removed` for both voluntary leave and
-/// administrative removal; the v2 API keeps those lifecycle states distinct.
-fn member_standing(
-    status: iroh_rooms::room::Status,
-    identity: &iroh_rooms::identity::IdentityKey,
-    removed_ids: &BTreeSet<iroh_rooms::identity::IdentityKey>,
-    left_ids: &BTreeSet<iroh_rooms::identity::IdentityKey>,
-) -> Standing {
-    let left = left_ids.contains(identity);
-    let removed = removed_ids.contains(identity)
-        || (!left && matches!(status, iroh_rooms::room::Status::Removed));
-    proj::standing(removed, left)
+/// This daemon's observed path labels for one room's peers.
+type PeerPathMap =
+    std::collections::HashMap<iroh_rooms::experimental::session::EndpointId, &'static str>;
+
+/// The per-device provider rows for a set of devices — the one
+/// `{subject_id, device_id, link}` shape `room.peers`, `file.list`, and
+/// `provider_unreachable` all serve. A device the fold cannot bind to a subject
+/// is omitted rather than attributed to an invented one.
+fn provider_rows(
+    devices: &[iroh_rooms::identity::DeviceKey],
+    snapshot: &MembershipSnapshot,
+    peer_entries: &PeerEntryMap,
+    peer_paths: &PeerPathMap,
+) -> Vec<PeerRow> {
+    devices
+        .iter()
+        .filter_map(|device| {
+            let subject = snapshot.identity_of_device(device)?;
+            let endpoint = crate::supervisor::endpoint_id_of(*device).ok();
+            let link = endpoint
+                .as_ref()
+                .and_then(|endpoint| peer_entries.get(endpoint))
+                .map_or(
+                    Link::NotConnected {
+                        reason: LinkReason::NeverDialed,
+                    },
+                    |entry| {
+                        peer_link(
+                            entry,
+                            endpoint
+                                .as_ref()
+                                .and_then(|endpoint| peer_paths.get(endpoint).copied()),
+                        )
+                    },
+                );
+            Some(PeerRow {
+                subject_id: SubjectId::new(subject.to_string()),
+                device_id: DeviceId::new(device.to_string()),
+                link,
+            })
+        })
+        .collect()
 }
 
 /// The v2 wire label for a status label (snake_case, matching the Iroh
@@ -1720,35 +2404,6 @@ fn status_label_parse(label: &str) -> CoreResult<StatusLabel> {
     })
 }
 
-/// Map an on-wire progress percent to the v2 variant.
-fn proj_progress(pct: Option<u64>) -> Progress {
-    match pct {
-        Some(p) => Progress::Reported {
-            percent: u8::try_from(p.min(100)).unwrap_or(100),
-        },
-        None => Progress::Absent,
-    }
-}
-
-/// The wire `<ts>` for an author-dated ms instant.
-fn proj_ts(created_at_ms: u64) -> Timestamp {
-    checked_timestamp(created_at_ms).unwrap_or_else(proj_epoch)
-}
-
-/// Convert a millisecond instant only when it is representable on the wire.
-fn checked_timestamp(created_at_ms: u64) -> Option<Timestamp> {
-    let secs = i64::try_from(created_at_ms / 1000).ok()?;
-    time::OffsetDateTime::from_unix_timestamp(secs)
-        .ok()
-        .map(Timestamp::new)
-}
-
-/// The Unix epoch as a `<ts>` (an honest "unknown instant", never the wall
-/// clock).
-fn proj_epoch() -> Timestamp {
-    Timestamp::new(time::OffsetDateTime::UNIX_EPOCH)
-}
-
 /// Whether a socket address is loopback (IPv4 127.0.0.0/8 or IPv6 ::1).
 fn is_loopback_addr(addr: &std::net::SocketAddr) -> bool {
     addr.ip().is_loopback()
@@ -1757,17 +2412,19 @@ fn is_loopback_addr(addr: &std::net::SocketAddr) -> bool {
 /// Convert the runtime's observed peer state to the one shared v2 link
 /// vocabulary. The state-change clock is observability data (the `since`
 /// field), not a signed room-event timestamp.
+///
+/// A `since` that will not convert to a wire instant makes the link
+/// `not_connected { no_route }` rather than a connection dated to the epoch:
+/// the `direct` and `relay` arms carry `since` as a required field, so a link
+/// this daemon cannot date is a link it cannot assert.
 fn peer_link(entry: &iroh_rooms::experimental::session::PeerEntry, path: Option<&str>) -> Link {
     use iroh_rooms::experimental::session::{OfflineReason, PeerConnState};
 
     if entry.state == PeerConnState::Connected {
-        return match path {
-            Some("relay") => Link::Relay {
-                since: proj_ts(entry.last_change_ms),
-            },
-            Some("direct" | "mixed") => Link::Direct {
-                since: proj_ts(entry.last_change_ms),
-            },
+        let since = proj::ts(entry.last_change_ms);
+        return match (path, since) {
+            (Some("relay"), Some(since)) => Link::Relay { since },
+            (Some("direct" | "mixed"), Some(since)) => Link::Direct { since },
             _ => Link::NotConnected {
                 reason: LinkReason::NoRoute,
             },
@@ -1781,12 +2438,33 @@ fn peer_link(entry: &iroh_rooms::experimental::session::PeerEntry, path: Option<
     Link::NotConnected { reason }
 }
 
-/// Split a `"host:port"` loopback address into a `Target`.
-fn split_host_port(addr: &str) -> (String, u64) {
-    match addr.rsplit_once(':') {
-        Some((host, port)) => (host.to_string(), port.parse().unwrap_or(0)),
-        None => (addr.to_string(), 0),
-    }
+/// A room's `room_created` origin event, looked up **by kind**.
+///
+/// Never `room_tail(room_id, 1)`: that is the newest row, which equals the
+/// genesis only on a room that has exactly one event.
+fn genesis_event(
+    store: &iroh_rooms::experimental::store::EventStore,
+    room_id: &IrohRoomId,
+) -> Option<SignedEvent> {
+    store
+        .by_type(room_id, EventType::RoomCreated)
+        .ok()?
+        .iter()
+        .find_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+}
+
+/// A `"host:port"` address as the v2 `target` object, or `None` when the
+/// string is not a socket address.
+///
+/// It parses rather than splits on the last colon: a bare IPv6 literal has
+/// several, and the old split produced `port: 0` for anything it could not
+/// read — a port the caller would dial and a listener that never bound.
+fn parse_target(addr: &str) -> Option<Target> {
+    let parsed: std::net::SocketAddr = addr.parse().ok()?;
+    Some(Target {
+        host: parsed.ip().to_string(),
+        port: u64::from(parsed.port()),
+    })
 }
 
 /// The closed pipe ids (revoked), for the pipe list filter.
@@ -1808,51 +2486,140 @@ fn closed_pipe_ids(
     Ok(ids)
 }
 
-/// The room an authority-gated operation targets, for the dispatch-time
-/// validation-order step 6 role check. Returns `Some((api_room, iroh_room))`
-/// for `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`;
-/// `None` for every other operation. A malformed room id yields no gate here
-/// — the operation's own `parse_room` reports it.
-/// The room an authority-gated operation targets, for the dispatch-time
-/// validation-order steps 5–6. Returns `Ok(Some((api_room, iroh_room)))` for
-/// `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`;
-/// `Ok(None)` for every other operation. A malformed room id yields no gate
-/// (the operation's own `parse_room` reports it). Step 1 (structure) runs
-/// here for `invite.list`: an out-of-bounds paging `limit` is
-/// `invalid_argument` before the room/role preflight, per the normative
-/// validation order.
-fn authority_gated_room(call: &TypedCall) -> Result<Option<(RoomId, IrohRoomId)>, ApiError> {
-    let api_room = match call {
-        TypedCall::MemberRemove(r) => {
-            if r.subject_id
-                .as_str()
-                .trim()
-                .parse::<iroh_rooms::identity::IdentityKey>()
-                .is_err()
-            {
-                return Err(ApiError::InvalidArgument {
-                    field: "in.subject_id".into(),
-                    reason: InvalidReason::Format,
-                });
-            }
-            &r.room_id
+// ---------------------------------------------------------------------------
+// The normative validation pipeline (see the module docs)
+// ---------------------------------------------------------------------------
+
+/// The paging fields an operation carries, if any. Exactly the record's **six
+/// paging operations** — `room.timeline`, `room.archive`, `status.history`,
+/// `invite.list`, `file.list`, and `pipe.list` — answer `Some`, and they all
+/// take the same three fields with the same bounds.
+fn request_page(call: &TypedCall) -> Option<&Page> {
+    match call {
+        TypedCall::RoomTimeline(r) => Some(&r.page),
+        TypedCall::RoomArchive(r) => Some(&r.page),
+        TypedCall::StatusHistory(r) => Some(&r.page),
+        TypedCall::InviteList(r) => Some(&r.page),
+        TypedCall::FileList(r) => Some(&r.page),
+        TypedCall::PipeList(r) => Some(&r.page),
+        _ => None,
+    }
+}
+
+/// **Validation-order step 1** — the structural checks the codec could not
+/// make, applied before every later stage for every operation.
+///
+/// The codec owns the rest of step 1: it decodes each request into its typed
+/// shape, so a missing key, an unrecognised key, a wrong JSON type, and a
+/// malformed `cursor` or `direction` are all refused at the edge. What is left
+/// here is what needs a **served** value the wire types cannot express:
+///
+/// - `limit` against `timeline_page_max`, for all six paging operations. The
+///   record refuses an out-of-range page size, never silently clamps it, and
+///   never answers `resource_exhausted` for it.
+/// - `member.remove`'s `subject_id` format, so a malformed identity is a
+///   structural refusal rather than reaching the authority gate.
+///
+/// This runs **ahead of the subject stage**, per the record's normative table
+/// and its stated reason: step 1 discloses only value formats and served
+/// limits — both already published in `hello` — and never daemon state, so
+/// putting it first costs the non-oracle property nothing while sparing a
+/// caller a round trip that reports the wrong problem.
+pub(crate) fn validate_structure(call: &TypedCall) -> Result<(), ApiError> {
+    if let Some(page) = request_page(call) {
+        Window::resolve(page)?;
+    }
+    if let TypedCall::MemberRemove(r) = call {
+        if r.subject_id
+            .as_str()
+            .trim()
+            .parse::<iroh_rooms::identity::IdentityKey>()
+            .is_err()
+        {
+            return Err(ApiError::InvalidArgument {
+                field: "in.subject_id".into(),
+                reason: InvalidReason::Format,
+            });
         }
-        TypedCall::InviteMint(r) => &r.room_id,
-        TypedCall::InviteRevoke(r) => &r.room_id,
-        TypedCall::InviteList(r) => {
-            // Step 1 first: a structurally invalid page (limit outside
-            // 1..=timeline_page_max) is invalid_argument, never gated by
-            // role. Window::resolve is the one bound check.
-            Window::resolve(&r.page)?;
-            &r.room_id
-        }
-        _ => return Ok(None),
-    };
-    let iroh_room = match api_room.as_str().trim().parse() {
-        Ok(r) => r,
-        Err(_) => return Ok(None),
-    };
-    Ok(Some((api_room.clone(), iroh_room)))
+    }
+    Ok(())
+}
+
+/// **Validation-order steps 4–6 scope** — the `room_id` an operation's `in`
+/// carries, or `None` for one that carries none.
+///
+/// The record makes this decidable from the schema rather than by convention:
+/// the eight operations with no `room_id` are `subject.ensure`, `daemon.stop`,
+/// `room.list`, `invite.redeem`, `fleet.list`, `transfer.cancel`, and
+/// `pipe.release` — plus, in this dispatcher, nothing else, because the three
+/// `stream.*` operations are connection-scoped and their host authorizes them
+/// against the same typed reads (see the module docs).
+fn request_room(call: &TypedCall) -> Option<&RoomId> {
+    match call {
+        TypedCall::RoomActivate(r) => Some(&r.room_id),
+        TypedCall::RoomDeactivate(r) => Some(&r.room_id),
+        TypedCall::RoomLeave(r) => Some(&r.room_id),
+        TypedCall::RoomTimeline(r) => Some(&r.room_id),
+        TypedCall::RoomMembers(r) => Some(&r.room_id),
+        TypedCall::RoomArchive(r) => Some(&r.room_id),
+        TypedCall::RoomPeers(r) => Some(&r.room_id),
+        TypedCall::MemberRemove(r) => Some(&r.room_id),
+        TypedCall::InviteMint(r) => Some(&r.room_id),
+        TypedCall::InviteList(r) => Some(&r.room_id),
+        TypedCall::InviteRevoke(r) => Some(&r.room_id),
+        TypedCall::MessageSend(r) => Some(&r.room_id),
+        TypedCall::StatusPost(r) => Some(&r.room_id),
+        TypedCall::StatusHistory(r) => Some(&r.room_id),
+        TypedCall::FileShare(r) => Some(&r.room_id),
+        TypedCall::FileList(r) => Some(&r.room_id),
+        TypedCall::FileFetch(r) => Some(&r.room_id),
+        TypedCall::FileRead(r) => Some(&r.room_id),
+        TypedCall::PipePublish(r) => Some(&r.room_id),
+        TypedCall::PipeList(r) => Some(&r.room_id),
+        TypedCall::PipeConnect(r) => Some(&r.room_id),
+        TypedCall::PipeRevoke(r) => Some(&r.room_id),
+        TypedCall::StreamSubscribe(r) => Some(&r.room_id),
+        TypedCall::StreamUnsubscribe(r) => Some(&r.room_id),
+        TypedCall::StreamResync(r) => Some(&r.room_id),
+        TypedCall::SubjectEnsure(_)
+        | TypedCall::DaemonStop(_)
+        | TypedCall::RoomCreate(_)
+        | TypedCall::RoomList(_)
+        | TypedCall::InviteRedeem(_)
+        | TypedCall::FleetList(_)
+        | TypedCall::TransferCancel(_)
+        | TypedCall::PipeRelease(_) => None,
+    }
+}
+
+/// **Validation-order step 5 exception** — the operations defined over a
+/// *former* membership, which therefore skip the standing stage.
+///
+/// The record names exactly two: `room.archive` and `room.list`. Only
+/// `room.archive` appears here, because `room.list` carries no `room_id` and so
+/// never reaches step 4 in the first place. `room.archive` exists *to* open a
+/// room the caller has left, so refusing it on standing would make it
+/// unreachable in every state it is defined for; it checks the converse
+/// (`room_still_active`) in its own body.
+fn standing_exempt(call: &TypedCall) -> bool {
+    matches!(call, TypedCall::RoomArchive(_))
+}
+
+/// **Validation-order step 6 scope** — the four operations that require
+/// `role: "authority"`, and no others.
+///
+/// `member.remove`, `invite.mint`, `invite.revoke`, and `invite.list`. Every
+/// other operation is open to any active member; in particular `pipe.revoke`
+/// is **not** here — it is restricted to the pipe's publisher, a narrower
+/// relation than role that answers `pipe_not_publisher`.
+fn requires_authority(call: &TypedCall) -> bool {
+    matches!(
+        call,
+        TypedCall::MemberRemove(_)
+            | TypedCall::InviteMint(_)
+            | TypedCall::InviteRevoke(_)
+            | TypedCall::InviteList(_)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1871,152 +2638,121 @@ pub(crate) async fn dispatch(
     call: TypedCall,
 ) -> Result<TypedReply, ApiError> {
     let t = TypedSupervisor::new(sup);
-    // Validation-order step 2 (subject precondition): every operation except
-    // `subject.ensure` — which exists to create the subject — requires a local
-    // subject before any later stage (dedup, room index, standing, role,
-    // semantics) runs. `subject_absent` outranks `room_not_available` and is
-    // never a membership oracle.
-    if !matches!(call, TypedCall::SubjectEnsure(_)) && !t.subject_present()? {
+
+    // Step 1 — structural decode and bounds, for every operation.
+    validate_structure(&call)?;
+
+    // Step 2 — subject precondition. `subject_absent` outranks
+    // `room_not_available` and every later stage, so a subject-less caller can
+    // never use error-code selection as a room probe.
+    //
+    // Two operations skip it, and the stage table's own rule is why: a stage
+    // "runs only where its precondition is meaningful". `subject.ensure` skips
+    // it because it exists to create the subject. `daemon.stop` skips it
+    // because its precondition is a running daemon, not a local subject — it
+    // reads and writes no subject state, and `daemon_stop_does_not_require_a_
+    // subject` in the corpus settles that it must succeed on a fresh daemon.
+    //
+    // Refusing it here would also be a **refusal that still acts**: the stop is
+    // sequenced by `Engine::execute_with` before dispatch runs (the reply must
+    // flush before teardown), so a step-2 refusal would tell the client the
+    // operation failed while the daemon exited anyway. The record's stage table
+    // names only `subject.ensure`, and this second exemption is recorded as a
+    // divergence on #165 rather than left as a contradiction between the reply
+    // and the effect.
+    let skips_subject = matches!(call, TypedCall::SubjectEnsure(_) | TypedCall::DaemonStop(_));
+    if !skips_subject && !t.subject_present()? {
         return Err(ApiError::SubjectAbsent);
     }
-    // Validation-order steps 5 and 6 (standing, then role) for the four
-    // authority-gated operations (`member.remove`, `invite.mint`,
-    // `invite.revoke`, `invite.list`). Step 1 (structure) runs first: a
-    // structurally invalid request (a paging `limit` outside
-    // `1..=timeline_page_max`) is `invalid_argument` before any room/role
-    // preflight, so authorization behavior is never exposed for malformed
-    // input. Step 5 (standing) runs before step 6 (role): a former member is
-    // `membership_ended`, never `insufficient_standing` — the role code is
-    // defined only for active members. A room the caller cannot read answers
-    // `room_not_available` (step 4 outranks both), and a room-index failure
-    // is `room_index_unreadable`, never a generic error.
-    if let Some((api_room, iroh_room)) = authority_gated_room(&call)? {
-        let snapshot = t
-            .sup
-            .readable_snapshot(&iroh_room)
-            .await
-            .map_err(|e| match e.kind {
-                ErrorKind::Internal => ApiError::RoomIndexUnreadable,
-                _ => core_to_api_room(e, &api_room),
-            })?;
-        t.require_active_standing(&api_room, &iroh_room, &snapshot)?;
-        t.require_role(&api_room, &snapshot, Role::Authority)?;
-    }
+
+    // Step 3 — dedup. It lives in `Engine::execute_with`, which consults the
+    // ledger after running steps 1 and 2 and before calling this function, so a
+    // structurally invalid or subject-less request never binds an `op_id` to a
+    // refusal a corrected retry would then replay.
+
+    // Steps 4, 5, and 6 — room index, standing, role — for every operation
+    // whose `in` carries a `room_id`, in one place with one ordering.
+    let ctx = match request_room(&call) {
+        Some(api_room) => Some(
+            t.room_context(api_room, standing_exempt(&call), requires_authority(&call))
+                .await?,
+        ),
+        None => None,
+    };
+    // Every room-bearing arm below unwraps this; `request_room` and the match
+    // are the same total enumeration, so the two cannot drift apart without a
+    // compile error in `request_room`'s exhaustive match.
+    let room = || {
+        ctx.as_ref()
+            .expect("a room-bearing call resolved a context")
+    };
+
+    // Step 7 — operation semantics.
     match call {
         TypedCall::SubjectEnsure(_) => t
             .subject_ensure()
             .map(TypedReply::SubjectEnsure)
             .map_err(core_to_api),
-        TypedCall::RoomCreate(r) => t
-            .room_create(&r)
-            .map(TypedReply::RoomCreate)
-            .map_err(core_to_api),
+        TypedCall::RoomCreate(r) => t.room_create(&r).await.map(TypedReply::RoomCreate),
         TypedCall::RoomList(_) => t.room_list().await.map(TypedReply::RoomList),
         TypedCall::RoomActivate(r) => t
-            .room_activate(&r)
+            .room_activate(room(), &r)
             .await
-            .map(TypedReply::RoomActivate)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::RoomDeactivate(r) => t.room_deactivate(&r).await.map(TypedReply::RoomDeactivate),
-        TypedCall::RoomLeave(r) => t
-            .room_leave(&r)
+            .map(TypedReply::RoomActivate),
+        TypedCall::RoomDeactivate(r) => t
+            .room_deactivate(room(), &r)
             .await
-            .map(TypedReply::RoomLeave)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::RoomTimeline(r) => t.room_timeline(&r).await.map(TypedReply::RoomTimeline),
-        TypedCall::RoomMembers(r) => t.room_members(&r).await.map(TypedReply::RoomMembers),
-        TypedCall::RoomArchive(r) => t
-            .room_archive(&r)
+            .map(TypedReply::RoomDeactivate),
+        TypedCall::RoomLeave(r) => t.room_leave(room(), &r).await.map(TypedReply::RoomLeave),
+        TypedCall::RoomTimeline(r) => t.room_timeline(room(), &r).map(TypedReply::RoomTimeline),
+        TypedCall::RoomMembers(r) => t.room_members(room(), &r).map(TypedReply::RoomMembers),
+        TypedCall::RoomArchive(r) => t.room_archive(room(), &r).map(TypedReply::RoomArchive),
+        TypedCall::RoomPeers(r) => t.room_peers(room(), &r).await.map(TypedReply::RoomPeers),
+        TypedCall::MemberRemove(r) => t
+            .member_remove(room(), &r)
             .await
-            .map(TypedReply::RoomArchive)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::RoomPeers(r) => t
-            .room_peers(&r)
-            .await
-            .map(TypedReply::RoomPeers)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::MemberRemove(r) => t.member_remove(&r).await.map(TypedReply::MemberRemove),
-        TypedCall::InviteMint(r) => t
-            .invite_mint(&r)
-            .await
-            .map(TypedReply::InviteMint)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::InviteList(r) => t.invite_list(&r).await.map(TypedReply::InviteList),
+            .map(TypedReply::MemberRemove),
+        TypedCall::InviteMint(r) => t.invite_mint(room(), &r).await.map(TypedReply::InviteMint),
+        TypedCall::InviteList(r) => t.invite_list(room(), &r).map(TypedReply::InviteList),
         TypedCall::InviteRevoke(r) => t
-            .invite_revoke(&r)
+            .invite_revoke(room(), &r)
             .await
-            .map(TypedReply::InviteRevoke)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::InviteRedeem(r) => t
-            .invite_redeem(&r)
-            .await
-            .map(TypedReply::InviteRedeem)
-            .map_err(core_to_api),
+            .map(TypedReply::InviteRevoke),
+        TypedCall::InviteRedeem(r) => t.invite_redeem(&r).await.map(TypedReply::InviteRedeem),
         TypedCall::MessageSend(r) => t
-            .message_send(&r)
+            .message_send(room(), &r)
             .await
-            .map(TypedReply::MessageSend)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::StatusPost(r) => t
-            .status_post(&r)
+            .map(TypedReply::MessageSend),
+        TypedCall::StatusPost(r) => t.status_post(room(), &r).await.map(TypedReply::StatusPost),
+        TypedCall::StatusHistory(r) => t.status_history(room(), &r).map(TypedReply::StatusHistory),
+        TypedCall::FleetList(_) => t.fleet_list().await.map(TypedReply::FleetList),
+        TypedCall::FileShare(r) => t.file_share(room(), &r).await.map(TypedReply::FileShare),
+        TypedCall::FileList(r) => t.file_list(room(), &r).await.map(TypedReply::FileList),
+        TypedCall::FileFetch(r) => t.file_fetch(room(), &r).await.map(TypedReply::FileFetch),
+        TypedCall::FileRead(r) => t.file_read(room(), &r).await.map(TypedReply::FileRead),
+        TypedCall::TransferCancel(r) => t.transfer_cancel(&r).await.map(TypedReply::TransferCancel),
+        TypedCall::PipePublish(r) => t
+            .pipe_publish(room(), &r)
             .await
-            .map(TypedReply::StatusPost)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::StatusHistory(r) => t
-            .status_history(&r)
+            .map(TypedReply::PipePublish),
+        TypedCall::PipeList(r) => t.pipe_list(room(), &r).await.map(TypedReply::PipeList),
+        TypedCall::PipeConnect(r) => t
+            .pipe_connect(room(), &r)
             .await
-            .map(TypedReply::StatusHistory)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::FleetList(_) => t
-            .fleet_list()
-            .await
-            .map(TypedReply::FleetList)
-            .map_err(core_to_api),
-        TypedCall::FileShare(r) => t
-            .file_share(&r)
-            .await
-            .map(TypedReply::FileShare)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::FileList(r) => t
-            .file_list(&r)
-            .await
-            .map(TypedReply::FileList)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::FileFetch(r) => t
-            .file_fetch(&r)
-            .await
-            .map(TypedReply::FileFetch)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::FileRead(r) => t
-            .file_read(&r)
-            .await
-            .map(TypedReply::FileRead)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::TransferCancel(r) => t
-            .transfer_cancel(&r)
-            .await
-            .map(TypedReply::TransferCancel)
-            .map_err(core_to_api),
-        TypedCall::PipePublish(r) => t.pipe_publish(&r).await.map(TypedReply::PipePublish),
-        TypedCall::PipeList(r) => t
-            .pipe_list(&r)
-            .await
-            .map(TypedReply::PipeList)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        TypedCall::PipeConnect(r) => t.pipe_connect(&r).await.map(TypedReply::PipeConnect),
+            .map(TypedReply::PipeConnect),
         TypedCall::PipeRelease(r) => t.pipe_release(&r).await.map(TypedReply::PipeRelease),
-        TypedCall::PipeRevoke(r) => t
-            .pipe_revoke(&r)
-            .await
-            .map(TypedReply::PipeRevoke)
-            .map_err(|e| core_to_api_room(e, &r.room_id)),
-        // Stream operations are connection-scoped; the engine handles them
-        // against the connection's subscription set, not the supervisor.
-        TypedCall::StreamSubscribe(_)
-        | TypedCall::StreamUnsubscribe(_)
-        | TypedCall::StreamResync(_) => Err(ApiError::SubscriptionUnknown {
-            room_id: RoomId::new(""),
-        }),
+        TypedCall::PipeRevoke(r) => t.pipe_revoke(room(), &r).await.map(TypedReply::PipeRevoke),
+        // Stream operations are connection-scoped: the host resolves them
+        // against the connection's own subscription set, not the supervisor.
+        // Reaching this dispatcher means no such subscription exists on the
+        // caller's connection, and the refusal names the room it asked about
+        // rather than an invented empty id. The room-access stages above have
+        // already run, so this is never a membership oracle.
+        TypedCall::StreamSubscribe(r) => Err(ApiError::SubscriptionUnknown { room_id: r.room_id }),
+        TypedCall::StreamUnsubscribe(r) => {
+            Err(ApiError::SubscriptionUnknown { room_id: r.room_id })
+        }
+        TypedCall::StreamResync(r) => Err(ApiError::SubscriptionUnknown { room_id: r.room_id }),
         TypedCall::DaemonStop(_) => Ok(TypedReply::DaemonStop(DaemonStopOut { stopping: true })),
     }
 }
@@ -2307,66 +3043,88 @@ pub enum TypedReply {
     PipeRevoke(PipeRevokeOut),
 }
 
-/// Map a typed [`ApiError`] back onto a core error, for the typed-read paths
-/// that still surface `CoreResult` internally.
-fn api_to_core(err: ApiError) -> CoreError {
-    match err {
-        ApiError::InvalidArgument { .. } => {
-            CoreError::new(ErrorKind::InvalidParams, "invalid paging argument")
-        }
-        ApiError::RoomIndexUnreadable => {
-            CoreError::new(ErrorKind::Internal, "room index unreadable")
-        }
-        _ => CoreError::internal("typed projection error"),
+/// Map a core error onto the typed v2 taxonomy **with no room context**.
+///
+/// Every room-scoped code needs a `room_id`, and the record's error schema
+/// fixes that field: a client branches on it. So there is no roomless mapping
+/// that can produce one honestly, and this function does not invent `""`.
+///
+/// The room-scoped kinds are unreachable here by construction — every operation
+/// that can raise one names a room and uses [`core_to_api_room`] — and if one
+/// arrives anyway it is an index this daemon could not read, which is the
+/// fieldless `room_index_unreadable`, not a refusal about a room nobody named.
+fn core_to_api(err: CoreError) -> ApiError {
+    match err.kind {
+        ErrorKind::IdentityMissing => ApiError::SubjectAbsent,
+        ErrorKind::BadTicket => ApiError::CapabilityInvalid,
+        ErrorKind::IdentityExists | ErrorKind::InvalidParams => ApiError::InvalidArgument {
+            field: "in".to_string(),
+            reason: InvalidReason::Format,
+        },
+        ErrorKind::RoomUnknown
+        | ErrorKind::NotAMember
+        | ErrorKind::FileUnauthorized
+        | ErrorKind::RoomNotOpen
+        | ErrorKind::TicketExpired
+        | ErrorKind::FileUnavailable
+        | ErrorKind::HashMismatch
+        | ErrorKind::PipeDenied
+        | ErrorKind::PeerUnreachable
+        | ErrorKind::Internal => ApiError::RoomIndexUnreadable,
     }
 }
 
-/// Map a core error onto the typed v2 taxonomy at the engine boundary. A
-/// room-scoped error carries the identifier the operation named, never an
-/// empty placeholder — the typed error schema fixes the field and a client
-/// branches on it.
-fn core_to_api(err: CoreError) -> ApiError {
-    core_to_api_ctx(err, None)
-}
-
-/// [`core_to_api`] with the room the operation named, for room-scoped errors.
+/// Map a core error onto the typed v2 taxonomy for an operation that named a
+/// room. Every room-scoped code carries **that** identifier — the one the
+/// caller supplied one frame earlier, which discloses nothing back to it and is
+/// what the record's `room_not_available` echo requires.
+///
+/// Codes whose typed fields name something other than a room (`file_id`,
+/// `pipe_id`, a digest pair) are **not** produced here: the operation that owns
+/// them holds those values and builds the error itself, because an error whose
+/// typed field is an empty string is a schema satisfied and a fact invented.
 fn core_to_api_room(err: CoreError, room_id: &RoomId) -> ApiError {
-    core_to_api_ctx(err, Some(room_id.clone()))
-}
-
-fn core_to_api_ctx(err: CoreError, room_id: Option<RoomId>) -> ApiError {
-    let rid = || room_id.clone().unwrap_or_else(|| RoomId::new(""));
     match err.kind {
         ErrorKind::IdentityMissing => ApiError::SubjectAbsent,
         ErrorKind::RoomUnknown | ErrorKind::NotAMember | ErrorKind::FileUnauthorized => {
-            ApiError::RoomNotAvailable { room_id: rid() }
-        }
-        ErrorKind::RoomNotOpen => ApiError::RoomNotLive { room_id: rid() },
-        ErrorKind::BadTicket => ApiError::CapabilityInvalid,
-        ErrorKind::TicketExpired => ApiError::CapabilityExpired {
-            expired_at: proj_epoch(),
-        },
-        ErrorKind::FileUnavailable => ApiError::ProviderUnreachable {
-            file_id: FileId::new(""),
-            providers: Vec::new(),
-        },
-        ErrorKind::HashMismatch => ApiError::DigestMismatch {
-            expected: String::new(),
-            observed: String::new(),
-        },
-        ErrorKind::PipeDenied => ApiError::PolicyRefused { room_id: rid() },
-        ErrorKind::PeerUnreachable => ApiError::PipeUnreachable {
-            pipe_id: PipeId::new(""),
-            link: Link::NotConnected {
-                reason: LinkReason::NoRoute,
-            },
-        },
-        ErrorKind::IdentityExists | ErrorKind::InvalidParams | ErrorKind::Internal => {
-            ApiError::InvalidArgument {
-                field: "in".to_string(),
-                reason: InvalidReason::Format,
+            ApiError::RoomNotAvailable {
+                room_id: room_id.clone(),
             }
         }
+        ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
+            room_id: room_id.clone(),
+        },
+        ErrorKind::PipeDenied => ApiError::PolicyRefused {
+            room_id: room_id.clone(),
+        },
+        ErrorKind::BadTicket => ApiError::CapabilityInvalid,
+        ErrorKind::IdentityExists | ErrorKind::InvalidParams => ApiError::InvalidArgument {
+            field: "in".to_string(),
+            reason: InvalidReason::Format,
+        },
+        // A store or fold failure the operation did not classify. It is a read
+        // this daemon could not complete, not a malformed request.
+        ErrorKind::TicketExpired
+        | ErrorKind::FileUnavailable
+        | ErrorKind::HashMismatch
+        | ErrorKind::PeerUnreachable
+        | ErrorKind::Internal => ApiError::RoomIndexUnreadable,
+    }
+}
+
+/// The redemption-side refusal a failed `invite.redeem` earns.
+///
+/// `invite.redeem` is the only operation a non-member can reach, so **every**
+/// failure here is one of the four redemption-side codes. A room-scoped code
+/// would name a room to a caller who is not in it — the probe the non-oracle
+/// property exists to prevent — and `capability_invalid` is deliberately
+/// fieldless so a forged capability, one for a room that does not exist, and one
+/// naming a different identity are indistinguishable.
+fn redemption_error(err: CoreError, expired_at: Option<Timestamp>) -> ApiError {
+    match (err.kind, expired_at) {
+        // The instant comes from the capability the caller itself presented.
+        (ErrorKind::TicketExpired, Some(expired_at)) => ApiError::CapabilityExpired { expired_at },
+        _ => ApiError::CapabilityInvalid,
     }
 }
 
@@ -2375,84 +3133,1134 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// The dispatch-time role gate targets exactly the four authority
-    /// operations the record names — no more (an open operation must not be
-    /// gated by accident), no fewer.
-    #[test]
-    fn authority_gated_room_covers_exactly_the_four_authority_ops() {
-        let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
-        let gated = |call: &TypedCall| authority_gated_room(call).ok().flatten().is_some();
-        let member_id = iroh_rooms::identity::SigningKey::generate()
-            .identity_key()
-            .to_string();
-        assert!(gated(&TypedCall::MemberRemove(MemberRemove {
-            room_id: rid(),
-            subject_id: SubjectId::new(member_id),
-        })));
-        assert!(gated(&TypedCall::InviteMint(InviteMint {
-            room_id: rid(),
-            subject_id: SubjectId::new("s"),
-            role: Role::Member,
-            expires_at: proj_epoch(),
-        })));
-        assert!(gated(&TypedCall::InviteRevoke(InviteRevoke {
-            room_id: rid(),
-            invite_id: InviteId::new("i"),
-        })));
-        assert!(gated(&TypedCall::InviteList(InviteList {
-            room_id: rid(),
-            page: Page {
-                cursor: Cursor::Start,
-                direction: Direction::Forward,
-                limit: 1,
-            },
-        })));
-        // Open operations are NOT gated: a plain member runs them.
-        assert!(!gated(&TypedCall::MessageSend(MessageSend {
-            room_id: rid(),
-            body: "hi".into(),
-        })));
-        assert!(!gated(&TypedCall::PipePublish(PipePublish {
-            room_id: rid(),
-            target: Target {
-                host: "127.0.0.1".into(),
-                port: 9,
-            },
-            audience: Audience::Room,
-        })));
+    // ------------------------------------------------------------------
+    // The pipeline's scope tables
+    //
+    // Each stage runs for a set the record fixes. These assert the set, not a
+    // sample of it: a stage that quietly grew or lost an operation is the
+    // "rule with a carve-out" failure the record warns about, and only an
+    // exhaustive table catches it.
+    // ------------------------------------------------------------------
+
+    fn rid() -> RoomId {
+        RoomId::new(format!("blake3:{}", "ab".repeat(32)))
     }
 
-    /// Validation-order step 1 (structure) precedes the role gate: an
-    /// `invite.list` with a `limit` outside `1..=timeline_page_max` is
-    /// `invalid_argument { field: "in.limit", reason: bound }`, never
-    /// `insufficient_standing` — authorization is not exposed for malformed
-    /// input.
-    #[test]
-    fn invite_list_out_of_bounds_limit_is_invalid_argument_before_role() {
-        let rid = || RoomId::new(format!("blake3:{}", "ab".repeat(32)));
-        for limit in [0, limits().timeline_page_max + 1] {
-            let call = TypedCall::InviteList(InviteList {
+    fn page() -> Page {
+        Page {
+            cursor: Cursor::Start,
+            direction: Direction::Forward,
+            limit: 32,
+        }
+    }
+
+    fn subject() -> SubjectId {
+        SubjectId::new(
+            iroh_rooms::identity::SigningKey::generate()
+                .identity_key()
+                .to_string(),
+        )
+    }
+
+    /// One well-formed call per operation, so a scope table can be asserted
+    /// over all 33 rather than over a sample.
+    fn every_call() -> Vec<TypedCall> {
+        vec![
+            TypedCall::SubjectEnsure(SubjectEnsure {}),
+            TypedCall::DaemonStop(DaemonStop {}),
+            TypedCall::RoomCreate(RoomCreate { name: "R".into() }),
+            TypedCall::RoomList(RoomList {}),
+            TypedCall::RoomActivate(RoomActivate { room_id: rid() }),
+            TypedCall::RoomDeactivate(RoomDeactivate { room_id: rid() }),
+            TypedCall::RoomLeave(RoomLeave { room_id: rid() }),
+            TypedCall::RoomTimeline(RoomTimeline {
                 room_id: rid(),
-                page: Page {
-                    cursor: Cursor::Start,
-                    direction: Direction::Forward,
-                    limit,
+                page: page(),
+            }),
+            TypedCall::RoomMembers(RoomMembers { room_id: rid() }),
+            TypedCall::RoomArchive(RoomArchive {
+                room_id: rid(),
+                page: page(),
+            }),
+            TypedCall::RoomPeers(RoomPeers { room_id: rid() }),
+            TypedCall::MemberRemove(MemberRemove {
+                room_id: rid(),
+                subject_id: subject(),
+            }),
+            TypedCall::InviteMint(InviteMint {
+                room_id: rid(),
+                subject_id: subject(),
+                role: Role::Member,
+                expires_at: Timestamp::new(time::OffsetDateTime::UNIX_EPOCH),
+            }),
+            TypedCall::InviteList(InviteList {
+                room_id: rid(),
+                page: page(),
+            }),
+            TypedCall::InviteRevoke(InviteRevoke {
+                room_id: rid(),
+                invite_id: InviteId::new("i"),
+            }),
+            TypedCall::InviteRedeem(InviteRedeem {
+                capability: "cap".into(),
+            }),
+            TypedCall::MessageSend(MessageSend {
+                room_id: rid(),
+                body: "hi".into(),
+            }),
+            TypedCall::StatusPost(StatusPost {
+                room_id: rid(),
+                label: StatusLabel::Working,
+                progress: Progress::Absent,
+            }),
+            TypedCall::StatusHistory(StatusHistory {
+                room_id: rid(),
+                subject_id: subject(),
+                page: page(),
+            }),
+            TypedCall::FleetList(FleetList {}),
+            TypedCall::FileShare(FileShare {
+                room_id: rid(),
+                name: "f".into(),
+                declared_bytes: 1,
+                declared_content_type: "text/plain".into(),
+            }),
+            TypedCall::FileList(FileList {
+                room_id: rid(),
+                page: page(),
+            }),
+            TypedCall::FileFetch(FileFetch {
+                room_id: rid(),
+                file_id: FileId::new("file_00"),
+            }),
+            TypedCall::FileRead(FileRead {
+                room_id: rid(),
+                file_id: FileId::new("file_00"),
+            }),
+            TypedCall::TransferCancel(TransferCancel {
+                transfer_op_id: OpId::new("t"),
+            }),
+            TypedCall::PipePublish(PipePublish {
+                room_id: rid(),
+                target: Target {
+                    host: "127.0.0.1".into(),
+                    port: 9,
                 },
-            });
-            let err = authority_gated_room(&call)
-                .expect_err("an out-of-bounds limit is refused at step 1");
-            assert!(
-                matches!(
+                audience: Audience::Room,
+            }),
+            TypedCall::PipeList(PipeList {
+                room_id: rid(),
+                page: page(),
+            }),
+            TypedCall::PipeConnect(PipeConnect {
+                room_id: rid(),
+                pipe_id: PipeId::new("ab".repeat(16)),
+            }),
+            TypedCall::PipeRelease(PipeRelease {
+                connection_id: "127.0.0.1:1".into(),
+            }),
+            TypedCall::PipeRevoke(PipeRevoke {
+                room_id: rid(),
+                pipe_id: PipeId::new("ab".repeat(16)),
+            }),
+            TypedCall::StreamSubscribe(StreamSubscribe {
+                room_id: rid(),
+                from: Cursor::Start,
+            }),
+            TypedCall::StreamUnsubscribe(StreamUnsubscribe { room_id: rid() }),
+            TypedCall::StreamResync(StreamResync {
+                room_id: rid(),
+                from_pos: 0,
+            }),
+        ]
+    }
+
+    #[test]
+    fn the_call_table_covers_all_thirty_three_operations() {
+        let calls = every_call();
+        let mut paths: Vec<&str> = calls.iter().map(TypedCall::path).collect();
+        paths.sort_unstable();
+        paths.dedup();
+        assert_eq!(paths.len(), 33, "one call per approved operation");
+    }
+
+    /// Validation-order step 4/5/6 scope. Every operation whose `in` carries a
+    /// `room_id` resolves a [`RoomContext`]; the eight that do not are named
+    /// exactly.
+    #[test]
+    fn room_bearing_scope_is_decidable_from_the_schema() {
+        let roomless: BTreeSet<&str> = every_call()
+            .iter()
+            .filter(|c| request_room(c).is_none())
+            .map(TypedCall::path)
+            .collect();
+        assert_eq!(
+            roomless,
+            BTreeSet::from([
+                "subject.ensure",
+                "daemon.stop",
+                "room.create",
+                "room.list",
+                "invite.redeem",
+                "fleet.list",
+                "transfer.cancel",
+                "pipe.release",
+            ]),
+            "the roomless set is exactly the operations whose `in` carries no room_id"
+        );
+    }
+
+    /// Validation-order step 5 exemption. `room.archive` is the only
+    /// room-bearing operation defined over a former membership; `room.list` is
+    /// the record's other exemption but carries no `room_id`, so it never
+    /// reaches the stage at all.
+    #[test]
+    fn standing_exemption_is_exactly_room_archive() {
+        let exempt: BTreeSet<&str> = every_call()
+            .iter()
+            .filter(|c| standing_exempt(c))
+            .map(TypedCall::path)
+            .collect();
+        assert_eq!(exempt, BTreeSet::from(["room.archive"]));
+        assert!(
+            request_room(&TypedCall::RoomList(RoomList {})).is_none(),
+            "room.list carries no room_id, so its exemption is structural"
+        );
+    }
+
+    /// Validation-order step 6 scope: exactly the four operations the record
+    /// lists, and no others. `pipe.revoke` in particular is publisher-scoped,
+    /// not authority-gated.
+    #[test]
+    fn authority_gate_is_exactly_the_four_authority_operations() {
+        let gated: BTreeSet<&str> = every_call()
+            .iter()
+            .filter(|c| requires_authority(c))
+            .map(TypedCall::path)
+            .collect();
+        assert_eq!(
+            gated,
+            BTreeSet::from([
+                "member.remove",
+                "invite.mint",
+                "invite.revoke",
+                "invite.list"
+            ])
+        );
+        assert!(
+            !requires_authority(&TypedCall::PipeRevoke(PipeRevoke {
+                room_id: rid(),
+                pipe_id: PipeId::new("ab".repeat(16)),
+            })),
+            "pipe.revoke answers pipe_not_publisher, never insufficient_standing"
+        );
+    }
+
+    /// The six paging operations, and only those, carry a [`Page`] the
+    /// structural stage bounds.
+    #[test]
+    fn paging_scope_is_exactly_the_six_paging_operations() {
+        let paged: BTreeSet<&str> = every_call()
+            .iter()
+            .filter(|c| request_page(c).is_some())
+            .map(TypedCall::path)
+            .collect();
+        assert_eq!(
+            paged,
+            BTreeSet::from([
+                "room.timeline",
+                "room.archive",
+                "status.history",
+                "invite.list",
+                "file.list",
+                "pipe.list"
+            ])
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Validation-order regressions
+    // ------------------------------------------------------------------
+
+    /// A paging call with the given limit, for each of the six.
+    fn paging_calls(limit: u64) -> Vec<TypedCall> {
+        let page = Page {
+            cursor: Cursor::Start,
+            direction: Direction::Forward,
+            limit,
+        };
+        vec![
+            TypedCall::RoomTimeline(RoomTimeline {
+                room_id: rid(),
+                page: page.clone(),
+            }),
+            TypedCall::RoomArchive(RoomArchive {
+                room_id: rid(),
+                page: page.clone(),
+            }),
+            TypedCall::StatusHistory(StatusHistory {
+                room_id: rid(),
+                subject_id: subject(),
+                page: page.clone(),
+            }),
+            TypedCall::InviteList(InviteList {
+                room_id: rid(),
+                page: page.clone(),
+            }),
+            TypedCall::FileList(FileList {
+                room_id: rid(),
+                page: page.clone(),
+            }),
+            TypedCall::PipeList(PipeList {
+                room_id: rid(),
+                page,
+            }),
+        ]
+    }
+
+    /// **Step 1 outranks step 2.** All six paging operations refuse an
+    /// out-of-range `limit` as `invalid_argument { field: "in.limit", bound }`
+    /// on a daemon with **no subject at all** — so the bound check demonstrably
+    /// precedes the subject precondition, and with it every room, standing,
+    /// role, and storage access.
+    ///
+    /// The record puts structure first and states why: step 1 discloses only
+    /// value formats and served limits, both of which `hello` already published
+    /// to this very connection, so it reveals no daemon state and costs the
+    /// non-oracle property nothing.
+    #[tokio::test]
+    async fn structural_bounds_outrank_subject_absence_for_all_six_paging_operations() {
+        let dir = tempdir().unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        // No identity is created: every later stage would refuse.
+        for limit in [0, limits().timeline_page_max + 1] {
+            for call in paging_calls(limit) {
+                let path = call.path();
+                let err = dispatch(&sup, call)
+                    .await
+                    .expect_err("an out-of-range limit is refused");
+                assert_eq!(
                     err,
                     ApiError::InvalidArgument {
-                        reason: InvalidReason::Bound { .. },
-                        ..
-                    }
-                ),
-                "limit {limit}: got {err:?}"
+                        field: "in.limit".into(),
+                        reason: InvalidReason::Bound {
+                            min: 1,
+                            max: limits().timeline_page_max,
+                        },
+                    },
+                    "{path} with limit {limit}"
+                );
+            }
+        }
+    }
+
+    /// A `limit` inside the bound passes step 1 and then meets step 2, proving
+    /// the previous test measured the bound rather than a blanket refusal.
+    #[tokio::test]
+    async fn an_in_range_limit_reaches_the_subject_stage() {
+        let dir = tempdir().unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        for call in paging_calls(32) {
+            let path = call.path();
+            let err = dispatch(&sup, call).await.expect_err("no subject exists");
+            assert_eq!(err, ApiError::SubjectAbsent, "{path}");
+        }
+    }
+
+    /// **Step 2 outranks step 4.** Every room-bearing operation answers
+    /// `subject_absent` on a subject-less daemon, whatever room it names —
+    /// unknown, well-formed, or unparseable. Error-code selection is therefore
+    /// not a room probe for a caller with no subject.
+    #[tokio::test]
+    async fn subject_absence_outranks_room_state_and_is_not_a_membership_oracle() {
+        let dir = tempdir().unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        for spelling in [
+            format!("blake3:{}", "00".repeat(32)),
+            format!("blake3:{}", "ff".repeat(32)),
+            "not-a-room-id".to_owned(),
+        ] {
+            for mut call in every_call() {
+                if request_room(&call).is_none() {
+                    continue;
+                }
+                // Re-point the call at this room spelling.
+                let room = RoomId::new(spelling.clone());
+                call = repoint(call, room);
+                let path = call.path();
+                let err = dispatch(&sup, call).await.expect_err("no subject exists");
+                assert_eq!(err, ApiError::SubjectAbsent, "{path} with room {spelling}");
+            }
+        }
+    }
+
+    /// Rebuild a call against a different room id, for the non-oracle sweep.
+    fn repoint(call: TypedCall, room_id: RoomId) -> TypedCall {
+        match call {
+            TypedCall::RoomActivate(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomActivate(r)
+            }
+            TypedCall::RoomDeactivate(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomDeactivate(r)
+            }
+            TypedCall::RoomLeave(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomLeave(r)
+            }
+            TypedCall::RoomTimeline(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomTimeline(r)
+            }
+            TypedCall::RoomMembers(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomMembers(r)
+            }
+            TypedCall::RoomArchive(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomArchive(r)
+            }
+            TypedCall::RoomPeers(mut r) => {
+                r.room_id = room_id;
+                TypedCall::RoomPeers(r)
+            }
+            TypedCall::MemberRemove(mut r) => {
+                r.room_id = room_id;
+                TypedCall::MemberRemove(r)
+            }
+            TypedCall::InviteMint(mut r) => {
+                r.room_id = room_id;
+                TypedCall::InviteMint(r)
+            }
+            TypedCall::InviteList(mut r) => {
+                r.room_id = room_id;
+                TypedCall::InviteList(r)
+            }
+            TypedCall::InviteRevoke(mut r) => {
+                r.room_id = room_id;
+                TypedCall::InviteRevoke(r)
+            }
+            TypedCall::MessageSend(mut r) => {
+                r.room_id = room_id;
+                TypedCall::MessageSend(r)
+            }
+            TypedCall::StatusPost(mut r) => {
+                r.room_id = room_id;
+                TypedCall::StatusPost(r)
+            }
+            TypedCall::StatusHistory(mut r) => {
+                r.room_id = room_id;
+                TypedCall::StatusHistory(r)
+            }
+            TypedCall::FileShare(mut r) => {
+                r.room_id = room_id;
+                TypedCall::FileShare(r)
+            }
+            TypedCall::FileList(mut r) => {
+                r.room_id = room_id;
+                TypedCall::FileList(r)
+            }
+            TypedCall::FileFetch(mut r) => {
+                r.room_id = room_id;
+                TypedCall::FileFetch(r)
+            }
+            TypedCall::FileRead(mut r) => {
+                r.room_id = room_id;
+                TypedCall::FileRead(r)
+            }
+            TypedCall::PipePublish(mut r) => {
+                r.room_id = room_id;
+                TypedCall::PipePublish(r)
+            }
+            TypedCall::PipeList(mut r) => {
+                r.room_id = room_id;
+                TypedCall::PipeList(r)
+            }
+            TypedCall::PipeConnect(mut r) => {
+                r.room_id = room_id;
+                TypedCall::PipeConnect(r)
+            }
+            TypedCall::PipeRevoke(mut r) => {
+                r.room_id = room_id;
+                TypedCall::PipeRevoke(r)
+            }
+            TypedCall::StreamSubscribe(mut r) => {
+                r.room_id = room_id;
+                TypedCall::StreamSubscribe(r)
+            }
+            TypedCall::StreamUnsubscribe(mut r) => {
+                r.room_id = room_id;
+                TypedCall::StreamUnsubscribe(r)
+            }
+            TypedCall::StreamResync(mut r) => {
+                r.room_id = room_id;
+                TypedCall::StreamResync(r)
+            }
+            other => other,
+        }
+    }
+
+    /// **Step 4 is the non-oracle answer, and an unparseable room id is one of
+    /// its causes.** With a subject present, an unknown room and a room id this
+    /// daemon cannot even parse produce the *same* `room_not_available`
+    /// echoing what the caller sent. A distinct `invalid_argument` for the
+    /// malformed spelling would be a second, distinguishable answer for "no
+    /// such room" — and identifiers are opaque, so there is no published format
+    /// to refuse against.
+    #[tokio::test]
+    async fn an_unparseable_room_id_is_room_not_available_not_invalid_argument() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        for spelling in ["not-a-room-id", &format!("blake3:{}", "cd".repeat(32))] {
+            let room_id = RoomId::new(spelling);
+            let err = dispatch(
+                &sup,
+                TypedCall::RoomTimeline(RoomTimeline {
+                    room_id: room_id.clone(),
+                    page: page(),
+                }),
+            )
+            .await
+            .expect_err("neither room is available");
+            assert_eq!(
+                err,
+                ApiError::RoomNotAvailable { room_id },
+                "spelling {spelling}"
             );
         }
     }
+
+    /// Build an authority with one room, plus a joined member on its own
+    /// daemon. Returns `(authority, member, room_id)`.
+    async fn authority_and_member() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        RoomSupervisor,
+        RoomSupervisor,
+        String,
+    ) {
+        let owner_dir = tempdir().unwrap();
+        crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id = owner.create_room("Pipeline").unwrap();
+        let opened = owner.open_room(&room_id, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        (owner_dir, member_dir, owner, member, room_id)
+    }
+
+    /// **Step 5 outranks step 6.** A former member that *was* the room's
+    /// authority-gated caller answers `membership_ended`, never
+    /// `insufficient_standing` — the role code is defined only for active
+    /// members, so reaching it from an ended membership would report the wrong
+    /// reason and leak that the caller once held a role.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn standing_outranks_role_for_an_authority_gated_operation() {
+        let (_od, _md, owner, member, room_id) = authority_and_member().await;
+        member.open_room(&room_id, &[]).await.unwrap();
+        member.leave_room(&room_id).await.unwrap();
+
+        let err = dispatch(
+            &member,
+            TypedCall::InviteList(InviteList {
+                room_id: RoomId::new(&room_id),
+                page: page(),
+            }),
+        )
+        .await
+        .expect_err("a former member cannot enumerate invites");
+        assert_eq!(
+            err,
+            ApiError::MembershipEnded {
+                room_id: RoomId::new(&room_id),
+                standing: Standing::Left,
+            },
+            "standing precedes role"
+        );
+        owner.close_room(&room_id).await.unwrap();
+    }
+
+    /// **Step 6 outranks step 7.** A plain active member calling an
+    /// authority-gated operation gets `insufficient_standing` naming the role
+    /// tokens — not the operation's own semantic code, which would disclose
+    /// room state to a caller who may not read it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn role_outranks_operation_semantics() {
+        let (_od, _md, owner, member, room_id) = authority_and_member().await;
+        // `member.remove` against a subject that is not a member would answer
+        // `member_unknown` at step 7 — but the caller is not an authority, so
+        // step 6 refuses first.
+        let err = dispatch(
+            &member,
+            TypedCall::MemberRemove(MemberRemove {
+                room_id: RoomId::new(&room_id),
+                subject_id: subject(),
+            }),
+        )
+        .await
+        .expect_err("a member may not remove");
+        assert_eq!(
+            err,
+            ApiError::InsufficientStanding {
+                room_id: RoomId::new(&room_id),
+                required: Role::Authority,
+                held: Role::Member,
+            }
+        );
+        owner.close_room(&room_id).await.unwrap();
+    }
+
+    /// The step-1 structural check on `member.remove`'s `subject_id` runs
+    /// before the room, standing, and role stages, so a malformed identity is
+    /// never answered with an authorization verdict.
+    #[tokio::test]
+    async fn a_malformed_member_remove_subject_is_structural_before_authorization() {
+        let dir = tempdir().unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let err = dispatch(
+            &sup,
+            TypedCall::MemberRemove(MemberRemove {
+                room_id: rid(),
+                subject_id: SubjectId::new("not-an-identity"),
+            }),
+        )
+        .await
+        .expect_err("a malformed subject is refused structurally");
+        assert_eq!(
+            err,
+            ApiError::InvalidArgument {
+                field: "in.subject_id".into(),
+                reason: InvalidReason::Format,
+            }
+        );
+    }
+
+    /// `room.archive` is exempt from the standing stage, and checks the
+    /// converse itself: an active membership is `room_still_active`, never the
+    /// generic `invalid_argument` an earlier revision returned.
+    #[tokio::test]
+    async fn room_archive_on_an_active_membership_is_room_still_active() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Still Active").unwrap();
+        let err = dispatch(
+            &sup,
+            TypedCall::RoomArchive(RoomArchive {
+                room_id: RoomId::new(&room_id),
+                page: page(),
+            }),
+        )
+        .await
+        .expect_err("the caller still belongs");
+        assert_eq!(
+            err,
+            ApiError::RoomStillActive {
+                room_id: RoomId::new(&room_id),
+            }
+        );
+    }
+
+    /// The standing stage refuses a left membership on a room-bearing
+    /// operation that is not exempt, and `room.archive` succeeds on the same
+    /// room — the exemption is real in both directions.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_left_membership_is_refused_everywhere_except_the_archive() {
+        let (_od, _md, owner, member, room_id) = authority_and_member().await;
+        member.open_room(&room_id, &[]).await.unwrap();
+        member.leave_room(&room_id).await.unwrap();
+        let api_room = RoomId::new(&room_id);
+
+        let err = dispatch(
+            &member,
+            TypedCall::RoomTimeline(RoomTimeline {
+                room_id: api_room.clone(),
+                page: page(),
+            }),
+        )
+        .await
+        .expect_err("a former member reads the archive, not the timeline");
+        assert_eq!(
+            err,
+            ApiError::MembershipEnded {
+                room_id: api_room.clone(),
+                standing: Standing::Left,
+            }
+        );
+
+        let reply = dispatch(
+            &member,
+            TypedCall::RoomArchive(RoomArchive {
+                room_id: api_room.clone(),
+                page: page(),
+            }),
+        )
+        .await
+        .expect("the archive is defined over a former membership");
+        let TypedReply::RoomArchive(archive) = reply else {
+            panic!("wrong reply");
+        };
+        assert_eq!(archive.standing, Standing::Left);
+        owner.close_room(&room_id).await.unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Typed honesty: no fabricated fact survives
+    // ------------------------------------------------------------------
+
+    /// `room.create` refuses a name outside the record's stated bounds with
+    /// `room_name_invalid` carrying the closed `reason` variant — a `bound` arm
+    /// for length and a `format` arm for whitespace-only.
+    #[tokio::test]
+    async fn room_create_refuses_an_invalid_name_with_its_own_code() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        for (name, expected) in [
+            ("", InvalidReason::Bound { min: 1, max: 128 }),
+            ("   ", InvalidReason::Format),
+            (&"x".repeat(129), InvalidReason::Bound { min: 1, max: 128 }),
+        ] {
+            let err = dispatch(
+                &sup,
+                TypedCall::RoomCreate(RoomCreate { name: name.into() }),
+            )
+            .await
+            .expect_err("the name fails the stated bounds");
+            assert_eq!(
+                err,
+                ApiError::RoomNameInvalid { reason: expected },
+                "name {name:?}"
+            );
+        }
+    }
+
+    /// `message.send` answers its own `message_too_large` carrying both counts,
+    /// never a generic `invalid_argument`.
+    #[tokio::test]
+    async fn message_send_over_the_limit_is_message_too_large() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Too Large").unwrap();
+        let limit = limits().max_message_body_bytes;
+        let err = dispatch(
+            &sup,
+            TypedCall::MessageSend(MessageSend {
+                room_id: RoomId::new(&room_id),
+                body: "x".repeat(limit as usize + 1),
+            }),
+        )
+        .await
+        .expect_err("the body exceeds the served limit");
+        assert_eq!(
+            err,
+            ApiError::MessageTooLarge {
+                declared_bytes: limit + 1,
+                limit_bytes: limit,
+            }
+        );
+    }
+
+    /// `invite.mint` refuses a role it may not grant with `role_not_grantable`
+    /// naming the requested role.
+    #[tokio::test]
+    async fn invite_mint_refuses_an_ungrantable_role_by_name() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Grant").unwrap();
+        let err = dispatch(
+            &sup,
+            TypedCall::InviteMint(InviteMint {
+                room_id: RoomId::new(&room_id),
+                subject_id: subject(),
+                role: Role::Authority,
+                expires_at: Timestamp::new(
+                    time::OffsetDateTime::from_unix_timestamp(
+                        (crate::now_ms() / 1000) as i64 + 3600,
+                    )
+                    .unwrap(),
+                ),
+            }),
+        )
+        .await
+        .expect_err("authority is not grantable");
+        assert_eq!(
+            err,
+            ApiError::RoleNotGrantable {
+                requested: Role::Authority
+            }
+        );
+    }
+
+    /// A mutation reply's `at` is the instant the event's author **signed**,
+    /// so it equals the instant the same event carries on the timeline. An
+    /// earlier revision served the wall clock at reply time, which is a
+    /// different number for the same fact.
+    #[tokio::test]
+    async fn a_mutation_reply_serves_the_signed_instant_not_the_wall_clock() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Signed Instant").unwrap();
+        let api_room = RoomId::new(&room_id);
+        // Authoring publishes through a live node in this build (see
+        // `LIVENESS_GATED`), so the room is activated first.
+        sup.activate_room(&room_id, &[]).await.unwrap();
+
+        let TypedReply::MessageSend(sent) = dispatch(
+            &sup,
+            TypedCall::MessageSend(MessageSend {
+                room_id: api_room.clone(),
+                body: "hello".into(),
+            }),
+        )
+        .await
+        .expect("message.send") else {
+            panic!("wrong reply");
+        };
+        let TypedReply::RoomTimeline(timeline) = dispatch(
+            &sup,
+            TypedCall::RoomTimeline(RoomTimeline {
+                room_id: api_room,
+                page: page(),
+            }),
+        )
+        .await
+        .expect("room.timeline") else {
+            panic!("wrong reply");
+        };
+        let committed = timeline
+            .events
+            .iter()
+            .find(|e| e.event_id == sent.event_id)
+            .expect("the authored event is on the timeline");
+        assert_eq!(
+            sent.at, committed.at,
+            "the reply and the timeline serve one signed instant"
+        );
+        assert_eq!(sent.pos, committed.pos, "and one position space");
+    }
+
+    /// `room.members` dates every row from a signed join. An earlier revision
+    /// fell back to the Unix epoch, which reads as a real instant in 1970.
+    #[tokio::test]
+    async fn room_members_dates_every_row_from_a_signed_join() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Dated").unwrap();
+        let TypedReply::RoomMembers(members) = dispatch(
+            &sup,
+            TypedCall::RoomMembers(RoomMembers {
+                room_id: RoomId::new(&room_id),
+            }),
+        )
+        .await
+        .expect("room.members") else {
+            panic!("wrong reply");
+        };
+        assert!(!members.members.is_empty());
+        for row in &members.members {
+            assert_ne!(
+                row.joined_at,
+                Timestamp::new(time::OffsetDateTime::UNIX_EPOCH),
+                "no row is dated to the epoch"
+            );
+        }
+    }
+
+    /// A room row's `last_event` reports the newest **committed** event. An
+    /// outstanding invitation is not a committed event and must not win the
+    /// recency max — an earlier revision let it, then dropped the kindless
+    /// winner, reporting `absent` for a room with a full timeline.
+    #[tokio::test]
+    async fn a_pending_invitation_does_not_hide_a_rooms_recency() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Recency").unwrap();
+        sup.activate_room(&room_id, &[]).await.unwrap();
+        dispatch(
+            &sup,
+            TypedCall::MessageSend(MessageSend {
+                room_id: RoomId::new(&room_id),
+                body: "the newest committed event".into(),
+            }),
+        )
+        .await
+        .expect("message.send");
+        // A later invitation is stored but never committed to the timeline.
+        sup.create_invite(&room_id, subject().as_str(), "member", Some("1h"))
+            .await
+            .expect("invite.create");
+
+        let TypedReply::RoomList(list) = dispatch(&sup, TypedCall::RoomList(RoomList {}))
+            .await
+            .expect("room.list")
+        else {
+            panic!("wrong reply");
+        };
+        let row = list
+            .rooms
+            .iter()
+            .find(|r| r.room_id.as_str() == room_id)
+            .expect("the room is listed");
+        assert!(
+            matches!(
+                row.last_event,
+                LastEvent::Present {
+                    kind: EventKind::Message,
+                    ..
+                }
+            ),
+            "the newest committed event is the message, not the invitation: {:?}",
+            row.last_event
+        );
+    }
+
+    /// Capabilities are the operations the caller may invoke **right now**.
+    /// The three liveness-gated operations appear only on a live room; the
+    /// authority-only four only for an authority; `pipe.revoke` is present for
+    /// any active member because it is publisher-scoped, not role-scoped; and a
+    /// former membership advertises `room.archive` alone.
+    #[test]
+    fn capabilities_advertise_exactly_what_would_not_be_refused() {
+        use CapabilityToken::*;
+        let authority_only = [InviteMint, InviteList, InviteRevoke, MemberRemove];
+
+        let offline = room_capabilities(Standing::Active, Role::Member, false);
+        let live = room_capabilities(Standing::Active, Role::Member, true);
+        for token in LIVENESS_GATED {
+            assert!(
+                !offline.contains(&token),
+                "{token:?} is refused on a non-live room in this build"
+            );
+            assert!(live.contains(&token), "{token:?} is reachable when live");
+        }
+        // Naturally idempotent in both directions, so never liveness-gated.
+        for token in [RoomActivate, RoomDeactivate] {
+            assert!(offline.contains(&token) && live.contains(&token));
+        }
+        // Reads that work identically whether or not the room is live.
+        for token in [RoomTimeline, RoomMembers, FileList, PipeList, FileRead] {
+            assert!(
+                offline.contains(&token) && live.contains(&token),
+                "{token:?} reads committed state and needs no transport"
+            );
+        }
+        for token in authority_only {
+            assert!(
+                !live.contains(&token),
+                "{token:?} is authority-only and must be absent for a member"
+            );
+        }
+        assert!(
+            live.contains(&PipeRevoke),
+            "pipe.revoke is publisher-scoped, not authority-gated"
+        );
+        let authority = room_capabilities(Standing::Active, Role::Authority, true);
+        for token in authority_only {
+            assert!(authority.contains(&token), "{token:?} is an authority's");
+        }
+        // `room.archive` is advertised only where it would succeed.
+        assert!(!live.contains(&RoomArchive));
+        for standing in [Standing::Left, Standing::Removed] {
+            assert_eq!(
+                room_capabilities(standing, Role::Authority, true),
+                vec![RoomArchive],
+                "a former membership reaches exactly one room-scoped operation"
+            );
+        }
+    }
+
+    /// Every advertised capability is one this daemon would actually serve.
+    /// The array is composed from `(standing, role, live)`, and every token in
+    /// it is a room-scoped operation — a check that catches a token added to
+    /// the list without a corresponding gate.
+    #[test]
+    fn every_advertised_capability_is_room_scoped() {
+        let roomless: BTreeSet<&str> = every_call()
+            .iter()
+            .filter(|c| request_room(c).is_none())
+            .map(TypedCall::path)
+            .collect();
+        for standing in [Standing::Active, Standing::Left, Standing::Removed] {
+            for role in [Role::Member, Role::Authority] {
+                for live in [false, true] {
+                    for token in room_capabilities(standing, role, live) {
+                        let name = serde_json::to_value(token).expect("a token serializes");
+                        let name = name.as_str().expect("tokens encode as strings").to_owned();
+                        assert!(
+                            !roomless.contains(name.as_str()),
+                            "{name} is not an answer about one room"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Every typed refusal this module can construct carries a **real** value
+    /// in every identifier field: the record's error schema fixes those fields
+    /// and a client branches on them, so `""` is a schema satisfied and a fact
+    /// invented.
+    #[test]
+    fn no_typed_error_carries_an_empty_identifier() {
+        let room = RoomId::new("blake3:room");
+        let file = FileId::new("file_00");
+        let pipe = PipeId::new("ab".repeat(16));
+        let errors = vec![
+            ApiError::RoomNotAvailable {
+                room_id: room.clone(),
+            },
+            ApiError::RoomNotLive {
+                room_id: room.clone(),
+            },
+            ApiError::PolicyRefused {
+                room_id: room.clone(),
+            },
+            ApiError::RoomStillActive {
+                room_id: room.clone(),
+            },
+            ApiError::MembershipEnded {
+                room_id: room.clone(),
+                standing: Standing::Left,
+            },
+            ApiError::FileUnknown {
+                file_id: file.clone(),
+            },
+            ApiError::FileNotFetched {
+                file_id: file.clone(),
+            },
+            ApiError::PipeUnknown {
+                pipe_id: pipe.clone(),
+            },
+            ApiError::PipeNotPublisher {
+                pipe_id: pipe.clone(),
+            },
+            ApiError::SubscriptionUnknown {
+                room_id: room.clone(),
+            },
+            core_to_api(CoreError::internal("a store read failed")),
+            core_to_api_room(CoreError::internal("a store read failed"), &room),
+            core_to_api_room(
+                CoreError::new(ErrorKind::RoomUnknown, "no such room"),
+                &room,
+            ),
+            redemption_error(CoreError::new(ErrorKind::BadTicket, "forged"), None),
+        ];
+        for err in errors {
+            let value = serde_json::to_value(&err).expect("errors serialize");
+            assert_no_empty_ids(&value, &err);
+            assert_no_nulls(&value, &format!("{err:?}"));
+        }
+    }
+
+    fn assert_no_empty_ids(value: &serde_json::Value, err: &ApiError) {
+        const ID_KEYS: [&str; 7] = [
+            "room_id",
+            "subject_id",
+            "device_id",
+            "file_id",
+            "pipe_id",
+            "invite_id",
+            "connection_id",
+        ];
+        if let serde_json::Value::Object(map) = value {
+            for key in ID_KEYS {
+                if let Some(serde_json::Value::String(s)) = map.get(key) {
+                    assert!(!s.is_empty(), "{err:?} carries an empty {key}");
+                }
+            }
+        }
+    }
+
+    fn assert_no_nulls(value: &serde_json::Value, label: &str) {
+        match value {
+            serde_json::Value::Null => panic!("{label} encodes a JSON null"),
+            serde_json::Value::Object(map) => {
+                for v in map.values() {
+                    assert_no_nulls(v, label);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for v in items {
+                    assert_no_nulls(v, label);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// `invite.redeem` is the only operation a non-member can reach, so every
+    /// failure is a fieldless-or-instant redemption-side code. In particular a
+    /// capability for a room this daemon does not hold must not surface as
+    /// `room_not_available` naming that room.
+    #[tokio::test]
+    async fn invite_redeem_never_answers_a_room_scoped_code() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        for capability in ["", "not-a-ticket", "roomticket1qqq"] {
+            let err = dispatch(
+                &sup,
+                TypedCall::InviteRedeem(InviteRedeem {
+                    capability: capability.into(),
+                }),
+            )
+            .await
+            .expect_err("no capability verifies");
+            assert!(
+                matches!(
+                    err,
+                    ApiError::CapabilityInvalid
+                        | ApiError::CapabilityExpired { .. }
+                        | ApiError::CapabilityRevoked { .. }
+                        | ApiError::CapabilityRedeemed { .. }
+                ),
+                "capability {capability:?} answered {err:?}"
+            );
+        }
+    }
+
+    /// The `stream.*` refusal this dispatcher produces names the room the
+    /// caller asked about rather than an empty id.
+    #[tokio::test]
+    async fn a_stream_refusal_names_the_room_it_was_asked_about() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Streamed").unwrap();
+        let api_room = RoomId::new(&room_id);
+        let err = dispatch(
+            &sup,
+            TypedCall::StreamUnsubscribe(StreamUnsubscribe {
+                room_id: api_room.clone(),
+            }),
+        )
+        .await
+        .expect_err("no connection-scoped subscription exists here");
+        assert_eq!(err, ApiError::SubscriptionUnknown { room_id: api_room });
+    }
+
+    // ------------------------------------------------------------------
+    // Preserved behavior
+    // ------------------------------------------------------------------
 
     fn first_page(room_id: &str) -> InviteList {
         InviteList {
@@ -2484,8 +4292,13 @@ mod tests {
             .await
             .unwrap();
 
-        let typed = TypedSupervisor::new(&sup);
-        let outstanding = typed.invite_list(&first_page(&room_id_str)).await.unwrap();
+        let TypedReply::InviteList(outstanding) =
+            dispatch(&sup, TypedCall::InviteList(first_page(&room_id_str)))
+                .await
+                .unwrap()
+        else {
+            panic!("wrong reply");
+        };
         assert_eq!(outstanding.invites.len(), 1);
         assert_eq!(
             outstanding.invites[0].redeemability,
@@ -2528,7 +4341,13 @@ mod tests {
         .unwrap();
         sup.open_store().unwrap().insert(&validated).unwrap();
 
-        let redeemed = typed.invite_list(&first_page(&room_id_str)).await.unwrap();
+        let TypedReply::InviteList(redeemed) =
+            dispatch(&sup, TypedCall::InviteList(first_page(&room_id_str)))
+                .await
+                .unwrap()
+        else {
+            panic!("wrong reply");
+        };
         assert_eq!(redeemed.invites[0].redeemability, Redeemability::Redeemed);
     }
 
@@ -2539,13 +4358,18 @@ mod tests {
         let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
         let room_id = sup.create_room("Idempotent Deactivate").unwrap();
         sup.activate_room(&room_id, &[]).await.unwrap();
-        let typed = TypedSupervisor::new(&sup);
-        let req = RoomDeactivate {
-            room_id: RoomId::new(&room_id),
+        let call = || {
+            TypedCall::RoomDeactivate(RoomDeactivate {
+                room_id: RoomId::new(&room_id),
+            })
         };
 
-        let first = typed.room_deactivate(&req).await.unwrap();
-        let second = typed.room_deactivate(&req).await.unwrap();
+        let TypedReply::RoomDeactivate(first) = dispatch(&sup, call()).await.unwrap() else {
+            panic!("wrong reply");
+        };
+        let TypedReply::RoomDeactivate(second) = dispatch(&sup, call()).await.unwrap() else {
+            panic!("wrong reply");
+        };
 
         assert_eq!(first, second);
         assert!(!first.live);
@@ -2554,33 +4378,18 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn room_deactivate_rejects_an_ended_membership_before_idempotency() {
-        let owner_dir = tempdir().unwrap();
-        crate::identity::create(owner_dir.path()).unwrap();
-        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
-        let room_id = owner.create_room("Ended Deactivate").unwrap();
-        let opened = owner.open_room(&room_id, &[]).await.unwrap();
-        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
-
-        let member_dir = tempdir().unwrap();
-        let member_profile = crate::identity::create(member_dir.path()).unwrap();
-        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
-        let ticket = owner
-            .create_invite(&room_id, &member_profile.identity_id, "member", None)
-            .await
-            .unwrap();
-        member
-            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
-            .await
-            .unwrap();
+        let (_od, _md, owner, member, room_id) = authority_and_member().await;
         member.open_room(&room_id, &[]).await.unwrap();
         member.leave_room(&room_id).await.unwrap();
 
-        let err = TypedSupervisor::new(&member)
-            .room_deactivate(&RoomDeactivate {
+        let err = dispatch(
+            &member,
+            TypedCall::RoomDeactivate(RoomDeactivate {
                 room_id: RoomId::new(&room_id),
-            })
-            .await
-            .unwrap_err();
+            }),
+        )
+        .await
+        .unwrap_err();
         assert_eq!(
             err,
             ApiError::MembershipEnded {
@@ -2598,40 +4407,42 @@ mod tests {
         let profile = crate::identity::create(dir.path()).unwrap();
         let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
         let room_id = sup.create_room("Exact Errors").unwrap();
-        let typed = TypedSupervisor::new(&sup);
 
-        let authority = typed
-            .member_remove(&MemberRemove {
+        let authority = dispatch(
+            &sup,
+            TypedCall::MemberRemove(MemberRemove {
                 room_id: RoomId::new(&room_id),
                 subject_id: SubjectId::new(&profile.identity_id),
-            })
-            .await
-            .unwrap_err();
+            }),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(
             authority,
             ApiError::AuthorityCannotBeRemoved { .. }
         ));
 
-        let unknown_subject = iroh_rooms::identity::SigningKey::generate()
-            .identity_key()
-            .to_string();
-        let unknown = typed
-            .member_remove(&MemberRemove {
+        let unknown = dispatch(
+            &sup,
+            TypedCall::MemberRemove(MemberRemove {
                 room_id: RoomId::new(&room_id),
-                subject_id: SubjectId::new(unknown_subject),
-            })
-            .await
-            .unwrap_err();
+                subject_id: subject(),
+            }),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(unknown, ApiError::MemberUnknown { .. }));
 
         let connection_id = "127.0.0.1:65535".to_owned();
         assert_eq!(
-            typed
-                .pipe_release(&PipeRelease {
+            dispatch(
+                &sup,
+                TypedCall::PipeRelease(PipeRelease {
                     connection_id: connection_id.clone(),
                 })
-                .await
-                .unwrap_err(),
+            )
+            .await
+            .unwrap_err(),
             ApiError::ConnectionUnknown { connection_id }
         );
     }
@@ -2642,50 +4453,279 @@ mod tests {
         crate::identity::create(dir.path()).unwrap();
         let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
         sup.create_room("Known Room").unwrap();
-        let typed = TypedSupervisor::new(&sup);
         let unknown_room = RoomId::new(format!("blake3:{}", "de".repeat(32)));
 
-        let publish = typed
-            .pipe_publish(&PipePublish {
+        // A non-loopback target would be `pipe_target_refused` at step 7 — but
+        // the room is not available, and step 4 outranks it.
+        let publish = dispatch(
+            &sup,
+            TypedCall::PipePublish(PipePublish {
                 room_id: unknown_room.clone(),
                 target: Target {
                     host: "203.0.113.10".into(),
                     port: 4444,
                 },
                 audience: Audience::Room,
-            })
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            publish,
-            ApiError::RoomNotAvailable { ref room_id } if room_id == &unknown_room
-        ));
-
-        let connect = typed
-            .pipe_connect(&PipeConnect {
-                room_id: unknown_room.clone(),
-                pipe_id: PipeId::new("ab".repeat(16)),
-            })
-            .await
-            .unwrap_err();
-        assert!(matches!(
-            connect,
-            ApiError::RoomNotAvailable { ref room_id } if room_id == &unknown_room
-        ));
-    }
-
-    #[test]
-    fn malformed_member_remove_subject_is_structural_before_authorization() {
-        let call = TypedCall::MemberRemove(MemberRemove {
-            room_id: RoomId::new(format!("blake3:{}", "ab".repeat(32))),
-            subject_id: SubjectId::new("not-an-identity"),
-        });
+            }),
+        )
+        .await
+        .unwrap_err();
         assert_eq!(
-            authority_gated_room(&call).unwrap_err(),
-            ApiError::InvalidArgument {
-                field: "in.subject_id".into(),
-                reason: InvalidReason::Format,
+            publish,
+            ApiError::RoomNotAvailable {
+                room_id: unknown_room.clone()
             }
         );
+
+        let connect = dispatch(
+            &sup,
+            TypedCall::PipeConnect(PipeConnect {
+                room_id: unknown_room.clone(),
+                pipe_id: PipeId::new("ab".repeat(16)),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            connect,
+            ApiError::RoomNotAvailable {
+                room_id: unknown_room
+            }
+        );
+    }
+
+    /// A loopback-policy refusal still names the rejected target verbatim,
+    /// once the room stages have passed.
+    #[tokio::test]
+    async fn pipe_publish_refuses_a_non_loopback_target_verbatim() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Loopback Policy").unwrap();
+        let target = Target {
+            host: "192.168.1.10".into(),
+            port: 4444,
+        };
+        let err = dispatch(
+            &sup,
+            TypedCall::PipePublish(PipePublish {
+                room_id: RoomId::new(&room_id),
+                target: target.clone(),
+                audience: Audience::Room,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ApiError::PipeTargetRefused { target });
+    }
+
+    /// An outstanding invitation is **not** a member. The fold yields an
+    /// `Invited` row with no device binding and no join to date, so including
+    /// it would either fabricate a `joined_at` or — as an earlier revision did
+    /// — fail the entire roster with `membership_unresolved` the moment any
+    /// invite is outstanding, taking `stream.subscribe` and `stream.resync`
+    /// with it (both authorize through `room.members`).
+    #[tokio::test]
+    async fn an_outstanding_invitation_is_not_a_member_and_does_not_break_the_roster() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Invited Not Member").unwrap();
+        let api_room = RoomId::new(&room_id);
+        let invitee = subject();
+
+        async fn roster(sup: &RoomSupervisor, room_id: &RoomId) -> Vec<MemberRow> {
+            let call = TypedCall::RoomMembers(RoomMembers {
+                room_id: room_id.clone(),
+            });
+            let TypedReply::RoomMembers(out) = dispatch(sup, call).await.expect("room.members")
+            else {
+                panic!("wrong reply");
+            };
+            out.members
+        }
+
+        let before = roster(&sup, &api_room).await;
+        assert_eq!(before.len(), 1, "the authority is the only member");
+
+        sup.create_invite(&room_id, invitee.as_str(), "member", Some("1h"))
+            .await
+            .expect("invite.create");
+
+        let after = roster(&sup, &api_room).await;
+        assert_eq!(
+            after, before,
+            "an outstanding invitation changes no roster row"
+        );
+        assert!(
+            after.iter().all(|m| m.subject_id != invitee),
+            "the invitee is not a member until it redeems"
+        );
+
+        // `room.list`'s member_count is the same set, so the count and the
+        // roster can never disagree.
+        let TypedReply::RoomList(list) = dispatch(&sup, TypedCall::RoomList(RoomList {}))
+            .await
+            .expect("room.list")
+        else {
+            panic!("wrong reply");
+        };
+        let row = list
+            .rooms
+            .iter()
+            .find(|r| r.room_id == api_room)
+            .expect("the room is listed");
+        assert_eq!(row.member_count, after.len() as u64);
+    }
+
+    /// `invite.mint` serves the expiry the capability was **signed** with, so
+    /// the reply and the `invite.list` row for the same invite agree. Echoing
+    /// the requested instant promised an expiry the capability does not carry.
+    #[tokio::test]
+    async fn invite_mint_serves_the_signed_expiry_not_the_requested_one() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Signed Expiry").unwrap();
+        let api_room = RoomId::new(&room_id);
+        // A requested instant with a fractional second, so a truncating
+        // conversion is observable.
+        let requested = Timestamp::new(
+            time::OffsetDateTime::from_unix_timestamp((crate::now_ms() / 1000) as i64 + 3600)
+                .unwrap(),
+        );
+        let TypedReply::InviteMint(minted) = dispatch(
+            &sup,
+            TypedCall::InviteMint(InviteMint {
+                room_id: api_room.clone(),
+                subject_id: subject(),
+                role: Role::Member,
+                expires_at: requested,
+            }),
+        )
+        .await
+        .expect("invite.mint") else {
+            panic!("wrong reply");
+        };
+        let ticket: iroh_rooms::room::RoomInviteTicket =
+            minted.capability.trim().parse().expect("the ticket parses");
+        let signed = proj::ts(ticket.expires_at.expect("the ticket carries an expiry"))
+            .expect("the signed expiry converts");
+        assert_eq!(
+            minted.expires_at, signed,
+            "the reply serves the capability's own signed expiry"
+        );
+
+        let TypedReply::InviteList(listed) =
+            dispatch(&sup, TypedCall::InviteList(first_page(&room_id)))
+                .await
+                .expect("invite.list")
+        else {
+            panic!("wrong reply");
+        };
+        assert_eq!(
+            listed.invites[0].expires_at, minted.expires_at,
+            "mint and list agree about one invite's expiry"
+        );
+    }
+
+    /// A past expiry is refused with a bound whose `min` and `max` are the same
+    /// unit — whole seconds since the epoch, the domain the refused `<ts>` sits
+    /// in. An earlier revision mixed seconds and milliseconds.
+    #[tokio::test]
+    async fn invite_mint_expiry_bound_states_one_unit() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Past Expiry").unwrap();
+        let err = dispatch(
+            &sup,
+            TypedCall::InviteMint(InviteMint {
+                room_id: RoomId::new(&room_id),
+                subject_id: subject(),
+                role: Role::Member,
+                expires_at: Timestamp::new(time::OffsetDateTime::UNIX_EPOCH),
+            }),
+        )
+        .await
+        .expect_err("a past expiry is refused");
+        let ApiError::InvalidArgument {
+            field,
+            reason: InvalidReason::Bound { min, max },
+        } = err
+        else {
+            panic!("wrong error: {err:?}");
+        };
+        assert_eq!(field, "in.expires_at");
+        let now_secs = crate::now_ms() / 1000;
+        assert!(
+            min > now_secs - 5 && min < now_secs + 5,
+            "min is whole seconds since the epoch, got {min} against {now_secs}"
+        );
+        assert_eq!(
+            max,
+            u64::from(u32::MAX),
+            "max is the same unit as min, not milliseconds"
+        );
+    }
+
+    /// `transfer.cancel` names the transfer the caller asked about with its own
+    /// distinctive code. This build tracks no transfers by `op_id`, so no
+    /// `transfer_op_id` names one for this principal — which is what
+    /// `transfer_unknown` states, and it is true.
+    #[tokio::test]
+    async fn transfer_cancel_answers_its_own_code_naming_the_transfer() {
+        let dir = tempdir().unwrap();
+        crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let transfer_op_id = OpId::new("op-that-never-started");
+        let err = dispatch(
+            &sup,
+            TypedCall::TransferCancel(TransferCancel {
+                transfer_op_id: transfer_op_id.clone(),
+            }),
+        )
+        .await
+        .expect_err("no transfer is tracked");
+        assert_eq!(err, ApiError::TransferUnknown { transfer_op_id });
+    }
+
+    /// `daemon.stop` skips the subject stage. Refusing it would be a refusal
+    /// that still acts: the engine sequences teardown before dispatch runs, so
+    /// a `subject_absent` reply would be paired with a daemon that exits.
+    #[tokio::test]
+    async fn daemon_stop_does_not_require_a_subject() {
+        let dir = tempdir().unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let reply = dispatch(&sup, TypedCall::DaemonStop(DaemonStop {}))
+            .await
+            .expect("daemon.stop needs no subject");
+        let TypedReply::DaemonStop(out) = reply else {
+            panic!("wrong reply");
+        };
+        assert!(out.stopping);
+    }
+
+    /// A `"host:port"` string becomes a `target` by parsing, never by
+    /// splitting on the last colon and defaulting a bad port to `0`.
+    #[test]
+    fn a_local_endpoint_is_parsed_not_split() {
+        assert_eq!(
+            parse_target("127.0.0.1:4321"),
+            Some(Target {
+                host: "127.0.0.1".into(),
+                port: 4321
+            })
+        );
+        assert_eq!(
+            parse_target("[::1]:4321"),
+            Some(Target {
+                host: "::1".into(),
+                port: 4321
+            })
+        );
+        // No `port: 0` is invented for a value that is not an address.
+        assert_eq!(parse_target("not-an-address"), None);
+        assert_eq!(parse_target("127.0.0.1:not-a-port"), None);
     }
 }

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -74,6 +74,7 @@ use std::path::Path;
 use jeliya_api::*;
 use serde::{Deserialize, Serialize};
 
+use iroh_rooms::events::constants::SHORT_ID_LEN;
 use iroh_rooms::events::{capability_hash, Content, EventType, SignedEvent};
 use iroh_rooms::room::{MembershipSnapshot, RoomId as IrohRoomId};
 
@@ -406,15 +407,42 @@ impl<'a> TypedSupervisor<'a> {
     /// `subject.ensure` — establish the local subject exactly once; a second
     /// call returns the same subject with `created: false` (naturally
     /// idempotent, never an `identity_exists` refusal).
-    pub fn subject_ensure(&self) -> CoreResult<SubjectEnsureOut> {
-        if let Some(profile) = crate::identity::load_profile(self.sup.data_dir())? {
+    ///
+    /// A creation this daemon cannot persist is `subject_store_unwritable`, the
+    /// one operation error the record gives `subject.ensure`. It does not reach
+    /// the roomless fallback: that answers `room_index_unreadable`, which names
+    /// an index this operation never opened and denies the caller the only code
+    /// that tells them their fresh subject was not written to disk.
+    pub fn subject_ensure(&self) -> Result<SubjectEnsureOut, ApiError> {
+        let existing = crate::identity::load_profile(self.sup.data_dir())
+            .map_err(|_| ApiError::SubjectStoreUnwritable)?;
+        if let Some(profile) = existing {
             return Ok(SubjectEnsureOut {
                 subject_id: SubjectId::new(profile.identity_id),
                 device_id: DeviceId::new(profile.device_id),
                 created: false,
             });
         }
-        let profile = crate::identity::create(self.sup.data_dir())?;
+        let profile = match crate::identity::create(self.sup.data_dir()) {
+            Ok(profile) => profile,
+            // The TOCTOU loser: `create_new(true)` is the atomic guard, so a
+            // concurrent `subject.ensure` can win the race between the read
+            // above and this write. v2 removed `identity_exists`, and the
+            // operation is naturally idempotent, so the loser re-reads what the
+            // winner wrote and reports it as the existing subject it is.
+            Err(err) if err.kind == ErrorKind::IdentityExists => {
+                let profile = crate::identity::load_profile(self.sup.data_dir())
+                    .ok()
+                    .flatten()
+                    .ok_or(ApiError::SubjectStoreUnwritable)?;
+                return Ok(SubjectEnsureOut {
+                    subject_id: SubjectId::new(profile.identity_id),
+                    device_id: DeviceId::new(profile.device_id),
+                    created: false,
+                });
+            }
+            Err(_) => return Err(ApiError::SubjectStoreUnwritable),
+        };
         Ok(SubjectEnsureOut {
             subject_id: SubjectId::new(profile.identity_id),
             device_id: DeviceId::new(profile.device_id),
@@ -874,7 +902,18 @@ impl<'a> TypedSupervisor<'a> {
         // the caller asked for must be the expiry the capability is signed
         // with, or the reply, the `invite.list` row, and the capability itself
         // can all name different instants.
-        const TS_MAX_SECS: u64 = u32::MAX as u64;
+        //
+        // `max` is the largest instant a `<ts>` can carry — `time` is built
+        // without `large-dates`, so year 9999 is the ceiling. It is a
+        // **representability** ceiling, not a maximum invite TTL: the record
+        // defines no maximum TTL (`invites.json` records its absence as an open
+        // resource gap), so an invented threshold would refuse expiries v2
+        // permits. An earlier revision served `u32::MAX` here — borrowed from
+        // the unrelated `room_tail(_, u32::MAX)` idiom, with no basis in the
+        // timestamp domain — which advertised an "inclusive maximum" the daemon
+        // happily minted a thousand-fold past. A bound no two implementations
+        // can agree on is the thing this arm exists to prevent.
+        const TS_MAX_SECS: u64 = 253_402_300_799; // 9999-12-31T23:59:59Z
         let now_ms = crate::now_ms();
         // Milliseconds, not whole seconds: the instant is the caller's, and it
         // is signed verbatim so the reply, the `invite.list` row, and the
@@ -950,9 +989,13 @@ impl<'a> TypedSupervisor<'a> {
             .as_ref()
             .and_then(|t| t.expires_at)
             .and_then(proj::ts_millis);
+        // Keyed on the capability being redeemed, so "already a member" means
+        // "this capability already authored a join" and not "I have joined this
+        // room at some point" — the two differ for a subject that was removed
+        // and walked back in on a fresh capability.
         let joined_before = ticket
             .as_ref()
-            .and_then(|t| self.membership_event(&t.room_id));
+            .and_then(|t| self.membership_event(&t.room_id, Some(&t.invite_id)));
 
         let room_id_str = self
             .sup
@@ -981,12 +1024,19 @@ impl<'a> TypedSupervisor<'a> {
         let departures = crate::supervisor::departure_sets(&store, &room_id)
             .map_err(|_| ApiError::RoomIndexUnreadable)?;
         drop(store);
-        let (event_id, pos) =
-            self.membership_event(&room_id)
-                .ok_or_else(|| ApiError::MembershipUnresolved {
-                    room_id: api_room.clone(),
-                    subject_id: subject_id.clone(),
-                })?;
+        // The same key as the pre-call lookup, so the reply names the join
+        // *this* capability authored. Unkeyed, a rejoin would report the
+        // superseded pre-removal event — an `event_id` belonging to a
+        // membership the room already terminated, beside a `standing` of
+        // `active` the fold correctly derives from the new one.
+        let (event_id, pos) = ticket
+            .as_ref()
+            .and_then(|t| self.membership_event(&room_id, Some(&t.invite_id)))
+            .or_else(|| self.membership_event(&room_id, None))
+            .ok_or_else(|| ApiError::MembershipUnresolved {
+                room_id: api_room.clone(),
+                subject_id: subject_id.clone(),
+            })?;
         Ok(InviteRedeemOut {
             room_id: api_room,
             subject_id,
@@ -994,8 +1044,9 @@ impl<'a> TypedSupervisor<'a> {
             standing: departures.standing_of(member.status, &member.identity),
             event_id,
             pos,
-            // `false` when the membership event already existed before this
-            // call reached the runtime.
+            // `false` when a join authored by *this* capability already existed
+            // before the call reached the runtime — a replay. A rejoin after a
+            // departure carries a different capability and so reports `true`.
             joined: joined_before.is_none(),
         })
     }
@@ -1828,6 +1879,12 @@ impl<'a> TypedSupervisor<'a> {
     /// `pipe.connect` — connect to a pipe. Requires liveness. A caller outside
     /// the pipe's audience answers `pipe_unknown`, indistinguishable from no
     /// such pipe.
+    ///
+    /// A caller *inside* the audience is told the difference, because for them
+    /// it is not a disclosure: a pipe its publisher withdrew answers
+    /// `pipe_revoked` with the withdrawal's signed instant, so a client stops
+    /// retrying a tunnel that is never coming back rather than reading a
+    /// permanent withdrawal as a not-yet-synced announcement.
     pub async fn pipe_connect(
         &self,
         ctx: &RoomContext,
@@ -1876,8 +1933,11 @@ impl<'a> TypedSupervisor<'a> {
     /// Restricted to the pipe's **publisher**, which is a narrower relation
     /// than role: an authority that did not publish a pipe cannot revoke it
     /// either, and that refusal is `pipe_not_publisher`, not
-    /// `insufficient_standing`. `revoked_at` is the withdrawal event's signed
-    /// instant, not the wall clock at reply time.
+    /// `insufficient_standing`. The runtime enforces exactly that relation —
+    /// it admitted the room's administrator until this was corrected, which let
+    /// a role bypass a relation the record deliberately made narrower than any
+    /// role. `revoked_at` is the withdrawal event's signed instant, not the
+    /// wall clock at reply time.
     pub async fn pipe_revoke(
         &self,
         ctx: &RoomContext,
@@ -1971,7 +2031,24 @@ impl<'a> TypedSupervisor<'a> {
     /// canonical position — the event `invite.redeem` reports. Looking for the
     /// *membership* event specifically (not merely the newest event this
     /// subject authored) is what lets `joined` tell a fresh join from a replay.
-    fn membership_event(&self, room_id: &IrohRoomId) -> Option<(EventId, u64)> {
+    ///
+    /// The join is identified by **the capability that authored it**, not by
+    /// "any join by me". A subject that was removed and later redeemed a new
+    /// capability has two `member_joined` rows, and "have I ever joined this
+    /// room" cannot tell that rejoin from a replay: it would report the fresh
+    /// membership as `joined: false` and name the superseded, pre-removal event
+    /// — a reply whose `standing` says `active` while its `event_id` belongs to
+    /// a membership the room already terminated. Matching `via_invite_id`
+    /// against the ticket keeps a replay of one capability answering from its
+    /// own original join, which is what the record's idempotence requires.
+    ///
+    /// `via_invite_id` of `None` keeps the unkeyed "any join by me" behaviour,
+    /// for the callers that hold no ticket.
+    fn membership_event(
+        &self,
+        room_id: &IrohRoomId,
+        via_invite_id: Option<&[u8; SHORT_ID_LEN]>,
+    ) -> Option<(EventId, u64)> {
         let self_key = self.sup.local_identity_key().ok()?;
         let store = self.sup.open_store().ok()?;
         let rows = store.room_tail(room_id, u32::MAX).ok()?;
@@ -1982,10 +2059,13 @@ impl<'a> TypedSupervisor<'a> {
             }
             if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
                 let is_join = match &ev.content {
-                    Content::MemberJoined(c) => c.device_binding.identity_key == self_key,
+                    Content::MemberJoined(c) => {
+                        c.device_binding.identity_key == self_key
+                            && via_invite_id.is_none_or(|id| &c.via_invite_id == id)
+                    }
                     // The authority never authors a join: its membership is the
-                    // genesis it signed.
-                    Content::RoomCreated(_) => ev.sender_id == self_key,
+                    // genesis it signed, which no capability authorized.
+                    Content::RoomCreated(_) => via_invite_id.is_none() && ev.sender_id == self_key,
                     _ => false,
                 };
                 if is_join {
@@ -2122,14 +2202,75 @@ impl<'a> TypedSupervisor<'a> {
             ErrorKind::RoomNotOpen => ApiError::RoomNotLive {
                 room_id: req.room_id.clone(),
             },
-            // "No such pipe", "you are outside its audience", and "it was
-            // withdrawn while you connected" are all `pipe_unknown` to a caller
-            // that may not distinguish them.
-            ErrorKind::InvalidParams | ErrorKind::PipeDenied => ApiError::PipeUnknown {
-                pipe_id: req.pipe_id.clone(),
-            },
+            // A deliberate withdrawal is `pipe_revoked`, and only for a caller
+            // the publisher already admitted: the record lists it beside
+            // `pipe_unknown` among `pipe.connect`'s errors precisely so a
+            // client can stop retrying a tunnel that is never coming back.
+            //
+            // Entitlement is checked **first**, and the close event is only
+            // resolved for a caller inside the announcement's audience. An
+            // unconditional lookup would answer `pipe_revoked` to an outsider
+            // and so confirm the pipe ever existed, which is the existence
+            // oracle the record forbids — "a caller MUST NOT be able to
+            // distinguish a pipe it is not entitled to from one that does not
+            // exist". For everyone else "no such pipe" and "you are outside its
+            // audience" remain one indistinguishable answer.
+            ErrorKind::InvalidParams | ErrorKind::PipeDenied => {
+                match self.revoked_pipe_instant(ctx, &req.pipe_id) {
+                    Some(revoked_at) => ApiError::PipeRevoked {
+                        pipe_id: req.pipe_id.clone(),
+                        revoked_at,
+                    },
+                    None => ApiError::PipeUnknown {
+                        pipe_id: req.pipe_id.clone(),
+                    },
+                }
+            }
             _ => core_to_api_room(error, &req.room_id),
         }
+    }
+
+    /// The instant a withdrawn pipe was revoked — **only** for a caller the
+    /// publisher authorized, and `None` for everyone and everything else.
+    ///
+    /// Three facts must all hold, in this order, or the answer is `None` and
+    /// the caller keeps the indistinguishable `pipe_unknown`:
+    ///
+    /// 1. this daemon holds the governing `pipe.opened`;
+    /// 2. the caller is its publisher or is named in `allowed_members` — the
+    ///    audience resolved at publish time, which is what makes the disclosure
+    ///    a fact the caller was already entitled to;
+    /// 3. a `pipe.closed` for it is committed here.
+    ///
+    /// The instant is the one the close event's author **signed**, read exactly
+    /// as [`Self::committed_pos_and_instant`] reads it, so the `revoked_at` a
+    /// connector is told matches the `revoked_at` the publisher's own
+    /// `pipe.revoke` reply reported for the same event. A wall clock read at
+    /// reply time would name a different instant on every daemon.
+    fn revoked_pipe_instant(&self, ctx: &RoomContext, pipe_id: &PipeId) -> Option<Timestamp> {
+        let raw: [u8; SHORT_ID_LEN] = hex::decode(pipe_id.as_str()).ok()?.try_into().ok()?;
+        let store = self.sup.open_store().ok()?;
+        let opened = store
+            .by_type(&ctx.room_id, EventType::PipeOpened)
+            .ok()?
+            .into_iter()
+            .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+            .find_map(|ev| match ev.content {
+                Content::PipeOpened(p) if p.pipe_id == raw => Some(p),
+                _ => None,
+            })?;
+        if opened.owner_id != ctx.self_key && !opened.allowed_members.contains(&ctx.self_key) {
+            return None;
+        }
+        store
+            .by_type(&ctx.room_id, EventType::PipeClosed)
+            .ok()?
+            .into_iter()
+            .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+            .find_map(|ev| match &ev.content {
+                Content::PipeClosed(c) if c.pipe_id == raw => proj::ts(ev.created_at),
+                _ => None,
+            })
     }
 
     /// The observed link to a pipe's publisher device, for
@@ -2689,10 +2830,7 @@ pub(crate) async fn dispatch(
 
     // Step 7 — operation semantics.
     match call {
-        TypedCall::SubjectEnsure(_) => t
-            .subject_ensure()
-            .map(TypedReply::SubjectEnsure)
-            .map_err(core_to_api),
+        TypedCall::SubjectEnsure(_) => t.subject_ensure().map(TypedReply::SubjectEnsure),
         TypedCall::RoomCreate(r) => t.room_create(&r).await.map(TypedReply::RoomCreate),
         TypedCall::RoomList(_) => t.room_list().await.map(TypedReply::RoomList),
         TypedCall::RoomActivate(r) => t
@@ -4663,9 +4801,60 @@ mod tests {
             "min is whole seconds since the epoch, got {min} against {now_secs}"
         );
         assert_eq!(
-            max,
-            u64::from(u32::MAX),
-            "max is the same unit as min, not milliseconds"
+            max, 253_402_300_799,
+            "max is the same unit as min, not milliseconds, and is the largest \
+             instant a `<ts>` can represent rather than an invented ceiling"
+        );
+        // The advertised maximum has to be one the daemon honours: an expiry
+        // below it mints, so a client can trust the range it was handed.
+        assert!(
+            max > crate::now_ms() / 1000,
+            "an inclusive maximum in the past would refuse every expiry"
+        );
+    }
+
+    /// `subject.ensure` answers the one operation error the record gives it
+    /// when its store defeats it. An earlier revision passed the failure
+    /// through the roomless fallback, which named `room_index_unreadable` — an
+    /// index this operation never opens, and a code that says nothing about the
+    /// subject that could not be persisted. Both halves of the store are
+    /// covered, because either one defeats the operation on its own.
+    #[tokio::test]
+    async fn subject_ensure_reports_a_defeated_store_as_subject_store_unwritable() {
+        // The profile is present but unreadable: neither "no subject yet" nor a
+        // subject this daemon can name.
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(crate::identity::IDENTITY_FILE)).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let err = dispatch(&sup, TypedCall::SubjectEnsure(SubjectEnsure {}))
+            .await
+            .expect_err("an unreadable subject store is refused");
+        assert!(
+            matches!(err, ApiError::SubjectStoreUnwritable),
+            "expected subject_store_unwritable, got {err:?}"
+        );
+
+        // The creation cannot complete: the secret half of the store is already
+        // taken, so no subject can be written even though none exists to serve.
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(crate::identity::SECRET_FILE)).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let err = dispatch(&sup, TypedCall::SubjectEnsure(SubjectEnsure {}))
+            .await
+            .expect_err("a subject that cannot be persisted is refused");
+        assert!(
+            matches!(err, ApiError::SubjectStoreUnwritable),
+            "expected subject_store_unwritable, got {err:?}"
+        );
+
+        // And nothing was fabricated: a store that refused the write serves no
+        // subject afterwards either.
+        assert!(
+            crate::identity::load_profile(dir.path())
+                .ok()
+                .flatten()
+                .is_none(),
+            "a refused subject.ensure must not leave a subject behind"
         );
     }
 

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -718,8 +718,19 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
         // The typed refusal is already the record's error object; it is served
         // verbatim rather than flattened into a prose HTTP error, so the
         // legacy staging edge answers the same taxonomy the WS surface does.
+        //
+        // The `ok` discriminator stays, because it is the envelope and not the
+        // taxonomy: `json_ok` pairs every success with `ok: true` and every
+        // other refusal on this endpoint carries `ok: false`, so dropping it
+        // here would leave one response shape a consumer decoding the envelope
+        // before the status could not classify. Only the nested object changed
+        // generation — `message`/`hint` are gone from v2 deliberately and are
+        // not re-added.
         Err(err) => match serde_json::to_value(&err) {
-            Ok(body) => json_response(StatusCode::BAD_REQUEST, serde_json::json!({"error": body})),
+            Ok(body) => json_response(
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({"ok": false, "error": body}),
+            ),
             Err(_) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &CoreError::internal("could not encode the typed refusal"),

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -715,7 +715,16 @@ async fn share_upload(req: Request<Incoming>, state: AppState) -> Response<Full<
     let _ = std::fs::remove_file(&stage_path);
     match result {
         Ok(value) => json_ok(value),
-        Err(err) => json_error(StatusCode::BAD_REQUEST, &err),
+        // The typed refusal is already the record's error object; it is served
+        // verbatim rather than flattened into a prose HTTP error, so the
+        // legacy staging edge answers the same taxonomy the WS surface does.
+        Err(err) => match serde_json::to_value(&err) {
+            Ok(body) => json_response(StatusCode::BAD_REQUEST, serde_json::json!({"error": body})),
+            Err(_) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &CoreError::internal("could not encode the typed refusal"),
+            ),
+        },
     }
 }
 


### PR DESCRIPTION
Implements the smallest complete "typed honesty and validation" slice for #165. Draft: **do not merge without explicit authorization.**

## What this changes

### One normative validation pipeline

`typed::dispatch` now runs the record's seven stages once, for every operation, instead of leaving each body to re-implement them. Each stage's scope is a table decidable from the operation's own schema, and each table is asserted exhaustively over all 33 operations rather than sampled:

| Stage | Scope | Where |
|---|---|---|
| 1 structural | every operation | `validate_structure` |
| 2 subject | every operation except `subject.ensure`, `daemon.stop` | `dispatch` |
| 3 dedup | the `op_id` class | `Engine::execute_with` |
| 4 room index | the 25 operations whose `in` carries `room_id` | `request_room` → `room_context` |
| 5 standing | as 4, minus `room.archive` | `standing_exempt` |
| 6 role | `member.remove`, `invite.mint`, `invite.revoke`, `invite.list` | `requires_authority` |
| 7 semantics | the operation body | — |

Steps 4–6 produce one `RoomContext` — room, snapshot, **resolved** role, **resolved** standing, departure facts — handed to the body, so no body can re-derive an authorization answer the pipeline already settled. Step 1 also moved ahead of the dedup ledger in the engine, so a refusal from an earlier stage is never recorded against an `op_id` (reachable today via `member.remove`, which deduplicates and carries a step-1 check).

Two ordering holes closed: an unparseable `room_id` used to skip the authority gate entirely, and now answers `room_not_available` like any other unavailable room — identifiers are opaque, so a distinct `invalid_argument` was a second, distinguishable answer for "no such room".

### No fabricated facts

| Removed | Replaced with |
|---|---|
| default `Role::Member` (4 sites) | resolved role, else `membership_unresolved` |
| default `Standing::Active` (3 sites, one treating a caller absent from the fold as active) | resolved standing, else `membership_unresolved` |
| epoch timestamps for unreadable instants | fallible conversion; the row is not a committed event |
| empty `room_id` / `file_id` / `pipe_id` in typed errors | the identifier the caller named |
| `digest_mismatch { expected: "", observed: "" }` | both digests real — the observed one recomputed from the bytes upstream hands back on mismatch |
| empty room name | `room_index_unreadable` |
| `port: 0` from splitting an address on its last colon | parsed `SocketAddr`, else refusal |
| progress percents clamped with `.min(100)` | refused; the event is not committed |
| `author.standing` hardcoded `active` | the same derivation `room.members` serves |
| `at` / `revoked_at` from the wall clock | the instant the event was signed |

`room.list`'s `last_event` also stopped reporting `absent` for rooms with a full timeline (a non-committed row could win the recency max and then be dropped), and its ordering compares signed milliseconds rather than the second-precision wire form.

Exact typed codes replace generic ones for `room_name_invalid`, `message_too_large`, `role_not_grantable`, `room_still_active`, `file_unknown`, `file_not_fetched`, `pipe_not_publisher`, `pipe_unknown`, `sole_authority_cannot_leave`, `transport_unavailable`, `room_not_live`, and the `*_index_unreadable` family.

### Capabilities

`room.list`'s `capabilities` array now advertises only what the daemon would actually serve: `invite.list` is authority-only, `pipe.revoke` is publisher-scoped (not authority-gated), `room.archive` appears only for a former membership, and the liveness set is what this build really requires. The record names three liveness-gated operations; this daemon's authoring path publishes through a live node, so five more are gated. That divergence is **recorded in the code**, because the array is normatively "would not be refused *at the instant the reply was composed*".

### One conformance fixture corrected

`subject-daemon.json`'s non-oracle case asserted that an over-limit page size does not preempt the subject precondition. That contradicts the normative stage table the case exists to cover: the record puts structural decode and bounds at step 1, subject at step 2, and states outright that doing so "does not weaken the non-oracle property" because step 1 "discloses only the value formats this record publishes, never any daemon state" — and `timeline_page_max` is served in `hello` to that same connection before any subject exists.

The correction is transcribed from the record, not from this implementation, and the reasoning is written into the case. **The room-lookup steps — the ones the property actually turns on — are unchanged and still assert `subject_absent` for an unknown, a plausible, and an unparseable room id.**

## Review round

An adversarial review over four lenses raised 28 findings; 17 were refuted and 11 confirmed. Seven were mine and are fixed here, including two severe ones the tests I wrote then caught:

- `room.members` failed outright for any room with an outstanding invitation — and took `stream.subscribe` / `stream.resync` with it, since both authorize through it. An invited-but-never-joined identity is not a member.
- `joined_at` dated the authority from `room_tail(room_id, 1)`, which is the **newest** row, not the genesis. Any second event moved every roster row's `joined_at`.
- `provider_unreachable` named the candidate provider set where the record requires the attempted set.
- `invite.mint` echoed the requested expiry rather than the signed one; the expiry is now signed verbatim in milliseconds, so the reply, the `invite.list` row, and the capability agree exactly.
- `file.read` reported a file that was never shared as merely not-fetched.
- `membership_unresolved` carried a device key in its `subject_id` field.
- `transfer.cancel` replied with the gate-only `not_ready`; it now answers its own `transfer_unknown`.

Four confirmed findings are **pre-existing on `main`** and out of this slice; they are listed on #165 as follow-ups.

## Verification

- `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace`, `cargo +1.91.0 check --locked --workspace --all-targets`, `git diff --check` — all clean
- `node scripts/check-v2-corpus.mjs` — 344 cases, 2196 steps, OK
- jeliya-core unit tests: **143** (from 92)
- Live corpus replay vs a binary built from `origin/main`, matched settings, two runs each: **zero cases regressed**, **8 newly green**
- The 14 pinned CI conformance cases: **14/14**

## Scope held

No `invite.revoke`, `transfer.cancel` semantics, v2 file streaming, session cutover, or FFI deletion. No persistence rewrite. `InviteRevoked` remains an irreducible upstream blocker — nine of the record's ten committed kinds are covered by a table-driven encoding test, and the tenth is asserted as explicitly uncovered so nine-of-ten cannot read as complete.

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
