### PR TITLE
feat(codec): add protocol-v2 byte-stream primitives

### DIFF
--- a/crates/jeliya-api/src/ids.rs
+++ b/crates/jeliya-api/src/ids.rs
@@ -5,6 +5,71 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use thiserror::Error;
+
+/// Largest request id exactly representable by ordinary browser and Node JSON
+/// numbers (`2^53 - 1`).
+pub const MAX_REQUEST_ID: u64 = 9_007_199_254_740_991;
+
+/// The request envelope's browser-safe integer identifier.
+///
+/// It is unique only while outstanding on one connection; that lifecycle
+/// property is deliberately not modeled by this structural value type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub struct RequestId(u64);
+
+impl RequestId {
+    /// Constructs a request id when `value` is in the canonical
+    /// `0..=9_007_199_254_740_991` range.
+    pub fn new(value: u64) -> Result<Self, RequestIdOutOfRange> {
+        if value <= MAX_REQUEST_ID {
+            Ok(Self(value))
+        } else {
+            Err(RequestIdOutOfRange { value })
+        }
+    }
+
+    /// Returns the underlying browser-safe integer.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = u64::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl TryFrom<u64> for RequestId {
+    type Error = RequestIdOutOfRange;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<RequestId> for u64 {
+    fn from(value: RequestId) -> Self {
+        value.get()
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A request id exceeded the canonical browser-safe integer range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("request id {value} exceeds {MAX_REQUEST_ID}")]
+pub struct RequestIdOutOfRange {
+    /// The rejected integer.
+    pub value: u64,
+}
 
 macro_rules! opaque_id {
     ($name:ident, $doc:literal) => {

--- a/crates/jeliya-api/src/lib.rs
+++ b/crates/jeliya-api/src/lib.rs
@@ -31,7 +31,10 @@ mod push;
 mod shared;
 mod types;
 
-pub use ids::{DeviceId, EventId, FileId, InviteId, OpId, PipeId, RoomId, SubjectId};
+pub use ids::{
+    DeviceId, EventId, FileId, InviteId, OpId, PipeId, RequestId, RequestIdOutOfRange, RoomId,
+    SubjectId, MAX_REQUEST_ID,
+};
 pub use ops::*;
 pub use push::*;
 pub use shared::*;
@@ -65,7 +68,7 @@ pub trait Operation: Serialize + DeserializeOwned + Sized {
 pub struct Envelope<O: Operation> {
     /// Correlates the reply to this request; unique per connection while
     /// outstanding.
-    pub id: u64,
+    pub id: RequestId,
     /// The operation's wire name — serialized as `op` so the envelope is
     /// dispatchable as-is. It is `O::PATH`, always.
     pub op: &'static str,
@@ -84,13 +87,13 @@ impl<O: Operation> Envelope<O> {
     pub const OP: &'static str = O::PATH;
 
     /// Builds an envelope for a request, pinning `op` to the operation's
-    /// wire name.
-    pub fn new(id: u64, op_id: Option<OpId>, input: O) -> Self {
-        Self {
-            id,
+    /// wire name and rejecting ids outside the browser-safe range.
+    pub fn new(id: u64, op_id: Option<OpId>, input: O) -> Result<Self, RequestIdOutOfRange> {
+        Ok(Self {
+            id: RequestId::new(id)?,
             op: O::PATH,
             op_id,
             input,
-        }
+        })
     }
 }

--- a/crates/jeliya-api/src/push.rs
+++ b/crates/jeliya-api/src/push.rs
@@ -201,6 +201,10 @@ pub enum ErrorCode {
     DigestMismatch,
     /// No forward progress within `transfer_stall_ms`.
     TransferStalled,
+    /// The size-aware absolute transfer budget expired.
+    TransferDeadlineExceeded,
+    /// An admitted transfer ended without a more specific operation error.
+    StreamAborted,
     /// No such transfer for this principal.
     TransferUnknown,
 
@@ -507,6 +511,24 @@ pub enum ApiError {
         transferred_bytes: u64,
         /// The total, or genuinely unknown.
         total: ByteTotal,
+    },
+    /// The size-aware absolute transfer budget expired.
+    TransferDeadlineExceeded {
+        /// Bytes transferred before expiry.
+        transferred_bytes: u64,
+        /// The total, or genuinely unknown.
+        total: ByteTotal,
+        /// The admitted transfer's absolute budget in milliseconds.
+        budget_ms: u64,
+    },
+    /// An admitted transfer ended without a more specific operation error.
+    StreamAborted {
+        /// Bytes accepted before the abort.
+        transferred_bytes: u64,
+        /// The total, or genuinely unknown.
+        total: ByteTotal,
+        /// Why the stream ended.
+        reason: StreamAbortReason,
     },
     /// No such in-flight transfer for this principal.
     TransferUnknown {

--- a/crates/jeliya-api/src/shared.rs
+++ b/crates/jeliya-api/src/shared.rs
@@ -448,6 +448,26 @@ pub enum ByteTotal {
     Unknown,
 }
 
+/// `stream_abort_reason` — why an admitted transfer ended without a more
+/// specific operation error.
+///
+/// This JSON-facing vocabulary deliberately excludes the Binary ABORT value
+/// `operation_error` and includes locally synthesized `transport_lost`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamAbortReason {
+    /// The transfer was cancelled.
+    Cancelled,
+    /// The source could not produce bytes.
+    SourceFailed,
+    /// The sink could not accept bytes.
+    SinkFailed,
+    /// The transport ended before the stream could terminate.
+    TransportLost,
+    /// A protocol violation ended the stream.
+    ProtocolError,
+}
+
 /// `outcome` of `transfer.cancel` — closed on the two terminal results, so
 /// idempotence is observable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/jeliya-api/tests/contract.rs
+++ b/crates/jeliya-api/tests/contract.rs
@@ -284,13 +284,48 @@ fn op_id_is_envelope_level() {
         RoomCreate {
             name: "Build".into(),
         },
-    );
+    )
+    .unwrap();
     let json = serde_json::to_string(&env).unwrap();
     assert!(json.contains("\"op\":\"room.create\""));
     assert!(json.contains("\"op_id\":\"op-1\""));
     assert!(json.contains("\"in\":{\"name\":\"Build\"}"));
     // `in` carries no op_id key
     assert!(!json.contains("\"in\":{\"name\":\"Build\",\"op_id\""));
+}
+
+/// Typed clients cannot originate request ids that ordinary browser JSON
+/// numbers would round or alias.
+#[test]
+fn request_id_is_browser_safe_by_construction() {
+    let at_limit = Envelope::new(
+        MAX_REQUEST_ID,
+        None,
+        RoomCreate {
+            name: "Build".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(at_limit.id.get(), MAX_REQUEST_ID);
+    assert_eq!(
+        serde_json::to_value(&at_limit).unwrap()["id"],
+        serde_json::json!(MAX_REQUEST_ID)
+    );
+
+    assert_eq!(
+        Envelope::<RoomCreate>::new(
+            MAX_REQUEST_ID + 1,
+            None,
+            RoomCreate {
+                name: "Build".into(),
+            },
+        ),
+        Err(RequestIdOutOfRange {
+            value: MAX_REQUEST_ID + 1,
+        })
+    );
+    assert!(serde_json::from_str::<RequestId>(&MAX_REQUEST_ID.to_string()).is_ok());
+    assert!(serde_json::from_str::<RequestId>(&(MAX_REQUEST_ID + 1).to_string()).is_err());
 }
 
 /// A push carries `t` and never `id`.
@@ -342,6 +377,90 @@ fn error_payload_is_code_discriminated() {
     assert_eq!(
         serde_json::to_string(&err).unwrap(),
         "{\"code\":\"subject_absent\"}"
+    );
+}
+
+/// The two stream terminal errors carry exactly the fields added by the
+/// canonical byte-stream record.
+#[test]
+fn stream_terminal_errors_have_exact_wire_shapes() {
+    let deadline = ApiError::TransferDeadlineExceeded {
+        transferred_bytes: 1_024,
+        total: ByteTotal::Known { bytes: 4_096 },
+        budget_ms: 30_000,
+    };
+    assert_eq!(
+        serde_json::to_value(&deadline).unwrap(),
+        serde_json::json!({
+            "code": "transfer_deadline_exceeded",
+            "transferred_bytes": 1024,
+            "total": {"state": "known", "bytes": 4096},
+            "budget_ms": 30000
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<ApiError>(serde_json::to_value(deadline).unwrap()).unwrap(),
+        ApiError::TransferDeadlineExceeded {
+            transferred_bytes: 1_024,
+            total: ByteTotal::Known { bytes: 4_096 },
+            budget_ms: 30_000,
+        }
+    );
+
+    let aborted = ApiError::StreamAborted {
+        transferred_bytes: 512,
+        total: ByteTotal::Unknown,
+        reason: StreamAbortReason::TransportLost,
+    };
+    assert_eq!(
+        serde_json::to_value(&aborted).unwrap(),
+        serde_json::json!({
+            "code": "stream_aborted",
+            "transferred_bytes": 512,
+            "total": {"state": "unknown"},
+            "reason": "transport_lost"
+        })
+    );
+    assert_eq!(
+        serde_json::from_value::<ApiError>(serde_json::to_value(aborted).unwrap()).unwrap(),
+        ApiError::StreamAborted {
+            transferred_bytes: 512,
+            total: ByteTotal::Unknown,
+            reason: StreamAbortReason::TransportLost,
+        }
+    );
+}
+
+/// JSON stream-abort reasons are closed independently from Binary ABORT:
+/// `transport_lost` is local, while wire-only `operation_error` is forbidden.
+#[test]
+fn stream_abort_reason_is_closed() {
+    let cases = [
+        (StreamAbortReason::Cancelled, "cancelled"),
+        (StreamAbortReason::SourceFailed, "source_failed"),
+        (StreamAbortReason::SinkFailed, "sink_failed"),
+        (StreamAbortReason::TransportLost, "transport_lost"),
+        (StreamAbortReason::ProtocolError, "protocol_error"),
+    ];
+    for (reason, token) in cases {
+        assert_eq!(
+            serde_json::to_string(&reason).unwrap(),
+            format!("\"{token}\"")
+        );
+        assert_eq!(
+            serde_json::from_str::<StreamAbortReason>(&format!("\"{token}\"")).unwrap(),
+            reason
+        );
+    }
+    assert!(serde_json::from_str::<StreamAbortReason>("\"operation_error\"").is_err());
+    assert!(serde_json::from_str::<StreamAbortReason>("\"unknown\"").is_err());
+    assert_eq!(
+        serde_json::to_string(&ErrorCode::TransferDeadlineExceeded).unwrap(),
+        "\"transfer_deadline_exceeded\""
+    );
+    assert_eq!(
+        serde_json::to_string(&ErrorCode::StreamAborted).unwrap(),
+        "\"stream_aborted\""
     );
 }
 

--- a/crates/jeliya-codec/Cargo.toml
+++ b/crates/jeliya-codec/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-description = "Protocol-v2 JSON/WebSocket codec: the edge between wire frames and jeliya-api types. Generation gate, bounded envelopes, exhaustive request routing, bounded malformed-input handling. No v1 facade, no dual codec, no domain logic."
+description = "Protocol-v2 Text/Binary WebSocket codec: bounded JSON envelopes and JBS2 stream records at the jeliya-api edge. No v1 facade, no dual codec, no domain logic."
 
 [dependencies]
 jeliya-api = { path = "../jeliya-api" }

--- a/crates/jeliya-codec/src/byte_stream.rs
+++ b/crates/jeliya-codec/src/byte_stream.rs
@@ -1,0 +1,569 @@
+//! Protocol-v2 byte-stream records.
+//!
+//! This module owns only the structural Binary-message format. Stream
+//! binding, sender direction, offset continuity, cumulative credit state,
+//! cancellation ordering, and transfer lifecycle remain transport/runtime
+//! concerns.
+
+use crate::CodecBounds;
+use jeliya_api::{RequestId, MAX_REQUEST_ID};
+use std::num::NonZeroU128;
+use thiserror::Error;
+
+/// The fixed `JBS2` header length in bytes.
+pub const STREAM_HEADER_BYTES: usize = 48;
+
+/// The protocol-wide ceiling on one DATA payload.
+pub const MAX_STREAM_DATA_BYTES: usize = 65_536;
+
+const MAGIC: [u8; 4] = *b"JBS2";
+
+/// The complete structural identity of one connection-local byte stream.
+///
+/// This type validates only the browser-safe request-id range and nonzero
+/// stream id. Active lookup, connection ownership, uniqueness, and reuse are
+/// runtime responsibilities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StreamIdentity {
+    request_id: RequestId,
+    stream_id: NonZeroU128,
+}
+
+impl StreamIdentity {
+    /// Constructs a structurally valid identity.
+    pub fn new(request_id: u64, stream_id: u128) -> Result<Self, StreamCodecError> {
+        let request_id =
+            RequestId::new(request_id).map_err(|error| StreamCodecError::RequestIdOutOfRange {
+                request_id: error.value,
+            })?;
+        let stream_id = NonZeroU128::new(stream_id).ok_or(StreamCodecError::ZeroStreamId)?;
+        Ok(Self {
+            request_id,
+            stream_id,
+        })
+    }
+
+    /// Returns the browser-safe request id.
+    pub const fn request_id(self) -> RequestId {
+        self.request_id
+    }
+
+    /// Returns the nonzero connection-local stream id.
+    pub const fn stream_id(self) -> NonZeroU128 {
+        self.stream_id
+    }
+}
+
+/// Returns the largest DATA payload permitted by a served frame limit.
+///
+/// The subtraction is checked before use. Protocol-v2 byte streaming requires
+/// room for the 48-byte header and at least one DATA byte, so limits at or
+/// below 48 are rejected.
+pub fn max_stream_data_bytes(max_frame_bytes: usize) -> Result<usize, StreamCodecError> {
+    let payload_capacity = max_frame_bytes
+        .checked_sub(STREAM_HEADER_BYTES)
+        .filter(|capacity| *capacity > 0)
+        .ok_or(StreamCodecError::FrameLimitTooSmall { max_frame_bytes })?;
+    Ok(payload_capacity.min(MAX_STREAM_DATA_BYTES))
+}
+
+/// A decoded or to-be-encoded byte-stream record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamRecord {
+    /// The request-id/stream-id pair this record belongs to.
+    pub identity: StreamIdentity,
+    /// The record's kind-specific structural fields.
+    pub body: StreamRecordBody,
+}
+
+impl StreamRecord {
+    /// Returns this record's closed kind.
+    pub fn kind(&self) -> StreamRecordKind {
+        self.body.kind()
+    }
+}
+
+/// The kind-specific body of a byte-stream record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamRecordBody {
+    /// Admission, carrying the expected total byte count.
+    Open {
+        /// Expected total bytes for the admitted transfer.
+        total: u64,
+    },
+    /// A nonempty contiguous payload beginning at `offset`.
+    Data {
+        /// Zero-based offset of the payload's first byte.
+        offset: u64,
+        /// File bytes. Encoding enforces the served and protocol bounds.
+        payload: Vec<u8>,
+    },
+    /// Cumulative receiver credit.
+    Credit {
+        /// Exclusive end of bytes accepted by the receiver's sink.
+        accepted_through: u64,
+        /// Exclusive end through which the producer may send.
+        send_through: u64,
+    },
+    /// The producer's explicit end marker.
+    End {
+        /// Total bytes sent by the producer.
+        total: u64,
+    },
+    /// A stream abort.
+    Abort {
+        /// Sender's accepted-byte high-water mark.
+        accepted_through: u64,
+        /// The sender's local abort reason.
+        reason: BinaryAbortReason,
+    },
+    /// Acknowledgement of an ABORT.
+    Ack {
+        /// Final receiver-accepted byte count.
+        accepted_through: u64,
+    },
+}
+
+impl StreamRecordBody {
+    fn kind(&self) -> StreamRecordKind {
+        match self {
+            Self::Open { .. } => StreamRecordKind::Open,
+            Self::Data { .. } => StreamRecordKind::Data,
+            Self::Credit { .. } => StreamRecordKind::Credit,
+            Self::End { .. } => StreamRecordKind::End,
+            Self::Abort { .. } => StreamRecordKind::Abort,
+            Self::Ack { .. } => StreamRecordKind::Ack,
+        }
+    }
+}
+
+/// The closed record-kind byte vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum StreamRecordKind {
+    /// `0x01` OPEN.
+    Open = 0x01,
+    /// `0x02` DATA.
+    Data = 0x02,
+    /// `0x03` CREDIT.
+    Credit = 0x03,
+    /// `0x04` END.
+    End = 0x04,
+    /// `0x05` ABORT.
+    Abort = 0x05,
+    /// `0x06` ACK.
+    Ack = 0x06,
+}
+
+impl StreamRecordKind {
+    fn from_wire(value: u8) -> Result<Self, StreamCodecError> {
+        match value {
+            0x01 => Ok(Self::Open),
+            0x02 => Ok(Self::Data),
+            0x03 => Ok(Self::Credit),
+            0x04 => Ok(Self::End),
+            0x05 => Ok(Self::Abort),
+            0x06 => Ok(Self::Ack),
+            kind => Err(StreamCodecError::UnknownKind { kind }),
+        }
+    }
+
+    fn wire(self) -> u8 {
+        self as u8
+    }
+}
+
+/// The closed numeric reason vocabulary carried by a Binary ABORT record.
+///
+/// This deliberately differs from `jeliya_api::StreamAbortReason`:
+/// `OperationError` exists only on the wire, while `transport_lost` is
+/// synthesized locally and therefore has no Binary value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u64)]
+pub enum BinaryAbortReason {
+    /// `0x01`: local cancellation.
+    Cancelled = 0x01,
+    /// `0x02`: the source could not produce bytes.
+    SourceFailed = 0x02,
+    /// `0x03`: the sink could not accept bytes.
+    SinkFailed = 0x03,
+    /// `0x04`: the sender detected a protocol violation.
+    ProtocolError = 0x04,
+    /// `0x05`: daemon-only; the following typed operation error is authoritative.
+    OperationError = 0x05,
+}
+
+impl BinaryAbortReason {
+    fn from_wire(value: u64) -> Result<Self, StreamCodecError> {
+        match value {
+            0x01 => Ok(Self::Cancelled),
+            0x02 => Ok(Self::SourceFailed),
+            0x03 => Ok(Self::SinkFailed),
+            0x04 => Ok(Self::ProtocolError),
+            0x05 => Ok(Self::OperationError),
+            value => Err(StreamCodecError::InvalidAbortReason { value }),
+        }
+    }
+
+    fn wire(self) -> u64 {
+        self as u64
+    }
+}
+
+/// A fixed numeric field in the `JBS2` header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StreamHeaderField {
+    /// Header bytes 32 through 39.
+    Offset,
+    /// Header bytes 40 through 47.
+    Value,
+}
+
+/// A structural byte-stream encode/decode failure.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum StreamCodecError {
+    /// The served frame limit cannot carry a header plus one DATA byte.
+    #[error("max_frame_bytes {max_frame_bytes} cannot frame a DATA record")]
+    FrameLimitTooSmall {
+        /// The rejected served limit.
+        max_frame_bytes: usize,
+    },
+    /// The complete Binary message exceeds `max_frame_bytes`.
+    #[error("Binary record is {actual_bytes} bytes, exceeding limit {limit_bytes}")]
+    FrameTooLarge {
+        /// Actual complete-message bytes.
+        actual_bytes: usize,
+        /// Served complete-message limit.
+        limit_bytes: usize,
+    },
+    /// The Binary message ends before the fixed header does.
+    #[error("Binary record is {actual_bytes} bytes, shorter than the 48-byte header")]
+    HeaderTooShort {
+        /// Actual complete-message bytes.
+        actual_bytes: usize,
+    },
+    /// Header bytes 0 through 3 are not `JBS2`.
+    #[error("Binary record has bad JBS2 magic")]
+    BadMagic,
+    /// At least one of the three reserved bytes is nonzero.
+    #[error("Binary record has nonzero reserved bytes")]
+    ReservedBytesNonzero,
+    /// The kind byte is outside the closed `0x01..=0x06` vocabulary.
+    #[error("Binary record has unknown kind {kind:#04x}")]
+    UnknownKind {
+        /// Rejected kind byte.
+        kind: u8,
+    },
+    /// The request id exceeds the browser-safe JSON integer range.
+    #[error("request id {request_id} exceeds {MAX_REQUEST_ID}")]
+    RequestIdOutOfRange {
+        /// Rejected request id.
+        request_id: u64,
+    },
+    /// Stream ids are required to be nonzero.
+    #[error("stream id is zero")]
+    ZeroStreamId,
+    /// A non-DATA record carried bytes after its fixed header.
+    #[error("{kind:?} record carries a forbidden {payload_bytes}-byte payload")]
+    UnexpectedPayload {
+        /// Parsed control-record kind.
+        kind: StreamRecordKind,
+        /// Bytes present after the header.
+        payload_bytes: usize,
+    },
+    /// DATA is nonempty by definition; END is the only empty terminator.
+    #[error("DATA record has an empty payload")]
+    EmptyData,
+    /// A DATA payload exceeds the effective served/protocol bound.
+    #[error("DATA payload is {actual_bytes} bytes, exceeding limit {limit_bytes}")]
+    DataTooLarge {
+        /// Actual DATA payload bytes.
+        actual_bytes: usize,
+        /// Effective payload limit.
+        limit_bytes: usize,
+    },
+    /// A field required to be zero (or a fixed value) was not.
+    #[error("{kind:?}.{field:?} has invalid value {value}; expected {expected}")]
+    InvalidField {
+        /// Parsed record kind.
+        kind: StreamRecordKind,
+        /// Invalid header field.
+        field: StreamHeaderField,
+        /// Rejected value.
+        value: u64,
+        /// The closed required numeric value.
+        expected: u64,
+    },
+    /// CREDIT's accepted high-water mark exceeds its send limit.
+    #[error("CREDIT accepted_through {accepted_through} exceeds send_through {send_through}")]
+    InvalidCredit {
+        /// Rejected accepted high-water mark.
+        accepted_through: u64,
+        /// Rejected send limit.
+        send_through: u64,
+    },
+    /// ABORT's value is outside its closed reason vocabulary.
+    #[error("ABORT has invalid reason {value}")]
+    InvalidAbortReason {
+        /// Rejected value field.
+        value: u64,
+    },
+    /// DATA's exclusive end offset is not representable as `u64`.
+    #[error("DATA offset {offset} plus payload length {payload_bytes} overflows u64")]
+    OffsetOverflow {
+        /// DATA start offset.
+        offset: u64,
+        /// DATA payload bytes.
+        payload_bytes: usize,
+    },
+    /// Header-plus-payload length overflowed the platform's `usize`.
+    #[error("Binary record length arithmetic overflowed")]
+    RecordLengthOverflow,
+}
+
+/// Validates one complete Binary message through its stream identity.
+///
+/// Runtime code can call this first, perform the authoritative active-pair
+/// lookup and direction/state checks, and only then call
+/// [`decode_stream_record`]. This preserves the record's required validation
+/// order without putting transport state in the codec and without allocating a
+/// DATA payload before binding.
+pub fn decode_stream_identity(
+    bytes: &[u8],
+    bounds: &CodecBounds,
+) -> Result<StreamIdentity, StreamCodecError> {
+    if bytes.len() > bounds.max_frame_bytes {
+        return Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: bytes.len(),
+            limit_bytes: bounds.max_frame_bytes,
+        });
+    }
+    max_stream_data_bytes(bounds.max_frame_bytes)?;
+    if bytes.len() < STREAM_HEADER_BYTES {
+        return Err(StreamCodecError::HeaderTooShort {
+            actual_bytes: bytes.len(),
+        });
+    }
+    if bytes[..MAGIC.len()] != MAGIC {
+        return Err(StreamCodecError::BadMagic);
+    }
+
+    let request_id = read_u64(bytes, 8);
+    let stream_id = read_u128(bytes, 16);
+    StreamIdentity::new(request_id, stream_id)
+}
+
+/// Decodes one complete Binary message into a typed byte-stream record.
+///
+/// No allocation occurs until every header field and payload bound has been
+/// validated. The only input-dependent allocation is a DATA payload capped at
+/// 65,536 bytes. Stateful runtimes must retain the result of
+/// [`decode_stream_identity`] and perform active binding lookup before calling
+/// this full structural decoder.
+pub fn decode_stream_record(
+    bytes: &[u8],
+    bounds: &CodecBounds,
+) -> Result<StreamRecord, StreamCodecError> {
+    let identity = decode_stream_identity(bytes, bounds)?;
+    let max_payload = max_stream_data_bytes(bounds.max_frame_bytes)?;
+
+    let kind = StreamRecordKind::from_wire(bytes[4])?;
+    if bytes[5..8] != [0, 0, 0] {
+        return Err(StreamCodecError::ReservedBytesNonzero);
+    }
+
+    let offset = read_u64(bytes, 32);
+    let value = read_u64(bytes, 40);
+    let payload = &bytes[STREAM_HEADER_BYTES..];
+
+    let body = match kind {
+        StreamRecordKind::Open => {
+            require_no_payload(kind, payload)?;
+            require_field(kind, StreamHeaderField::Offset, offset, 0)?;
+            StreamRecordBody::Open { total: value }
+        }
+        StreamRecordKind::Data => {
+            require_field(kind, StreamHeaderField::Value, value, 0)?;
+            if payload.is_empty() {
+                return Err(StreamCodecError::EmptyData);
+            }
+            if payload.len() > max_payload {
+                return Err(StreamCodecError::DataTooLarge {
+                    actual_bytes: payload.len(),
+                    limit_bytes: max_payload,
+                });
+            }
+            checked_data_end(offset, payload.len())?;
+            StreamRecordBody::Data {
+                offset,
+                payload: payload.to_vec(),
+            }
+        }
+        StreamRecordKind::Credit => {
+            require_no_payload(kind, payload)?;
+            if offset > value {
+                return Err(StreamCodecError::InvalidCredit {
+                    accepted_through: offset,
+                    send_through: value,
+                });
+            }
+            StreamRecordBody::Credit {
+                accepted_through: offset,
+                send_through: value,
+            }
+        }
+        StreamRecordKind::End => {
+            require_field(kind, StreamHeaderField::Value, value, 0)?;
+            require_no_payload(kind, payload)?;
+            StreamRecordBody::End { total: offset }
+        }
+        StreamRecordKind::Abort => {
+            let reason = BinaryAbortReason::from_wire(value)?;
+            require_no_payload(kind, payload)?;
+            StreamRecordBody::Abort {
+                accepted_through: offset,
+                reason,
+            }
+        }
+        StreamRecordKind::Ack => {
+            require_field(kind, StreamHeaderField::Value, value, 0x05)?;
+            require_no_payload(kind, payload)?;
+            StreamRecordBody::Ack {
+                accepted_through: offset,
+            }
+        }
+    };
+
+    Ok(StreamRecord { identity, body })
+}
+
+/// Encodes one typed byte-stream record as one complete Binary message.
+///
+/// Every structural invariant and the effective DATA bound is checked before
+/// output allocation.
+pub fn encode_stream_record(
+    record: &StreamRecord,
+    bounds: &CodecBounds,
+) -> Result<Vec<u8>, StreamCodecError> {
+    let max_payload = max_stream_data_bytes(bounds.max_frame_bytes)?;
+    let kind = record.kind();
+    let (offset, value, payload): (u64, u64, &[u8]) = match &record.body {
+        StreamRecordBody::Open { total } => (0, *total, &[]),
+        StreamRecordBody::Data { offset, payload } => {
+            if payload.is_empty() {
+                return Err(StreamCodecError::EmptyData);
+            }
+            let total_bytes = STREAM_HEADER_BYTES
+                .checked_add(payload.len())
+                .ok_or(StreamCodecError::RecordLengthOverflow)?;
+            if total_bytes > bounds.max_frame_bytes {
+                return Err(StreamCodecError::FrameTooLarge {
+                    actual_bytes: total_bytes,
+                    limit_bytes: bounds.max_frame_bytes,
+                });
+            }
+            if payload.len() > max_payload {
+                return Err(StreamCodecError::DataTooLarge {
+                    actual_bytes: payload.len(),
+                    limit_bytes: max_payload,
+                });
+            }
+            checked_data_end(*offset, payload.len())?;
+            (*offset, 0, payload)
+        }
+        StreamRecordBody::Credit {
+            accepted_through,
+            send_through,
+        } => {
+            if accepted_through > send_through {
+                return Err(StreamCodecError::InvalidCredit {
+                    accepted_through: *accepted_through,
+                    send_through: *send_through,
+                });
+            }
+            (*accepted_through, *send_through, &[])
+        }
+        StreamRecordBody::End { total } => (*total, 0, &[]),
+        StreamRecordBody::Abort {
+            accepted_through,
+            reason,
+        } => (*accepted_through, reason.wire(), &[]),
+        StreamRecordBody::Ack { accepted_through } => (*accepted_through, 0x05, &[]),
+    };
+
+    let total_bytes = STREAM_HEADER_BYTES
+        .checked_add(payload.len())
+        .ok_or(StreamCodecError::RecordLengthOverflow)?;
+    if total_bytes > bounds.max_frame_bytes {
+        return Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: total_bytes,
+            limit_bytes: bounds.max_frame_bytes,
+        });
+    }
+
+    let mut bytes = Vec::with_capacity(total_bytes);
+    bytes.extend_from_slice(&MAGIC);
+    bytes.push(kind.wire());
+    bytes.extend_from_slice(&[0, 0, 0]);
+    bytes.extend_from_slice(&record.identity.request_id().get().to_be_bytes());
+    bytes.extend_from_slice(&record.identity.stream_id().get().to_be_bytes());
+    bytes.extend_from_slice(&offset.to_be_bytes());
+    bytes.extend_from_slice(&value.to_be_bytes());
+    bytes.extend_from_slice(payload);
+    Ok(bytes)
+}
+
+fn require_no_payload(kind: StreamRecordKind, payload: &[u8]) -> Result<(), StreamCodecError> {
+    if payload.is_empty() {
+        Ok(())
+    } else {
+        Err(StreamCodecError::UnexpectedPayload {
+            kind,
+            payload_bytes: payload.len(),
+        })
+    }
+}
+
+fn require_field(
+    kind: StreamRecordKind,
+    field: StreamHeaderField,
+    actual: u64,
+    required: u64,
+) -> Result<(), StreamCodecError> {
+    if actual == required {
+        Ok(())
+    } else {
+        Err(StreamCodecError::InvalidField {
+            kind,
+            field,
+            value: actual,
+            expected: required,
+        })
+    }
+}
+
+fn checked_data_end(offset: u64, payload_bytes: usize) -> Result<u64, StreamCodecError> {
+    let payload_bytes_u64 =
+        u64::try_from(payload_bytes).map_err(|_| StreamCodecError::OffsetOverflow {
+            offset,
+            payload_bytes,
+        })?;
+    offset
+        .checked_add(payload_bytes_u64)
+        .ok_or(StreamCodecError::OffsetOverflow {
+            offset,
+            payload_bytes,
+        })
+}
+
+fn read_u64(bytes: &[u8], start: usize) -> u64 {
+    let mut value = [0_u8; 8];
+    value.copy_from_slice(&bytes[start..start + 8]);
+    u64::from_be_bytes(value)
+}
+
+fn read_u128(bytes: &[u8], start: usize) -> u128 {
+    let mut value = [0_u8; 16];
+    value.copy_from_slice(&bytes[start..start + 16]);
+    u128::from_be_bytes(value)
+}

--- a/crates/jeliya-codec/src/frame.rs
+++ b/crates/jeliya-codec/src/frame.rs
@@ -5,7 +5,7 @@
 
 use crate::error::CodecError;
 use crate::routing;
-use crate::CodecBounds;
+use crate::{CodecBounds, MAX_REQUEST_ID};
 use jeliya_api::{ApiError, OpId, Operation, Push};
 use serde::{Deserialize, Serialize};
 
@@ -122,6 +122,11 @@ pub(crate) fn decode_frame(bytes: &[u8], bounds: &CodecBounds) -> Result<Frame, 
             return Err(CodecError::UnrecoverableId("frame carries no id".into()));
         }
     };
+    if id > MAX_REQUEST_ID {
+        return Err(CodecError::UnrecoverableId(format!(
+            "frame id exceeds the browser-safe maximum {MAX_REQUEST_ID}"
+        )));
+    }
 
     // A frame with `t` is a push; pushes do not flow client-to-daemon. Its
     // id is already known usable, so this is the correlated path.
@@ -190,7 +195,7 @@ fn recover_id(bytes: &[u8]) -> Option<u64> {
     let end = rest
         .find(|c: char| !c.is_ascii_digit())
         .unwrap_or(rest.len());
-    rest[..end].parse().ok()
+    rest[..end].parse().ok().filter(|id| *id <= MAX_REQUEST_ID)
 }
 
 /// Walks a decoded value enforcing depth and array-length bounds.

--- a/crates/jeliya-codec/src/lib.rs
+++ b/crates/jeliya-codec/src/lib.rs
@@ -1,5 +1,5 @@
-//! Protocol-v2 JSON/WebSocket codec — the edge between wire frames and
-//! `jeliya-api` types.
+//! Protocol-v2 Text/Binary WebSocket codec — the edge between wire messages
+//! and `jeliya-api` types.
 //!
 //! The codec owns the protocol's *only* JSON. Everything wire-side of this
 //! crate is bytes; everything domain-side is a typed `jeliya-api` value. No
@@ -19,7 +19,10 @@
 //!    into its `jeliya-api` request type; an unknown `op` is
 //!    `unknown_operation`, and an unknown request field is
 //!    `invalid_argument` with `unrecognised_field`.
-//! 4. **Bounded malformed-input handling** — a frame whose `id` cannot be
+//! 4. **Typed Binary stream records** — the exact 48-byte `JBS2` header and
+//!    closed OPEN/DATA/CREDIT/END/ABORT/ACK bodies are encoded and decoded
+//!    with bounded allocation and checked arithmetic.
+//! 5. **Bounded malformed-input handling** — a frame whose `id` cannot be
 //!    recovered closes `4007` (`malformed_frame`); a frame that decodes far
 //!    enough to correlate always gets a correlated error reply instead, so
 //!    one bad request never strands the others in flight.
@@ -40,16 +43,23 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+mod byte_stream;
 mod error;
 mod frame;
 mod gate;
 mod routing;
 
+pub use byte_stream::{
+    decode_stream_identity, decode_stream_record, encode_stream_record, max_stream_data_bytes,
+    BinaryAbortReason, StreamCodecError, StreamHeaderField, StreamIdentity, StreamRecord,
+    StreamRecordBody, StreamRecordKind, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
+};
 pub use error::{CodecError, GateRejection};
 pub use frame::push_to_bytes;
 pub use frame::{Frame, Reply, Request};
 pub use gate::{gate, GateDecision, GateParams, SessionPrincipal};
 
+pub use jeliya_api::MAX_REQUEST_ID;
 use jeliya_api::{ApiError, Operation};
 
 /// The protocol generation this codec speaks. One generation at a time.

--- a/crates/jeliya-codec/tests/byte_stream.rs
+++ b/crates/jeliya-codec/tests/byte_stream.rs
@@ -1,0 +1,577 @@
+//! Spec-authored protocol-v2 Binary-record vectors and structural boundaries.
+
+use jeliya_codec::{
+    decode_stream_identity, decode_stream_record, encode_stream_record, max_stream_data_bytes,
+    BinaryAbortReason, CodecBounds, StreamCodecError, StreamHeaderField, StreamIdentity,
+    StreamRecord, StreamRecordBody, StreamRecordKind, MAX_REQUEST_ID, MAX_STREAM_DATA_BYTES,
+    STREAM_HEADER_BYTES,
+};
+
+const REQUEST_ID: u64 = 0x0001_0203_0405_0607;
+const STREAM_ID: u128 = 0x1011_1213_1415_1617_1819_1a1b_1c1d_1e1f;
+
+fn bounds(max_frame_bytes: usize) -> CodecBounds {
+    CodecBounds {
+        max_frame_bytes,
+        ..CodecBounds::default()
+    }
+}
+
+fn record(body: StreamRecordBody) -> StreamRecord {
+    StreamRecord {
+        identity: StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap(),
+        body,
+    }
+}
+
+/// Constructs a raw vector directly from the normative field table. This is
+/// deliberately independent of the codec's encoder.
+fn wire(
+    kind: u8,
+    request_id: u64,
+    stream_id: u128,
+    offset: u64,
+    value: u64,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(STREAM_HEADER_BYTES + payload.len());
+    bytes.extend_from_slice(b"JBS2");
+    bytes.push(kind);
+    bytes.extend_from_slice(&[0, 0, 0]);
+    bytes.extend_from_slice(&request_id.to_be_bytes());
+    bytes.extend_from_slice(&stream_id.to_be_bytes());
+    bytes.extend_from_slice(&offset.to_be_bytes());
+    bytes.extend_from_slice(&value.to_be_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+#[test]
+fn header_is_exactly_48_bytes_and_big_endian() {
+    // Hand-transcribed from docs/protocol-v2.md#the-binary-record. No codec
+    // behavior was used to construct this expected vector.
+    let expected = vec![
+        0x4a, 0x42, 0x53, 0x32, // JBS2
+        0x02, 0x00, 0x00, 0x00, // DATA + reserved
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // request id
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, // stream id, high
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, // stream id, low
+        0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, // offset
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // DATA value
+        0xaa, 0xbb, // payload
+    ];
+    let encoded = encode_stream_record(
+        &record(StreamRecordBody::Data {
+            offset: 0x2021_2223_2425_2627,
+            payload: vec![0xaa, 0xbb],
+        }),
+        &bounds(1024),
+    )
+    .unwrap();
+    assert_eq!(encoded, expected);
+    assert_eq!(STREAM_HEADER_BYTES, 48);
+}
+
+#[test]
+fn every_record_kind_matches_the_record_and_round_trips() {
+    let cases = [
+        (
+            record(StreamRecordBody::Open { total: 12 }),
+            wire(0x01, REQUEST_ID, STREAM_ID, 0, 12, &[]),
+        ),
+        (
+            record(StreamRecordBody::Data {
+                offset: 7,
+                payload: vec![0xde, 0xad, 0xbe, 0xef],
+            }),
+            wire(0x02, REQUEST_ID, STREAM_ID, 7, 0, &[0xde, 0xad, 0xbe, 0xef]),
+        ),
+        (
+            record(StreamRecordBody::Credit {
+                accepted_through: 8,
+                send_through: 21,
+            }),
+            wire(0x03, REQUEST_ID, STREAM_ID, 8, 21, &[]),
+        ),
+        (
+            record(StreamRecordBody::End { total: 12 }),
+            wire(0x04, REQUEST_ID, STREAM_ID, 12, 0, &[]),
+        ),
+        (
+            record(StreamRecordBody::Abort {
+                accepted_through: 8,
+                reason: BinaryAbortReason::ProtocolError,
+            }),
+            wire(0x05, REQUEST_ID, STREAM_ID, 8, 0x04, &[]),
+        ),
+        (
+            record(StreamRecordBody::Ack {
+                accepted_through: 8,
+            }),
+            wire(0x06, REQUEST_ID, STREAM_ID, 8, 0x05, &[]),
+        ),
+    ];
+    let bounds = bounds(1024);
+
+    for (expected_record, expected_bytes) in cases {
+        assert_eq!(
+            encode_stream_record(&expected_record, &bounds).unwrap(),
+            expected_bytes,
+            "{:?}",
+            expected_record.kind()
+        );
+        assert_eq!(
+            decode_stream_record(&expected_bytes, &bounds).unwrap(),
+            expected_record
+        );
+    }
+}
+
+#[test]
+fn data_payload_helper_checks_subtraction_and_protocol_cap() {
+    for invalid in [0, 1, 47, 48] {
+        assert_eq!(
+            max_stream_data_bytes(invalid),
+            Err(StreamCodecError::FrameLimitTooSmall {
+                max_frame_bytes: invalid
+            })
+        );
+    }
+    assert_eq!(max_stream_data_bytes(49), Ok(1));
+    assert_eq!(max_stream_data_bytes(65_583), Ok(65_535));
+    assert_eq!(max_stream_data_bytes(65_584), Ok(65_536));
+    assert_eq!(max_stream_data_bytes(65_585), Ok(65_536));
+    assert_eq!(max_stream_data_bytes(usize::MAX), Ok(65_536));
+
+    let control = record(StreamRecordBody::Open { total: 0 });
+    let control_wire = wire(0x01, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+    for invalid in [0, 48] {
+        let invalid_bounds = bounds(invalid);
+        assert_eq!(
+            encode_stream_record(&control, &invalid_bounds),
+            Err(StreamCodecError::FrameLimitTooSmall {
+                max_frame_bytes: invalid,
+            })
+        );
+        assert_eq!(
+            decode_stream_record(
+                if invalid == 0 { &[] } else { &control_wire },
+                &invalid_bounds,
+            ),
+            Err(StreamCodecError::FrameLimitTooSmall {
+                max_frame_bytes: invalid,
+            })
+        );
+    }
+}
+
+#[test]
+fn data_lengths_cover_empty_exact_and_one_past_boundaries() {
+    let one_byte_bounds = bounds(49);
+    let one = record(StreamRecordBody::Data {
+        offset: 0,
+        payload: vec![1],
+    });
+    assert_eq!(
+        encode_stream_record(&one, &one_byte_bounds).unwrap().len(),
+        49
+    );
+    assert_eq!(
+        decode_stream_record(
+            &wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]),
+            &one_byte_bounds
+        )
+        .unwrap(),
+        one
+    );
+
+    let empty = record(StreamRecordBody::Data {
+        offset: 0,
+        payload: Vec::new(),
+    });
+    assert_eq!(
+        encode_stream_record(&empty, &one_byte_bounds),
+        Err(StreamCodecError::EmptyData)
+    );
+    assert_eq!(
+        decode_stream_record(
+            &wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+            &one_byte_bounds
+        ),
+        Err(StreamCodecError::EmptyData)
+    );
+
+    let full_payload = vec![0x5a; MAX_STREAM_DATA_BYTES];
+    let at_limit = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &full_payload);
+    let protocol_bounds = bounds(STREAM_HEADER_BYTES + MAX_STREAM_DATA_BYTES + 1);
+    assert!(decode_stream_record(&at_limit, &protocol_bounds).is_ok());
+    assert_eq!(
+        encode_stream_record(
+            &record(StreamRecordBody::Data {
+                offset: 0,
+                payload: full_payload,
+            }),
+            &protocol_bounds,
+        )
+        .unwrap(),
+        at_limit
+    );
+
+    let one_past_payload = vec![0x5a; MAX_STREAM_DATA_BYTES + 1];
+    let one_past = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &one_past_payload);
+    assert_eq!(
+        decode_stream_record(&one_past, &protocol_bounds),
+        Err(StreamCodecError::DataTooLarge {
+            actual_bytes: MAX_STREAM_DATA_BYTES + 1,
+            limit_bytes: MAX_STREAM_DATA_BYTES,
+        })
+    );
+    assert_eq!(
+        encode_stream_record(
+            &record(StreamRecordBody::Data {
+                offset: 0,
+                payload: one_past_payload,
+            }),
+            &protocol_bounds,
+        ),
+        Err(StreamCodecError::DataTooLarge {
+            actual_bytes: MAX_STREAM_DATA_BYTES + 1,
+            limit_bytes: MAX_STREAM_DATA_BYTES,
+        })
+    );
+}
+
+#[test]
+fn complete_message_bound_is_checked_before_header_parsing() {
+    let bounds = bounds(49);
+    let at_limit = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]);
+    assert!(decode_stream_record(&at_limit, &bounds).is_ok());
+
+    let mut one_past_with_bad_magic = vec![0; 50];
+    one_past_with_bad_magic[..4].copy_from_slice(b"NOPE");
+    assert_eq!(
+        decode_stream_record(&one_past_with_bad_magic, &bounds),
+        Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: 50,
+            limit_bytes: 49,
+        })
+    );
+
+    let two_bytes = record(StreamRecordBody::Data {
+        offset: 0,
+        payload: vec![1, 2],
+    });
+    assert_eq!(
+        encode_stream_record(&two_bytes, &bounds),
+        Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: 50,
+            limit_bytes: 49,
+        })
+    );
+    assert_eq!(
+        decode_stream_record(&wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1, 2]), &bounds,),
+        Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: 50,
+            limit_bytes: 49,
+        })
+    );
+}
+
+#[test]
+fn every_short_header_is_rejected_without_parsing() {
+    let full = wire(0x01, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+    for len in 0..STREAM_HEADER_BYTES {
+        assert_eq!(
+            decode_stream_record(&full[..len], &bounds(1024)),
+            Err(StreamCodecError::HeaderTooShort { actual_bytes: len }),
+            "prefix length {len}"
+        );
+    }
+}
+
+#[test]
+fn bad_magic_reserved_bytes_and_unknown_kinds_are_closed() {
+    let valid = wire(0x01, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+
+    for index in 0..4 {
+        let mut bad_magic = valid.clone();
+        bad_magic[index] ^= 0xff;
+        assert_eq!(
+            decode_stream_record(&bad_magic, &bounds(1024)),
+            Err(StreamCodecError::BadMagic),
+            "magic byte {index}"
+        );
+    }
+
+    for index in 5..8 {
+        let mut reserved = valid.clone();
+        reserved[index] = 1;
+        assert_eq!(
+            decode_stream_record(&reserved, &bounds(1024)),
+            Err(StreamCodecError::ReservedBytesNonzero),
+            "reserved byte {index}"
+        );
+    }
+
+    for kind in [0x00, 0x07, 0xff] {
+        let unknown = wire(kind, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+        assert_eq!(
+            decode_stream_record(&unknown, &bounds(1024)),
+            Err(StreamCodecError::UnknownKind { kind })
+        );
+    }
+}
+
+#[test]
+fn request_and_stream_id_boundaries_are_exact() {
+    for request_id in [0, MAX_REQUEST_ID] {
+        let bytes = wire(0x01, request_id, 1, 0, 0, &[]);
+        let decoded = decode_stream_record(&bytes, &bounds(1024)).unwrap();
+        assert_eq!(decoded.identity.request_id().get(), request_id);
+        assert_eq!(decoded.identity.stream_id().get(), 1);
+    }
+
+    let request_one_past = wire(0x01, MAX_REQUEST_ID + 1, 1, 0, 0, &[]);
+    assert_eq!(
+        decode_stream_record(&request_one_past, &bounds(1024)),
+        Err(StreamCodecError::RequestIdOutOfRange {
+            request_id: MAX_REQUEST_ID + 1
+        })
+    );
+
+    for stream_id in [1, u128::MAX] {
+        let bytes = wire(0x01, 0, stream_id, 0, 0, &[]);
+        assert_eq!(
+            decode_stream_record(&bytes, &bounds(1024))
+                .unwrap()
+                .identity
+                .stream_id()
+                .get(),
+            stream_id
+        );
+    }
+    assert_eq!(
+        decode_stream_record(&wire(0x01, 0, 0, 0, 0, &[]), &bounds(1024)),
+        Err(StreamCodecError::ZeroStreamId)
+    );
+
+    assert_eq!(
+        StreamIdentity::new(MAX_REQUEST_ID + 1, 1),
+        Err(StreamCodecError::RequestIdOutOfRange {
+            request_id: MAX_REQUEST_ID + 1
+        })
+    );
+    assert_eq!(
+        StreamIdentity::new(0, 0),
+        Err(StreamCodecError::ZeroStreamId)
+    );
+}
+
+#[test]
+fn identity_can_be_validated_before_binding_and_body_parsing() {
+    for mut bytes in [
+        wire(0xff, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+        wire(0x02, REQUEST_ID, STREAM_ID, 0, 1, &[0xaa]),
+    ] {
+        let identity = decode_stream_identity(&bytes, &bounds(1024)).unwrap();
+        assert_eq!(identity.request_id().get(), REQUEST_ID);
+        assert_eq!(identity.stream_id().get(), STREAM_ID);
+
+        // Reserved bytes are also intentionally after the binding stage.
+        bytes[5] = 1;
+        assert_eq!(
+            decode_stream_identity(&bytes, &bounds(1024)).unwrap(),
+            identity
+        );
+        assert!(decode_stream_record(&bytes, &bounds(1024)).is_err());
+    }
+}
+
+#[test]
+fn control_records_are_exactly_header_length() {
+    for kind in [0x01, 0x03, 0x04, 0x05, 0x06] {
+        let value = match kind {
+            0x05 => 0x01,
+            0x06 => 0x05,
+            _ => 0,
+        };
+        let with_payload = wire(kind, REQUEST_ID, STREAM_ID, 0, value, &[0xaa]);
+        assert_eq!(
+            decode_stream_record(&with_payload, &bounds(1024)),
+            Err(StreamCodecError::UnexpectedPayload {
+                kind: match kind {
+                    0x01 => StreamRecordKind::Open,
+                    0x03 => StreamRecordKind::Credit,
+                    0x04 => StreamRecordKind::End,
+                    0x05 => StreamRecordKind::Abort,
+                    0x06 => StreamRecordKind::Ack,
+                    _ => unreachable!(),
+                },
+                payload_bytes: 1,
+            })
+        );
+    }
+}
+
+#[test]
+fn fixed_fields_credit_abort_and_ack_are_validated() {
+    assert!(matches!(
+        decode_stream_record(&wire(0x01, REQUEST_ID, STREAM_ID, 1, 0, &[]), &bounds(1024)),
+        Err(StreamCodecError::InvalidField {
+            kind: StreamRecordKind::Open,
+            field: StreamHeaderField::Offset,
+            ..
+        })
+    ));
+    assert!(matches!(
+        decode_stream_record(
+            &wire(0x02, REQUEST_ID, STREAM_ID, 0, 1, &[1]),
+            &bounds(1024)
+        ),
+        Err(StreamCodecError::InvalidField {
+            kind: StreamRecordKind::Data,
+            field: StreamHeaderField::Value,
+            ..
+        })
+    ));
+    assert!(matches!(
+        decode_stream_record(&wire(0x04, REQUEST_ID, STREAM_ID, 0, 1, &[]), &bounds(1024)),
+        Err(StreamCodecError::InvalidField {
+            kind: StreamRecordKind::End,
+            field: StreamHeaderField::Value,
+            ..
+        })
+    ));
+
+    let equal_credit = wire(0x03, REQUEST_ID, STREAM_ID, 7, 7, &[]);
+    assert!(decode_stream_record(&equal_credit, &bounds(1024)).is_ok());
+    assert_eq!(
+        decode_stream_record(&wire(0x03, REQUEST_ID, STREAM_ID, 8, 7, &[]), &bounds(1024)),
+        Err(StreamCodecError::InvalidCredit {
+            accepted_through: 8,
+            send_through: 7,
+        })
+    );
+    assert_eq!(
+        encode_stream_record(
+            &record(StreamRecordBody::Credit {
+                accepted_through: 8,
+                send_through: 7,
+            }),
+            &bounds(1024),
+        ),
+        Err(StreamCodecError::InvalidCredit {
+            accepted_through: 8,
+            send_through: 7,
+        })
+    );
+
+    for (value, expected) in [
+        (1, BinaryAbortReason::Cancelled),
+        (2, BinaryAbortReason::SourceFailed),
+        (3, BinaryAbortReason::SinkFailed),
+        (4, BinaryAbortReason::ProtocolError),
+        (5, BinaryAbortReason::OperationError),
+    ] {
+        let expected_wire = wire(0x05, REQUEST_ID, STREAM_ID, 0, value, &[]);
+        assert_eq!(
+            decode_stream_record(&expected_wire, &bounds(1024))
+                .unwrap()
+                .body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: expected,
+            }
+        );
+        assert_eq!(
+            encode_stream_record(
+                &record(StreamRecordBody::Abort {
+                    accepted_through: 0,
+                    reason: expected,
+                }),
+                &bounds(1024),
+            )
+            .unwrap(),
+            expected_wire
+        );
+    }
+    for value in [0, 6, u64::MAX] {
+        assert_eq!(
+            decode_stream_record(
+                &wire(0x05, REQUEST_ID, STREAM_ID, 0, value, &[]),
+                &bounds(1024)
+            ),
+            Err(StreamCodecError::InvalidAbortReason { value })
+        );
+    }
+
+    assert!(decode_stream_record(
+        &wire(0x06, REQUEST_ID, STREAM_ID, 0, 0x05, &[]),
+        &bounds(1024)
+    )
+    .is_ok());
+    for value in [0, 0x04, 0x06, u64::MAX] {
+        assert!(matches!(
+            decode_stream_record(
+                &wire(0x06, REQUEST_ID, STREAM_ID, 0, value, &[]),
+                &bounds(1024)
+            ),
+            Err(StreamCodecError::InvalidField {
+                kind: StreamRecordKind::Ack,
+                field: StreamHeaderField::Value,
+                ..
+            })
+        ));
+    }
+}
+
+#[test]
+fn data_offset_arithmetic_is_checked_at_exact_u64_boundary() {
+    let exact = record(StreamRecordBody::Data {
+        offset: u64::MAX - 1,
+        payload: vec![0xaa],
+    });
+    let exact_wire = wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX - 1, 0, &[0xaa]);
+    assert_eq!(
+        decode_stream_record(&exact_wire, &bounds(1024)).unwrap(),
+        exact
+    );
+    assert!(encode_stream_record(&exact, &bounds(1024)).is_ok());
+
+    let overflow_wire = wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX, 0, &[0xaa]);
+    assert_eq!(
+        decode_stream_record(&overflow_wire, &bounds(1024)),
+        Err(StreamCodecError::OffsetOverflow {
+            offset: u64::MAX,
+            payload_bytes: 1,
+        })
+    );
+    assert_eq!(
+        encode_stream_record(
+            &record(StreamRecordBody::Data {
+                offset: u64::MAX,
+                payload: vec![0xaa],
+            }),
+            &bounds(1024),
+        ),
+        Err(StreamCodecError::OffsetOverflow {
+            offset: u64::MAX,
+            payload_bytes: 1,
+        })
+    );
+}
+
+#[test]
+fn data_payload_is_opaque_and_does_not_imply_concatenated_records_or_resume() {
+    let payload = b"prefixJBS2\x06suffix".to_vec();
+    let expected = record(StreamRecordBody::Data {
+        offset: 913,
+        payload: payload.clone(),
+    });
+    let decoded = decode_stream_record(
+        &wire(0x02, REQUEST_ID, STREAM_ID, 913, 0, &payload),
+        &bounds(1024),
+    )
+    .unwrap();
+    assert_eq!(decoded, expected);
+}

--- a/crates/jeliya-codec/tests/fuzz.rs
+++ b/crates/jeliya-codec/tests/fuzz.rs
@@ -5,7 +5,10 @@
 // cause unbounded work.
 
 use jeliya_api::ApiError;
-use jeliya_codec::{decode, CodecBounds, CodecError};
+use jeliya_codec::{
+    decode, decode_stream_record, max_stream_data_bytes, CodecBounds, CodecError, StreamCodecError,
+    StreamRecordBody, STREAM_HEADER_BYTES,
+};
 
 /// A structured fuzz corpus: byte sequences that probe every refusal path.
 /// Each must return a CodecError (never panic, never Ok-garbage), and each
@@ -144,4 +147,100 @@ fn out_of_vocabulary_values_are_refused() {
             ..
         }
     ));
+}
+
+fn binary_data(payload: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(STREAM_HEADER_BYTES + payload.len());
+    bytes.extend_from_slice(b"JBS2");
+    bytes.extend_from_slice(&[0x02, 0, 0, 0]);
+    bytes.extend_from_slice(&42_u64.to_be_bytes());
+    bytes.extend_from_slice(&1_u128.to_be_bytes());
+    bytes.extend_from_slice(&0_u64.to_be_bytes());
+    bytes.extend_from_slice(&0_u64.to_be_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+/// Every prefix and single-byte mutation of a valid Binary DATA message is
+/// total. Successful mutations can allocate only the payload bytes admitted by
+/// the checked effective bound.
+#[test]
+fn mutated_binary_records_are_total_and_payload_bounded() {
+    let bounds = CodecBounds {
+        max_frame_bytes: 128,
+        ..CodecBounds::default()
+    };
+    let payload_limit = max_stream_data_bytes(bounds.max_frame_bytes).unwrap();
+    let valid = binary_data(&[0x5a; 64]);
+
+    for len in 0..valid.len() {
+        let _ = decode_stream_record(&valid[..len], &bounds);
+    }
+
+    for index in 0..valid.len() {
+        for replacement in [0x00, 0x01, 0x06, 0x4a, 0xff] {
+            let mut mutated = valid.clone();
+            mutated[index] = replacement;
+            if let Ok(record) = decode_stream_record(&mutated, &bounds) {
+                if let StreamRecordBody::Data { payload, .. } = record.body {
+                    assert!(!payload.is_empty());
+                    assert!(payload.len() <= payload_limit);
+                }
+            }
+        }
+    }
+}
+
+/// A deterministic pseudo-random byte corpus exercises all message lengths
+/// around a small configured ceiling without any panic, unbounded loop, or
+/// header-directed allocation.
+#[test]
+fn arbitrary_binary_input_fails_or_decodes_boundedly() {
+    let bounds = CodecBounds {
+        max_frame_bytes: 128,
+        ..CodecBounds::default()
+    };
+    let payload_limit = max_stream_data_bytes(bounds.max_frame_bytes).unwrap();
+    let mut state = 0x6a09_e667_f3bc_c909_u64;
+
+    for case in 0..4_096_usize {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        let len = (state as usize) % 130;
+        let mut bytes = vec![0_u8; len];
+        for byte in &mut bytes {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *byte = state as u8;
+        }
+
+        match decode_stream_record(&bytes, &bounds) {
+            Ok(record) => {
+                if let StreamRecordBody::Data { payload, .. } = record.body {
+                    assert!(!payload.is_empty(), "case {case}");
+                    assert!(payload.len() <= payload_limit, "case {case}");
+                }
+            }
+            Err(
+                StreamCodecError::FrameLimitTooSmall { .. }
+                | StreamCodecError::FrameTooLarge { .. }
+                | StreamCodecError::HeaderTooShort { .. }
+                | StreamCodecError::BadMagic
+                | StreamCodecError::ReservedBytesNonzero
+                | StreamCodecError::UnknownKind { .. }
+                | StreamCodecError::RequestIdOutOfRange { .. }
+                | StreamCodecError::ZeroStreamId
+                | StreamCodecError::UnexpectedPayload { .. }
+                | StreamCodecError::EmptyData
+                | StreamCodecError::DataTooLarge { .. }
+                | StreamCodecError::InvalidField { .. }
+                | StreamCodecError::InvalidCredit { .. }
+                | StreamCodecError::InvalidAbortReason { .. }
+                | StreamCodecError::OffsetOverflow { .. }
+                | StreamCodecError::RecordLengthOverflow,
+            ) => {}
+        }
+    }
 }

--- a/crates/jeliya-codec/tests/golden.rs
+++ b/crates/jeliya-codec/tests/golden.rs
@@ -4,7 +4,7 @@
 // malformed frame bounded.
 
 use jeliya_api::*;
-use jeliya_codec::{decode, encode_push, encode_reply, CodecBounds, Frame};
+use jeliya_codec::{decode, encode_push, encode_reply, CodecBounds, Frame, MAX_REQUEST_ID};
 
 fn default_bounds() -> CodecBounds {
     CodecBounds::default()
@@ -191,6 +191,46 @@ fn recoverable_id_gets_a_correlated_error() {
     )
     .unwrap_err();
     assert!(matches!(err, jeliya_codec::CodecError::Malformed { .. }));
+}
+
+/// #234 bounded JSON request ids to the largest integer ordinary browser and
+/// Node numbers preserve exactly. The same id is echoed in Binary records.
+#[test]
+fn json_request_id_browser_safe_boundary_is_enforced() {
+    for id in [0, MAX_REQUEST_ID] {
+        let frame = serde_json::json!({"id": id, "op": "room.list", "in": {}});
+        let decoded = decode(&serde_json::to_vec(&frame).unwrap(), &default_bounds()).unwrap();
+        match decoded {
+            Frame::Request(request) => assert_eq!(request.id, id),
+            Frame::Malformed(error) => panic!("valid id {id} was malformed: {error:?}"),
+        }
+    }
+
+    let one_past = serde_json::json!({
+        "id": MAX_REQUEST_ID + 1,
+        "op": "room.list",
+        "in": {}
+    });
+    assert!(matches!(
+        decode(&serde_json::to_vec(&one_past).unwrap(), &default_bounds()),
+        Err(jeliya_codec::CodecError::UnrecoverableId(_))
+    ));
+
+    // Best-effort recovery from malformed JSON must apply the same bound;
+    // an out-of-range prefix is not a trustworthy correlation id.
+    let recoverable = format!("{{\"id\":{MAX_REQUEST_ID},\"op\":");
+    assert!(matches!(
+        decode(recoverable.as_bytes(), &default_bounds()),
+        Err(jeliya_codec::CodecError::Malformed {
+            id: MAX_REQUEST_ID,
+            error: ApiError::MalformedFrame,
+        })
+    ));
+    let untrustworthy = format!("{{\"id\":{},\"op\":", MAX_REQUEST_ID + 1);
+    assert!(matches!(
+        decode(untrustworthy.as_bytes(), &default_bounds()),
+        Err(jeliya_codec::CodecError::UnrecoverableId(_))
+    ));
 }
 
 /// A frame carrying `t` is a push; pushes do not flow client-to-daemon.


### PR DESCRIPTION
## Summary

- add checked browser-safe request IDs, paired nonzero stream identities, and the missing `stream_aborted` / `transfer_deadline_exceeded` API shapes
- add bounded encode/decode primitives for the exact 48-byte big-endian `JBS2` OPEN, DATA, CREDIT, END, ABORT, and ACK records
- expose staged identity validation plus the checked `min(65_536, max_frame_bytes - 48)` DATA bound
- add spec-authored golden vectors, exact/one-past boundaries, malformed-field coverage, overflow checks, and deterministic bounded mutation input

## Scope

This is the first implementation slice only. It does not add active-stream lookup, direction or credit history, cancellation races, daemon/core wiring, HTTP route changes, file-transfer runtime behavior, or replay-harness execution.

Fixtures and expected bytes are transcribed from `docs/protocol-v2.md#byte-stream-framing`, not generated from implementation behavior.

## Adversarial review

The parser was reviewed for complete-message precedence, allocation bounds, checked length/offset arithmetic, trustworthy identity staging, malformed-control ambiguity, and accidental chunk/resume semantics. DATA is copied only after validation and is capped at 65,536 bytes; stream identity can be validated before any body parsing or allocation.

## Validation

- `cargo +1.96.0 fmt --all --check`
- `cargo +1.96.0 build --locked --workspace`
- `cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings`
- `cargo +1.96.0 test --locked --workspace`
- `cargo +1.91.0 check --locked --workspace --all-targets`
- `node scripts/check-docs.mjs`
- `node scripts/check-v2-corpus.mjs`
- `git diff --check`

Refs #233