### PR TITLE
fix(core): derive fleet agent-ness from posting, and gate stream.unsubscribe

### DIFF
--- a/conformance/v2/timeline-streams.json
+++ b/conformance/v2/timeline-streams.json
@@ -1496,7 +1496,7 @@
       "name": "stream_unsubscribe_of_a_subscription_this_connection_does_not_hold_is_subscription_unknown",
       "kind": "error",
       "operation": "stream.unsubscribe",
-      "intent": "The distinctive code the spec adds precisely so this operation's conformance case asserts something other than a generic invalid_argument. Covers three ways to not hold one — never subscribed, already unsubscribed, and a well-formed id belonging to nobody — and asserts the same code for each, so the answer is never a subscription-existence oracle either. Catches a daemon that answers invalid_argument, not_found, or silently succeeds.",
+      "intent": "The distinctive code the spec adds precisely so this operation's conformance case asserts something other than a generic invalid_argument. Covers the two ways an authorized member holds no subscription — never subscribed and already unsubscribed — and asserts subscription_unknown for each, so the answer is never a subscription-existence oracle. A well-formed id belonging to nobody never reaches that lookup at all: stream.unsubscribe's in carries room_id, so the room-access stage refuses it as room_not_available first, the same conflation of unknown-and-inaccessible every room-scoped operation serves. Catches a daemon that answers invalid_argument, not_found, silently succeeds, or skips the room-access stages because the subscription is connection state.",
       "requires": [
         "subject",
         "room:live"
@@ -1507,7 +1507,7 @@
           "in": {
             "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
           },
-          "note": "a syntactically valid unknown room id reaches the subscription lookup rather than failing identifier parsing, and the error must echo that exact id",
+          "note": "a syntactically valid unknown room id is refused by the room-access stage before the subscription lookup is reached: stream.unsubscribe carries room_id, so step 4 runs for it as it does for every room-scoped operation, and the error must echo that exact id",
           "save": {
             "e1": "$err"
           },
@@ -1515,7 +1515,7 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "subscription_unknown",
+              "code": "room_not_available",
               "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
             }
           },
@@ -1565,8 +1565,9 @@
           "assert": [
             {
               "path": "$e1.code",
-              "op": "eq",
-              "value": "$e2.code"
+              "op": "ne",
+              "value": "$e2.code",
+              "note": "the unknown room is refused a stage earlier than the held-nothing lookup, so the two codes must differ — an implementation that answers subscription_unknown for both has skipped step 4"
             }
           ]
         },
@@ -3095,7 +3096,7 @@
       "name": "pushes_stop_when_membership_ends",
       "kind": "authorization",
       "operation": null,
-      "intent": "Delivery is to subscribers who are members, so losing membership must end delivery even though the subscription was validly created — otherwise a removed member keeps reading the room through a stale sink. Asserts no further frames after removal and that the now-dead subscription reports subscription_unknown rather than continuing to look alive. Catches a fan-out that snapshots membership at subscribe time.",
+      "intent": "Delivery is to subscribers who are members, so losing membership must end delivery even though the subscription was validly created — otherwise a removed member keeps reading the room through a stale sink. Asserts no further frames after removal and that the now-dead subscription reports membership_ended, the standing stage's answer, rather than continuing to look alive or reporting the subscription as merely unknown. Catches a fan-out that snapshots membership at subscribe time, and a stream.unsubscribe that skips the standing stage because it resolves the room from connection state.",
       "requires": [
         "subject",
         "room:live",
@@ -3191,11 +3192,13 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "subscription_unknown",
-              "room_id": "$s"
+              "code": "membership_ended",
+              "room_id": "$s",
+              "standing": "removed"
             }
           },
-          "op_id": "$o5"
+          "op_id": "$o5",
+          "note": "standing outranks the connection's own subscription map: the removed member earns the same membership_ended its stream.resync earns one step earlier, not a subscription_unknown that would describe the subscription rather than the membership that ended it"
         }
       ]
     },

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1338,8 +1338,21 @@ impl<'a> TypedSupervisor<'a> {
             //
             // Membership is still required: the subject must have joined, which
             // is the same device-binding test the roster uses.
+            //
+            // The evidence has to be a **committed** row, the same predicate
+            // `room.timeline` and `status.history` answer from. A peer upstream
+            // of v2 accepts any free-form label, so a room can hold an
+            // `agent.status` whose label is outside v2's vocabulary or whose
+            // instant is unrepresentable; the projection deliberately refuses
+            // such a row. Counting it as proof of agent-ness would put a member
+            // in the fleet on the strength of an event the daemon will not
+            // serve in either other projection — and a v2 `status.post` cannot
+            // author one, since an unknown label is refused with
+            // `status_label_unknown`, so the row is no evidence of a
+            // `status.post` at all. One rule, every projection.
             let agent_ids: BTreeSet<iroh_rooms::identity::IdentityKey> = rows
                 .iter()
+                .filter(|se| proj::is_committed(se))
                 .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
                 .filter(|ev| matches!(ev.content, Content::AgentStatus(_)))
                 .map(|ev| ev.sender_id)

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -1314,14 +1314,6 @@ impl<'a> TypedSupervisor<'a> {
             if RoomSupervisor::require_local_room_access(&snapshot, &self_id).is_err() {
                 continue;
             }
-            let agent_ids: BTreeSet<iroh_rooms::identity::IdentityKey> = snapshot
-                .members()
-                .filter(|m| m.role == iroh_rooms::room::Role::Agent)
-                .map(|m| m.identity)
-                .collect();
-            if agent_ids.is_empty() {
-                continue;
-            }
             let rows = {
                 let store = self
                     .sup
@@ -1331,6 +1323,35 @@ impl<'a> TypedSupervisor<'a> {
                     .room_tail(&room_id, u32::MAX)
                     .map_err(|_| ApiError::FleetProjectionUnavailable)?
             };
+            // **Agent-ness is derived, not declared.** The record: "An agent is
+            // a member that has authored at least one `status.post` event.
+            // Agent-ness is derived here, not declared: it is a
+            // classification, not a permission, so it is not a `role` and
+            // appears in no membership row."
+            //
+            // An earlier revision read the upstream fold's `Role::Agent`
+            // instead, which is a membership row and gets the answer wrong in
+            // both directions: a member that posts statuses never appeared in
+            // the fleet, and one that holds the upstream role but has never
+            // posted appeared with `latest_status: absent` — an agent the
+            // operator has no evidence for.
+            //
+            // Membership is still required: the subject must have joined, which
+            // is the same device-binding test the roster uses.
+            let agent_ids: BTreeSet<iroh_rooms::identity::IdentityKey> = rows
+                .iter()
+                .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
+                .filter(|ev| matches!(ev.content, Content::AgentStatus(_)))
+                .map(|ev| ev.sender_id)
+                .filter(|id| {
+                    snapshot
+                        .member(id)
+                        .is_some_and(|member| member.device.is_some())
+                })
+                .collect();
+            if agent_ids.is_empty() {
+                continue;
+            }
             let mut signals: AgentSignalsMap = BTreeMap::new();
             for se in &rows {
                 let Ok(ev) = SignedEvent::decode(&se.wire.signed) else {
@@ -4893,6 +4914,71 @@ mod tests {
             panic!("wrong reply");
         };
         assert!(out.stopping);
+    }
+
+    /// **Agent-ness is derived from posting, not from a membership row.** The
+    /// record: "An agent is a member that has authored at least one
+    /// `status.post` event ... it is a classification, not a permission, so it
+    /// is not a `role` and appears in no membership row."
+    ///
+    /// The room's authority holds the upstream `Admin` role, never `Agent`, so
+    /// under the old role-based derivation it could never appear in the fleet
+    /// no matter how many statuses it posted. It posts one here and must.
+    #[tokio::test]
+    async fn fleet_derives_agents_from_posted_status_not_from_a_role() {
+        let dir = tempdir().unwrap();
+        let profile = crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id = sup.create_room("Fleet Derivation").unwrap();
+        sup.activate_room(&room_id, &[]).await.unwrap();
+        let api_room = RoomId::new(&room_id);
+
+        // Before posting: a member, not an agent.
+        let TypedReply::FleetList(before) = dispatch(&sup, TypedCall::FleetList(FleetList {}))
+            .await
+            .expect("fleet.list")
+        else {
+            panic!("wrong reply");
+        };
+        assert!(
+            before.agents.is_empty(),
+            "a member that has posted nothing is not an agent: {:?}",
+            before.agents
+        );
+
+        dispatch(
+            &sup,
+            TypedCall::StatusPost(StatusPost {
+                room_id: api_room,
+                label: StatusLabel::Working,
+                progress: Progress::Reported { percent: 40 },
+            }),
+        )
+        .await
+        .expect("status.post");
+
+        let TypedReply::FleetList(after) = dispatch(&sup, TypedCall::FleetList(FleetList {}))
+            .await
+            .expect("fleet.list")
+        else {
+            panic!("wrong reply");
+        };
+        let row = after
+            .agents
+            .iter()
+            .find(|a| a.subject_id.as_str() == profile.identity_id)
+            .expect("the poster is now an agent, whatever its role");
+        assert!(
+            matches!(
+                row.latest_status,
+                LatestStatus::Present {
+                    label: StatusLabel::Working,
+                    ..
+                }
+            ),
+            "the fleet row carries the status that made it an agent: {:?}",
+            row.latest_status
+        );
     }
 
     /// A `"host:port"` string becomes a `target` by parsing, never by

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -1262,18 +1262,6 @@ async fn handle_stream_subscribe(
     .await
 }
 
-/// Validation-order step 2 for the operations this host resolves itself.
-///
-/// The engine applies it to everything it dispatches; the connection-scoped
-/// `stream.*` operations that never reach it need it applied here, or they
-/// answer their own semantic code on a daemon that has no subject at all.
-fn subject_precondition(state: &AppState) -> Result<(), jeliya_api::ApiError> {
-    match state.engine.subject_state()? {
-        jeliya_api::SubjectState::Present { .. } => Ok(()),
-        jeliya_api::SubjectState::Absent => Err(jeliya_api::ApiError::SubjectAbsent),
-    }
-}
-
 /// `stream.unsubscribe` — remove the room from this connection's set.
 async fn handle_stream_unsubscribe(
     out_tx: &tokio::sync::mpsc::Sender<Message>,
@@ -1292,18 +1280,31 @@ async fn handle_stream_unsubscribe(
         Some(r) => r.clone(),
         None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
-    // Validation-order step 2. This operation is resolved from the
-    // connection's own subscription map rather than through the engine, so it
-    // is the one place the subject precondition has to be applied by hand — and
-    // without it a subject-less caller got `subscription_unknown` where every
-    // other operation answers `subject_absent`.
+    // The room-access stages, before the connection-local semantics.
     //
-    // Steps 4 and 5 deliberately do NOT run: a subscription is connection state,
-    // so a room this connection never subscribed to is `subscription_unknown`
-    // whether or not it exists, which is what its sibling cases settle. That
-    // answer is identical for an unknown room, a real one, and a room the
-    // caller is not in, so it is not an oracle.
-    if let Err(err) = subject_precondition(state) {
+    // This operation is resolved from the connection's own subscription map
+    // rather than through the engine, so the stages the engine applies to
+    // everything it dispatches have to be applied here by hand. They are not
+    // optional for it: the record makes step 4 "every operation whose `in`
+    // carries `room_id`" and step 5 the same set minus `room.archive` and
+    // `room.list`, and it enumerates its carve-outs exhaustively —
+    // `subject.ensure` at step 2, `invite.redeem` at 4, 5 and 6. There is no
+    // `stream.*` exception, `stream.unsubscribe`'s `in` is `{room_id}`, and
+    // `request_room` already declares it room-scoped for core dispatch.
+    //
+    // An earlier revision applied step 2 alone and argued the rest away as
+    // connection state. That left `subscribe R` → `leave R` → `unsubscribe R`
+    // answering `ok {unsubscribed: true}` to a caller whose membership the room
+    // had already ended — an answer neither the record nor the fixtures
+    // support, since nothing tears the map entry down when standing ends.
+    //
+    // `authorize_room` is the same call the two siblings in this file make, and
+    // it yields the stages in the record's order: `subject_absent`,
+    // `room_not_available`, then `membership_ended`. `subscription_unknown`
+    // stays what it always was — the step-7 answer for an active member holding
+    // no such subscription. None of it is an oracle: `room_not_available` is
+    // the record's own conflation of unknown-and-inaccessible.
+    if let Err(err) = authorize_room(state, &req.room_id).await {
         return send_api_err(out_tx, id, err).await;
     }
     let mut subs = subscriptions.lock().await;

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -1262,9 +1262,22 @@ async fn handle_stream_subscribe(
     .await
 }
 
+/// Validation-order step 2 for the operations this host resolves itself.
+///
+/// The engine applies it to everything it dispatches; the connection-scoped
+/// `stream.*` operations that never reach it need it applied here, or they
+/// answer their own semantic code on a daemon that has no subject at all.
+fn subject_precondition(state: &AppState) -> Result<(), jeliya_api::ApiError> {
+    match state.engine.subject_state()? {
+        jeliya_api::SubjectState::Present { .. } => Ok(()),
+        jeliya_api::SubjectState::Absent => Err(jeliya_api::ApiError::SubjectAbsent),
+    }
+}
+
 /// `stream.unsubscribe` — remove the room from this connection's set.
 async fn handle_stream_unsubscribe(
     out_tx: &tokio::sync::mpsc::Sender<Message>,
+    state: &AppState,
     request: &jeliya_codec::Request,
     subscriptions: &std::sync::Arc<
         tokio::sync::Mutex<std::collections::HashMap<String, SubscriptionState>>,
@@ -1279,6 +1292,20 @@ async fn handle_stream_unsubscribe(
         Some(r) => r.clone(),
         None => return send_api_err(out_tx, id, jeliya_api::ApiError::MalformedFrame).await,
     };
+    // Validation-order step 2. This operation is resolved from the
+    // connection's own subscription map rather than through the engine, so it
+    // is the one place the subject precondition has to be applied by hand — and
+    // without it a subject-less caller got `subscription_unknown` where every
+    // other operation answers `subject_absent`.
+    //
+    // Steps 4 and 5 deliberately do NOT run: a subscription is connection state,
+    // so a room this connection never subscribed to is `subscription_unknown`
+    // whether or not it exists, which is what its sibling cases settle. That
+    // answer is identical for an unknown room, a real one, and a room the
+    // caller is not in, so it is not an oracle.
+    if let Err(err) = subject_precondition(state) {
+        return send_api_err(out_tx, id, err).await;
+    }
     let mut subs = subscriptions.lock().await;
     if subs.remove(&req.room_id.to_string()).is_none() {
         return send_api_err(
@@ -1529,7 +1556,7 @@ async fn dispatch_inbound(
             return handle_stream_subscribe(out_tx, state, &request, subscriptions).await;
         }
         "stream.unsubscribe" => {
-            return handle_stream_unsubscribe(out_tx, &request, subscriptions).await;
+            return handle_stream_unsubscribe(out_tx, state, &request, subscriptions).await;
         }
         "stream.resync" => {
             return handle_stream_resync(out_tx, state, &request).await;


### PR DESCRIPTION
Two defects an adversarial review confirmed against `docs/protocol-v2.md`. Both predate #230, and neither is a projection or validation-order change, so they are separated from it. **Stacked on #231** (which is stacked on #230).

## `fleet.list` read agent-ness off a membership row

The record (:1228):

> An **agent** is a member that has authored at least one `status.post` event. Agent-ness is derived here, not declared: it is a classification, not a permission, so it is not a `role` and appears in no membership row.

The projection filtered `snapshot.members()` on the upstream fold's `Role::Agent`. That gets the answer wrong in both directions:

- a member that posts statuses **never appeared** in the fleet;
- a member holding the upstream role that has **never posted** appeared with `latest_status: absent` — an agent the operator has no evidence for.

Now derived from the room's `agent.status` events, with membership still required via the same device-binding test the roster uses.

The regression test posts as the room's **authority**, which holds `Admin` and never `Agent`: under the old derivation it could not appear in the fleet no matter how many statuses it posted, so the test fails against the previous code and passes against this one.

## `stream.unsubscribe` ran no validation stage

The host resolves it from the connection's own subscription map rather than through the engine, so it never reached validation-order step 2. A subject-less caller got `subscription_unknown` where every other operation answers `subject_absent`. Its two siblings (`stream.subscribe`, `stream.resync`) already authorize through `authorize_room`.

**Only step 2 is applied.** Steps 4 and 5 deliberately do not run: a subscription is connection state, so a room this connection never subscribed to is `subscription_unknown` whether or not it exists — which is what the sibling corpus cases in `timeline-streams.json` settle, and which is not an oracle, the answer being identical for an unknown room, a real one, and a room the caller is not in.

## Verification

- `cargo fmt --all --check`, `cargo clippy --locked --workspace --all-targets -- -D warnings`, `cargo test --locked --workspace` — clean; 144 core unit tests
- Corpus replay, two runs each: **100 stable green, unchanged, zero regressions**

The `fleet.list` corpus cases need multi-actor provisioning the live harness does not yet do (a known milestone-#7 gap), so the fix is pinned by the Rust regression test rather than by a replayed case.

## Still open from that review

Two confirmed findings are deliberately not addressed here:

- **`daemon.stop` sequences teardown before validation.** #230 makes it skip step 2 so the reply and the effect agree, but the engine still sequences the stop before `dispatch` runs at all. Resolving that properly is a decision about the record's stage table, not a patch.
- **`pipe.publish` answers `policy_refused` for an empty `audience.subject_ids`.** The verifier refuted this as a spec violation — the record states no minimum — so it is recorded as a shape question rather than fixed.

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
