### PR TITLE
test(conformance): align file streams with v2 framing

### DIFF
--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -1,12 +1,13 @@
 # Protocol v2 conformance corpus
 
 Hand-authored, language-neutral fixtures for
-[protocol v2](../../docs/protocol-v2.md). Intended to be replayed by an
-independent harness against every adapter: the codec, the typed daemon, the
-Rust adapters, and the agent cutover.
+[protocol v2](../../docs/protocol-v2.md). They define cases that independent
+adapters can consume; the status matrix below states which execution slices
+actually exist.
 
-This directory is data. It contains no TypeScript, no Rust, and no test runner,
-because a corpus that only one language can replay is not a conformance corpus.
+The fixture JSON is language-neutral data. The repository also contains a Node
+structural validator and a partial live replay harness. Their existence is not
+evidence that every fixture or adapter is executable.
 
 ## The independence rule
 
@@ -21,33 +22,60 @@ conformance corpus is for. #161 states it as an acceptance criterion.
 
 The v1 surface was consulted **only** to know what to avoid transcribing.
 
-## Status — replayable
+## Status
 
-The specification is canonical and the fixtures are normalized to the DSL
-(#213). Every case conforms; the corpus can be replayed by an independent
-harness and may be cited as evidence for any adapter.
+The specification is canonical and the fixtures use the normative DSL. Shape
+validation, implemented execution, and adapter applicability are different
+claims:
 
-| | |
-|---|---|
+| Slice | Status | What the claim means |
+|---|---|---|
+| Structural validation | Implemented for all 342 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics, and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
+| Selected JSON-envelope/subject slice | Partial (14 CI-selected cases) | The Node harness runs this selected JSON-envelope and subject-lifecycle slice against `jeliyad`; this is neither corpus coverage nor file-stream evidence. It is not a smoke, E2E, or Dart execution claim. |
+| Binary byte-stream executor | Unimplemented | No harness codec/runtime executes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records, so file-stream cases are declarative, not live evidence. |
+| Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
+
+| Computed corpus fact | Value |
+|---|---:|
 | Cases | 342 |
-| Cases conforming to the DSL | **342** |
-| Distinct step verbs in use | 7, the closed set (`call`, `http`, `upgrade`, `send`, `await`, `control`, `assert`) |
-| Codes in the taxonomy without a case | **0** |
-| Blocked on upstream | 10 |
+| Attributed to an operation | 237 |
+| `operation: null` | 105 |
+| Untargeted / in-process-core / client-adapter targeted | 336 / 1 / 5 |
+| Distinct step verbs in use | 7 |
+| Taxonomy codes / without a direct canonical operation case or verified transport representation | 64 / 9 (`forbidden_origin`, `pairing_code_invalid`, `protocol_unsupported`, `role_not_grantable`, `session_expired`, `storage_generation_mismatch`, `stream_aborted`, `unauthenticated`, `unknown_operation`) |
+| Blocked on upstream | 14 (U1: 5, U2: 8, U3: 1) |
+| Blocked on a settled record contradiction | 1 |
 
-Two cases were retired in the files pass-3 re-transcription: `declared_bytes` is a
-required `<uint>` and there are no optional request fields, so an *unknown*
-declared size is not expressible in v2, and both cases collapsed onto ones that
-already exist.
+Per-file case totals are: `files.json` 44, `handshake.json` 69,
+`invites.json` 37, `pipes.json` 43, `rooms.json` 65,
+`subject-daemon.json` 24, and `timeline-streams.json` 60.
+
+Corpus values are recomputed by the validator from every fixture JSON and
+reconciled against `manifest.json`; they are not execution results. Distinctive
+code coverage requires a literal, canonical `expect.err.code` on a direct
+`call` whose operation equals the case's `operation`; notes, intents, setup
+calls, nested generic objects, and `authoring_notes` never count. The general
+codes-without-a-case ledger uses the same direct canonical operation-case rule,
+with only the four verified close/status fixture-name exceptions for
+`frame_too_large`, `idle_timeout`, `malformed_frame`, and `not_ready`. The selected live-slice count
+comes from every explicit CI `--case` selector, each of which must resolve
+exactly once; it is status metadata, not corpus coverage.
+
+The files pass-3 re-transcription retired cases about an unknown declared size:
+`declared_bytes` is a required `<uint>` and there are no optional request fields,
+so that state is not expressible in v2 and collapsed onto existing cases.
+
+Top-level `authoring_notes`, where retained in unchanged domains, are historical,
+non-normative transcription notes. Validators never use them as taxonomy-code
+or coverage evidence.
 
 Normalization was tracked as **#213** and landed with the promotion of the
-specification to canonical: the fourteen refused codes retired, the fixture
-bugs #212 catalogued fixed, every case retranscribed, the uncovered codes
-authored, and the manifest recomputed from the fixtures.
+specification to canonical: refused codes were retired, the fixture bugs #212
+catalogued were fixed, cases were retranscribed, uncovered codes were authored,
+and the manifest was recomputed from the fixtures.
 
-**Ten cases are blocked on upstream work** (U1, U2, U3 in the spec). They
-**fail**; they do not skip. A skipped case reads as coverage and quietly
-becomes permanent. A failing case reads as work.
+Blocked cases **fail**; they do not skip. A skipped case reads as coverage and
+quietly becomes permanent. A failing case reads as work.
 
 ### What normalization did not do
 
@@ -85,9 +113,8 @@ Normative. A harness implements exactly this, and a fixture that uses anything
 not defined here is invalid rather than interestingly extended.
 
 The design constraint is that it must lose no assertion the corpus currently
-expresses while replacing 178 ad-hoc verbs and three `assert` dialects — string,
-object, and array — with one language. Every construct below exists because some
-committed fixture needs it.
+expresses while replacing the earlier ad-hoc verbs and `assert` dialects with
+one language. Every construct below exists because some fixture needs it.
 
 ## The case object
 
@@ -98,6 +125,7 @@ committed fixture needs it.
   "operation": "room.list",
   "intent": "Proves room.list answers from local evidence with zero network activity, catching any change that makes the room list depend on liveness.",
   "requires": ["subject", "room:live", "observe:network"],
+  "targets": ["daemon"],
   "steps": [ … ],
   "blocked_on_upstream": "U1"
 }
@@ -106,13 +134,19 @@ committed fixture needs it.
 | Key | Required | Value |
 |---|---|---|
 | `name` | yes | `snake_case`, corpus-wide unique |
-| `kind` | yes | one of the eight below |
-| `operation` | yes | one of the 33 operation names, or `null` |
+| `kind` | yes | one of the closed values below |
+| `operation` | yes | one of the closed operation names, or `null` |
 | `intent` | yes | prose naming the breaking change this case would catch |
 | `requires` | yes | array of preconditions, closed vocabulary below |
+| `targets` | no | non-empty unique array whose values are from `daemon`, `in_process_core`, `client_adapter` |
 | `steps` | yes | non-empty array |
 | `blocked_on_upstream` | no | `"U1"`, `"U2"`, or `"U3"` |
 | `blocked_on_record` | no | Named settled record/corpus contradiction retained as an expected failure until the stale case is retired |
+
+Omitting `targets` means every adapter to which the case is applicable. An
+adapter executes cases whose `targets` contain it, plus applicable untargeted
+cases. A target mismatch is an applicability decision only: it is not a pass or
+skip and contributes no such claim to global coverage.
 
 Both block forms **fail, never skip**. A passing blocked case is reported as a
 surprise; a setup/runner error is still an error rather than an expected block.
@@ -121,17 +155,17 @@ surprise; a setup/runner error is still an error rather than an expected block.
 `handshake`, `push`, `ordering`.
 
 **`operation: null` is legal and means the case is not about one operation** —
-gate behaviour, envelope framing, cross-room ordering. 103 of the 335 committed
-cases are in this class, and the manifest's coverage table counts only the
-attributed ones, which is why its rows sum to 232 rather than 335. A case may
-not use `null` merely because attributing it is inconvenient.
+gate behaviour, envelope framing, and cross-room ordering are examples. The
+manifest lists every such case by file, and its coverage table counts only
+operation-attributed cases. A case may not use `null` merely because attributing
+it is inconvenient.
 
 `intent` is required and is not decoration: a case whose intent cannot name the
 breaking change it would catch is not worth running.
 
 ## Steps
 
-A step has **exactly one verb**. The verb set is closed at seven.
+A step has **exactly one verb**. The table below is the closed verb set.
 
 | Verb | Value | Meaning |
 |---|---|---|
@@ -153,11 +187,37 @@ Any step may additionally carry:
 | `expect` | the reply matcher |
 | `save` | capture values from this step's result into variables |
 | `stream` | the bytes the operation streams, for `call` |
+| `defer` | boolean `true`, for `call` only; send the request without awaiting its terminal reply |
 | `note` | prose for a human; a harness ignores it |
 
 `save` is an **auxiliary key, not a verb**. It always captures from the step it
 sits on, so making it a verb would force every capture into a second step with
 nothing to capture from.
+
+### `defer` — keep a call outstanding
+
+A deferred call has `"defer": true`, sends its request, and saves a request
+handle without waiting for the terminal reply:
+
+```json
+{ "call": "file.fetch", "in": { "room_id": "$rid", "file_id": "$fid" },
+  "op_id": "op-fetch", "defer": true,
+  "save": { "fetch_request": "$request" } }
+{ "await": { "reply": "$fetch_request" },
+  "expect": { "ok": false, "err": { "code": "stream_aborted" } } }
+```
+
+`defer` is legal only on `call`, has no false form, and the deferred call does
+not carry `expect`; its later `await {reply: "$handle"}` receives and matches the
+terminal reply. The special save path `$request` captures the harness request
+handle, not a protocol reply field.
+`save: {"handle": "$request"}` is legal only on a deferred call. Every saved
+handle has exactly one later terminal path on the same effective session: either
+one `await {"reply": "$handle"}`, or one `control.disconnect` that names that
+session and explicitly abandons its connection-local handles. A disconnect on a
+different session does not terminate the handle. Duplicate awaits, an await on
+the wrong session, and a live deferred handle at case end are invalid. This
+defines the DSL contract; the current live harness does not implement it.
 
 ### `stream` — the bytes an operation carries
 
@@ -179,13 +239,20 @@ separate HTTP upload edge into the operation itself: `file.share` streams bytes
 and the declaration are one operation, so a separate verb would leave a step
 holding a stream with nothing to stream for — and it would let a fixture put
 them in the wrong order, which is exactly the ambiguity the record removes by
-combining the two edges.
+combining the two edges. `stream` and `defer` cannot share a call step.
 
 It takes exactly one key, fixed by the operation: `send_bytes` for `file.share`,
 `receive_bytes` for `file.read`. A `stream` on any other operation is invalid,
 because no other operation streams. The value is a `<uint>`, a `$variable`, or a
 computed node, so a boundary case can say "exactly the served limit" without
 compiling the number in.
+
+A fresh admitted daemon `file.share` or `file.read` requires its matching stream.
+A terminal refusal before OPEN has no stream and records zero receiver-accepted
+bytes. A faithful replay of a completed result also has no stream and opens no
+second one. Validators may require stream presence only when admission is safely
+decidable from the case's explicit `expect` result or replay shape; they must not
+guess from prose or from operation name alone.
 
 **`stream.send_bytes` is deliberately independent of `in.declared_bytes`.**
 Declaring one size and sending another is not a malformed fixture — it is the
@@ -199,14 +266,17 @@ Without this key the files domain is not transcribable: `stage_stream`,
 obligations on `file.read` all describe what happens to bytes in flight, and
 `observe: bytes_streamed` can only assert the outcome, never cause it.
 
-`note` is the only annotation key. The committed corpus also uses `why`,
-`comment`, `intent_note`, and `meaning` for the same thing.
+`note` is the only annotation key. The retired forms `why`, `comment`,
+`intent_note`, and `meaning` are invalid. Domain files accept only `domain`,
+`note`, `cases`, and optional `authoring_notes`; case objects accept only the
+keys in the table above. `authoring_notes` are historical and non-normative and
+never count as coverage or error-code evidence.
 
 ### `control` — driving the harness
 
-`control` is discriminated by `do`, closed at ten. It is the one verb that does
-not touch the daemon's protocol surface, so leaving it as an open object would
-have let every harness invent its own dialect — which is what the committed
+`control` is discriminated by `do`; the table below is closed. It is the one
+verb that does not touch the daemon's protocol surface, so leaving it open
+would have let every harness invent its own dialect — which is what the committed
 corpus already did, spelling this idea four ways (`harness`, `control`, `fault`,
 `trigger`) split cleanly by authoring file.
 
@@ -218,10 +288,25 @@ corpus already did, spelling this idea four ways (`harness`, `control`, `fault`,
 | `reconnect` | `on` | Re-establish it, same principal |
 | `inject_fault` | `fault` | Force a named fault condition |
 | `set_limit` | `limit`, `value` | Override a served limit for this case |
+| `set_link_rate` | `between`, `bits_per_second` | Cap the harness link between exactly two session/provider labels; the rate is a positive value node |
+| `set_provider_response_bytes` | `file_id`, `bytes` | Make the named provider serve the nonnegative byte count |
+| `client_preflight` | `source_bytes`, `source_reports_size` | Exercise client preflight with a nonnegative byte-count value node and a boolean size-report flag |
+| `client_render_limit` | `served_bytes` | Render a limit from a nonnegative served-byte value node |
+| `client_render_file` | `declared_content_type`, `body_kind` | Exercise client rendering with two non-empty strings |
 | `stop_daemon` | `daemon` | Terminate a daemon process |
 | `start_daemon` | `daemon` | Start a previously stopped daemon — restart cases cannot be written without it; the pair expresses one restart, never a fresh daemon |
-| `start_transfers` | `count` | Begin N concurrent transfers |
+| `start_transfers` | `count`, `aggregate_bytes`, `op_id_prefix` | Begin a positive number of file transfers reserving a nonnegative aggregate byte count under a non-empty prefix |
+| `cancel_transfers` | `op_id_prefix` | Cancel the harness-started file-transfer set under a non-empty prefix |
 | `pause_link` | `between` | Suspend transport between two daemons |
+
+Each file-domain form above is closed and includes `do`: exactly
+`{do,file_id,bytes}`, `{do,source_bytes,source_reports_size}`,
+`{do,served_bytes}`, `{do,declared_content_type,body_kind}`,
+`{do,count,aggregate_bytes,op_id_prefix}`, or `{do,op_id_prefix}` respectively.
+The two pre-existing handshake request-concurrency fixtures retain their exact
+legacy `start_transfers` shape `{do,count}`; it drives requests rather than file
+transfers. `set_link_rate` remains exactly `{do,between,bits_per_second}`. These
+controls make fixtures declarative; they do not add a protocol or executor.
 
 `inject_fault`'s `fault` is a **taxonomy code**, so a fault a case wants that
 names no code is a signal the taxonomy is incomplete — that is how
@@ -234,6 +319,13 @@ to force in order to test gap detection at all.
 reach — `max_connections` and `max_subscriptions_per_connection` cannot be
 exercised against production values in a test.
 
+`set_link_rate` is harness control, not a protocol operation. Its object has
+exactly `do`, `between`, and `bits_per_second`; `between` contains exactly two
+distinct non-empty session/provider labels, and `bits_per_second` is a positive
+`<uint>`, a `$variable`, or a computed node. It makes the size-aware deadline
+cases declarative, but the U2 cases still fail until executable progress/rate
+support exists.
+
 ### `on` — which session
 
 `on` names a session established by `requires`, defaulting to `subject:self`'s
@@ -245,14 +337,15 @@ primary connection when omitted:
 { "call": "room.list",   "on": "subject:self#2", "in": {} }
 ```
 
-**Nothing else selects an actor**, and without this key roughly a third of the
-corpus is inexpressible. The committed fixtures spell the same idea four ways —
-`as` (504 uses, 25 distinct actor labels), `conn`, `session`, and `client` — and
-the cases that need it are not marginal: the non-oracle property needs a
-non-member, `op_ids_do_not_collide_across_session_principals` needs two
-principals on one daemon, and every reconnect case needs two connections for one
-subject. `#2` names a second connection for the same principal, which is what
-distinguishes a per-connection scope from a per-principal one.
+**Nothing else selects an actor.** `principal:self` and `principal:second`
+explicitly name distinct authenticated session principals — distinct
+`client_id`/session credentials — on one daemon and one cryptographic subject.
+They are the labels principal-isolation cases must use. By contrast,
+`subject:second` establishes another daemon/subject; it is not evidence of
+same-daemon principal isolation. The other cases that need actor selection are
+not marginal: the non-oracle property needs a non-member, reconnect cases need
+two connections for one subject, and `#2` names a second connection for the same
+principal, distinguishing per-connection from per-principal scope.
 
 ## `expect` — one reply matcher
 
@@ -262,6 +355,24 @@ distinguishes a per-connection scope from a per-principal one.
 { "expect": { "ok": true,  "out": { "room_id": "<room_id>", "live": true } } }
 { "expect": { "ok": false, "err": { "code": "room_not_available" } } }
 ```
+
+In `files.json`, a literal error code also closes the canonical error matcher:
+`invalid_argument` has exactly `code,field,reason`; `room_not_available`
+`code,room_id`; `membership_ended` `code,room_id,standing`; `file_unknown` and
+`file_not_fetched` `code,file_id`; `provider_unreachable`
+`code,file_id,providers`; `transfer_unknown` `code,transfer_op_id`;
+`declared_size_mismatch` `code,declared_bytes,observed_bytes`;
+`transfer_stalled` `code,transferred_bytes,total`; `transfer_deadline_exceeded`
+adds `budget_ms`; `stream_aborted` uses `code,transferred_bytes,total,reason`;
+`file_too_large` uses `code,declared_bytes,limit_bytes,enforced_at`;
+`resource_exhausted` uses `code,resource,limit`; `digest_mismatch` uses
+`code,expected,observed`; `room_not_live` uses `code,room_id`;
+`op_id_conflict` uses `code,op_id`; and `subject_absent` and
+`file_index_unreadable` are code-only. The non-empty
+`provider_unreachable.providers` array contains rows with exactly
+`subject_id,device_id,link`.
+Every `files.json` error matcher carries a literal code and uses one of these
+schemas; they never apply to prose notes.
 
 For `http` and `upgrade` steps the matcher instead carries `status`, `headers`,
 and `body`:
@@ -283,9 +394,8 @@ To pin a key set exactly, use the `exact_keys` assertion. To require a key be
 "asserted absent" — the distinction is load-bearing, and conflating the two is
 how a fixture starts passing against an implementation that leaks a field.
 
-`expect` replaces **all 42 `expect_*` verbs** the corpus currently uses. They
-divide three ways, and the division is the point — a flat list of replacements
-would hide that a third of them are not reply matchers at all:
+`expect` replaces the earlier `expect_*` forms. They divide into reply
+matchers, assertions, and frame/process observations; the division is the point:
 
 | Corpus verbs | Become |
 |---|---|
@@ -293,17 +403,16 @@ would hide that a third of them are not reply matchers at all:
 | `expect_absent`, `expect_no_null`, `expect_identical_to`, `expect_one_of`, `expect_any_of`, `expect_all`, `expect_each_subset`, `expect_every_element`, `expect_across`, `expect_at_least_one_error`, `expect_all_replies`, `expect_hello_assert`, `expect_rendering` | an `assert` predicate — they are assertions wearing an `expect_` prefix |
 | `expect_frame`, `expect_push`, `expect_no_push`, `expect_frame_order`, `expect_each_frame`, `expect_close`, `expect_no_further_frames_of_type`, `expect_transport`, `expect_process`, `expect_connect_failure`, `expect_timing_indistinguishable`, `expect_reply_for_id`, `expect_reply_for_id_2`, `expect_error_for_id`, `expect_no_reply_for_id` | `await` or an `observe` assertion — they are about frames and processes, not about one reply |
 
-`expect_reply_for_id` and its three siblings deserve their own note: they exist
-because **replies may arrive out of order**, which the record makes normative.
+The retired reply-by-id forms deserve their own note: they existed because
+**replies may arrive out of order**, which the record makes normative.
 A harness that could only match replies in request order would silently pass an
 implementation that violated it. `await {reply: "$id"}` is how a case names the
 reply it means.
 
 ## `assert` — one assertion form, two families
 
-`assert` is **always an array of objects**. It is never a bare string and never a
-single object; the committed corpus uses all three, which is the single largest
-source of the dialect problem.
+`assert` is **always an array of objects**. It is never a bare string or a
+single object.
 
 ### Value assertions
 
@@ -317,7 +426,7 @@ This is what lets one predicate replace the corpus's `every_row_has_fields`,
 `every_row_has_non_null`, `every_push_has_non_null`, `all_eq`, `every_has_key`,
 and `every_row_has_value`.
 
-`op` is closed at nineteen:
+`op` is closed:
 
 | `op` | `value` | Holds when |
 |---|---|---|
@@ -352,11 +461,21 @@ every multi-byte boundary case silently wrong.
 successive progress frames may legitimately repeat, and asserting strict
 increase there would fail a correct implementation.
 
+For `files.json`, value assertions are additionally shape-checked so they cannot
+be empty claims. `present`, `absent`, `unique`, `increasing`, `non_decreasing`,
+`contiguous`, and `no_nulls` take no `value`. `eq`, `ne`, numeric comparisons,
+`member_of`, `type`, `exact_keys`, `len`, `byte_len`, and `eq_except` require the
+value forms in the table; `ne` cannot take an array. A `type` value is one of the
+bare names in the type-tag vocabulary (for example `uint`, not `<uint>`).
+Assertion objects admit only `path`, `op`, `value`, and the optional historical
+`note` used by current file fixtures. These stronger file-domain checks are not
+a claim that every fixture's intended semantics have been proved.
+
 `no_nulls` deserves its own predicate rather than being a convention because
 [the specification's no-null rule](../../docs/protocol-v2.md#bounded-parsing) is
 normative for every frame, and a corpus that cannot assert it cannot test it.
 
-These fourteen replace the corpus's `eq`, `equals`, `equal_modulo`, `all_eq`,
+These predicates replace the corpus's `eq`, `equals`, `equal_modulo`, `all_eq`,
 `same_value_as`, `codes_equal`, `identical_to`, `errors_identical`, `ne`, `neq`,
 `not_equal`, `not_equals`, `distinct_from`, `len`, `len_eq`, `array_len`,
 `byte_len`, `len_lte`, `len_gte`, `no_null`, `no_nulls_deep`, `no_null_values`,
@@ -376,23 +495,36 @@ reply. Those are a separate family, because no path names them:
 { "observe": "timing_indistinguishable", "between": ["step:3", "step:5"] }
 ```
 
-`observe` is closed at ten. Each row states the keys it takes, because an
-observation with no slot for its argument cannot be written down:
+`observe` is closed. Each row states the keys it takes, because an observation
+with no slot for its argument cannot be written down:
 
 | `observe` | Additional keys | Holds when |
 |---|---|---|
 | `no_network_activity` | `scope` | No packet left the host during `scope` |
 | `no_durable_mutation` | `scope` | No byte of the data dir changed during `scope` |
 | `no_event_authored` | `scope` | No room event was written during `scope` |
-| `bytes_streamed` | `value` | Bytes sent satisfies a nested comparison |
+| `bytes_streamed` | `value`, optional `call` | Receiver-accepted payload bytes satisfy a nested comparison; `call` is `step:<n>` |
 | `connection_open` | `on` | That session is still open |
 | `close_code` | `value`, `on` | That connection closed with this code |
 | `push_count` | `value`, `room_id` | Pushes received for a room satisfies a comparison |
-| `no_push` | `room_id`, `scope` | No push arrived for that room |
+| `no_push` | either `room_id`, `scope`; or `on`, `match`, `scope` | No room-scoped push arrived, or no push matching a non-empty object arrived on the named principal |
 | `timing_indistinguishable` | `between` | Two named steps are not separable by latency |
 | `process_exited` | `value` | The daemon process exited with this status |
 
-`scope` is `step`, `case`, or `step:<n>..step:<m>`.
+The closed sets above are also enforced by the validator; their sizes are not
+coverage claims.
+
+`scope` is `step`, `case`, or `step:<n>..step:<m>`. `no_push` is exactly either
+the legacy room form `{observe,room_id,scope}` or the principal matcher form
+`{observe,on,match,scope}`. In the latter, `on` is non-empty and `match` is a
+non-empty object; `room_id` is neither required nor allowed.
+
+`bytes_streamed.value` is the nested comparison object. Its metric is bytes the
+receiver accepted into its bounded sink, never bytes merely generated, read, or
+queued to a socket. Optional `call: "step:<n>"` selects the call whose counter is
+observed; omission selects the most recent call on the same session. A terminal
+pre-OPEN refusal records zero accepted bytes, and a completed faithful replay
+has no stream and therefore also records zero.
 
 Steps are addressable as `step:<n>`, one-indexed within the case. That is what
 makes `timing_indistinguishable` writable at all — it is a claim about a *pair*
@@ -410,9 +542,11 @@ asserts only the code proves half the property.
 { "call": "room.timeline", "in": { "room_id": "$r", "…": "…" } }
 ```
 
-`save` maps variable names to paths and rides on the step that produces them. A
-`$name` reference resolves to the captured value anywhere a literal is legal.
-Variables are scoped to the case.
+`save` maps variable names to string paths and rides on the step that produces
+them. A `$name` reference resolves to the captured value anywhere a literal is
+legal. Variables are scoped to the case. Ordinary paths root at `out`, `err`,
+`frame`, or `$` for the whole step value; `$request` is the deferred-call handle
+capture. Retired `$result` and `$error` paths are invalid: use `out` and `err`.
 
 This replaces `save`, `save_out`, and `save_error`, which differed only in which
 root they read from — now expressed as the path's root.
@@ -434,8 +568,7 @@ value may also be a single-key computed node:
 
 Without these, **every case that probes a served limit would have to hard-code
 the limit**, which is precisely the failure the record's served-limits object
-exists to prevent — and the corpus already embeds thirteen ad-hoc operators to
-avoid it.
+exists to prevent.
 
 `{"$unknown": …}` is separate from a literal because the non-oracle cases need a
 value that is syntactically valid and semantically absent, and a fixture cannot
@@ -449,16 +582,17 @@ pins a shape without pinning a clock or a random identifier.
 **A tag names a value domain, not an encoding.**
 
 `<room_id>` `<subject_id>` `<device_id>` `<event_id>` `<invite_id>` `<file_id>`
-`<pipe_id>` `<op_id>` `<ts>` `<uint>` `<bool>` `<string>` `<pos>` `<capability>`
-`<daemon_sg>` `<port>` `<object>` `<any>` `<version>` `<standing>` `<link_connected>`
+`<pipe_id>` `<op_id>` `<request_id>` `<ts>` `<uint>` `<bool>` `<string>` `<pos>`
+`<capability>` `<daemon_sg>` `<port>` `<object>` `<any>` `<version>` `<standing>` `<link_connected>`
 `<link_reason>`
 
-The second line is the domain additions #213's normalization minted, each named
-here in the same change that uses it, as the rule above requires:
+The table names the additional domains beyond the obvious identifier and scalar
+tags; each new tag is added here in the same change that uses it:
 
 | Tag | Domain |
 |---|---|
 | `<pos>` | a room position — stricter than `<uint>` because positions are per-room and monotonic |
+| `<request_id>` | the request envelope's exact integer correlation domain |
 | `<capability>` | an invite capability string |
 | `<daemon_sg>` | the daemon's storage generation, discovered at Layer 0 |
 | `<port>` | a TCP port |
@@ -469,10 +603,8 @@ here in the same change that uses it, as the rule above requires:
 | `<link_connected>` | a `link` variant in its `direct` or `relay` arm |
 | `<link_reason>` | the `link.reason` bare enum |
 
-- **`<hex64>` is not a tag.** It names an encoding shared by four distinct
-  domains, so asserting it where `<device_id>` belongs would pass against a
-  subject id. The corpus uses it 
-  in exactly that ambiguous way today.
+- **`<hex64>` is not a tag.** It names an encoding shared by distinct domains,
+  so asserting it where `<device_id>` belongs could pass against a subject id.
 - `<u64>`, `<number>`, and `<int>` all collapse into `<uint>`.
 - **`<variant>` and `<array>` are not tags.** `{"state": "<variant>"}` asserts
   that a discriminant exists without asserting which arms are legal — it asserts
@@ -482,12 +614,9 @@ here in the same change that uses it, as the rule above requires:
 
 ## `requires`
 
-A closed vocabulary of preconditions the harness must establish. The committed
-corpus uses **133 flat tokens**, many of them synonyms (`daemon`,
-`authority_daemon`, `member_daemon`, `fresh_daemon`, `disposable_daemon`), which
-no harness can implement as a closed set.
-
-The replacement is a `namespace:argument` form. Namespaces are closed at nine:
+A closed vocabulary of preconditions the harness must establish. Preconditions
+use a `namespace:argument` form rather than adapter-specific synonyms. The
+namespace table is closed:
 
 | Namespace | Arguments | Establishes |
 |---|---|---|

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -564,6 +564,7 @@ value may also be a single-key computed node:
 | `{"$bytes_of_len": "$max"}` | A string of exactly that many bytes |
 | `{"$concat": ["a", "$b"]}` | Concatenation |
 | `{"$expires_in_ms": 3600000}` | An absolute RFC 3339 `Z` timestamp that many milliseconds from run time |
+| `{"$transfer_budget_ms": ["$total", "$allowance", "$floor_bps"]}` | `allowance + ceil(total * 8 * 1000 / floor_bps)`, the record's size-aware transfer budget |
 | `{"$unknown": "<room_id>"}` | A well-formed value of that domain naming nothing that exists |
 
 Without these, **every case that probes a served limit would have to hard-code

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -118,8 +118,7 @@
               "value": "uint",
               "note": "path recovered from context; exclusions: [\"string\", \"float\", \"null\", \"object\"]"
             }
-          ],
-          "note": "[split from a multi-verb step; review]"
+          ]
         },
         {
           "assert": [
@@ -149,14 +148,6 @@
               "op": "absent"
             }
           ]
-        },
-        {
-          "assert": [],
-          "note": "CORPUS-META OBLIGATION, no protocol surface: no other fixture may hard-code 104857600, 104857601, \"100 MiB\", or \"104_857_600\" - every other case derives its boundary from $limit, which is why this one case is allowed to pin the served value."
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"scope\": \"corpus\", \"except_case\": \"handshake_serves_the_file_and_transfer_limits_as_integers\", \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
         }
       ]
     },
@@ -164,6 +155,9 @@
       "name": "client_reads_the_shared_file_limit_from_the_handshake",
       "kind": "handshake",
       "operation": "file.share",
+      "targets": [
+        "client_adapter"
+      ],
       "intent": "Proves the client's share preflight threshold moves with a harness-reduced served max_shared_file_bytes rather than a compiled-in constant, catching any client that reintroduces one of the six hard-coded copies the size policy exists to delete.",
       "requires": [],
       "steps": [
@@ -200,40 +194,76 @@
           ]
         },
         {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": \"$limit\"} -> {\"decision\": \"accepted\"}; kept as a harness-driven check [harness orchestration: client_preflight]",
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "client_preflight",
+            "source_bytes": "$limit",
+            "source_reports_size": true
           }
-        },
-        {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": \"$limit+1\"} -> {\"decision\": \"refused\", \"bytes_sent\": 0, \"requests_emitted\": 0}; kept as a harness-driven check [harness orchestration: client_preflight]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.preflight_threshold\", \"op\": \"eq\", \"value\": null} - the record fixes what the daemon serves, not how a client preflights or renders it."
         },
         {
           "assert": [
             {
-              "path": "$limit",
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "accepted"
+            },
+            {
+              "path": "frame.accepted",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.source_bytes",
               "op": "eq",
               "value": "$limit"
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 1
             }
-          ],
-          "note": "[split from a multi-verb step; review]"
+          ]
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"values\": [104857600, \"100 MiB\"], \"note\": \"[bare-string assert 'client_source_has_no_literal' needs manual retranscription]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": true
+          }
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"scope\": [\"client_code\", \"locale_catalogs\", \"scripts\"], \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
+            }
+          ]
         }
       ]
     },
@@ -241,6 +271,9 @@
       "name": "client_renders_the_limit_message_from_the_served_integer",
       "kind": "handshake",
       "operation": "file.share",
+      "targets": [
+        "client_adapter"
+      ],
       "intent": "Proves the human-readable limit is rendered from the SERVED integer, so no catalog carries the number verbatim and a served change cannot make a translation lie. Asserted two ways: no locale catalog contains the number, and the rendered string moves when the harness overrides the limit.",
       "requires": [],
       "steps": [
@@ -268,38 +301,32 @@
           }
         },
         {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": \"$limit+1\"} -> {\"decision\": \"refused\"}; kept as a harness-driven check [harness orchestration: client_preflight]",
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "client_render_limit",
+            "served_bytes": "$limit"
           }
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.over_limit_message\", \"op\": \"present\"} - the record fixes what the daemon serves, not how a client preflights or renders it."
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.over_limit_message\", \"op\": \"present\"} - the record fixes what the daemon serves, not how a client preflights or renders it."
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"values\": [\"100 MiB\", \"104857600\"], \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.max_shared_file_bytes\", \"op\": \"type\", \"value\": \"uint\"} - the record fixes what the daemon serves, not how a client preflights or renders it."
         },
         {
           "assert": [
             {
-              "path": "$limit",
+              "path": "frame.source_bytes",
+              "op": "eq",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.rendered",
               "op": "type",
-              "value": "uint",
-              "note": "path recovered from context; exclusions: [\"string\"]"
+              "value": "string"
+            },
+            {
+              "path": "frame.rendered",
+              "op": "byte_len",
+              "value": {
+                "op": "gt",
+                "value": 0
+              }
             }
-          ],
-          "note": "[split from a multi-verb step; review]"
+          ]
         }
       ]
     },
@@ -353,18 +380,18 @@
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
               "file_id": "<file_id>",
-              "event_id": "<string>",
+              "event_id": "<event_id>",
               "pos": "<uint>",
-              "digest": "<string>",
-              "bytes": 1024
+              "bytes": 1024,
+              "digest": "<string>"
             }
           },
-          "op_id": "op-share-2"
-        },
-        {
-          "assert": [],
-          "note": "[split]"
+          "op_id": "op-share-2",
+          "stream": {
+            "send_bytes": 1024
+          }
         },
         {
           "assert": [
@@ -420,7 +447,7 @@
       "name": "share_at_exactly_the_served_limit_is_accepted",
       "kind": "boundary",
       "operation": "file.share",
-      "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes (104857600 as pinned by the handshake case) is accepted, catching an off-by-one that would silently refuse the largest legal file.",
+      "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes is accepted, catching an off-by-one that would silently refuse the largest legal file.",
       "requires": [
         "subject",
         "room:live"
@@ -463,10 +490,12 @@
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
               "file_id": "<file_id>",
-              "event_id": "<string>",
-              "digest": "<string>",
-              "bytes": "$limit"
+              "event_id": "<event_id>",
+              "pos": "<uint>",
+              "bytes": "$limit",
+              "digest": "<string>"
             }
           },
           "op_id": "op-atlimit-2",
@@ -480,7 +509,7 @@
       "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
       "kind": "boundary",
       "operation": "file.share",
-      "intent": "Proves the earliest daemon-side enforcement point fires on the declared length before any body is read, refusing $limit+1 (104857601) with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared, catching both an off-by-one and a daemon that buffers the body before checking.",
+      "intent": "Proves the earliest daemon-side enforcement point fires on a declaration one byte above the served limit before OPEN or any body byte, with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared.",
       "requires": [
         "subject",
         "room:live"
@@ -542,13 +571,6 @@
           "op_id": "op-over-2"
         },
         {
-          "note": "[stream {\"send_bytes\": 0}; forbidden codes on this refusal: [\"invalid_params\", \"invalid_argument\", \"digest_mismatch\"] \u2014 asserted via the pinned code in expect] [harness orchestration: stream_bytes]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
           "assert": [
             {
               "path": "err.hint",
@@ -564,6 +586,7 @@
           "assert": [
             {
               "observe": "bytes_streamed",
+              "call": "step:4",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -610,8 +633,7 @@
               "value": "uint",
               "note": "path recovered from context; exclusions: [\"string\"]"
             }
-          ],
-          "note": "[split from a multi-verb step; review]"
+          ]
         }
       ]
     },
@@ -668,32 +690,21 @@
               "enforced_at": "stage_stream"
             }
           },
-          "op_id": "op-liar-2"
-        },
-        {
-          "note": "[split from a multi-verb step; review] [stream {\"send_bytes\": \"$limit+4096\"}] [harness orchestration: stream_bytes]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch",
-                "invalid_argument"
+          "op_id": "op-liar-2",
+          "stream": {
+            "send_bytes": {
+              "$add": [
+                "$limit",
+                1
               ]
             }
-          ]
+          }
         },
         {
           "assert": [
             {
               "observe": "bytes_streamed",
+              "call": "step:4",
               "value": {
                 "op": "eq",
                 "value": "$limit"
@@ -733,26 +744,21 @@
       "name": "share_over_limit_in_process_core_is_refused_at_authoring",
       "kind": "error",
       "operation": "file.share",
+      "targets": [
+        "in_process_core"
+      ],
       "intent": "Proves the core authoring layer enforces the limit on file metadata before hashing or blob import, which is the only enforcement point that exists for an in-process adapter with no daemon upload edge, catching an implementation that relies on the stage checks alone.",
       "requires": [
         "subject",
-        "room:live"
+        "room:live",
+        "control:limits"
       ],
       "steps": [
         {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
+          "control": {
+            "do": "set_limit",
+            "limit": "max_shared_file_bytes",
+            "value": 4096
           }
         },
         {
@@ -770,32 +776,19 @@
           "in": {
             "room_id": "$rid",
             "name": "too-big-in-process.bin",
-            "declared_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
+            "declared_bytes": 4097,
             "declared_content_type": "application/octet-stream"
           },
           "expect": {
             "ok": false,
             "err": {
               "code": "file_too_large",
-              "declared_bytes": {
-                "$add": [
-                  "$limit",
-                  1
-                ]
-              },
-              "limit_bytes": "$limit",
+              "declared_bytes": 4097,
+              "limit_bytes": 4096,
               "enforced_at": "authoring"
             }
           },
-          "op_id": "op-authoring-2",
-          "stream": {
-            "send_bytes": 0
-          }
+          "op_id": "op-authoring-2"
         },
         {
           "assert": [
@@ -804,11 +797,7 @@
               "scope": "case"
             }
           ],
-          "note": "an aborted stage leaves nothing behind"
-        },
-        {
-          "assert": [],
-          "note": "BLOCKED ON U2: {\"path\": \"frame.op-authoring-2\", \"op\": \"present\"} - transfer progress is the `transfer` push frame, which depends on upstream progress handles; until it exists there is no frame to assert against."
+          "note": "authoring refusal leaves nothing behind"
         }
       ]
     },
@@ -816,7 +805,10 @@
       "name": "client_preflight_refuses_over_limit_before_any_bytes_are_sent",
       "kind": "boundary",
       "operation": "file.share",
-      "intent": "Proves the sixth enforcement point \u2014 the client preflight, which by definition never reaches the daemon \u2014 refuses an over-limit source with zero bytes sent, zero request frames emitted and no local copy made, catching a client that uploads a 100 MiB file only to be told no.",
+      "targets": [
+        "client_adapter"
+      ],
+      "intent": "Proves the sixth enforcement point \u2014 the client preflight, which by definition never reaches the daemon \u2014 refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
       "requires": [
         "room:live"
       ],
@@ -838,24 +830,38 @@
           }
         },
         {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": \"$limit+1\", \"source_reports_size\": true} -> {\"decision\": \"refused\", \"bytes_sent\": 0, \"requests_emitted\": 0, \"source_copies_made\": 0}; kept as a harness-driven check [harness orchestration: client_preflight]",
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": true
           }
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: the preflight emits no file.share request at all \u2014 the sixth enforcement point never reaches the daemon, so there is no reply to assert against."
         },
         {
           "assert": [
             {
-              "observe": "bytes_streamed",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
             }
           ]
         }
@@ -865,6 +871,9 @@
       "name": "client_unsized_source_streams_through_a_counting_bound",
       "kind": "boundary",
       "operation": "file.share",
+      "targets": [
+        "client_adapter"
+      ],
       "intent": "Proves a client facing a source that reports no size neither rejects it for lacking a size nor copies it unbounded, but streams it through a byte-counting bound that stops at the served limit, catching the two failure modes the size policy names for the Android SAF path.",
       "requires": [
         "room:live"
@@ -883,26 +892,86 @@
             }
           },
           "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
+            "limit": "frame.limits.max_shared_file_bytes",
+            "max_frame_bytes": "frame.limits.max_frame_bytes"
           }
         },
         {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": 65536, \"source_reports_size\": false} -> {\"decision\": \"accepted\", \"bytes_sent\": 65536}; kept as a harness-driven check [harness orchestration: client_preflight]",
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "client_preflight",
+            "source_bytes": 65536,
+            "source_reports_size": false
           }
         },
         {
-          "note": "client-side preflight observation (not a wire assertion): input {\"source_bytes\": \"$limit+1\", \"source_reports_size\": false} -> {\"decision\": \"aborted_at_bound\", \"bytes_sent_at_most\": \"$limit\", \"peak_buffered_bytes_at_most\": \"$max_frame_bytes\"}; kept as a harness-driven check [harness orchestration: client_preflight]",
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "accepted"
+            },
+            {
+              "path": "frame.accepted",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 65536
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 1
+            }
+          ]
+        },
+        {
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": false
           }
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.decision_for_unsized_under_limit\", \"op\": \"eq\", \"value\": \"refused\"} - the record fixes what the daemon serves, not how a client preflights or renders it."
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.staged_bytes",
+              "op": "lte",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.peak_buffered_bytes",
+              "op": "lte",
+              "value": "$max_frame_bytes"
+            }
+          ]
         }
       ]
     },
@@ -959,30 +1028,17 @@
             "ok": false,
             "err": {
               "code": "file_too_large",
-              "enforced_at": "stage_declared",
-              "limit_bytes": "$limit"
+              "declared_bytes": {
+                "$add": [
+                  "$limit",
+                  1
+                ]
+              },
+              "limit_bytes": "$limit",
+              "enforced_at": "stage_declared"
             }
           },
           "op_id": "op-pairA-2"
-        },
-        {
-          "note": "[split from a multi-verb step; review] [stream {\"send_bytes\": 0}] [harness orchestration: stream_bytes]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch"
-              ]
-            }
-          ]
         }
       ]
     },
@@ -1042,27 +1098,6 @@
             }
           },
           "op_id": "op-pairB-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "file_too_large",
-                "invalid_argument"
-              ]
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$fid",
-              "op": "present"
-            }
-          ]
         }
       ]
     },
@@ -1088,20 +1123,14 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-malformed-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": "file_too_large"
-            }
-          ]
         },
         {
           "call": "file.share",
@@ -1115,7 +1144,11 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-malformed-2"
@@ -1161,41 +1194,14 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-null-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": "file_too_large"
-            }
-          ]
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": null,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes"
-            }
-          },
-          "op_id": "op-null-2"
-        },
-        {
-          "assert": [],
-          "note": "HARNESS STATE, not a wire field: {\"path\": \"frame.0.in.size\", \"op\": \"present\"}"
         },
         {
           "call": "file.share",
@@ -1209,7 +1215,11 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-null-3"
@@ -1226,7 +1236,11 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-null-4"
@@ -1245,7 +1259,11 @@
             "ok": false,
             "err": {
               "code": "invalid_argument",
-              "field": "in.declared_bytes"
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
             }
           },
           "op_id": "op-null-5"
@@ -1253,13 +1271,14 @@
       ]
     },
     {
-      "name": "share_replayed_op_id_returns_the_original_result_and_authors_once",
+      "name": "share_completed_result_replays_without_a_second_stream_and_authors_once",
       "kind": "success",
       "operation": "file.share",
-      "intent": "Proves file.share is op_id deduplicated across a reconnection: the replay returns the byte-identical original result and performs no second blob import or second authored fact, catching a daemon whose ledger dies with the connection and duplicates a 100 MiB import on retry.",
+      "intent": "Proves a completed file.share result is op_id deduplicated across a same-principal reconnection: the replay returns the original out directly, opens no second stream, accepts zero bytes, and performs no second blob import or authored fact.",
       "requires": [
         "subject",
-        "room:live"
+        "room:live",
+        "control:reconnect"
       ],
       "steps": [
         {
@@ -1276,14 +1295,19 @@
             "declared_bytes": 2048,
             "declared_content_type": "application/octet-stream"
           },
+          "on": "subject:self",
           "save": {
-            "first": "$result"
+            "first": "out"
           },
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
               "file_id": "<file_id>",
-              "event_id": "<string>"
+              "event_id": "<event_id>",
+              "pos": "<uint>",
+              "bytes": 2048,
+              "digest": "<string>"
             }
           },
           "op_id": "op-dedup-share",
@@ -1293,14 +1317,8 @@
         },
         {
           "control": {
-            "do": "disconnect",
-            "on": "primary"
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
+            "do": "reconnect",
+            "on": "subject:self"
           }
         },
         {
@@ -1311,22 +1329,26 @@
             "declared_bytes": 2048,
             "declared_content_type": "application/octet-stream"
           },
-          "op_id": "op-dedup-share"
-        },
-        {
-          "assert": [],
-          "note": "[split]"
+          "on": "subject:self",
+          "op_id": "op-dedup-share",
+          "expect": {
+            "ok": true,
+            "out": "$first"
+          }
         },
         {
           "assert": [
             {
               "path": "out",
-              "op": "eq_except",
+              "op": "eq",
+              "value": "$first"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:4",
               "value": {
-                "path": "$first",
-                "keys": [
-                  "id"
-                ]
+                "op": "eq",
+                "value": 0
               }
             }
           ]
@@ -1341,6 +1363,7 @@
             "direction": "forward",
             "limit": 50
           },
+          "on": "subject:self",
           "note": "[bare-string assert 'exactly_one_entry_with' needs manual retranscription]"
         },
         {
@@ -1350,10 +1373,6 @@
               "op": "present"
             }
           ]
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": 1, \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
         }
       ]
     },
@@ -1381,6 +1400,7 @@
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
               "files": [
                 {
                   "file_id": "<file_id>",
@@ -1388,19 +1408,19 @@
                   "digest": "<string>",
                   "providers": [
                     {
-                      "device_id": "<string>",
-                      "subject_id": "<string>",
+                      "device_id": "<device_id>",
+                      "subject_id": "<subject_id>",
                       "link": {
                         "state": "direct",
                         "since": "<ts>"
                       }
                     }
                   ],
-                  "fetchable": true,
-                  "self_hosted": false,
+                  "fetchable": "<bool>",
+                  "self_hosted": "<bool>",
                   "bytes": "<uint>",
                   "declared_content_type": "application/pdf",
-                  "shared_by": "<string>",
+                  "shared_by": "<subject_id>",
                   "shared_at": "<ts>"
                 }
               ]
@@ -1410,35 +1430,35 @@
         {
           "assert": [
             {
-              "path": "out.files[].available",
+              "path": "out.files[*].available",
               "op": "absent"
             },
             {
-              "path": "out.files[].providers_count",
+              "path": "out.files[*].providers_count",
               "op": "absent"
             },
             {
-              "path": "out.files[].local_path",
+              "path": "out.files[*].local_path",
               "op": "absent"
             },
             {
-              "path": "out.files[].local_bytes",
+              "path": "out.files[*].local_bytes",
               "op": "absent"
             },
             {
-              "path": "out.files[].fetched",
+              "path": "out.files[*].fetched",
               "op": "absent"
             },
             {
-              "path": "out.files[].fetched_at_ms",
+              "path": "out.files[*].fetched_at_ms",
               "op": "absent"
             },
             {
-              "path": "out.files[].mime",
+              "path": "out.files[*].mime",
               "op": "absent"
             },
             {
-              "path": "out.files[].path",
+              "path": "out.files[*].path",
               "op": "absent"
             }
           ]
@@ -1446,47 +1466,24 @@
         {
           "assert": [
             {
-              "path": "out.files[0].providers",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "type",
-              "value": "array_of_object",
-              "note": "path recovered from context; exclusions: [\"integer\", \"number\"]"
-            }
-          ],
-          "note": "[split from a multi-verb step; review]"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[0].fetchable",
-              "op": "type",
-              "value": "uint"
+              "path": "out.files[*].providers",
+              "op": "len",
+              "value": {
+                "op": "gte",
+                "value": 1
+              }
             },
             {
-              "path": "out.files[0].self_hosted",
+              "path": "out.files[*].fetchable",
               "op": "type",
-              "value": "uint"
+              "value": "bool"
+            },
+            {
+              "path": "out.files[*].self_hosted",
+              "op": "type",
+              "value": "bool"
             }
           ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "type",
-              "value": "boolean",
-              "note": "path recovered from context; exclusions: []"
-            }
-          ],
-          "note": "[split from a multi-verb step; review]"
         },
         {
           "assert": [
@@ -1637,21 +1634,10 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
             }
           }
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "invalid_argument"
-              ]
-            }
-          ]
         }
       ]
     },
@@ -1691,15 +1677,15 @@
         {
           "assert": [
             {
-              "path": "out.files[].path",
+              "path": "out.files[*].path",
               "op": "absent"
             },
             {
-              "path": "out.files[].local_path",
+              "path": "out.files[*].local_path",
               "op": "absent"
             },
             {
-              "path": "out.files[].save_dir",
+              "path": "out.files[*].save_dir",
               "op": "absent"
             }
           ]
@@ -1892,33 +1878,10 @@
           "op_id": "op-preflight-1"
         },
         {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch",
-                "provider_unreachable"
-              ]
-            }
-          ]
-        },
-        {
           "assert": [
             {
               "observe": "bytes_streamed",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
+              "call": "step:4",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -1932,29 +1895,13 @@
       "name": "fetch_stream_refuses_a_peer_serving_more_than_it_declared",
       "kind": "boundary",
       "operation": "file.fetch",
-      "intent": "Proves the mid-stream fetch bound reports an oversized response as file_too_large with enforced_at=fetch_stream rather than folding it into the content-lie variant, which is the false accusation against an honest peer the size policy forbids; it fails until U3 lands because the pinned transport has no size-distinguishable outcome.",
+      "intent": "Proves the mid-stream fetch bound reports a provider response exceeding the signed declaration as file_too_large at fetch_stream after accepting exactly the declared bytes; it remains blocked until U3 supplies a size-distinguishable fetch outcome.",
       "requires": [
         "subject",
         "room:live",
         "link:up"
       ],
       "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
         {
           "call": "file.list",
           "in": {
@@ -1966,7 +1913,20 @@
             "limit": 50
           },
           "save": {
-            "fid": "out.files[0].file_id"
+            "fid": "out.files[0].file_id",
+            "declared_bytes": "out.files[0].bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "set_provider_response_bytes",
+            "file_id": "$fid",
+            "bytes": {
+              "$add": [
+                "$declared_bytes",
+                1
+              ]
+            }
           }
         },
         {
@@ -1979,41 +1939,22 @@
             "ok": false,
             "err": {
               "code": "file_too_large",
-              "declared_bytes": 4096,
-              "limit_bytes": "$limit",
+              "declared_bytes": "$declared_bytes",
+              "limit_bytes": "$declared_bytes",
               "enforced_at": "fetch_stream"
             }
           },
           "op_id": "op-fetchstream-1"
         },
         {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch"
-              ]
-            }
-          ]
-        },
-        {
           "assert": [
             {
               "observe": "bytes_streamed",
+              "call": "step:3",
               "value": {
                 "op": "eq",
-                "value": "$limit"
+                "value": "$declared_bytes"
               }
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$fid",
-              "op": "present"
             }
           ]
         }
@@ -2028,16 +1969,9 @@
       "requires": [
         "subject",
         "room:live",
-        "link:up"
+        "link:down"
       ],
       "steps": [
-        {
-          "note": "[control shape {\"provider_link\": \"down\"} needs review] [harness orchestration: provider_link]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
         {
           "call": "file.list",
           "in": {
@@ -2072,25 +2006,20 @@
             "ok": false,
             "err": {
               "code": "provider_unreachable",
-              "providers_tried": "<uint>"
+              "file_id": "$fid",
+              "providers": [
+                {
+                  "subject_id": "<subject_id>",
+                  "device_id": "<device_id>",
+                  "link": {
+                    "state": "not_connected",
+                    "reason": "no_route"
+                  }
+                }
+              ]
             }
           },
           "op_id": "op-unreach-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch",
-                "file_too_large",
-                "invalid_argument",
-                "room_not_available"
-              ]
-            }
-          ]
         },
         {
           "assert": [
@@ -2099,10 +2028,66 @@
               "op": "present"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
+      "kind": "malformed",
+      "operation": "file.fetch",
+      "intent": "Proves file.fetch rejects a missing envelope op_id during structural decode, before room lookup or provider contact, even when the room and file inputs are otherwise valid.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": false, \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "op_id",
+              "reason": {
+                "state": "missing"
+              }
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_network_activity",
+              "scope": "step"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:2",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
         }
       ]
     },
@@ -2121,41 +2106,32 @@
           "in": {
             "room_id": "$rid",
             "file_id": {
-              "$unknown": "{\"$unknown\": \"<file_id>\"}"
+              "$unknown": "<file_id>"
             }
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "file_unknown"
+              "code": "file_unknown",
+              "file_id": {
+                "$unknown": "<file_id>"
+              }
             }
           },
           "op_id": "op-unknownfile-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "invalid_argument",
-                "room_not_available"
-              ]
-            }
-          ]
         }
       ]
     },
     {
-      "name": "fetch_replayed_op_id_performs_no_second_transfer",
+      "name": "fetch_completed_result_replays_without_a_second_transfer",
       "kind": "success",
       "operation": "file.fetch",
-      "intent": "Proves file.fetch is op_id deduplicated and the ledger survives reconnection, so a client retrying a fetch whose reply was lost to a dropped connection gets the original result and does not move a second copy of the bytes across the network.",
+      "intent": "Proves a completed file.fetch result is op_id deduplicated across a same-principal reconnection, so replay returns the original out directly and moves no second copy of the bytes across the network.",
       "requires": [
         "subject",
         "room:live",
-        "link:up"
+        "link:up",
+        "control:reconnect"
       ],
       "steps": [
         {
@@ -2170,8 +2146,9 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
+          "on": "subject:self",
           "save": {
-            "first": "$result"
+            "first": "out"
           },
           "expect": {
             "ok": true,
@@ -2198,14 +2175,8 @@
         },
         {
           "control": {
-            "do": "disconnect",
-            "on": "primary"
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
+            "do": "reconnect",
+            "on": "subject:self"
           }
         },
         {
@@ -2214,33 +2185,29 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
+          "on": "subject:self",
+          "expect": {
+            "ok": true,
+            "out": "$first"
+          },
           "op_id": "op-dedup-fetch"
         },
         {
           "assert": [
             {
               "path": "out",
-              "op": "eq_except",
+              "op": "eq",
+              "value": "$first"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:5",
               "value": {
-                "path": "$first",
-                "keys": [
-                  "id"
-                ]
+                "op": "eq",
+                "value": 0
               }
             }
           ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$fid",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": 1, \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
         }
       ]
     },
@@ -2248,13 +2215,29 @@
       "name": "fetch_deadline_scales_with_the_declared_size",
       "kind": "boundary",
       "operation": "file.fetch",
-      "intent": "Proves the per-provider budget is computed from the served transfer_connect_allowance_ms and transfer_floor_bits_per_second against the declared size rather than being a fixed constant, so a large transfer progressing at the served floor completes instead of being killed by a timeout sized for a small file.",
+      "intent": "Proves the absolute file.fetch deadline uses the declared total and served floor: progress at the floor succeeds, while progress below the required rate exhausts the fixed size-aware budget with a truthful accepted-byte count.",
       "requires": [
         "subject",
         "room:live",
-        "link:up"
+        "link:up",
+        "resource:large_file",
+        "control:limits"
       ],
       "steps": [
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "transfer_connect_allowance_ms",
+            "value": 1000
+          }
+        },
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "transfer_floor_bits_per_second",
+            "value": 8192
+          }
+        },
         {
           "upgrade": {
             "query": {},
@@ -2273,24 +2256,44 @@
           }
         },
         {
-          "note": "[split from a multi-verb step; review] [control shape {\"link_rate_bits_per_second\": \"$floor_bps*2\"} needs review] [harness orchestration: link_rate_bits_per_second]",
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid_at_floor": "out.files[0].file_id",
+            "total_at_floor": "out.files[0].bytes",
+            "fid_below_floor": "out.files[1].file_id",
+            "total_below_floor": "out.files[1].bytes"
+          }
+        },
+        {
           "control": {
-            "do": "idle",
-            "ms": 0
+            "do": "set_link_rate",
+            "between": [
+              "subject:self",
+              "provider"
+            ],
+            "bits_per_second": "$floor_bps"
           }
         },
         {
           "call": "file.fetch",
           "in": {
             "room_id": "$rid",
-            "file_id": "$fid"
+            "file_id": "$fid_at_floor"
           },
           "expect": {
             "ok": true,
             "out": {
-              "file_id": "$fid",
               "room_id": "$rid",
-              "bytes": "<uint>",
+              "file_id": "$fid_at_floor",
+              "bytes": "$total_at_floor",
               "digest": "<string>",
               "provider": {
                 "subject_id": "<subject_id>",
@@ -2298,25 +2301,59 @@
               }
             }
           },
-          "op_id": "op-budget-1"
+          "op_id": "op-budget-floor"
+        },
+        {
+          "control": {
+            "do": "set_link_rate",
+            "between": [
+              "subject:self",
+              "provider"
+            ],
+            "bits_per_second": 1
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid_below_floor"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_deadline_exceeded",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total_below_floor"
+              },
+              "budget_ms": "<uint>"
+            }
+          },
+          "op_id": "op-budget-expiry"
         },
         {
           "assert": [
             {
-              "path": "out.local",
-              "op": "absent"
+              "path": "err.transferred_bytes",
+              "op": "lt",
+              "value": "$total_below_floor"
+            },
+            {
+              "path": "err.transferred_bytes",
+              "op": "gt",
+              "value": 0
+            },
+            {
+              "path": "err.budget_ms",
+              "op": "gt",
+              "value": "$connect_ms"
             }
           ]
-        },
-        {
-          "assert": [],
-          "note": "BLOCKED ON U2: {\"path\": \"frame.op-budget-1\", \"op\": \"present\"} - transfer progress is the `transfer` push frame, which depends on upstream progress handles; until it exists there is no frame to assert against."
-        },
-        {
-          "assert": [],
-          "note": "BLOCKED ON U2: {\"path\": \"frame.op-budget-1\", \"op\": \"present\"} - transfer progress is the `transfer` push frame, which depends on upstream progress handles; until it exists there is no frame to assert against."
         }
-      ]
+      ],
+      "blocked_on_upstream": "U2"
     },
     {
       "name": "read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field",
@@ -2338,17 +2375,15 @@
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
               "file_id": "$fid",
-              "digest": "<string>",
-              "name": "design.pdf",
-              "bytes": "<uint>",
+              "bytes": 4096,
               "declared_content_type": "application/pdf"
             }
+          },
+          "stream": {
+            "receive_bytes": 4096
           }
-        },
-        {
-          "assert": [],
-          "note": "[split]"
         },
         {
           "assert": [
@@ -2377,23 +2412,6 @@
               "op": "absent"
             }
           ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.declared_content_type",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
         }
       ]
     },
@@ -2401,6 +2419,9 @@
       "name": "client_must_not_render_peer_declared_bytes_inline",
       "kind": "boundary",
       "operation": "file.read",
+      "targets": [
+        "client_adapter"
+      ],
       "intent": "Proves a client treats the peer-declared type as a hint only: a peer declaring text/html with a script-bearing body is never rendered inline as markup and never executes, catching a client that restores v1's inline-render behaviour now that the protective HTTP headers are gone.",
       "requires": [
         "resource:fetched_file",
@@ -2416,13 +2437,36 @@
           "expect": {
             "ok": true,
             "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": 4096,
               "declared_content_type": "text/html"
             }
+          },
+          "stream": {
+            "receive_bytes": 4096
           }
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface: {\"path\": \"frame.render_decision_source\", \"op\": \"eq\", \"value\": \"peer_declared_type_untrusted\"} - the record fixes what the daemon serves, not how a client preflights or renders it."
+          "control": {
+            "do": "client_render_file",
+            "declared_content_type": "text/html",
+            "body_kind": "script_bearing_html"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "download_only"
+            },
+            {
+              "path": "frame.executed",
+              "op": "eq",
+              "value": false
+            }
+          ]
         }
       ]
     },
@@ -2468,41 +2512,20 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "file_not_fetched"
+              "code": "file_not_fetched",
+              "file_id": "$fid"
             }
           }
         },
         {
-          "note": "[split from a multi-verb step; review]",
           "assert": [
             {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "invalid_argument",
-                "file_unknown",
-                "provider_unreachable"
-              ]
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "out.bytes",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": 0, \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
-        },
-        {
-          "assert": [
-            {
-              "path": "out.bytes",
-              "op": "present"
+              "observe": "bytes_streamed",
+              "call": "step:2",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
             }
           ]
         }
@@ -2512,18 +2535,29 @@
       "name": "transfer_cancel_after_the_originating_connection_dropped",
       "kind": "success",
       "operation": "transfer.cancel",
-      "intent": "Proves cancellation is authorized at the ledger's scope rather than the connection's: a transfer started on a connection that has since dropped is cancellable from a fresh connection of the same principal by op_id alone, which is precisely the case cancellation exists for and which a connection-scoped design makes impossible.",
+      "intent": "Proves a deferred file.fetch remains cancellable after its originating transport drops: the same principal reconnects, cancels by transfer_op_id, and replaying the original request on that session returns the recorded cancelled stream_aborted result without awaiting a dead connection handle.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "resource:large_file"
+        "resource:large_file",
+        "control:reconnect"
       ],
       "steps": [
         {
-          "upgrade": {
-            "query": {},
-            "headers": {}
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "subject:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
           }
         },
         {
@@ -2532,42 +2566,24 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
-          "note": "left in flight",
-          "op_id": "op-cancel-target"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
+          "on": "subject:self",
+          "op_id": "op-cancel-target",
+          "defer": true,
           "save": {
-            "max_transfers": "frame.limits.max_concurrent_transfers"
+            "abandoned_fetch_request": "$request"
           },
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.op-cancel-target",
-              "op": "present"
-            }
-          ]
+          "note": "The disconnect abandons this connection-local request handle; it is saved only because the current deferred-call DSL validator requires a handle."
         },
         {
           "control": {
             "do": "disconnect",
-            "on": "primary"
+            "on": "subject:self"
           }
         },
         {
-          "note": "same principal, new connection",
-          "upgrade": {
-            "query": {},
-            "headers": {}
+          "control": {
+            "do": "reconnect",
+            "on": "subject:self"
           }
         },
         {
@@ -2575,77 +2591,75 @@
           "in": {
             "transfer_op_id": "op-cancel-target"
           },
+          "on": "subject:self",
           "expect": {
             "ok": true,
             "out": {
+              "transfer_op_id": "op-cancel-target",
               "outcome": {
                 "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
               }
             }
+          },
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes"
           }
         },
         {
-          "assert": [
-            {
-              "path": "out.room_id",
-              "op": "absent"
-            },
-            {
-              "path": "out.path",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.op-cancel-target",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$fid",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "call": "transfer.cancel",
+          "call": "file.fetch",
           "in": {
-            "transfer_op_id": "op-cancel-target"
+            "room_id": "$rid",
+            "file_id": "$fid"
           },
+          "on": "subject:self",
+          "op_id": "op-cancel-target",
           "expect": {
-            "ok": true,
-            "out": {
-              "outcome": {
-                "state": "already_cancelled"
-              }
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              },
+              "reason": "cancelled"
             }
-          },
-          "note": "cancelling twice is not an error"
+          }
         }
-      ]
+      ],
+      "blocked_on_upstream": "U2"
     },
     {
       "name": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
       "kind": "authorization",
       "operation": "transfer.cancel",
-      "intent": "Proves the (principal, op_id) authorization is enforced and does not leak: another principal's cancel of a live transfer answers exactly as it answers for an op_id that never existed, so op_id space cannot be probed to learn that another client has a transfer running.",
+      "intent": "Proves the principal-scoped cancellation ledger is not an oracle on one daemon: a second principal sees the same transfer_unknown shape for the owner's live transfer and an absent transfer, while the owner can still cancel and receives the original fetch's terminal cancellation reply.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "subject:second",
         "resource:large_file"
       ],
       "steps": [
         {
-          "upgrade": {
-            "query": {},
-            "headers": {}
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "principal:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
           }
         },
         {
@@ -2654,23 +2668,11 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
-          "op_id": "op-cancel-owned"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
-            }
-          ]
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
+          "on": "principal:self",
+          "op_id": "op-cancel-owned",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
           }
         },
         {
@@ -2678,14 +2680,15 @@
           "in": {
             "transfer_op_id": "op-cancel-owned"
           },
+          "on": "principal:second",
           "save": {
-            "foreign_err": "$error"
+            "foreign_err": "err"
           },
-          "on": "subject:principal_b",
           "expect": {
             "ok": false,
             "err": {
-              "code": "transfer_unknown"
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-cancel-owned"
             }
           }
         },
@@ -2694,14 +2697,15 @@
           "in": {
             "transfer_op_id": "op-never-existed"
           },
+          "on": "principal:second",
           "save": {
-            "absent_err": "$error"
+            "absent_err": "err"
           },
-          "on": "subject:principal_b",
           "expect": {
             "ok": false,
             "err": {
-              "code": "transfer_unknown"
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-never-existed"
             }
           }
         },
@@ -2709,23 +2713,60 @@
           "assert": [
             {
               "path": "$foreign_err",
-              "op": "present"
-            },
-            {
-              "path": "$absent_err",
-              "op": "present"
+              "op": "eq_except",
+              "value": {
+                "path": "$absent_err",
+                "keys": [
+                  "transfer_op_id"
+                ]
+              }
             }
           ]
         },
         {
-          "assert": [
-            {
-              "path": "err.op-cancel-owned",
-              "op": "present"
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-cancel-owned"
+          },
+          "on": "principal:self",
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "transfer_op_id": "op-cancel-owned",
+              "outcome": {
+                "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
             }
-          ]
+          }
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "on": "principal:self",
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              },
+              "reason": "cancelled"
+            }
+          }
         }
-      ]
+      ],
+      "blocked_on_upstream": "U2"
     },
     {
       "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
@@ -2744,22 +2785,10 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "transfer_unknown"
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-does-not-exist"
             }
           }
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "invalid_argument",
-                "room_not_available"
-              ]
-            }
-          ]
         }
       ]
     },
@@ -2767,12 +2796,13 @@
       "name": "transfer_cancel_releases_the_concurrent_transfer_slot",
       "kind": "success",
       "operation": "transfer.cancel",
-      "intent": "Proves cancellation actually returns the transfer to the daemon's budget rather than merely reporting success: a fetch refused with resource_exhausted at the concurrency ceiling succeeds immediately after one in-flight transfer is cancelled.",
+      "intent": "Proves cancellation actually returns the transfer to the daemon budget rather than merely reporting success: after filling the served concurrency ceiling, cancelling op-slot-0 frees that slot for a succeeding fetch, then cleanup cancels the remaining harness-started set.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "resource:large_file"
+        "resource:large_file",
+        "control:concurrency"
       ],
       "steps": [
         {
@@ -2782,18 +2812,31 @@
           }
         },
         {
-          "note": "[split from a multi-verb step; review]",
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
           "save": {
             "max_transfers": "frame.limits.max_concurrent_transfers"
-          },
+          }
+        },
+        {
           "assert": [
             {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
+              "path": "$max_transfers",
+              "op": "type",
+              "value": "uint"
             }
           ]
+        },
+        {
+          "control": {
+            "do": "start_transfers",
+            "count": "$max_transfers",
+            "aggregate_bytes": "$max_transfers",
+            "op_id_prefix": "op-slot-"
+          }
         },
         {
           "call": "file.fetch",
@@ -2819,8 +2862,14 @@
           "expect": {
             "ok": true,
             "out": {
+              "transfer_op_id": "op-slot-0",
               "outcome": {
                 "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
               }
             }
           }
@@ -2853,19 +2902,27 @@
               "op": "absent"
             }
           ]
+        },
+        {
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-slot-"
+          }
         }
-      ]
+      ],
+      "blocked_on_upstream": "U2"
     },
     {
       "name": "concurrent_transfers_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
       "kind": "boundary",
       "operation": "file.fetch",
-      "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of transfers run, and the next is refused with resource_exhausted naming the resource and the limit, catching a daemon that queues instead of refusing and commits multiple gigabytes at a 100 MiB per-file limit.",
+      "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of harness-started transfers run, the next is refused, and the harness cleans the started set up at case end.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "resource:large_file"
+        "resource:large_file",
+        "control:concurrency"
       ],
       "steps": [
         {
@@ -2875,22 +2932,31 @@
           }
         },
         {
-          "note": "[split from a multi-verb step; review]",
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
           "save": {
             "max_transfers": "frame.limits.max_concurrent_transfers"
-          },
+          }
+        },
+        {
           "assert": [
             {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
+              "path": "$max_transfers",
+              "op": "type",
+              "value": "uint"
             }
           ]
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": \"$max_transfers\", \"note\": \"[bare-string assert 'transfers_in_flight' needs manual retranscription]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
+          "control": {
+            "do": "start_transfers",
+            "count": "$max_transfers",
+            "aggregate_bytes": "$max_transfers",
+            "op_id_prefix": "op-conc-"
+          }
         },
         {
           "call": "file.fetch",
@@ -2909,26 +2975,10 @@
           "op_id": "op-conc-past"
         },
         {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "file_too_large",
-                "provider_unreachable",
-                "invalid_argument"
-              ]
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.op-conc-past",
-              "op": "present"
-            }
-          ]
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-conc-"
+          }
         }
       ]
     },
@@ -2936,12 +2986,13 @@
       "name": "inflight_transfer_bytes_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
       "kind": "boundary",
       "operation": "file.fetch",
-      "intent": "Proves max_transfer_bytes_inflight is a second, independent bound: transfers whose declared sizes total exactly the served value are accepted, and one that would carry the total one byte past is refused with resource_exhausted naming that resource, catching a daemon that bounds only the transfer count.",
+      "intent": "Proves max_transfer_bytes_inflight is independent: harness-started transfers reserve exactly the served byte budget, one more byte is refused, and the harness cleans the started set up at case end.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "resource:large_file"
+        "resource:large_file",
+        "control:concurrency"
       ],
       "steps": [
         {
@@ -2951,19 +3002,32 @@
           }
         },
         {
-          "note": "[split from a multi-verb step; review]",
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
           "save": {
             "max_inflight": "frame.limits.max_transfer_bytes_inflight",
             "max_transfers": "frame.limits.max_concurrent_transfers"
-          },
+          }
+        },
+        {
           "assert": [
             {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
+              "path": "$max_inflight",
+              "op": "type",
+              "value": "uint"
             }
           ]
+        },
+        {
+          "control": {
+            "do": "start_transfers",
+            "count": 1,
+            "aggregate_bytes": "$max_inflight",
+            "op_id_prefix": "op-bytes-"
+          }
         },
         {
           "call": "file.fetch",
@@ -2982,16 +3046,6 @@
           "op_id": "op-bytes-past"
         },
         {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": "file_too_large"
-            }
-          ]
-        },
-        {
           "assert": [
             {
               "path": "err.limit",
@@ -3003,33 +3057,24 @@
         {
           "assert": [
             {
-              "path": "$limit",
-              "op": "type",
-              "value": "uint",
-              "note": "path recovered from context; exclusions: []"
-            }
-          ],
-          "note": "[split from a multi-verb step; review]"
-        },
-        {
-          "assert": [
-            {
               "path": "err.resource",
               "op": "present"
             }
           ]
         },
         {
-          "assert": [],
-          "note": "CLIENT-SIDE OBLIGATION, no protocol surface and therefore no DSL home: {\"value\": \"max_concurrent_transfers\", \"note\": \"[split from a multi-verb step; review]\"} \u2014 the record fixes the daemon's answer, not how a client stores or renders it, so this is recorded for a reviewer rather than asserted against the wire."
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-bytes-"
+          }
         }
       ]
     },
     {
-      "name": "transfer_progress_frames_report_monotonic_transferred_bytes",
+      "name": "transfer_progress_pushes_report_monotonic_transferred_bytes",
       "kind": "push",
       "operation": "file.fetch",
-      "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: progress pushes carry the op_id, a non-decreasing transferred_bytes, and a total as a tagged known/unknown variant that is never a null; fails until U2 provides a byte-count channel.",
+      "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: transfer pushes carry transfer_op_id, a non-decreasing receiver-accepted byte count, and the signed total, with no room-scoped fields; fails until U2 provides a byte-count channel.",
       "requires": [
         "subject",
         "room:live",
@@ -3038,57 +3083,104 @@
       ],
       "steps": [
         {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          },
+          "on": "subject:self"
+        },
+        {
           "call": "file.fetch",
           "in": {
             "room_id": "$rid",
             "file_id": "$fid"
           },
-          "op_id": "op-progress-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
-            }
-          ]
+          "op_id": "op-progress-1",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          },
+          "on": "subject:self"
         },
         {
           "await": {
             "push": {
-              "op_id": "op-progress-1",
+              "t": "transfer",
+              "transfer_op_id": "op-progress-1",
               "transferred_bytes": "<uint>",
               "total": {
                 "state": "known",
-                "bytes": "<uint>"
+                "bytes": "$total"
               }
             }
-          }
+          },
+          "save": {
+            "progress_one": "frame.transferred_bytes"
+          },
+          "on": "subject:self"
         },
         {
-          "assert": [],
-          "note": "BLOCKED ON U2: {\"path\": \"frame.transfer_progress[op_id=op-progress-1].transferred_bytes\", \"op\": \"present\"} - transfer progress is the `transfer` push frame, which depends on upstream progress handles; until it exists there is no frame to assert against."
+          "await": {
+            "push": {
+              "t": "transfer",
+              "transfer_op_id": "op-progress-1",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          },
+          "on": "subject:self"
         },
         {
           "assert": [
             {
-              "path": "out",
+              "path": "frame.transferred_bytes",
+              "op": "gte",
+              "value": "$progress_one"
+            },
+            {
+              "path": "frame.op_id",
+              "op": "absent"
+            },
+            {
+              "path": "frame.room_id",
+              "op": "absent"
+            },
+            {
+              "path": "frame",
               "op": "no_nulls"
             }
           ]
         },
         {
           "await": {
-            "push": {
-              "op_id": "op-progress-1",
-              "total": {
-                "state": "unknown"
+            "reply": "$fetch_request"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": "$total",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
               }
             }
-          }
+          },
+          "on": "subject:self"
         }
       ],
       "blocked_on_upstream": "U2"
@@ -3097,37 +3189,30 @@
       "name": "transfer_progress_is_delivered_only_to_the_initiating_principal",
       "kind": "push",
       "operation": "file.fetch",
-      "intent": "Proves progress frames are not a side channel: a second principal subscribed to the same room observes no transfer_progress for a transfer it did not start, so the frames report one client's work rather than broadcasting daemon activity; fails until U2.",
+      "intent": "Proves transfer progress is principal-private on one daemon: the owner receives the canonical transfer push, the second principal receives no matching transfer push, and the owner's deferred fetch still reaches terminal success; fails until U2.",
       "requires": [
         "subject",
         "room:live",
         "link:up",
-        "subject:second",
-        "resource:large_file"
+        "resource:large_file",
+        "observe:frames"
       ],
       "steps": [
         {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "call": "stream.subscribe",
+          "call": "file.list",
           "in": {
             "room_id": "$rid",
-            "from": {
+            "cursor": {
               "state": "start"
-            }
+            },
+            "direction": "forward",
+            "limit": 50
           },
-          "on": "subject:principal_b",
-          "op_id": "op-sub-b"
+          "on": "principal:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          }
         },
         {
           "call": "file.fetch",
@@ -3135,24 +3220,24 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
-          "on": "subject:principal_a",
-          "op_id": "op-progress-private"
+          "on": "principal:self",
+          "op_id": "op-progress-private",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          }
         },
         {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
-            }
-          ]
-        },
-        {
+          "on": "principal:self",
           "await": {
             "push": {
-              "op_id": "op-progress-private"
+              "t": "transfer",
+              "transfer_op_id": "op-progress-private",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
             }
           }
         },
@@ -3160,10 +3245,33 @@
           "assert": [
             {
               "observe": "no_push",
-              "room_id": "$rid",
+              "on": "principal:second",
+              "match": {
+                "t": "transfer",
+                "transfer_op_id": "op-progress-private"
+              },
               "scope": "case"
             }
           ]
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "on": "principal:self",
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": "$total",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          }
         }
       ],
       "blocked_on_upstream": "U2"
@@ -3215,22 +3323,13 @@
           "op_id": "op-stall-1"
         },
         {
-          "note": "[split from a multi-verb step; review]",
           "assert": [
             {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "digest_mismatch",
-                "file_too_large",
-                "provider_unreachable"
-              ]
+              "path": "err.transferred_bytes",
+              "op": "eq",
+              "value": 16384
             }
           ]
-        },
-        {
-          "assert": [],
-          "note": "BLOCKED ON U2: {\"path\": \"frame.op-stall-1\", \"op\": \"present\"} - transfer progress is the `transfer` push frame, which depends on upstream progress handles; until it exists there is no frame to assert against."
         },
         {
           "call": "file.fetch",
@@ -3242,6 +3341,7 @@
             "ok": false,
             "err": {
               "code": "transfer_stalled",
+              "transferred_bytes": "<uint>",
               "total": {
                 "state": "unknown"
               }
@@ -3252,7 +3352,7 @@
         {
           "assert": [
             {
-              "path": "out",
+              "path": "err",
               "op": "no_nulls"
             }
           ]
@@ -3278,25 +3378,26 @@
             "room_id": "$rid",
             "file_id": "$fid"
           },
-          "op_id": "op-cancel-bytes"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "step",
-              "note": "no push expected for this transfer on this connection"
-            }
-          ]
+          "op_id": "op-cancel-bytes",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          },
+          "on": "subject:self"
         },
         {
           "await": {
             "push": {
-              "op_id": "op-cancel-bytes"
+              "t": "transfer",
+              "transfer_op_id": "op-cancel-bytes",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
+              }
             }
-          }
+          },
+          "on": "subject:self"
         },
         {
           "call": "transfer.cancel",
@@ -3306,6 +3407,7 @@
           "expect": {
             "ok": true,
             "out": {
+              "transfer_op_id": "op-cancel-bytes",
               "outcome": {
                 "state": "cancelled"
               },
@@ -3315,27 +3417,45 @@
                 "bytes": "<uint>"
               }
             }
-          }
+          },
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes",
+            "cancel_total": "out.total.bytes"
+          },
+          "on": "subject:self"
         },
         {
           "assert": [
             {
-              "path": "err.code",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
+              "path": "out.transferred_bytes",
+              "op": "gt",
+              "value": 0
+            },
             {
-              "path": "$limit",
-              "op": "type",
-              "value": "uint",
-              "note": "path recovered from context; exclusions: []"
+              "path": "out.transferred_bytes",
+              "op": "lte",
+              "value": "$cancel_total"
             }
           ],
-          "note": "[split from a multi-verb step; review]"
+          "on": "subject:self"
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$cancel_total"
+              },
+              "reason": "cancelled"
+            }
+          },
+          "on": "subject:self"
         }
       ],
       "blocked_on_upstream": "U2"
@@ -3344,20 +3464,14 @@
       "name": "file_operations_are_not_a_membership_oracle",
       "kind": "authorization",
       "operation": null,
-      "intent": "Proves every room-scoped file operation answers room_not_available with identical fields and indistinguishable timing whether the room does not exist or exists with the caller outside it, so file.share, file.list, file.fetch and file.read cannot be used to confirm that a room exists or that a given file was shared in it.",
+      "intent": "Proves each room-scoped file operation returns the same room_not_available shape and indistinguishable timing for a foreign room and a well-formed unknown room, while echoing the caller-supplied room_id and opening no upload stream.",
       "requires": [
         "subject",
-        "subject:second"
+        "room:foreign",
+        "observe:timing"
       ],
       "steps": [
         {
-          "note": "[control shape {\"foreign_room\": \"$foreign_rid\", \"foreign_file\": \"$foreign_fid\", \"note\": \"a room the caller is not a member of, holding  needs review] [harness orchestration: foreign_room]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
           "call": "file.list",
           "in": {
             "room_id": "$foreign_rid",
@@ -3368,19 +3482,22 @@
             "limit": 50
           },
           "save": {
-            "e1": "$error"
+            "list_foreign": "err"
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
             }
           }
         },
         {
           "call": "file.list",
           "in": {
-            "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+            "room_id": {
+              "$unknown": "<room_id>"
+            },
             "cursor": {
               "state": "start"
             },
@@ -3388,42 +3505,36 @@
             "limit": 50
           },
           "save": {
-            "e2": "$error"
+            "list_unknown": "err",
+            "unknown_rid": "err.room_id"
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": {
+                "$unknown": "<room_id>"
+              }
             }
           }
         },
         {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$foreign_rid",
-            "file_id": "$foreign_fid"
-          },
-          "save": {
-            "e3": "$error"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available"
-            }
-          },
-          "op_id": "op-oracle-1"
-        },
-        {
-          "note": "[split from a multi-verb step; review]",
           "assert": [
             {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "file_unknown",
-                "provider_unreachable",
-                "file_not_fetched"
+              "path": "$list_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$list_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:1",
+                "step:2"
               ]
             }
           ]
@@ -3432,20 +3543,60 @@
           "call": "file.fetch",
           "in": {
             "room_id": "$foreign_rid",
-            "file_id": {
-              "$unknown": "{\"$unknown\": \"<file_id>\"}"
-            }
+            "file_id": "$foreign_fid"
           },
+          "op_id": "op-oracle-fetch-foreign",
           "save": {
-            "e4": "$error"
+            "fetch_foreign": "err"
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
+            }
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$unknown_rid",
+            "file_id": {
+              "$unknown": "<file_id>"
             }
           },
-          "op_id": "op-oracle-2"
+          "op_id": "op-oracle-fetch-unknown",
+          "save": {
+            "fetch_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$fetch_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$fetch_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:4",
+                "step:5"
+              ]
+            }
+          ]
         },
         {
           "call": "file.read",
@@ -3453,15 +3604,58 @@
             "room_id": "$foreign_rid",
             "file_id": "$foreign_fid"
           },
+          "op_id": "op-oracle-read-foreign",
           "save": {
-            "e5": "$error"
+            "read_foreign": "err"
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
             }
           }
+        },
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$unknown_rid",
+            "file_id": {
+              "$unknown": "<file_id>"
+            }
+          },
+          "op_id": "op-oracle-read-unknown",
+          "save": {
+            "read_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$read_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$read_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:7",
+                "step:8"
+              ]
+            }
+          ]
         },
         {
           "call": "file.share",
@@ -3471,62 +3665,68 @@
             "declared_bytes": 16,
             "declared_content_type": "application/octet-stream"
           },
+          "op_id": "op-oracle-share-foreign",
           "save": {
-            "e6": "$error"
+            "share_foreign": "err"
           },
           "expect": {
             "ok": false,
             "err": {
-              "code": "room_not_available"
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
             }
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$unknown_rid",
+            "name": "a.bin",
+            "declared_bytes": 16,
+            "declared_content_type": "application/octet-stream"
           },
-          "op_id": "op-oracle-3",
-          "stream": {
-            "send_bytes": 0
+          "op_id": "op-oracle-share-unknown",
+          "save": {
+            "share_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
           }
         },
         {
           "assert": [
             {
-              "path": "$e1",
-              "op": "present"
+              "path": "$share_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$share_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
             },
             {
-              "path": "$e2",
-              "op": "present"
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:10",
+                "step:11"
+              ]
             },
-            {
-              "path": "$e3",
-              "op": "present"
-            },
-            {
-              "path": "$e4",
-              "op": "present"
-            },
-            {
-              "path": "$e5",
-              "op": "present"
-            },
-            {
-              "path": "$e6",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "note": "the push stream is not an oracle either",
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
             {
               "observe": "bytes_streamed",
+              "call": "step:10",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:11",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -3691,10 +3891,6 @@
           "note": "baseline: the index is readable and names the shared file"
         },
         {
-          "assert": [],
-          "note": "baseline: the index is readable and names the shared file"
-        },
-        {
           "assert": [
             {
               "path": "out",
@@ -3736,24 +3932,9 @@
           }
         },
         {
-          "note": "[split from a multi-verb step; review]",
           "assert": [
             {
-              "path": "err.code",
-              "op": "ne",
-              "value": [
-                "room_not_available",
-                "invalid_argument",
-                "subject_absent",
-                "resource_exhausted"
-              ]
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "out",
+              "path": "err",
               "op": "no_nulls"
             }
           ]
@@ -3811,24 +3992,18 @@
           "expect": {
             "ok": false,
             "err": {
-              "code": "declared_size_mismatch"
+              "code": "declared_size_mismatch",
+              "declared_bytes": 4096,
+              "observed_bytes": 4095
             }
           },
-          "note": "the streamed body carries a byte count that disagrees with declared_bytes 4096",
-          "op_id": "op-mismatch-1"
+          "op_id": "op-mismatch-1",
+          "stream": {
+            "send_bytes": 4095
+          }
         },
         {
           "assert": [
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": "digest_mismatch"
-            },
-            {
-              "path": "err.code",
-              "op": "ne",
-              "value": "file_too_large"
-            },
             {
               "path": "err.hint",
               "op": "absent"
@@ -3845,24 +4020,5 @@
         }
       ]
     }
-  ],
-  "authoring_notes": [
-    "SOURCE INDEPENDENCE. Every expected value here is derived from docs/protocol-v2.md (85cfdaf) and docs/shared-file-size.md. I read only the v1 *specification* table in docs/PROTOCOL.md (lines 400-425) to identify what must NOT be transcribed, and did not read engine.rs. Concretely, none of v1's file shapes survive: `{file_id,event_id}` alone, `files[].{available,providers,fetched,local_path,local_bytes,fetched_at_ms,mime}`, `{path,bytes,verified:true}`, `save_dir`, `hash_mismatch`, and the `hint` field appear in this corpus ONLY inside `expect_absent` / `forbid_codes` / `no_keys` assertions, i.e. as removal contracts.",
-    "THE NUMBER IS PINNED EXACTLY ONCE. The task requires both a boundary at literally 104857600/104857601 and that no fixture hard-code the number. Reconciled by pinning 104857600 in one place \u2014 the `assert equals` step of `handshake_serves_the_file_and_transfer_limits_as_integers`, which is where docs/shared-file-size.md Decision 1 is normatively asserted \u2014 and deriving every other boundary from `$limit` / `$limit+1` saved out of the hello frame. That same case carries a meta-assertion (`corpus_has_no_literal`) that the harness runs over the corpus text itself, naming the one permitted exception. Boundary cases therefore also run cheaply under a harness-reduced served limit (`served_limit_override`) without changing a single expected value.",
-    "STEP VOCABULARY (harness contract this corpus assumes; language-neutral, extends the v1 harness). Call steps: `call`/`in`/`save`/`as`/`await`/`stream`, with `expect` (subset match unless `exact:true`), `expect_absent` (dotted paths, `[]` meaning every array element), `expect_error {code, fields}`, `forbid_codes`, `expect_identical_to`. Non-call steps: `connect {as}` + `expect_hello` + `save`; `drop_connection`; `harness {...}` (serve_limits, provider_link, link_rate, foreign_room); `provider {...}` (test-peer behaviour); `client {action, in, observe}` for client-side-only assertions; `start_transfers`; `await_push`/`expect_no_push`; and `assert {...}` for structural predicates (json_type, no_keys, no_nulls, no_type_tag, no_value_matching, indistinguishable, monotonic_non_decreasing, bytes_consumed_at_most, provider_connections, no_event_authored, corpus_has_no_literal). Symbols: `$name` from `save`, with `+1`/`*2` arithmetic.",
-    "TYPE TAGS. Reuses v1's `<hex64>`, `<room_id>`, `<file_id>`, `<ts>` and adds `<u64>` (an integer count \u2014 stricter than v1's `<number>`, because v2 sizes are typed u64 and must never be strings or floats), `<bool>`, `<pos>`, `<op_id>`, `<absent_file_id>`. `<path>` is used ONLY as a forbidden tag: if normalization ever produces it inside a file-domain frame, the no-paths case fails.",
-    "ERROR-CODE NAMES I PROPOSED. The spec fixes `file_too_large`, `digest_mismatch`, `resource_exhausted`, `transfer_stalled`, `room_not_available`, `invalid_argument`. It says the taxonomy is 40 codes but enumerates only the ones whose shape is normative, so four names here are my proposals in the spec's own naming style and #161 must ratify or rename them: `provider_unreachable` (file.fetch, no reachable provider), `file_unknown` (file id not in the room's signed history), `file_not_fetched` (file.read on bytes not held locally), `transfer_unknown` (transfer.cancel, by analogy with the spec's own `subscription_unknown` for stream.unsubscribe).",
-    "file.list HAS NO OPERATION-SPECIFIC CODE IN THE SPEC. Every operation is required to have one, but the taxonomy names none for a pure room-scoped read. `list_of_a_room_that_is_not_available_answers_room_not_available` uses the most specific code the spec does define for that surface. The manifest must either record this as a named exemption or #161 must add a list-specific code; I did not invent one, because a fabricated code would be worse than a recorded gap.",
-    "SIZE AS A TAGGED VARIANT. `file.share.in.size` is modelled as `{state:\"declared\",bytes:N}` | `{state:\"unknown\"}`. Derived, not stated: the spec's absolute no-JSON-null rule plus Decision 4 point 1's requirement that a client MUST NOT reject a file merely for lacking a declared size (the Android SAF cloud-provider path, explicitly \"a normal path, not an edge case\"). An optional-with-null size would violate the null rule; an always-required integer would make the unsized path unrepresentable.",
-    "UNRESOLVED: file_too_large.declared_bytes WHEN NOTHING WAS DECLARED. shared-file-size.md Decision 3 says the declared size and the limit are separate *integer* fields, but the stage_stream and fetch_stream points can fire on a transfer with no declaration at all. `share_with_unknown_size_streaming_past_the_limit_aborts_at_stage_stream` therefore asserts only that `declared_bytes` is an integer and carries an explicit `spec_gap` step. #161 must state whether it carries the observed count or becomes a tagged variant like `transfer_stalled.total`. Where a declaration does exist (stage_declared, stage_stream-with-a-lying-declaration, fetch_preflight, fetch_stream) the fixtures pin it exactly.",
-    "enforced_at=\"authoring\" NEEDS AN ADAPTER WITHOUT AN UPLOAD EDGE. With a daemon in the path, stage_declared always fires first and authoring is unreachable through the protocol, so a fixture cannot observe it. The case therefore `requires: [\"in_process_core_adapter\"]` \u2014 the configuration shared-file-size.md describes for v2 on Android, where core runs in-process and there is no daemon upload edge, making authoring the earliest enforcement point.",
-    "transfer.cancel IS MARKED M BUT APPEARS IN NEITHER IDEMPOTENCY ROW, while the table claims every mutating operation is in one of them. I treated it as naturally idempotent with a tagged outcome (`cancelled` / `already_cancelled`), and its `in` carries the TARGET transfer's op_id, not one of its own. #161 must close this.",
-    "AUTHORIZATION SCOPE TENSION. The spec says the dedup ledger is keyed on `(authenticated session principal, op_id)` and explicitly NOT on the subject, but then says transfer.cancel is authorized by `(subject, op_id)` \"matching the ledger's scope\". Those are two different scopes. The fixtures assert the behaviour both spellings agree on \u2014 same principal on a NEW connection may cancel, a DIFFERENT principal may not and cannot distinguish refusal from non-existence \u2014 and leave the spelling to #161.",
-    "PROGRESS IS ASSERTED AS A PUSH, WHICH THE SPEC DOES NOT STATE. `transfer_stalled` is listed among error codes, so a stall terminates the operation; but the spec only says v2 \"MUST surface transfer progress\" without giving it a frame. I modelled progress as a `transfer_progress` push (carrying `t`, never `id`, per the envelope rule) with `total` as a tagged known/unknown variant mirroring `transfer_stalled.total`. Both are U2-blocked.",
-    "THE SIZE-AWARE DEADLINE FORMULA IS DERIVED. `transfer_connect_allowance_ms + declared_bytes*8*1000/transfer_floor_bits_per_second` is my reading of why exactly those two fields are served; the spec defers the formula to #161 and the constants to #198. The fixture asserts the observable consequence (a transfer that would have died at the retired fixed 30 s budget must succeed) and records the formula as an annotation rather than a hard expectation.",
-    "U3 SCOPE. Only the fetch_stream size distinction is blocked. fetch_preflight (Decision 4 point 5) is a purely local check on the signed size_bytes before any connection, so it is unblocked and its case asserts zero provider connections. The digest_mismatch direction is unblocked and must pass today.",
-    "OTHER SHAPES I HAD TO NAME. `peer_declared_type_untrusted` (the spec fixes only that the field be distinctly named and explicitly untrusted); `file.share` out `{file_id,event_id,pos,size_bytes,digest}`; `file.fetch` out `{file_id,size_bytes,digest,provider,local}` with no `verified` boolean, since success already implies verification and a failure is `digest_mismatch`; `local: {state: held|absent}` as a tagged variant. All are asserted as subsets so #161 may add fields without invalidating the corpus, and the file_id lexical form is deliberately left to the `<file_id>` tag.",
-    "HOSTILE NAME SANITIZATION IS UNSTATED. `list_carries_a_hostile_peer_declared_name_as_an_opaque_display_string` pins verbatim carriage plus the absence of any path-typed field, and flags the gap rather than asserting a sanitization rule the spec does not contain. Silently rewriting peer-signed metadata would be its own defect, so verbatim-plus-no-path is the conservative assertion.",
-    "COVERAGE LEDGER. file.share: successes (below limit, at limit, unknown size, op_id replay) and own-code errors (file_too_large at stage_declared/stage_stream/authoring). file.list: successes (provider facts, fetchable-false evidence) and room_not_available. file.fetch: successes (baseline, replay, size-aware budget) and own-code errors (file_too_large at fetch_preflight/fetch_stream, provider_unreachable, file_unknown, digest_mismatch). file.read: success and own-code error file_not_fetched. transfer.cancel: successes (dropped-connection cancel, slot release) and own-code error transfer_unknown. Plus five daemon-side enforced_at values, the client preflight proved by zero bytes and zero frames, both paired code directions, both resource_exhausted resources at their boundaries, the no-paths sweep, and the non-oracle property across all four room-scoped file operations."
   ]
 }

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -892,8 +892,7 @@
             }
           },
           "save": {
-            "limit": "frame.limits.max_shared_file_bytes",
-            "max_frame_bytes": "frame.limits.max_frame_bytes"
+            "limit": "frame.limits.max_shared_file_bytes"
           }
         },
         {
@@ -969,7 +968,7 @@
             {
               "path": "frame.peak_buffered_bytes",
               "op": "lte",
-              "value": "$max_frame_bytes"
+              "value": "$limit"
             }
           ]
         }
@@ -1317,6 +1316,12 @@
         },
         {
           "control": {
+            "do": "disconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "control": {
             "do": "reconnect",
             "on": "subject:self"
           }
@@ -1345,7 +1350,7 @@
             },
             {
               "observe": "bytes_streamed",
-              "call": "step:4",
+              "call": "step:5",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -2175,6 +2180,12 @@
         },
         {
           "control": {
+            "do": "disconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "control": {
             "do": "reconnect",
             "on": "subject:self"
           }
@@ -2201,7 +2212,7 @@
             },
             {
               "observe": "bytes_streamed",
-              "call": "step:5",
+              "call": "step:6",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -2215,7 +2226,7 @@
       "name": "fetch_deadline_scales_with_the_declared_size",
       "kind": "boundary",
       "operation": "file.fetch",
-      "intent": "Proves the absolute file.fetch deadline uses the declared total and served floor: progress at the floor succeeds, while progress below the required rate exhausts the fixed size-aware budget with a truthful accepted-byte count.",
+      "intent": "Proves the absolute file.fetch deadline uses the signed total and served floor: one transfer at the floor succeeds, while another reports the exact size-derived budget rather than any fixed timeout, with a truthful accepted-byte count.",
       "requires": [
         "subject",
         "room:live",
@@ -2303,6 +2314,7 @@
           },
           "op_id": "op-budget-floor"
         },
+
         {
           "control": {
             "do": "set_link_rate",
@@ -2328,7 +2340,13 @@
                 "state": "known",
                 "bytes": "$total_below_floor"
               },
-              "budget_ms": "<uint>"
+              "budget_ms": {
+                "$transfer_budget_ms": [
+                  "$total_below_floor",
+                  "$connect_ms",
+                  "$floor_bps"
+                ]
+              }
             }
           },
           "op_id": "op-budget-expiry"

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -3,26 +3,197 @@
   "spec": "../../docs/protocol-v2.md",
   "dsl": "./README.md",
   "authored": "by hand, from the specification. NOT generated from any implementation.",
-  "replayable": true,
+  "replayable": {
+    "structural_validation": true,
+    "selected_json_envelope_subject_slice": {
+      "status": "partial",
+      "ci_selected_cases": 14
+    },
+    "binary_byte_stream_executor": "unimplemented",
+    "adapter_targeted_declarative_cases": "declarative_only"
+  },
   "rules": {
     "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
     "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
     "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
-    "counts_are_computed": "every count in this file is derived from the committed fixtures, not asserted alongside them. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
+    "counts_are_computed": "every count in this file is derived from the current fixture JSON, not asserted alongside it. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
   },
   "blocked_on_upstream": {
     "U1": "ConnEvent must carry the connection generation and a typed offline reason",
-    "U2": "a progress-observing or streaming blob-fetch API",
-    "U3": "a size-distinguishable fetch outcome"
+    "U2": "a progress-observing or streaming blob-fetch API (8 cases: 3 progress/stall, 1 deadline, 4 cancellation)",
+    "U3": "a size-distinguishable fetch outcome (1 fetch-stream size case)"
+  },
+  "blocked_case_counts": {
+    "U1": 5,
+    "U2": 8,
+    "U3": 1,
+    "blocked_on_record": 1
+  },
+  "blocked_on_upstream_cases": {
+    "U1": [
+      {
+        "file": "handshake.json",
+        "case": "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason"
+      },
+      {
+        "file": "pipes.json",
+        "case": "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability"
+      },
+      {
+        "file": "rooms.json",
+        "case": "room_peers_ignores_a_stale_generation_teardown"
+      },
+      {
+        "file": "rooms.json",
+        "case": "room_peers_reports_a_typed_reason_for_a_device_it_cannot_reach"
+      },
+      {
+        "file": "timeline-streams.json",
+        "case": "peer_push_carries_the_connection_generation_and_a_typed_offline_reason"
+      }
+    ],
+    "U2": [
+      {
+        "file": "files.json",
+        "case": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled"
+      },
+      {
+        "file": "files.json",
+        "case": "cancel_result_reports_bytes_transferred"
+      },
+      {
+        "file": "files.json",
+        "case": "fetch_deadline_scales_with_the_declared_size"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_after_the_originating_connection_dropped"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_releases_the_concurrent_transfer_slot"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_progress_is_delivered_only_to_the_initiating_principal"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_progress_pushes_report_monotonic_transferred_bytes"
+      }
+    ],
+    "U3": [
+      {
+        "file": "files.json",
+        "case": "fetch_stream_refuses_a_peer_serving_more_than_it_declared"
+      }
+    ]
+  },
+  "blocked_on_record_cases": [
+    {
+      "file": "timeline-streams.json",
+      "case": "message_send_omitting_op_id_is_refused_naming_the_field",
+      "record": "op_id_optional_but_deduplicated"
+    }
+  ],
+  "target_counts": {
+    "untargeted": 336,
+    "daemon": 0,
+    "in_process_core": 1,
+    "client_adapter": 5
   },
   "totals": {
     "cases": 342,
     "attributed_to_an_operation": 237,
     "not_operation_scoped": 105,
     "conforming_to_the_dsl": 342,
+    "distinct_step_verbs_in_use": 7,
     "quarantined": 0,
-    "blocked_on_upstream": 10,
+    "blocked_on_upstream": 14,
     "blocked_on_record": 1
+  },
+  "per_file_totals": {
+    "files.json": {
+      "cases": 44,
+      "attributed_to_an_operation": 41,
+      "not_operation_scoped": 3,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 8,
+        "U3": 1
+      },
+      "blocked_on_record": 0
+    },
+    "handshake.json": {
+      "cases": 69,
+      "attributed_to_an_operation": 0,
+      "not_operation_scoped": 69,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 0
+    },
+    "invites.json": {
+      "cases": 37,
+      "attributed_to_an_operation": 34,
+      "not_operation_scoped": 3,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 0
+    },
+    "pipes.json": {
+      "cases": 43,
+      "attributed_to_an_operation": 37,
+      "not_operation_scoped": 6,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 0
+    },
+    "rooms.json": {
+      "cases": 65,
+      "attributed_to_an_operation": 59,
+      "not_operation_scoped": 6,
+      "blocked_on_upstream": {
+        "U1": 2,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 0
+    },
+    "subject-daemon.json": {
+      "cases": 24,
+      "attributed_to_an_operation": 19,
+      "not_operation_scoped": 5,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 0
+    },
+    "timeline-streams.json": {
+      "cases": 60,
+      "attributed_to_an_operation": 47,
+      "not_operation_scoped": 13,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0
+      },
+      "blocked_on_record": 1
+    }
   },
   "exemptions": {
     "room.deactivate": {
@@ -31,9 +202,20 @@
       "reviewed_in": "#212"
     }
   },
+  "taxonomy_code_count": 64,
   "codes_without_a_case": {
-    "note": "Every code in the taxonomy has at least one case. idle_timeout is covered via close code 4004 and malformed_frame via close code 4007, the protocol's transport representations of those codes.",
-    "codes": []
+    "note": "Computed from literal expect.err.code on a direct call matching case.operation, with canonical file-error validation; notes, intents, setup calls, generic nested objects, and authoring_notes do not count. frame_too_large, idle_timeout, malformed_frame, and not_ready count only through their verified named close/status fixtures.",
+    "codes": [
+      "forbidden_origin",
+      "pairing_code_invalid",
+      "protocol_unsupported",
+      "role_not_grantable",
+      "session_expired",
+      "storage_generation_mismatch",
+      "stream_aborted",
+      "unauthenticated",
+      "unknown_operation"
+    ]
   },
   "coverage": {
     "daemon.stop": {
@@ -44,7 +226,7 @@
       "satisfies_required_kinds": true
     },
     "file.fetch": {
-      "cases": 13,
+      "cases": 14,
       "success": true,
       "distinctive_code": "provider_unreachable",
       "distinctive_code_has_a_case": true,
@@ -170,7 +352,7 @@
       "satisfies_required_kinds": true
     },
     "room.create": {
-      "cases": 10,
+      "cases": 9,
       "success": true,
       "distinctive_code": "room_name_invalid",
       "distinctive_code_has_a_case": true,
@@ -329,7 +511,7 @@
         "gate_refusal_mutates_nothing",
         "gate_rejection_reveals_nothing_about_local_state",
         "gate_runs_before_the_upgrade_so_a_refusal_is_a_status_not_a_close_code",
-        "health_limits_object_carries_all_eleven_named_integer_fields",
+        "health_limits_object_carries_all_sixteen_named_integer_fields",
         "health_serves_the_version_object_and_no_data_dir",
         "hello_carries_no_pid_no_port_and_no_data_dir",
         "hello_is_the_first_frame_and_arrives_exactly_once",

--- a/conformance/v2/rooms.json
+++ b/conformance/v2/rooms.json
@@ -310,38 +310,6 @@
       ]
     },
     {
-      "name": "room_create_without_an_op_id_is_refused",
-      "kind": "malformed",
-      "operation": "room.create",
-      "intent": "Proves op_id is mandatory for the op_id-deduplicated class (unlike the naturally idempotent class), so it would catch a daemon that accepts an undeduplicable mutation and thereby makes the documented retry policy unenforceable.",
-      "requires": [
-        "subject"
-      ],
-      "steps": [
-        {
-          "call": "room.create",
-          "in": {
-            "name": "No Op Id"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "op_id"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_durable_mutation",
-              "scope": "step"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "room_create_rejects_a_missing_name",
       "kind": "malformed",
       "operation": "room.create",
@@ -2192,8 +2160,8 @@
             "ok": false,
             "err": {
               "code": "membership_ended",
-              "room_id": "<room_id>",
-              "state": "left"
+              "room_id": "$rid_left",
+              "standing": "left"
             }
           },
           "op_id": "$op_id_new"
@@ -2211,14 +2179,18 @@
           "call": "status.post",
           "in": {
             "room_id": "$rid_left",
-            "label": "working"
+            "label": "working",
+            "progress": {
+              "state": "absent"
+            }
           },
           "on": "subject:member_b",
           "expect": {
             "ok": false,
             "err": {
               "code": "membership_ended",
-              "state": "left"
+              "room_id": "$rid_left",
+              "standing": "left"
             }
           },
           "op_id": "$op_id_new"
@@ -2228,14 +2200,18 @@
           "in": {
             "room_id": "$rid_left",
             "subject_id": "$subject_o",
-            "role": "member"
+            "role": "member",
+            "expires_at": {
+              "$expires_in_ms": 3600000
+            }
           },
           "on": "subject:member_b",
           "expect": {
             "ok": false,
             "err": {
               "code": "membership_ended",
-              "state": "left"
+              "room_id": "$rid_left",
+              "standing": "left"
             }
           },
           "op_id": "$op_id_new"
@@ -2251,7 +2227,8 @@
             "ok": false,
             "err": {
               "code": "membership_ended",
-              "state": "left"
+              "room_id": "$rid_left",
+              "standing": "left"
             }
           },
           "op_id": "$op_id_new"
@@ -2261,14 +2238,16 @@
           "in": {
             "room_id": "$rid_left",
             "name": "x.txt",
-            "bytes_ref": "$small_blob"
+            "declared_bytes": 1024,
+            "declared_content_type": "text/plain"
           },
           "on": "subject:member_b",
           "expect": {
             "ok": false,
             "err": {
               "code": "membership_ended",
-              "state": "left"
+              "room_id": "$rid_left",
+              "standing": "left"
             }
           },
           "op_id": "$op_id_new"
@@ -5347,7 +5326,6 @@
     "LIFECYCLE VS LIVENESS. I treat these as two orthogonal fields because room.deactivate is defined as stopping live participation WITHOUT changing membership: `standing.state` in {active, left, removed} (tokens taken from the spec's own prose 'a left or removed room' and #161's 'ACTIVE room') and a separate boolean `live`. `room_deactivate_stops_liveness_without_changing_membership` asserts exactly this split, so a daemon that collapses them into one enum fails. Member `standing.state` uses the same three tokens. If the manifest picks different tokens, only the tokens change; every assertion's shape survives.",
     "THE ROLE TOKEN IS NOT ASSERTED LITERALLY. The spec removes the two-vocabulary naming (log `admin` vs wire `owner`) and says 'one name, both places' without saying WHICH name. Inventing one would be authoring the implementation, so `role_vocabulary_is_one_token_across_every_surface` asserts cross-surface identity (room.list's role equals room.members' role for the same subject) plus authority != member, which is precisely the property the spec states and is spelling-independent.",
     "THE CAPABILITY VOCABULARY IS ALSO UNSPECIFIED. room.list must answer 'what may I do in each' and room.activate returns capabilities, but no token list exists. So capability cases assert behaviour, not tokens: `advertised_capabilities_match_enforcement_in_every_lifecycle_state` requires the harness to exercise each advertised capability (must succeed) and each omitted write (must refuse). RECOMMENDATION: the spec should enumerate the capability tokens, or this case degrades to a harness-defined probe list.",
-    "op_id REQUIRED VS ACCEPTED. The spec says every mutating operation 'accepts' an op_id but splits mutations into naturally-idempotent and op_id-deduplicated classes. I read that as: op_id is REQUIRED for the deduplicated class (an undeduplicable room.create makes the stated retry policy unenforceable) and OPTIONAL for the naturally idempotent class. `room_create_without_an_op_id_is_refused` and `room_activate_is_naturally_idempotent_and_needs_no_op_id` pin both halves. If the spec instead makes op_id optional everywhere, the first case must flip — it is the one to change, not the second.",
     "NO SERVED BOUND EXISTS FOR ROOMS. The limits object bounds frames, bodies, inflight requests, connections, transfers and timeline pages, but nothing bounds a room NAME, the number of rooms per subject, or the number of members. I therefore could not author boundary cases for room.create at all, and room.timeline is the only operation in this domain with a real at-limit/one-past-limit pair. RECOMMENDATION: add `max_room_name_bytes` (and consider `max_members_per_room`) to the limits object, or the corpus can never prove where room.create's argument bounds are — only that a missing name is refused.",
     "UNDECIDED, ASSERTED ANYWAY, FLAGGED HERE. (1) Does a naturally-idempotent room.deactivate succeed for a room the caller LEFT? I assert refusal with membership_ended, on the ground that a mutating operation must not be accepted against ended membership; idempotency is not a licence to accept writes. (2) Re-removing an already-removed member with a FRESH op_id: the reply shape is genuinely undecided, so `member_remove_repeated_with_a_fresh_op_id_authors_no_second_removal` asserts only the durable invariant (no second event, standing unchanged, exactly one member row) and deliberately does not pin the reply. Both need a spec sentence.",
     "SHARED-CODE CAVEAT AGAINST #161's OWN CRITERION. room.activate, room.deactivate and room.members all take `membership_ended` as their most-specific error, so the per-operation error requirement is satisfied as 'most specific applicable' but not as 'unique to the operation'. The manifest must either state that explicitly as acceptable, or the spec must add per-operation codes. I flag it rather than invent three near-synonyms.",

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -3,7 +3,7 @@ type: "Reference"
 title: "Jeliya protocol v2"
 description: "Normative clean-slate contract between the typed Rust core and every Jeliya client: the generation gate, approved operations, byte-stream framing, errors, sequenced pushes, authoritative resync, and binding conformance corpus."
 tags: ["clean-slate", "conformance", "protocol", "security"]
-timestamp: "2026-08-03T08:38:58Z"
+timestamp: "2026-08-03T17:54:45Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "unverified"
@@ -2398,10 +2398,10 @@ it.
 | `cursor_invalid` | → `cursor_unknown` for a pruned position, or `invalid_argument` with `reason: {"state": "format"}` for a malformed one. The single corpus code conflated the two |
 | `<the case's code>` | Not a code at all — an unsubstituted placeholder left in a fixture |
 
-`stream_aborted` and `transfer_deadline_exceeded` have no fixtures transcribed
-from this decision yet. That is a corpus gap, not permission to substitute
-another code; #233 owns their executable cases and the broader file-fixture
-correction.
+`stream_aborted` and `transfer_deadline_exceeded` now have declarative fixtures
+transcribed from this decision under #233. They remain blocked on U2 and are not
+live byte-stream evidence until the independent executor can produce truthful
+accepted-byte counts.
 
 ### The non-oracle property
 

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -36,6 +36,7 @@ const DOMAIN_BY_FILE = {
 };
 const COMPUTED_NODES = new Set([
   "$add", "$sub", "$bytes_of_len", "$concat", "$expires_in_ms", "$unknown",
+  "$transfer_budget_ms",
 ]);
 // `stream` is legal only on the two operations the record streams bytes for,
 // and carries exactly one direction.
@@ -189,6 +190,11 @@ function isComputedNode(value) {
       && operand.every((item) => typeof item === "string");
   }
   if (operator === "$expires_in_ms") return Number.isInteger(operand) && operand >= 0;
+  if (operator === "$transfer_budget_ms") {
+    return Array.isArray(operand) && operand.length === 3
+      && operand.every((item) => Number.isInteger(item)
+        || (typeof item === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(item)));
+  }
   if (operator === "$bytes_of_len") {
     return Number.isInteger(operand) && operand >= 0
       || (typeof operand === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(operand));
@@ -199,13 +205,15 @@ function isComputedNode(value) {
 function isValueNode(value, { positive = false } = {}) {
   if (Number.isInteger(value)) return positive ? value > 0 : value >= 0;
   if (typeof value === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) return true;
-  return isComputedNode(value) && ["$add", "$sub"].includes(Object.keys(value)[0]);
+  return isComputedNode(value)
+    && ["$add", "$sub", "$transfer_budget_ms"].includes(Object.keys(value)[0]);
 }
 
 function isNumericAssertionValue(value) {
   if (typeof value === "number") return Number.isFinite(value);
   if (typeof value === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) return true;
-  return isComputedNode(value) && ["$add", "$sub"].includes(Object.keys(value)[0]);
+  return isComputedNode(value)
+    && ["$add", "$sub", "$transfer_budget_ms"].includes(Object.keys(value)[0]);
 }
 
 function checkExactKeySet(value, required) {
@@ -331,9 +339,13 @@ function checkAssertion(a, file, caseName, where) {
       fail(file, caseName, where, `${a.observe} requires ${missing.join(" and ")}`);
     }
     if (a.observe === "bytes_streamed" && "value" in a) {
-      if (checkExactKeys(a.value, ["op", "value"], file, caseName, `${where} value`)
-          && !["eq", "ne", "lt", "lte", "gt", "gte"].includes(a.value.op)) {
-        fail(file, caseName, where, `bytes_streamed.value.op must be a numeric comparison`);
+      if (checkExactKeys(a.value, ["op", "value"], file, caseName, `${where} value`)) {
+        if (!["eq", "ne", "lt", "lte", "gt", "gte"].includes(a.value.op)) {
+          fail(file, caseName, where, `bytes_streamed.value.op must be a numeric comparison`);
+        }
+        if (!isNumericAssertionValue(a.value.value)) {
+          fail(file, caseName, where, `bytes_streamed.value.value must be numeric, a $variable, or an arithmetic computed node`);
+        }
       }
     }
     if (a.observe === "bytes_streamed" && "call" in a

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -12,12 +12,31 @@
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
 
 const DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "conformance", "v2");
 
 const DSL_VERBS = new Set(["call", "http", "upgrade", "send", "await", "control", "assert"]);
-const AUX_KEYS = new Set(["in", "op_id", "on", "expect", "save", "note", "stream"]);
+const AUX_KEYS = new Set(["in", "op_id", "on", "expect", "save", "note", "stream", "defer"]);
+const TOP_LEVEL_KEYS = new Set(["domain", "note", "cases", "authoring_notes"]);
+const CASE_KEYS = new Set([
+  "name", "kind", "operation", "intent", "requires", "steps", "targets",
+  "blocked_on_upstream", "blocked_on_record",
+]);
+const TARGETS = new Set(["daemon", "in_process_core", "client_adapter"]);
+const DOMAIN_BY_FILE = {
+  "files.json": "files",
+  "handshake.json": "handshake",
+  "invites.json": "invites",
+  "pipes.json": "pipes",
+  "rooms.json": "rooms",
+  "subject-daemon.json": "subject-daemon",
+  "timeline-streams.json": "timeline-streams",
+};
+const COMPUTED_NODES = new Set([
+  "$add", "$sub", "$bytes_of_len", "$concat", "$expires_in_ms", "$unknown",
+]);
 // `stream` is legal only on the two operations the record streams bytes for,
 // and carries exactly one direction.
 const STREAMING_OPS = new Map([
@@ -25,9 +44,15 @@ const STREAMING_OPS = new Map([
   ["file.read", "receive_bytes"],
 ]);
 const KINDS = new Set(["success", "error", "malformed", "boundary", "authorization", "handshake", "push", "ordering"]);
+const PRE_OPEN_STREAM_CODES = new Set([
+  "invalid_argument", "subject_absent", "room_not_available", "membership_ended",
+  "op_id_conflict", "file_unknown", "file_not_fetched", "resource_exhausted",
+]);
 const CONTROL_DO = new Set([
   "advance_clock", "idle", "disconnect", "reconnect", "inject_fault",
-  "set_limit", "stop_daemon", "start_daemon", "start_transfers", "pause_link",
+  "set_limit", "set_link_rate", "set_provider_response_bytes", "client_preflight",
+  "client_render_limit", "client_render_file", "stop_daemon", "start_daemon",
+  "start_transfers", "cancel_transfers", "pause_link",
 ]);
 const ASSERT_OPS = new Set([
   "eq", "ne", "lt", "lte", "gt", "gte", "member_of", "type", "present",
@@ -41,9 +66,53 @@ const OBSERVE = new Set([
 ]);
 const TYPE_TAGS = new Set([
   "room_id", "subject_id", "device_id", "event_id", "invite_id", "file_id",
-  "pipe_id", "op_id", "ts", "uint", "bool", "string",
+  "pipe_id", "op_id", "request_id", "ts", "uint", "bool", "string",
   "pos", "capability", "daemon_sg", "port", "object", "any", "version",
   "standing", "link_connected", "link_reason",
+]);
+const ASSERTION_KEYS = new Set(["path", "op", "value", "note"]);
+const ASSERTIONS_WITHOUT_VALUE = new Set([
+  "present", "absent", "unique", "increasing", "non_decreasing", "contiguous",
+  "no_nulls",
+]);
+const ASSERTIONS_WITH_VALUE = new Set([
+  "eq", "ne", "lt", "lte", "gt", "gte", "member_of", "type", "exact_keys",
+  "len", "byte_len", "eq_except",
+]);
+const COMPARISON_OPS = new Set(["eq", "ne", "lt", "lte", "gt", "gte"]);
+const FILE_ERROR_KEYS = new Map([
+  ["invalid_argument", ["code", "field", "reason"]],
+  ["room_not_available", ["code", "room_id"]],
+  ["membership_ended", ["code", "room_id", "standing"]],
+  ["file_unknown", ["code", "file_id"]],
+  ["file_not_fetched", ["code", "file_id"]],
+  ["provider_unreachable", ["code", "file_id", "providers"]],
+  ["transfer_unknown", ["code", "transfer_op_id"]],
+  ["declared_size_mismatch", ["code", "declared_bytes", "observed_bytes"]],
+  ["transfer_stalled", ["code", "transferred_bytes", "total"]],
+  ["transfer_deadline_exceeded", ["code", "transferred_bytes", "total", "budget_ms"]],
+  ["stream_aborted", ["code", "transferred_bytes", "total", "reason"]],
+  ["file_too_large", ["code", "declared_bytes", "limit_bytes", "enforced_at"]],
+  ["resource_exhausted", ["code", "resource", "limit"]],
+  ["digest_mismatch", ["code", "expected", "observed"]],
+  ["room_not_live", ["code", "room_id"]],
+  ["subject_absent", ["code"]],
+  ["op_id_conflict", ["code", "op_id"]],
+  ["file_index_unreadable", ["code"]],
+]);
+const TRANSPORT_CODE_FIXTURES = new Map([
+  ["frame_too_large", "close_code_4005_is_emitted_for_frame_too_large"],
+  ["idle_timeout", "close_code_4004_is_emitted_on_idle_timeout"],
+  ["malformed_frame", "a_frame_with_no_recoverable_id_closes_4007_malformed_frame"],
+  ["not_ready", "close_code_4003_is_emitted_when_the_daemon_is_not_ready"],
+]);
+const PRINCIPAL_ISOLATION_CASES = new Set([
+  "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
+  "transfer_progress_is_delivered_only_to_the_initiating_principal",
+]);
+const LEGACY_REQUEST_CONCURRENCY_CASES = new Set([
+  "inflight_requests_at_the_served_limit_are_all_answered",
+  "one_request_past_max_inflight_is_resource_exhausted_not_a_close",
 ]);
 const REQUIRE_ARGS = {
   subject: new Set(["self", "none", "second", "outsider"]),
@@ -87,15 +156,81 @@ const TAXONOMY_CODES = new Set([
   "shutdown_in_progress", "sole_authority_cannot_leave", "status_label_unknown",
   "status_subject_unknown", "storage_generation_mismatch", "subject_absent",
   "subject_store_unwritable", "subscription_limit_reached", "subscription_unknown",
-  "transfer_stalled", "transfer_unknown", "transport_unavailable", "unauthenticated", "unknown_operation",
+  "stream_aborted", "transfer_deadline_exceeded", "transfer_stalled", "transfer_unknown",
+  "transport_unavailable", "unauthenticated", "unknown_operation",
 ]);
 
 const problems = [];
 let caseCount = 0;
 let stepCount = 0;
+let fixtureProblemCount = 0;
+let computed = null;
 
 function fail(file, caseName, where, msg) {
   problems.push({ file, case: caseName, where, msg });
+}
+
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isComputedNode(value) {
+  if (!isObject(value) || Object.keys(value).length !== 1) return false;
+  const [operator] = Object.keys(value);
+  if (!COMPUTED_NODES.has(operator)) return false;
+  const operand = value[operator];
+  if (["$add", "$sub"].includes(operator)) {
+    return Array.isArray(operand) && operand.length === 2
+      && operand.every((item) => Number.isInteger(item)
+        || (typeof item === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(item)));
+  }
+  if (operator === "$concat") {
+    return Array.isArray(operand) && operand.length > 0
+      && operand.every((item) => typeof item === "string");
+  }
+  if (operator === "$expires_in_ms") return Number.isInteger(operand) && operand >= 0;
+  if (operator === "$bytes_of_len") {
+    return Number.isInteger(operand) && operand >= 0
+      || (typeof operand === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(operand));
+  }
+  return typeof operand === "string" && operand.length > 0;
+}
+
+function isValueNode(value, { positive = false } = {}) {
+  if (Number.isInteger(value)) return positive ? value > 0 : value >= 0;
+  if (typeof value === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) return true;
+  return isComputedNode(value) && ["$add", "$sub"].includes(Object.keys(value)[0]);
+}
+
+function isNumericAssertionValue(value) {
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "string" && /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(value)) return true;
+  return isComputedNode(value) && ["$add", "$sub"].includes(Object.keys(value)[0]);
+}
+
+function checkExactKeySet(value, required) {
+  if (!isObject(value)) return false;
+  const got = Object.keys(value).sort();
+  const want = [...required].sort();
+  return got.length === want.length && got.every((key, i) => key === want[i]);
+}
+
+function checkExactKeys(value, required, file, caseName, where) {
+  if (!isObject(value)) {
+    fail(file, caseName, where, `must be an object with keys {${required.join(", ")}}`);
+    return false;
+  }
+  if (!checkExactKeySet(value, required)) {
+    const got = Object.keys(value).sort();
+    const want = [...required].sort();
+    fail(file, caseName, where, `takes exactly {${want.join(", ")}}, got {${got.join(", ")}}`);
+    return false;
+  }
+  return true;
+}
+
+function sameJson(actual, expected) {
+  return isDeepStrictEqual(actual, expected);
 }
 
 function checkTypeTags(value, file, caseName, where) {
@@ -115,9 +250,41 @@ function checkTypeTags(value, file, caseName, where) {
       if (k === "state" && typeof v === "string" && v === "<variant>") {
         fail(file, caseName, where, `{"state": "<variant>"} asserts a discriminant exists without naming legal arms — use member_of with an explicit token set`);
       }
+      if (k === "code" && typeof v === "string" && !TAXONOMY_CODES.has(v)) {
+        fail(file, caseName, where, `unknown taxonomy code "${v}"`);
+      }
       checkTypeTags(v, file, caseName, where);
     }
   }
+}
+
+function checkFileError(err, file, caseName, where) {
+  const required = FILE_ERROR_KEYS.get(err.code);
+  if (!required) return false;
+  let valid = checkExactKeys(err, required, file, caseName, where);
+  if (err.code === "provider_unreachable" && Array.isArray(err.providers)) {
+    if (err.providers.length === 0) {
+      fail(file, caseName, where, `provider_unreachable.providers must contain at least one attempted provider`);
+      valid = false;
+    }
+    err.providers.forEach((provider, index) => {
+      if (!checkExactKeys(provider, ["subject_id", "device_id", "link"], file,
+        caseName, `${where}.providers[${index}]`)) valid = false;
+    });
+  } else if (err.code === "provider_unreachable") {
+    fail(file, caseName, where, `provider_unreachable.providers must be a non-empty array`);
+    valid = false;
+  }
+  return valid;
+}
+
+function fileErrorIsCanonical(err) {
+  const required = FILE_ERROR_KEYS.get(err?.code);
+  if (!required || !checkExactKeySet(err, required)) return false;
+  if (err.code !== "provider_unreachable") return true;
+  return Array.isArray(err.providers) && err.providers.length > 0
+    && err.providers.every((provider) =>
+      checkExactKeySet(provider, ["subject_id", "device_id", "link"]));
 }
 
 function checkAssertion(a, file, caseName, where) {
@@ -129,15 +296,66 @@ function checkAssertion(a, file, caseName, where) {
   if (keys.includes("observe")) {
     if (!OBSERVE.has(a.observe)) {
       fail(file, caseName, where, `unknown observation "${a.observe}" (closed set of ${OBSERVE.size})`);
+      return;
     }
-    if (a.observe === "close_code" && (!("value" in a) || !("on" in a))) {
-      fail(file, caseName, where, `close_code requires both value and on`);
+    const observationKeys = {
+      no_network_activity: new Set(["observe", "scope"]),
+      no_durable_mutation: new Set(["observe", "scope"]),
+      no_event_authored: new Set(["observe", "scope", "note"]),
+      bytes_streamed: new Set(["observe", "value", "call"]),
+      connection_open: new Set(["observe", "on", "note"]),
+      close_code: new Set(["observe", "value", "on"]),
+      push_count: new Set(["observe", "value", "room_id"]),
+      no_push: new Set(["observe", "room_id", "on", "match", "scope"]),
+      timing_indistinguishable: new Set(["observe", "between"]),
+      process_exited: new Set(["observe", "value"]),
+    };
+    const unexpected = keys.filter((key) => !observationKeys[a.observe].has(key));
+    if (unexpected.length > 0) {
+      fail(file, caseName, where, `${a.observe} has unexpected key(s): ${unexpected.join(", ")}`);
     }
-    if (a.observe === "push_count" && !("value" in a)) {
-      fail(file, caseName, where, `push_count requires value`);
+    const requiredObservationKeys = {
+      no_network_activity: ["scope"],
+      no_durable_mutation: ["scope"],
+      no_event_authored: ["scope"],
+      bytes_streamed: ["value"],
+      connection_open: ["on"],
+      close_code: ["value", "on"],
+      push_count: ["value", "room_id"],
+      no_push: ["scope"],
+      timing_indistinguishable: ["between"],
+      process_exited: ["value"],
+    };
+    const missing = requiredObservationKeys[a.observe].filter((key) => !(key in a));
+    if (missing.length > 0) {
+      fail(file, caseName, where, `${a.observe} requires ${missing.join(" and ")}`);
     }
-    if (a.observe === "timing_indistinguishable" && !("between" in a)) {
-      fail(file, caseName, where, `timing_indistinguishable requires between`);
+    if (a.observe === "bytes_streamed" && "value" in a) {
+      if (checkExactKeys(a.value, ["op", "value"], file, caseName, `${where} value`)
+          && !["eq", "ne", "lt", "lte", "gt", "gte"].includes(a.value.op)) {
+        fail(file, caseName, where, `bytes_streamed.value.op must be a numeric comparison`);
+      }
+    }
+    if (a.observe === "bytes_streamed" && "call" in a
+        && (typeof a.call !== "string" || !/^step:[1-9][0-9]*$/.test(a.call))) {
+      fail(file, caseName, where, `bytes_streamed.call must be a one-indexed step selector such as "step:4"`);
+    }
+    if (a.observe === "no_push") {
+      const legacy = checkExactKeySet(a, ["observe", "room_id", "scope"]);
+      const matcher = checkExactKeySet(a, ["observe", "on", "match", "scope"]);
+      if (!legacy && !matcher) {
+        fail(file, caseName, where,
+          `no_push must be exactly {observe, room_id, scope} or {observe, on, match, scope}`);
+      } else if (legacy && (typeof a.room_id !== "string" || a.room_id.length === 0)) {
+        fail(file, caseName, where, `no_push.room_id must be a non-empty room identifier or variable`);
+      } else if (matcher) {
+        if (typeof a.on !== "string" || a.on.length === 0) {
+          fail(file, caseName, where, `no_push.on must be a non-empty session label`);
+        }
+        if (!isObject(a.match) || Object.keys(a.match).length === 0) {
+          fail(file, caseName, where, `no_push.match must be a non-empty object`);
+        }
+      }
     }
     return;
   }
@@ -148,6 +366,57 @@ function checkAssertion(a, file, caseName, where) {
   if ("op" in a && !ASSERT_OPS.has(a.op)) {
     fail(file, caseName, where, `unknown assert op "${a.op}" (closed set of ${ASSERT_OPS.size})`);
   }
+  if (file === "files.json") {
+    const unknownKeys = keys.filter((key) => !ASSERTION_KEYS.has(key));
+    if (unknownKeys.length > 0) {
+      fail(file, caseName, where, `file assertion has unknown key(s): ${unknownKeys.join(", ")}`);
+    }
+    if (!("path" in a) || !("op" in a)) {
+      fail(file, caseName, where, `file value assertion requires both path and op`);
+    }
+    if (ASSERTIONS_WITHOUT_VALUE.has(a.op) && "value" in a) {
+      fail(file, caseName, where, `${a.op} takes no value`);
+    }
+    if (ASSERTIONS_WITH_VALUE.has(a.op) && !("value" in a)) {
+      fail(file, caseName, where, `${a.op} requires value`);
+    }
+    if (a.op === "ne" && Array.isArray(a.value)) {
+      fail(file, caseName, where, `array-valued ne is ambiguous — use one ne assertion per forbidden value`);
+    }
+    if (["lt", "lte", "gt", "gte"].includes(a.op) && !isNumericAssertionValue(a.value)) {
+      fail(file, caseName, where, `${a.op}.value must be a finite number, $variable, or arithmetic computed node`);
+    }
+    if (a.op === "member_of" && (!Array.isArray(a.value) || a.value.length === 0)) {
+      fail(file, caseName, where, `member_of.value must be a non-empty array`);
+    }
+    if (a.op === "type" && (typeof a.value !== "string" || !TYPE_TAGS.has(a.value))) {
+      fail(file, caseName, where, `type.value must be one of the ${TYPE_TAGS.size} type-tag names without angle brackets`);
+    }
+    if (a.op === "exact_keys"
+        && (!Array.isArray(a.value) || a.value.length === 0
+          || a.value.some((key) => typeof key !== "string" || key.length === 0)
+          || new Set(a.value).size !== a.value.length)) {
+      fail(file, caseName, where, `exact_keys.value must be a non-empty unique array of non-empty strings`);
+    }
+    if (["len", "byte_len"].includes(a.op)) {
+      if (checkExactKeys(a.value, ["op", "value"], file, caseName, `${where} value`)
+          && (!COMPARISON_OPS.has(a.value.op) || !isNumericAssertionValue(a.value.value))) {
+        fail(file, caseName, where, `${a.op}.value must contain a comparison op and numeric assertion value`);
+      }
+    }
+    if (a.op === "eq_except") {
+      if (checkExactKeys(a.value, ["path", "keys"], file, caseName, `${where} value`)) {
+        if (typeof a.value.path !== "string" || a.value.path.length === 0) {
+          fail(file, caseName, where, `eq_except.value.path must be a non-empty path string`);
+        }
+        if (!Array.isArray(a.value.keys) || a.value.keys.length === 0
+            || a.value.keys.some((key) => typeof key !== "string" || key.length === 0)
+            || new Set(a.value.keys).size !== a.value.keys.length) {
+          fail(file, caseName, where, `eq_except.value.keys must be a non-empty unique array of non-empty strings`);
+        }
+      }
+    }
+  }
   if ("path" in a) {
     // `path` is "a dotted path rooted at out, err, frame, or a $variable"
     // (README). A non-string path resolves against nothing, so an assertion
@@ -157,7 +426,7 @@ function checkAssertion(a, file, caseName, where) {
         `assert path is ${Array.isArray(a.path) ? "an array" : typeof a.path} — must be a dotted string`);
     } else {
       const root = a.path.split(/[.[]/)[0];
-      if (!["out", "err", "frame"].includes(root) && !root.startsWith("$")) {
+      if (!["out", "err", "frame"].includes(root) && !/^\$[A-Za-z_][A-Za-z0-9_]*$/.test(root)) {
         fail(file, caseName, where, `assert path rooted at "${root}" (must be out/err/frame/$variable)`);
       }
     }
@@ -166,7 +435,7 @@ function checkAssertion(a, file, caseName, where) {
 
 function checkStep(step, file, caseName, stepIdx) {
   const where = `step ${stepIdx + 1}`;
-  if (typeof step !== "object" || step === null) {
+  if (!isObject(step)) {
     fail(file, caseName, where, "step is not an object");
     return;
   }
@@ -190,16 +459,42 @@ function checkStep(step, file, caseName, stepIdx) {
   if (step.http !== undefined && (typeof step.http !== "object" || step.http === null || !step.http.method || !step.http.path)) {
     fail(file, caseName, where, `http is not the {method, path, headers, body} object form`);
   }
+  if (step.upgrade !== undefined && !isObject(step.upgrade)) {
+    fail(file, caseName, where, `upgrade must be an object`);
+  }
   if (step.call !== undefined && !OPERATIONS.has(step.call)) {
     fail(file, caseName, where, `call names unknown operation "${step.call}"`);
   }
+  if (step.on !== undefined && (typeof step.on !== "string" || step.on.length === 0)) {
+    fail(file, caseName, where, `on must be a non-empty session label`);
+  }
+  if (step.note !== undefined && typeof step.note !== "string") {
+    fail(file, caseName, where, `note must be a string`);
+  }
+  for (const key of ["stream", "defer"]) {
+    if (key in step && step.call === undefined) {
+      fail(file, caseName, where, `${key} is only legal on a call step`);
+    }
+  }
+  if (step.defer !== undefined) {
+    if (step.defer !== true) {
+      fail(file, caseName, where, `defer must be boolean true`);
+    }
+    if (step.expect !== undefined) {
+      fail(file, caseName, where, `a deferred call is matched by await {reply}; put expect on that await step`);
+    }
+    if (!isObject(step.save) || Object.values(step.save).length !== 1
+        || Object.values(step.save)[0] !== "$request") {
+      fail(file, caseName, where, `a deferred call must save its request handle as {handle: "$request"}`);
+    }
+  } else if (isObject(step.save) && Object.values(step.save).includes("$request")) {
+    fail(file, caseName, where, `$request may be saved only by a deferred call`);
+  }
   if (step.stream !== undefined) {
-    // `stream` rides on the call it belongs to, like `in`. It is not a verb:
-    // the bytes and the declaration are one operation, and splitting them
-    // would leave a step with a stream and nothing to stream for.
-    if (step.call === undefined) {
-      fail(file, caseName, where, `stream is only legal on a call step`);
-    } else if (!STREAMING_OPS.has(step.call)) {
+    if (step.defer === true) {
+      fail(file, caseName, where, `stream and defer cannot share one call step`);
+    }
+    if (!STREAMING_OPS.has(step.call)) {
       fail(file, caseName, where,
         `stream on "${step.call}" — only ${[...STREAMING_OPS.keys()].join(" and ")} stream bytes`);
     } else if (typeof step.stream !== "object" || step.stream === null || Array.isArray(step.stream)) {
@@ -212,10 +507,7 @@ function checkStep(step, file, caseName, stepIdx) {
           `stream on ${step.call} takes exactly {${direction}}, got {${got.join(", ")}}`);
       } else {
         const v = step.stream[direction];
-        const computed = v !== null && typeof v === "object" && Object.keys(v).length === 1
-          && Object.keys(v)[0].startsWith("$");
-        const variable = typeof v === "string" && v.startsWith("$");
-        if (!computed && !variable && !(Number.isInteger(v) && v >= 0)) {
+        if (!isValueNode(v)) {
           fail(file, caseName, where,
             `stream.${direction} must be a <uint>, a $variable, or a computed node`);
         }
@@ -224,10 +516,79 @@ function checkStep(step, file, caseName, stepIdx) {
   }
   if (step.control !== undefined) {
     const c = step.control;
-    if (!c.do || !CONTROL_DO.has(c.do)) {
-      fail(file, caseName, where, `control.do "${c.do}" not in the closed set of ${CONTROL_DO.size}`);
+    if (!isObject(c) || !c.do || !CONTROL_DO.has(c.do)) {
+      fail(file, caseName, where, `control.do "${c?.do}" not in the closed set of ${CONTROL_DO.size}`);
+    } else {
+      const exactControlKeys = {
+        set_provider_response_bytes: ["do", "file_id", "bytes"],
+        client_preflight: ["do", "source_bytes", "source_reports_size"],
+        client_render_limit: ["do", "served_bytes"],
+        client_render_file: ["do", "declared_content_type", "body_kind"],
+        cancel_transfers: ["do", "op_id_prefix"],
+      };
+      if (c.do === "set_link_rate") {
+        if (checkExactKeys(c, ["do", "between", "bits_per_second"], file, caseName, `${where} control`)) {
+          if (!Array.isArray(c.between) || c.between.length !== 2
+              || c.between.some((label) => typeof label !== "string" || label.length === 0)) {
+            fail(file, caseName, where, `set_link_rate.between must contain exactly two non-empty session/provider labels`);
+          } else if (c.between[0] === c.between[1]) {
+            fail(file, caseName, where, `set_link_rate.between labels must be distinct`);
+          }
+          if (!isValueNode(c.bits_per_second, { positive: true })) {
+            fail(file, caseName, where, `set_link_rate.bits_per_second must be a positive value node`);
+          }
+        }
+      } else if (c.do === "start_transfers") {
+        const fileShape = checkExactKeySet(c,
+          ["do", "count", "aggregate_bytes", "op_id_prefix"]);
+        const legacyShape = LEGACY_REQUEST_CONCURRENCY_CASES.has(caseName)
+          && checkExactKeySet(c, ["do", "count"]);
+        if (!fileShape && !legacyShape) {
+          fail(file, caseName, `${where} control`, file === "files.json"
+            ? `start_transfers takes exactly {aggregate_bytes, count, do, op_id_prefix} in files.json`
+            : `start_transfers takes either its current legacy {count, do} form or the file-transfer form`);
+        } else if (fileShape) {
+          if (!isValueNode(c.count, { positive: true })) {
+            fail(file, caseName, where, `start_transfers.count must be a positive value node`);
+          }
+          if (!isValueNode(c.aggregate_bytes)) {
+            fail(file, caseName, where, `start_transfers.aggregate_bytes must be a nonnegative value node`);
+          }
+          if (typeof c.op_id_prefix !== "string" || c.op_id_prefix.length === 0) {
+            fail(file, caseName, where, `start_transfers.op_id_prefix must be a non-empty string`);
+          }
+        } else if (!isValueNode(c.count, { positive: true })) {
+          fail(file, caseName, where, `start_transfers.count must be a positive value node`);
+        }
+      } else if (exactControlKeys[c.do]
+          && checkExactKeys(c, exactControlKeys[c.do], file, caseName, `${where} control`)) {
+        if (c.do === "set_provider_response_bytes") {
+          if (typeof c.file_id !== "string" || c.file_id.length === 0) {
+            fail(file, caseName, where, `set_provider_response_bytes.file_id must be a non-empty file identifier or variable`);
+          }
+          if (!isValueNode(c.bytes)) {
+            fail(file, caseName, where, `set_provider_response_bytes.bytes must be a nonnegative value node`);
+          }
+        } else if (c.do === "client_preflight") {
+          if (!isValueNode(c.source_bytes)) {
+            fail(file, caseName, where, `client_preflight.source_bytes must be a nonnegative value node`);
+          }
+          if (typeof c.source_reports_size !== "boolean") {
+            fail(file, caseName, where, `client_preflight.source_reports_size must be boolean`);
+          }
+        } else if (c.do === "client_render_limit" && !isValueNode(c.served_bytes)) {
+          fail(file, caseName, where, `client_render_limit.served_bytes must be a nonnegative value node`);
+        } else if (c.do === "client_render_file"
+            && [c.declared_content_type, c.body_kind].some((value) =>
+              typeof value !== "string" || value.length === 0)) {
+          fail(file, caseName, where, `client_render_file fields must be non-empty strings`);
+        } else if (c.do === "cancel_transfers"
+            && (typeof c.op_id_prefix !== "string" || c.op_id_prefix.length === 0)) {
+          fail(file, caseName, where, `cancel_transfers.op_id_prefix must be a non-empty string`);
+        }
+      }
     }
-    if (c.do === "inject_fault" && c.fault !== undefined && !TAXONOMY_CODES.has(c.fault) && !["backpressure", "subscription_lapse", "retention"].includes(c.fault)) {
+    if (c?.do === "inject_fault" && c.fault !== undefined && !TAXONOMY_CODES.has(c.fault) && !["backpressure", "subscription_lapse", "retention"].includes(c.fault)) {
       fail(file, caseName, where, `inject_fault "${c.fault}" is not a taxonomy code, backpressure, or subscription_lapse`);
     }
   }
@@ -235,45 +596,76 @@ function checkStep(step, file, caseName, stepIdx) {
     if (!Array.isArray(step.assert)) {
       fail(file, caseName, where, `assert is ${Array.isArray(step.assert) ? "array" : typeof step.assert}, must be an array`);
     } else {
+      if (file === "files.json" && step.assert.length === 0) {
+        fail(file, caseName, where, `files.json assert arrays must not be empty`);
+      }
       step.assert.forEach((a, i) => checkAssertion(a, file, caseName, `${where} assert[${i}]`));
     }
   }
   if (step.expect !== undefined) {
     const e = step.expect;
-    if (typeof e === "object" && e !== null) {
-      if ("ok" in e) {
-        if (e.ok === true && !("out" in e)) {
-          // ok:true without out is legal (success, unconstrained) — no-op
-        }
-        if (e.ok === false && !("err" in e)) {
-          fail(file, caseName, where, `expect {ok:false} without err`);
+    if (!isObject(e)) {
+      fail(file, caseName, where, `expect must be an object`);
+    } else {
+      if ("ok" in e && typeof e.ok !== "boolean") {
+        fail(file, caseName, where, `expect.ok must be boolean`);
+      }
+      if (e.ok === false && !("err" in e)) {
+        fail(file, caseName, where, `expect {ok:false} without err`);
+      }
+      if (file === "files.json" && "err" in e) {
+        if (typeof e.err?.code !== "string") {
+          fail(file, caseName, `${where} expect.err`,
+            `file-domain error matcher must carry a literal taxonomy code`);
+        } else if (!FILE_ERROR_KEYS.has(e.err.code)) {
+          fail(file, caseName, `${where} expect.err`,
+            `literal file-domain error code "${e.err.code}" has no canonical matcher schema`);
+        } else {
+          checkFileError(e.err, file, caseName, `${where} expect.err`);
         }
       }
       checkTypeTags(e, file, caseName, `${where} expect`);
     }
   }
   if (step.in !== undefined) checkTypeTags(step.in, file, caseName, `${where} in`);
+  if (step.op_id !== undefined) checkTypeTags(step.op_id, file, caseName, `${where} op_id`);
   if (step.await !== undefined) {
     const a = step.await;
-    const awKeys = typeof a === "object" && a !== null ? Object.keys(a) : [];
-    if (typeof a !== "object" || a === null || awKeys.length !== 1 || !["push", "frame", "reply"].includes(awKeys[0])) {
+    const awKeys = isObject(a) ? Object.keys(a) : [];
+    if (!isObject(a) || awKeys.length !== 1 || !["push", "frame", "reply"].includes(awKeys[0])) {
       fail(file, caseName, where, `await must be exactly one of {push}, {frame}, or {reply}`);
     } else {
+      if (!isObject(a[awKeys[0]]) && typeof a[awKeys[0]] !== "string") {
+        fail(file, caseName, where, `await.${awKeys[0]} must be an object matcher or string handle`);
+      }
+      if (awKeys[0] === "reply" && (typeof a.reply !== "string" || a.reply.length === 0)) {
+        fail(file, caseName, where, `await.reply must be a non-empty request handle or request id`);
+      }
       checkTypeTags(a, file, caseName, `${where} await`);
     }
   }
   if (step.send !== undefined) checkTypeTags(step.send, file, caseName, `${where} send`);
   if (Array.isArray(step.assert)) checkTypeTags(step.assert, file, caseName, `${where} assert`);
   if (step.save !== undefined) {
-    if (typeof step.save !== "object" || step.save === null || Array.isArray(step.save)) {
-      fail(file, caseName, where, `save is not a {name: path} object`);
+    if (!isObject(step.save) || Object.keys(step.save).length === 0) {
+      fail(file, caseName, where, `save is not a non-empty {name: path} object`);
     } else {
       for (const [varName, path] of Object.entries(step.save)) {
-        if (typeof path === "string") {
-          const root = path.split(/[.[]/)[0];
-          if (!["out", "err", "frame"].includes(root) && !root.startsWith("$")) {
-            fail(file, caseName, where, `save "${varName}" path rooted at "${root}" (must be out/err/frame)`);
-          }
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(varName)) {
+          fail(file, caseName, where, `save variable name "${varName}" is invalid`);
+        }
+        if (typeof path !== "string") {
+          fail(file, caseName, where, `save "${varName}" path must be a string`);
+          continue;
+        }
+        if (/^\$(?:result|error)(?:$|[.[])/.test(path)) {
+          fail(file, caseName, where, `save "${varName}" uses retired path "${path}" — use out or err`);
+          continue;
+        }
+        const root = path.split(/[.[]/)[0];
+        if (!["out", "err", "frame", "$"].includes(root)
+            && !/^\$[A-Za-z_][A-Za-z0-9_]*$/.test(root)) {
+          fail(file, caseName, where, `save "${varName}" path rooted at "${root}" (must be out/err/frame/$/$variable)`);
         }
       }
     }
@@ -287,7 +679,15 @@ function checkStep(step, file, caseName, stepIdx) {
 }
 
 function checkCase(c, file) {
+  if (!isObject(c)) {
+    fail(file, "(unnamed)", "case", "case is not an object");
+    return;
+  }
   const name = c.name ?? "(unnamed)";
+  const unknownKeys = Object.keys(c).filter((key) => !CASE_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    fail(file, name, "case", `unknown case key(s): ${unknownKeys.join(", ")}`);
+  }
   if (!c.name || !/^[a-z][a-z0-9_]*$/.test(c.name)) fail(file, name, "case", "name is not snake_case");
   if (!KINDS.has(c.kind)) fail(file, name, "case", `kind "${c.kind}" not in the closed set of ${KINDS.size}`);
   if (c.operation !== null && !OPERATIONS.has(c.operation)) {
@@ -296,10 +696,31 @@ function checkCase(c, file) {
   if (typeof c.intent !== "string" || c.intent.length < 20) {
     fail(file, name, "case", "intent missing or too short to name a breaking change");
   }
+  if (c.operation === undefined) {
+    fail(file, name, "case", "operation must be present and may be null only explicitly");
+  }
+  if ("targets" in c) {
+    if (!Array.isArray(c.targets) || c.targets.length === 0) {
+      fail(file, name, "case", "targets must be a non-empty array when present");
+    } else {
+      const seen = new Set();
+      for (const target of c.targets) {
+        if (!TARGETS.has(target)) {
+          fail(file, name, "case", `unknown target ${JSON.stringify(target)} (closed set: ${[...TARGETS].join(", ")})`);
+        } else if (seen.has(target)) {
+          fail(file, name, "case", `duplicate target "${target}"`);
+        }
+        seen.add(target);
+      }
+    }
+  }
   if (!Array.isArray(c.requires)) {
     fail(file, name, "case", "requires is not an array");
   } else {
+    const seenRequires = new Set();
     for (const r of c.requires) {
+      if (seenRequires.has(r)) fail(file, name, "requires", `duplicate precondition ${JSON.stringify(r)}`);
+      seenRequires.add(r);
       if (typeof r !== "string") {
         fail(file, name, "requires", `non-string precondition ${JSON.stringify(r)}`);
         continue;
@@ -317,20 +738,152 @@ function checkCase(c, file) {
       }
     }
   }
-  if ("blocked_on_upstream" in c && c.blocked_on_upstream !== null && !["U1", "U2", "U3"].includes(c.blocked_on_upstream)) {
+  if ("blocked_on_upstream" in c && !["U1", "U2", "U3"].includes(c.blocked_on_upstream)) {
     fail(file, name, "case", `blocked_on_upstream is "${c.blocked_on_upstream}" — must be U1, U2, or U3, or the key omitted`);
+  }
+  if ("blocked_on_record" in c
+      && (typeof c.blocked_on_record !== "string" || c.blocked_on_record.length === 0)) {
+    fail(file, name, "case", `blocked_on_record must be a non-empty string`);
   }
   if (!Array.isArray(c.steps) || c.steps.length === 0) {
     fail(file, name, "case", "steps missing or empty");
     return;
   }
+  if (c.blocked_on_upstream && c.blocked_on_record) {
+    fail(file, name, "case", `a case cannot be blocked on upstream and the record simultaneously`);
+  }
+  checkTypeTags(c.intent, file, name, "intent");
   c.steps.forEach((s, i) => {
     stepCount++;
     checkStep(s, file, name, i);
   });
+  const effectiveSession = (step) => step.on ?? "subject:self";
+  const deferredHandles = new Map();
+  c.steps.forEach((step, i) => {
+    if (step?.defer === true && isObject(step.save)) {
+      for (const [handle, path] of Object.entries(step.save)) {
+        if (path === "$request") {
+          const reference = `$${handle}`;
+          if (deferredHandles.has(reference)) {
+            fail(file, name, `step ${i + 1}`, `deferred request handle ${reference} is reused`);
+          } else {
+            deferredHandles.set(reference, {
+              step: i,
+              session: effectiveSession(step),
+              terminals: 0,
+            });
+          }
+        }
+      }
+    }
+  });
+  c.steps.forEach((step, i) => {
+    if (typeof step?.await?.reply === "string" && deferredHandles.has(step.await.reply)) {
+      const deferred = deferredHandles.get(step.await.reply);
+      if (i <= deferred.step) {
+        fail(file, name, `step ${i + 1}`, `await.reply must follow its deferred call`);
+      } else if (effectiveSession(step) !== deferred.session) {
+        fail(file, name, `step ${i + 1}`,
+          `await.reply for ${step.await.reply} is on ${effectiveSession(step)}; deferred handle belongs to ${deferred.session}`);
+      } else {
+        deferred.terminals++;
+      }
+    }
+    if (step?.control?.do === "disconnect") {
+      for (const deferred of deferredHandles.values()) {
+        if (i > deferred.step && step.control.on === deferred.session
+            && deferred.terminals === 0) deferred.terminals++;
+      }
+    }
+    if (step?.call === "file.fetch" && !("op_id" in step)
+        && name !== "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work") {
+      fail(file, name, `step ${i + 1}`, `file.fetch requires envelope op_id`);
+    }
+    if (step?.call === "file.fetch" && !("op_id" in step)
+        && name === "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work") {
+      if (!(step.expect?.ok === false && step.expect?.err?.code === "invalid_argument"
+          && step.expect?.err?.field === "op_id"
+          && step.expect?.err?.reason?.state === "missing")) {
+        fail(file, name, `step ${i + 1}`, `the sole malformed file.fetch omission must expect missing op_id invalid_argument`);
+      }
+    }
+    const daemonApplicable = !Array.isArray(c.targets) || c.targets.includes("daemon");
+    if (file === "files.json" && daemonApplicable && STREAMING_OPS.has(step?.call)) {
+      const replay = c.steps.slice(0, i).some((prior) => prior?.call === step.call
+        && "op_id" in step && "op_id" in prior && sameJson(prior.op_id, step.op_id)
+        && sameJson(prior.in, step.in) && prior.stream !== undefined
+        && prior.expect !== undefined);
+      const preOpen = step.expect?.ok === false
+        && (PRE_OPEN_STREAM_CODES.has(step.expect?.err?.code)
+          || (step.expect?.err?.code === "file_too_large"
+            && ["stage_declared", "authoring"].includes(step.expect.err.enforced_at)));
+      const admittedError = step.expect?.ok === false
+        && (step.expect?.err?.code === "declared_size_mismatch"
+          || (step.expect?.err?.code === "file_too_large"
+            && step.expect.err.enforced_at === "stage_stream"));
+      if (step.expect?.ok === true && !replay && step.stream === undefined) {
+        fail(file, name, `step ${i + 1}`, `fresh admitted ${step.call} with an explicit success result requires stream`);
+      }
+      if (replay && step.stream !== undefined) {
+        fail(file, name, `step ${i + 1}`, `completed faithful replay must not open a second stream`);
+      }
+      if (preOpen && step.stream !== undefined) {
+        fail(file, name, `step ${i + 1}`, `terminal pre-OPEN refusal must not carry stream`);
+      }
+      if (preOpen) {
+        const laterAssertions = c.steps.slice(i + 1).flatMap((later) =>
+          Array.isArray(later?.assert) ? later.assert : []);
+        const byteObservations = laterAssertions.filter((assertion) =>
+          assertion?.observe === "bytes_streamed" && assertion.call === `step:${i + 1}`);
+        if (byteObservations.some((assertion) =>
+          assertion.value?.op !== "eq" || assertion.value?.value !== 0)) {
+          fail(file, name, `step ${i + 1}`, `terminal pre-OPEN refusal can record only zero receiver-accepted bytes`);
+        }
+      }
+      if (admittedError && step.stream === undefined) {
+        fail(file, name, `step ${i + 1}`, `explicit admitted stream failure requires stream`);
+      }
+    }
+    for (const assertion of Array.isArray(step?.assert) ? step.assert : []) {
+      if (assertion?.observe !== "bytes_streamed" || !("call" in assertion)
+          || typeof assertion.call !== "string" || !/^step:[1-9][0-9]*$/.test(assertion.call)) continue;
+      const selectedIndex = Number(assertion.call.slice(5)) - 1;
+      const selected = c.steps[selectedIndex];
+      if (!selected || selected.call === undefined) {
+        fail(file, name, `step ${i + 1}`, `bytes_streamed.call selects a step that is not a call`);
+      } else if (selectedIndex >= i) {
+        fail(file, name, `step ${i + 1}`, `bytes_streamed.call must select an earlier call step`);
+      } else if (!["file.share", "file.fetch", "file.read"].includes(selected.call)) {
+        fail(file, name, `step ${i + 1}`, `bytes_streamed.call must select a file transfer call`);
+      }
+    }
+  });
+  for (const [handle, deferred] of deferredHandles) {
+    if (deferred.terminals === 0) {
+      fail(file, name, `step ${deferred.step + 1}`,
+        `deferred handle ${handle} remains live at case end; await it on ${deferred.session} or disconnect that session`);
+    } else if (deferred.terminals !== 1) {
+      fail(file, name, `step ${deferred.step + 1}`,
+        `deferred handle ${handle} has ${deferred.terminals} terminal paths; exactly one later await or same-session disconnect is required`);
+    }
+  }
+  if (PRINCIPAL_ISOLATION_CASES.has(name)) {
+    if (c.requires.includes("subject:second")) {
+      fail(file, name, "requires",
+        `same-daemon principal isolation must not use subject:second, which denotes another daemon/subject`);
+    }
+    const labels = new Set(c.steps.flatMap((step) => [
+      step?.on,
+      ...((step?.assert ?? []).map((assertion) => assertion?.on)),
+    ]).filter((on) => on === "principal:self" || on === "principal:second"));
+    if (!labels.has("principal:self") || !labels.has("principal:second")) {
+      fail(file, name, "steps", `principal-isolation case must use both principal:self and principal:second`);
+    }
+  }
 }
 
 const files = readdirSync(DIR).filter((f) => f.endsWith(".json") && f !== "manifest.json").sort();
+const corpus = [];
 for (const f of files) {
   let data;
   try {
@@ -339,15 +892,355 @@ for (const f of files) {
     fail(f, "(file)", "parse", e.message);
     continue;
   }
-  const cases = Array.isArray(data) ? data : data.cases ?? [];
-  for (const c of cases) {
+  if (!isObject(data)) {
+    fail(f, "(file)", "file", "domain file must be an object");
+    continue;
+  }
+  const unknownKeys = Object.keys(data).filter((key) => !TOP_LEVEL_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    fail(f, "(file)", "file", `unknown top-level key(s): ${unknownKeys.join(", ")}`);
+  }
+  if (data.domain !== DOMAIN_BY_FILE[f]) {
+    fail(f, "(file)", "file", `domain must be "${DOMAIN_BY_FILE[f]}"`);
+  }
+  if (typeof data.note !== "string" || data.note.length === 0) {
+    fail(f, "(file)", "file", "note must be a non-empty string");
+  }
+  if ("authoring_notes" in data
+      && (!Array.isArray(data.authoring_notes) || data.authoring_notes.length === 0
+        || data.authoring_notes.some((note) => typeof note !== "string"))) {
+    fail(f, "(file)", "file", "authoring_notes must be a non-empty array of strings when present");
+  }
+  if (!Array.isArray(data.cases)) {
+    fail(f, "(file)", "file", "cases must be an array");
+    continue;
+  }
+  for (const c of data.cases) {
     caseCount++;
+    corpus.push({ file: f, case: isObject(c) ? c : {} });
     checkCase(c, f);
   }
 }
 
+const names = new Map();
+for (const entry of corpus) {
+  if (typeof entry.case?.name !== "string") continue;
+  if (names.has(entry.case.name)) {
+    fail(entry.file, entry.case.name, "case", `duplicate corpus-wide case name also used in ${names.get(entry.case.name)}`);
+  } else {
+    names.set(entry.case.name, entry.file);
+  }
+}
+const fetchOmissions = corpus.flatMap(({ file, case: c }) =>
+  Array.isArray(c.steps) ? c.steps.flatMap((step) =>
+    step?.call === "file.fetch" && !("op_id" in step)
+      ? [{ file, case: c.name }]
+      : []) : []);
+const expectedFetchOmissions = [{
+  file: "files.json",
+  case: "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
+}];
+fetchOmissions.sort((a, b) => a.file.localeCompare(b.file) || a.case.localeCompare(b.case));
+if (!sameJson(fetchOmissions, expectedFetchOmissions)) {
+  fail("files.json", "(corpus)", "file.fetch", `op_id omissions must be exactly ${JSON.stringify(expectedFetchOmissions)}`);
+}
+fixtureProblemCount = problems.length;
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(join(DIR, "manifest.json"), "utf8"));
+} catch (e) {
+  fail("manifest.json", "(file)", "parse", e.message);
+}
+
+if (isObject(manifest)) {
+  const attributed = corpus.filter(({ case: c }) => c.operation !== null).length;
+  const operationNull = corpus.length - attributed;
+  const usedVerbs = new Set();
+  for (const { case: c } of corpus) {
+    for (const step of Array.isArray(c.steps) ? c.steps : []) {
+      for (const verb of DSL_VERBS) if (Object.hasOwn(step, verb)) usedVerbs.add(verb);
+    }
+  }
+  let ciSelectedCases = 0;
+  try {
+    const ci = readFileSync(join(DIR, "..", "..", ".github", "workflows", "ci.yml"), "utf8");
+    const liveStep = ci.match(/- name: Protocol-v2 conformance replay[\s\S]*?(?=\n      - name:|$)/)?.[0] ?? "";
+    const selectors = [...liveStep.matchAll(/--case\s+([^\s\\]+)/g)].map((match) => match[1]);
+    ciSelectedCases = selectors.length;
+    const seenSelectors = new Set();
+    for (const selector of selectors) {
+      if (seenSelectors.has(selector)) {
+        fail(".github/workflows/ci.yml", selector, "live slice", `duplicate --case selector`);
+      }
+      seenSelectors.add(selector);
+      const matches = corpus.filter(({ case: c }) => c.name === selector).length;
+      if (matches !== 1) {
+        fail(".github/workflows/ci.yml", selector, "live slice",
+          `--case selector must name exactly one corpus case; found ${matches}`);
+      }
+    }
+  } catch (e) {
+    fail(".github/workflows/ci.yml", "(file)", "parse", e.message);
+  }
+  if (ciSelectedCases === 0) {
+    fail(".github/workflows/ci.yml", "(file)", "live slice", "no explicit protocol-v2 live cases found");
+  }
+  const targetCounts = Object.fromEntries([...TARGETS].map((target) => [target, 0]));
+  let untargeted = 0;
+  for (const { case: c } of corpus) {
+    if (Array.isArray(c.targets)) {
+      for (const target of c.targets) if (target in targetCounts) targetCounts[target]++;
+    } else {
+      untargeted++;
+    }
+  }
+  const expectedTargetCounts = {
+    untargeted,
+    daemon: targetCounts.daemon,
+    in_process_core: targetCounts.in_process_core,
+    client_adapter: targetCounts.client_adapter,
+  };
+  if (!sameJson(manifest.target_counts, expectedTargetCounts)) {
+    fail("manifest.json", "(manifest)", "target_counts", `does not equal recomputed counts ${JSON.stringify(expectedTargetCounts)}`);
+  }
+  const blocked = { U1: 0, U2: 0, U3: 0 };
+  const blockedOnUpstreamCases = { U1: [], U2: [], U3: [] };
+  const blockedOnRecordCases = [];
+  for (const { file, case: c } of corpus) {
+    if (["U1", "U2", "U3"].includes(c.blocked_on_upstream)) {
+      blocked[c.blocked_on_upstream]++;
+      blockedOnUpstreamCases[c.blocked_on_upstream].push({ file, case: c.name });
+    }
+    if (Object.hasOwn(c, "blocked_on_record")) {
+      blockedOnRecordCases.push({ file, case: c.name, record: c.blocked_on_record });
+    }
+  }
+  const compareBlockedEntry = (a, b) =>
+    a.file.localeCompare(b.file) || a.case.localeCompare(b.case);
+  for (const entries of Object.values(blockedOnUpstreamCases)) entries.sort(compareBlockedEntry);
+  blockedOnRecordCases.sort(compareBlockedEntry);
+  const blockedOnRecord = blockedOnRecordCases.length;
+  const expectedTotals = {
+    cases: corpus.length,
+    attributed_to_an_operation: attributed,
+    not_operation_scoped: operationNull,
+    conforming_to_the_dsl: fixtureProblemCount === 0 ? corpus.length : null,
+    distinct_step_verbs_in_use: usedVerbs.size,
+    quarantined: 0,
+    blocked_on_upstream: blocked.U1 + blocked.U2 + blocked.U3,
+    blocked_on_record: blockedOnRecord,
+  };
+  if (attributed + operationNull !== corpus.length) {
+    fail("manifest.json", "(manifest)", "totals", "operation coverage does not reconcile to total cases");
+  }
+  const totalKeys = Object.keys(expectedTotals).sort();
+  if (!isObject(manifest.totals) || !sameJson(Object.keys(manifest.totals).sort(), totalKeys)) {
+    fail("manifest.json", "(manifest)", "totals", `must contain exactly ${totalKeys.join(", ")}`);
+  }
+  for (const [key, value] of Object.entries(expectedTotals)) {
+    if (key === "conforming_to_the_dsl" && value === null) {
+      if (!Number.isInteger(manifest.totals?.[key])
+          || manifest.totals[key] < 0 || manifest.totals[key] > corpus.length) {
+        fail("manifest.json", "(manifest)", `totals.${key}`, `must be an integer in 0..=${corpus.length}`);
+      }
+    } else if (manifest.totals?.[key] !== value) {
+      fail("manifest.json", "(manifest)", `totals.${key}`, `is ${JSON.stringify(manifest.totals?.[key])}; recomputed value is ${value}`);
+    }
+  }
+  if (!isObject(manifest.blocked_on_upstream)
+      || !sameJson(Object.keys(manifest.blocked_on_upstream).sort(), ["U1", "U2", "U3"])
+      || Object.values(manifest.blocked_on_upstream).some((value) =>
+        typeof value !== "string" || value.length === 0)) {
+    fail("manifest.json", "(manifest)", "blocked_on_upstream", "must preserve non-empty U1/U2/U3 descriptions");
+  }
+  const replayability = {
+    structural_validation: true,
+    selected_json_envelope_subject_slice: {
+      status: "partial",
+      ci_selected_cases: ciSelectedCases,
+    },
+    binary_byte_stream_executor: "unimplemented",
+    adapter_targeted_declarative_cases: "declarative_only",
+  };
+  if (!sameJson(manifest.replayable, replayability)) {
+    fail("manifest.json", "(manifest)", "replayable", "must equal the honest selected-slice and executor status from the README matrix");
+  }
+  if (!isObject(manifest.rules)
+      || !sameJson(Object.keys(manifest.rules).sort(), [
+        "counts_are_computed", "distinctive_code_exemption", "exemptions_fail",
+        "required_per_operation",
+      ])
+      || typeof manifest.rules.required_per_operation !== "string"
+      || typeof manifest.rules.exemptions_fail !== "string"
+      || typeof manifest.rules.distinctive_code_exemption !== "string"
+      || typeof manifest.rules.counts_are_computed !== "string") {
+    fail("manifest.json", "(manifest)", "rules", "must preserve the hand-authored coverage and independence rules");
+  }
+  if (!isObject(manifest.exemptions)
+      || !sameJson(Object.keys(manifest.exemptions), ["room.deactivate"])
+      || !isObject(manifest.exemptions["room.deactivate"])
+      || !sameJson(Object.keys(manifest.exemptions["room.deactivate"]).sort(), [
+        "from", "reason", "reviewed_in",
+      ])
+      || typeof manifest.exemptions["room.deactivate"].reason !== "string") {
+    fail("manifest.json", "(manifest)", "exemptions", "must preserve the hand-authored room.deactivate exemption");
+  }
+  if (manifest.authored !== "by hand, from the specification. NOT generated from any implementation.") {
+    fail("manifest.json", "(manifest)", "authored", "must preserve the independence statement");
+  }
+  const directCanonicalCodeCases = new Map(
+    [...TAXONOMY_CODES].map((code) => [code, new Set()]));
+  for (const { file, case: c } of corpus) {
+    for (const step of Array.isArray(c.steps) ? c.steps : []) {
+      const code = step?.expect?.err?.code;
+      if (typeof code !== "string" || !TAXONOMY_CODES.has(code)
+          || step.call !== c.operation) continue;
+      const canonical = file !== "files.json" || fileErrorIsCanonical(step.expect.err);
+      if (canonical) directCanonicalCodeCases.get(code).add(`${file}:${c.name}`);
+    }
+  }
+  const operations = [...OPERATIONS].sort();
+  const coverageKeys = isObject(manifest.coverage) ? Object.keys(manifest.coverage).sort() : [];
+  if (!sameJson(coverageKeys, operations)) {
+    fail("manifest.json", "(manifest)", "coverage", "operation keys do not equal the closed operation set");
+  }
+  let coverageSum = 0;
+  for (const operation of operations) {
+    const operationCases = corpus.filter(({ case: c }) => c.operation === operation);
+    const count = operationCases.length;
+    coverageSum += count;
+    const row = manifest.coverage?.[operation];
+    const coverageRowKeys = [
+      "cases", "distinctive_code", "distinctive_code_has_a_case",
+      "satisfies_required_kinds", "success",
+    ];
+    if (!isObject(row) || !sameJson(Object.keys(row).sort(), coverageRowKeys)) {
+      fail("manifest.json", "(manifest)", `coverage.${operation}`, `must contain exactly ${coverageRowKeys.join(", ")}`);
+    }
+    if (row?.cases !== count) {
+      fail("manifest.json", "(manifest)", `coverage.${operation}.cases`, `is ${row?.cases}; recomputed value is ${count}`);
+    }
+    const hasSuccess = operationCases.some(({ case: c }) => c.kind === "success");
+    if (row?.success !== hasSuccess) {
+      fail("manifest.json", "(manifest)", `coverage.${operation}.success`, `is ${row?.success}; recomputed value is ${hasSuccess}`);
+    }
+    if (typeof row?.distinctive_code === "string") {
+      const distinctiveCodeHasCase = operationCases.some(({ file, case: c }) =>
+        directCanonicalCodeCases.get(row.distinctive_code)?.has(`${file}:${c.name}`) ?? false);
+      if (row.distinctive_code_has_a_case !== distinctiveCodeHasCase) {
+        fail("manifest.json", "(manifest)", `coverage.${operation}.distinctive_code_has_a_case`, `is ${row.distinctive_code_has_a_case}; recomputed value is ${distinctiveCodeHasCase}`);
+      }
+    } else if (row?.distinctive_code === null) {
+      const exempt = isObject(manifest.exemptions?.[operation]);
+      if (row.distinctive_code_has_a_case !== exempt) {
+        fail("manifest.json", "(manifest)", `coverage.${operation}.distinctive_code_has_a_case`, `must reflect its named exemption`);
+      }
+    }
+    const satisfiesRequiredKinds = hasSuccess && row?.distinctive_code_has_a_case === true;
+    if (row?.satisfies_required_kinds !== satisfiesRequiredKinds) {
+      fail("manifest.json", "(manifest)", `coverage.${operation}.satisfies_required_kinds`, `is ${row?.satisfies_required_kinds}; recomputed value is ${satisfiesRequiredKinds}`);
+    }
+    if (!isObject(row) || typeof row.success !== "boolean"
+        || !(typeof row.distinctive_code === "string" || row.distinctive_code === null)
+        || typeof row.distinctive_code_has_a_case !== "boolean"
+        || typeof row.satisfies_required_kinds !== "boolean") {
+      fail("manifest.json", "(manifest)", `coverage.${operation}`, "must preserve success and distinctive-code fields");
+    }
+  }
+  if (coverageSum !== attributed) {
+    fail("manifest.json", "(manifest)", "coverage", `coverage rows sum to ${coverageSum}; attributed total is ${attributed}`);
+  }
+  const unsatisfied = operations.filter((operation) =>
+    manifest.coverage?.[operation]?.satisfies_required_kinds !== true);
+  if (!sameJson(manifest.operations_not_yet_satisfying_required_kinds, unsatisfied)) {
+    fail("manifest.json", "(manifest)", "operations_not_yet_satisfying_required_kinds", `does not equal recomputed list ${JSON.stringify(unsatisfied)}`);
+  }
+  const byFile = {};
+  for (const file of files) {
+    const caseNames = corpus
+      .filter((entry) => entry.file === file && entry.case.operation === null)
+      .map((entry) => entry.case.name)
+      .sort();
+    if (caseNames.length > 0) byFile[file] = caseNames;
+  }
+  if (!sameJson(manifest.operation_null_cases?.by_file, byFile)) {
+    fail("manifest.json", "(manifest)", "operation_null_cases.by_file", "does not equal the recomputed operation:null case lists");
+  }
+  if (manifest.operation_null_cases?.count !== operationNull) {
+    fail("manifest.json", "(manifest)", "operation_null_cases.count", `is ${manifest.operation_null_cases?.count}; recomputed value is ${operationNull}`);
+  }
+  const perFile = Object.fromEntries(files.map((file) => {
+    const entries = corpus.filter((entry) => entry.file === file);
+    const perFileBlocked = { U1: 0, U2: 0, U3: 0 };
+    let perFileBlockedOnRecord = 0;
+    for (const { case: c } of entries) {
+      if (["U1", "U2", "U3"].includes(c.blocked_on_upstream)) {
+        perFileBlocked[c.blocked_on_upstream]++;
+      }
+      if (Object.hasOwn(c, "blocked_on_record")) perFileBlockedOnRecord++;
+    }
+    return [file, {
+      cases: entries.length,
+      attributed_to_an_operation: entries.filter(({ case: c }) => c.operation !== null).length,
+      not_operation_scoped: entries.filter(({ case: c }) => c.operation === null).length,
+      blocked_on_upstream: perFileBlocked,
+      blocked_on_record: perFileBlockedOnRecord,
+    }];
+  }));
+  if (!sameJson(manifest.per_file_totals, perFile)) {
+    fail("manifest.json", "(manifest)", "per_file_totals", "does not equal the recomputed fixture-file totals");
+  }
+  const transportRepresentedCodes = new Set();
+  for (const [code, fixtureName] of TRANSPORT_CODE_FIXTURES) {
+    if (corpus.some(({ case: c }) => c.name === fixtureName)) transportRepresentedCodes.add(code);
+  }
+  const codesWithoutCase = [...directCanonicalCodeCases.entries()]
+    .filter(([code, cases]) => cases.size === 0 && !transportRepresentedCodes.has(code))
+    .map(([code]) => code)
+    .sort();
+  const taxonomyCodes = [...TAXONOMY_CODES].sort();
+  if (manifest.taxonomy_code_count !== taxonomyCodes.length) {
+    fail("manifest.json", "(manifest)", "taxonomy_code_count", `is ${manifest.taxonomy_code_count}; recomputed value is ${taxonomyCodes.length}`);
+  }
+  if (!sameJson(manifest.codes_without_a_case?.codes, codesWithoutCase)) {
+    fail("manifest.json", "(manifest)", "codes_without_a_case.codes", `does not equal recomputed list ${JSON.stringify(codesWithoutCase)}`);
+  }
+  const manifestBlocked = manifest.blocked_case_counts;
+  const expectedBlocked = { U1: blocked.U1, U2: blocked.U2, U3: blocked.U3, blocked_on_record: blockedOnRecord };
+  if (!sameJson(manifestBlocked, expectedBlocked)) {
+    fail("manifest.json", "(manifest)", "blocked_case_counts", `does not equal recomputed counts ${JSON.stringify(expectedBlocked)}`);
+  }
+  if (!sameJson(manifest.blocked_on_upstream_cases, blockedOnUpstreamCases)) {
+    fail("manifest.json", "(manifest)", "blocked_on_upstream_cases", "does not equal the recomputed U1/U2/U3 case lists");
+  }
+  if (!sameJson(manifest.blocked_on_record_cases, blockedOnRecordCases)) {
+    fail("manifest.json", "(manifest)", "blocked_on_record_cases", "does not equal the recomputed blocked-on-record case list");
+  }
+  computed = {
+    per_file: perFile,
+    totals: { ...expectedTotals, conforming_to_the_dsl: corpus.length },
+    target_counts: expectedTargetCounts,
+    blocked_case_counts: expectedBlocked,
+    ci_selected_cases: ciSelectedCases,
+    coverage: Object.fromEntries(operations.map((operation) => [operation, {
+      cases: corpus.filter(({ case: c }) => c.operation === operation).length,
+      success: corpus.some(({ case: c }) => c.operation === operation && c.kind === "success"),
+      distinctive_code_has_a_case: manifest.coverage?.[operation]?.distinctive_code_has_a_case,
+    }])),
+    coverage_sum: coverageSum,
+    taxonomy_code_count: taxonomyCodes.length,
+    codes_without_a_case: codesWithoutCase,
+    blocked_on_upstream_cases: blockedOnUpstreamCases,
+    blocked_on_record_cases: blockedOnRecordCases,
+    operation_null_cases: byFile,
+  };
+} else if (manifest !== undefined) {
+  fail("manifest.json", "(file)", "file", "manifest must be an object");
+}
+
 if (process.argv.includes("--json")) {
-  console.log(JSON.stringify({ cases: caseCount, steps: stepCount, problems }, null, 1));
+  console.log(JSON.stringify({ cases: caseCount, steps: stepCount, computed, problems }, null, 1));
 } else {
   console.log(`v2 corpus: ${caseCount} cases, ${stepCount} steps`);
   if (problems.length === 0) {


### PR DESCRIPTION
Replacement for #239 after #234 was squash-merged. The tree is byte-identical to the reviewed #239 head; only commit IDs changed while replaying onto current `main` without force-push or a merge commit.

## What changes

- retranscribes file-stream, deadline, cancellation, replay, and principal-privacy fixtures from the merged framing record
- adds the required `file.fetch` missing-`op_id` case
- restores honest U2/U3 blocks and adapter applicability
- hardens the closed fixture DSL, manifest recomputation, deferred lifecycle, canonical error shapes, and CI selector validation
- records that deadline/abort fixtures exist but remain U2-blocked and non-live

## Scope

No codec, daemon, core, client, or harness implementation. Binary framing remains #233 implementation work.

## Verification

- replacement tree equals #239 head byte-for-byte
- `node scripts/check-docs.mjs`
- `node scripts/check-v2-corpus.mjs`
- `node --test scripts/check-docs.test.mjs`
- full required CI was green on #239; this clean replacement reruns it

Refs #233
Supersedes #239