### PR TITLE
Implement protocol-v2 file.read producer runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
 name = "jeliyad"
 version = "0.6.1"
 dependencies = [
+ "blake3",
  "clap",
  "dirs",
  "fd-lock",

--- a/crates/jeliya-codec/src/byte_stream.rs
+++ b/crates/jeliya-codec/src/byte_stream.rs
@@ -353,12 +353,32 @@ pub fn decode_stream_identity(
     StreamIdentity::new(request_id, stream_id)
 }
 
+/// Validates one complete Binary message through its closed record kind.
+///
+/// Stateful runtimes call [`decode_stream_identity`] first, look up the exact
+/// active `(request id, stream id)` pair, and only then call this helper. The
+/// returned kind lets the runtime enforce stream state and sender direction
+/// before [`decode_stream_record`] validates reserved bytes, fixed fields, and
+/// payload rules. This helper deliberately repeats the size, header, magic, and
+/// structural-identity checks so it is also safe to call independently.
+///
+/// No payload byte is inspected or allocated by this stage, including for a
+/// DATA record.
+pub fn decode_stream_kind(
+    bytes: &[u8],
+    bounds: &CodecBounds,
+) -> Result<StreamRecordKind, StreamCodecError> {
+    decode_stream_identity(bytes, bounds)?;
+    StreamRecordKind::from_wire(bytes[4])
+}
+
 /// Decodes one complete Binary message into a typed byte-stream record.
 ///
 /// No allocation occurs until every header field and payload bound has been
 /// validated. The only input-dependent allocation is a DATA payload capped at
 /// 65,536 bytes. Stateful runtimes must retain the result of
-/// [`decode_stream_identity`] and perform active binding lookup before calling
+/// [`decode_stream_identity`], perform active binding lookup, call
+/// [`decode_stream_kind`] for direction/state validation, and only then call
 /// this full structural decoder.
 pub fn decode_stream_record(
     bytes: &[u8],

--- a/crates/jeliya-codec/src/lib.rs
+++ b/crates/jeliya-codec/src/lib.rs
@@ -21,7 +21,8 @@
 //!    `invalid_argument` with `unrecognised_field`.
 //! 4. **Typed Binary stream records** — the exact 48-byte `JBS2` header and
 //!    closed OPEN/DATA/CREDIT/END/ABORT/ACK bodies are encoded and decoded
-//!    with bounded allocation and checked arithmetic.
+//!    with staged identity/kind validation, bounded allocation, and checked
+//!    arithmetic.
 //! 5. **Bounded malformed-input handling** — a frame whose `id` cannot be
 //!    recovered closes `4007` (`malformed_frame`); a frame that decodes far
 //!    enough to correlate always gets a correlated error reply instead, so
@@ -50,9 +51,9 @@ mod gate;
 mod routing;
 
 pub use byte_stream::{
-    decode_stream_identity, decode_stream_record, encode_stream_record, max_stream_data_bytes,
-    BinaryAbortReason, StreamCodecError, StreamHeaderField, StreamIdentity, StreamRecord,
-    StreamRecordBody, StreamRecordKind, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
+    decode_stream_identity, decode_stream_kind, decode_stream_record, encode_stream_record,
+    max_stream_data_bytes, BinaryAbortReason, StreamCodecError, StreamHeaderField, StreamIdentity,
+    StreamRecord, StreamRecordBody, StreamRecordKind, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
 };
 pub use error::{CodecError, GateRejection};
 pub use frame::push_to_bytes;

--- a/crates/jeliya-codec/tests/byte_stream.rs
+++ b/crates/jeliya-codec/tests/byte_stream.rs
@@ -1,10 +1,10 @@
 //! Spec-authored protocol-v2 Binary-record vectors and structural boundaries.
 
 use jeliya_codec::{
-    decode_stream_identity, decode_stream_record, encode_stream_record, max_stream_data_bytes,
-    BinaryAbortReason, CodecBounds, StreamCodecError, StreamHeaderField, StreamIdentity,
-    StreamRecord, StreamRecordBody, StreamRecordKind, MAX_REQUEST_ID, MAX_STREAM_DATA_BYTES,
-    STREAM_HEADER_BYTES,
+    decode_stream_identity, decode_stream_kind, decode_stream_record, encode_stream_record,
+    max_stream_data_bytes, BinaryAbortReason, CodecBounds, StreamCodecError, StreamHeaderField,
+    StreamIdentity, StreamRecord, StreamRecordBody, StreamRecordKind, MAX_REQUEST_ID,
+    MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
 };
 
 const REQUEST_ID: u64 = 0x0001_0203_0405_0607;
@@ -385,6 +385,128 @@ fn identity_can_be_validated_before_binding_and_body_parsing() {
         );
         assert!(decode_stream_record(&bytes, &bounds(1024)).is_err());
     }
+}
+
+#[test]
+fn kind_can_be_checked_after_binding_before_reserved_value_or_payload_rules() {
+    let bounds = bounds(1024);
+
+    // The kind vocabulary is checked only after the structurally trustworthy
+    // identity is available for the runtime's exact-pair lookup.
+    let unknown = wire(0xff, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+    assert_eq!(
+        decode_stream_identity(&unknown, &bounds).unwrap(),
+        StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap()
+    );
+    assert_eq!(
+        decode_stream_kind(&unknown, &bounds),
+        Err(StreamCodecError::UnknownKind { kind: 0xff })
+    );
+
+    // Reserved bytes are deliberately deferred to the full decoder.
+    let mut bad_reserved = wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]);
+    bad_reserved[5] = 1;
+    assert_eq!(
+        decode_stream_kind(&bad_reserved, &bounds),
+        Ok(StreamRecordKind::Credit)
+    );
+    assert_eq!(
+        decode_stream_record(&bad_reserved, &bounds),
+        Err(StreamCodecError::ReservedBytesNonzero)
+    );
+
+    // Kind-specific fixed-field validation is also deliberately deferred.
+    let bad_value = wire(0x02, REQUEST_ID, STREAM_ID, 0, 1, &[0xaa]);
+    assert_eq!(
+        decode_stream_kind(&bad_value, &bounds),
+        Ok(StreamRecordKind::Data)
+    );
+    assert!(matches!(
+        decode_stream_record(&bad_value, &bounds),
+        Err(StreamCodecError::InvalidField {
+            kind: StreamRecordKind::Data,
+            field: StreamHeaderField::Value,
+            ..
+        })
+    ));
+
+    // Payload rules are deferred as well: this is still recognizably OPEN at
+    // the kind stage even though OPEN may not carry a payload.
+    let bad_payload = wire(0x01, REQUEST_ID, STREAM_ID, 0, 1, &[0xaa]);
+    assert_eq!(
+        decode_stream_kind(&bad_payload, &bounds),
+        Ok(StreamRecordKind::Open)
+    );
+    assert_eq!(
+        decode_stream_record(&bad_payload, &bounds),
+        Err(StreamCodecError::UnexpectedPayload {
+            kind: StreamRecordKind::Open,
+            payload_bytes: 1,
+        })
+    );
+}
+
+#[test]
+fn kind_stage_preserves_size_header_magic_and_identity_precedence() {
+    let bounds = bounds(64);
+
+    let mut oversized = vec![0; 65];
+    oversized[4] = 0xff;
+    assert_eq!(
+        decode_stream_kind(&oversized, &bounds),
+        Err(StreamCodecError::FrameTooLarge {
+            actual_bytes: 65,
+            limit_bytes: 64,
+        })
+    );
+
+    let short = [0_u8; STREAM_HEADER_BYTES - 1];
+    assert_eq!(
+        decode_stream_kind(&short, &bounds),
+        Err(StreamCodecError::HeaderTooShort {
+            actual_bytes: STREAM_HEADER_BYTES - 1,
+        })
+    );
+
+    let bad_magic = wire(0xff, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+    let mut bad_magic = bad_magic;
+    bad_magic[..4].copy_from_slice(b"NOPE");
+    assert_eq!(
+        decode_stream_kind(&bad_magic, &bounds),
+        Err(StreamCodecError::BadMagic)
+    );
+
+    let bad_request_id = wire(0xff, MAX_REQUEST_ID + 1, STREAM_ID, 0, 0, &[]);
+    assert_eq!(
+        decode_stream_kind(&bad_request_id, &bounds),
+        Err(StreamCodecError::RequestIdOutOfRange {
+            request_id: MAX_REQUEST_ID + 1,
+        })
+    );
+
+    let zero_stream_id = wire(0xff, REQUEST_ID, 0, 0, 0, &[]);
+    assert_eq!(
+        decode_stream_kind(&zero_stream_id, &bounds),
+        Err(StreamCodecError::ZeroStreamId)
+    );
+}
+
+#[test]
+fn kind_stage_recognizes_data_without_materializing_its_payload() {
+    // The complete message lives on the stack, and the staged result is only a
+    // Copy kind enum: no owned DATA body exists until the full decoder is
+    // deliberately invoked after runtime state/direction validation.
+    let mut bytes = [0_u8; STREAM_HEADER_BYTES + 1];
+    bytes[..4].copy_from_slice(b"JBS2");
+    bytes[4] = 0x02;
+    bytes[8..16].copy_from_slice(&REQUEST_ID.to_be_bytes());
+    bytes[16..32].copy_from_slice(&STREAM_ID.to_be_bytes());
+    bytes[STREAM_HEADER_BYTES] = 0xaa;
+
+    assert_eq!(
+        decode_stream_kind(&bytes, &bounds(bytes.len())),
+        Ok(StreamRecordKind::Data)
+    );
 }
 
 #[test]

--- a/crates/jeliya-core/Cargo.toml
+++ b/crates/jeliya-core/Cargo.toml
@@ -43,7 +43,7 @@ hex = "0.4"
 blake3 = "1"
 getrandom = "0.4"
 zeroize = "1"
-tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
+tokio = { version = "1", features = ["rt", "macros", "time", "sync", "fs", "io-util"] }
 tracing = "0.1"
 # The exact version is security-sensitive: on Windows it commits with
 # MOVEFILE_WRITE_THROUGH; on Unix it fsyncs the containing directories.

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -16,14 +16,18 @@
 //! any frame is parsed or any dispatch occurs.
 
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use jeliya_api::{
-    ApiError, FileRead, FileShare, FileShareOut, OpId, PeerRow, Push, RoomId, SubjectState,
+    ApiError, FileRead, FileReadOut, FileShare, FileShareOut, OpId, PeerRow, Push, RoomId,
+    SubjectState,
 };
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
@@ -81,6 +85,210 @@ pub struct LocalFile {
     pub declared_content_type: String,
     /// Verified byte count.
     pub bytes: u64,
+}
+
+/// The result of preparing one protocol-v2 `file.read` operation.
+///
+/// `out` is the eventual terminal reply body. `source` is deliberately still
+/// unopened: the connection runtime can reserve both served transfer limits
+/// and start its absolute deadline before it performs source setup. The source
+/// contains no public path or random-access API.
+pub struct PreparedFileRead {
+    /// Metadata returned only after the byte stream reaches its terminal END.
+    pub out: FileReadOut,
+    /// The resolved, unopened, sequential byte source.
+    pub source: FileReadSource,
+}
+
+/// A resolved but unopened `file.read` source.
+///
+/// The filesystem path is intentionally private. Opening consumes this handle,
+/// so it cannot be cloned, reopened, seeked, or used as resumability state.
+pub struct FileReadSource {
+    path: PathBuf,
+    expected_bytes: u64,
+}
+
+/// An opened, forward-only `file.read` source.
+///
+/// The only read operation is chunk-bounded and advances one private cursor.
+/// There is no path, seek, clone, or inner-reader escape hatch.
+pub struct OpenFileReadSource {
+    reader: Box<dyn AsyncRead + Send + Unpin>,
+    expected_bytes: u64,
+    cursor: u64,
+}
+
+/// A local source failure detected while opening or incrementally reading a
+/// prepared `file.read`.
+#[derive(Debug)]
+pub enum FileReadSourceError {
+    /// The resolved source could not be opened or inspected.
+    OpenFailed(std::io::Error),
+    /// The opened object is no longer a regular file.
+    NotAFile,
+    /// The opened file's current count disagrees with the verified count.
+    SizeChanged {
+        /// Count verified during preparation.
+        expected: u64,
+        /// Count observed from the opened file handle.
+        observed: u64,
+    },
+    /// EOF arrived before the verified count was produced.
+    Truncated,
+    /// An incremental source read failed for a reason other than early EOF.
+    ReadFailed(std::io::Error),
+    /// The source produced a byte after the verified count.
+    Grew,
+    /// Exact-EOF verification was requested before all verified bytes were read.
+    Incomplete {
+        /// Count the source was required to produce.
+        expected: u64,
+        /// Count read through the bounded source API.
+        observed: u64,
+    },
+    /// Private cursor arithmetic was inconsistent or unrepresentable.
+    Arithmetic,
+}
+
+impl fmt::Display for FileReadSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OpenFailed(error) => write!(f, "could not open the prepared file source: {error}"),
+            Self::NotAFile => f.write_str("the prepared file source is not a regular file"),
+            Self::SizeChanged { expected, observed } => write!(
+                f,
+                "the prepared file source changed size (expected {expected}, observed {observed})"
+            ),
+            Self::Truncated => f.write_str("the prepared file source ended before its verified count"),
+            Self::ReadFailed(error) => write!(f, "the prepared file source read failed: {error}"),
+            Self::Grew => f.write_str("the prepared file source grew beyond its verified count"),
+            Self::Incomplete { expected, observed } => write!(
+                f,
+                "exact EOF was checked before the verified count (expected {expected}, observed {observed})"
+            ),
+            Self::Arithmetic => f.write_str("the prepared file source cursor is inconsistent"),
+        }
+    }
+}
+
+impl std::error::Error for FileReadSourceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::OpenFailed(error) | Self::ReadFailed(error) => Some(error),
+            Self::NotAFile
+            | Self::SizeChanged { .. }
+            | Self::Truncated
+            | Self::Grew
+            | Self::Incomplete { .. }
+            | Self::Arithmetic => None,
+        }
+    }
+}
+
+/// The protocol's absolute DATA payload ceiling. The connection runtime also
+/// applies the smaller served-frame, credit, and outbound-byte-permit bounds
+/// before asking the source for a chunk.
+const FILE_READ_CHUNK_MAX: usize = 65_536;
+
+impl FileReadSource {
+    /// Open the resolved source and revalidate its type and byte count through
+    /// the opened handle. Consuming `self` prevents reopening it as an implicit
+    /// resume mechanism.
+    pub async fn open(self) -> Result<OpenFileReadSource, FileReadSourceError> {
+        let file = tokio::fs::File::open(self.path)
+            .await
+            .map_err(FileReadSourceError::OpenFailed)?;
+        let metadata = file
+            .metadata()
+            .await
+            .map_err(FileReadSourceError::OpenFailed)?;
+        if !metadata.is_file() {
+            return Err(FileReadSourceError::NotAFile);
+        }
+        let observed = metadata.len();
+        if observed != self.expected_bytes {
+            return Err(FileReadSourceError::SizeChanged {
+                expected: self.expected_bytes,
+                observed,
+            });
+        }
+        Ok(OpenFileReadSource {
+            reader: Box::new(file),
+            expected_bytes: self.expected_bytes,
+            cursor: 0,
+        })
+    }
+}
+
+impl OpenFileReadSource {
+    /// Read the next contiguous source bytes.
+    ///
+    /// The returned chunk is nonempty and at most both `max_bytes` and 65,536
+    /// bytes. `None` means the verified count has been read; callers must still
+    /// consume the source with [`Self::verify_eof`] before sending END.
+    /// Callers must retain each read future through completion or discard the
+    /// source with it; cancelling a partially polled read and then resuming the
+    /// same source is deliberately not a checkpoint/resume API.
+    pub async fn read_chunk(
+        &mut self,
+        max_bytes: NonZeroUsize,
+    ) -> Result<Option<Vec<u8>>, FileReadSourceError> {
+        let remaining = self
+            .expected_bytes
+            .checked_sub(self.cursor)
+            .ok_or(FileReadSourceError::Arithmetic)?;
+        if remaining == 0 {
+            return Ok(None);
+        }
+        let requested = u64::try_from(max_bytes.get()).unwrap_or(u64::MAX);
+        let chunk_bytes = remaining.min(requested).min(FILE_READ_CHUNK_MAX as u64);
+        let chunk_len =
+            usize::try_from(chunk_bytes).map_err(|_| FileReadSourceError::Arithmetic)?;
+        let mut chunk = vec![0; chunk_len];
+        if let Err(error) = self.reader.read_exact(&mut chunk).await {
+            return if error.kind() == std::io::ErrorKind::UnexpectedEof {
+                Err(FileReadSourceError::Truncated)
+            } else {
+                Err(FileReadSourceError::ReadFailed(error))
+            };
+        }
+        self.cursor = self
+            .cursor
+            .checked_add(chunk_bytes)
+            .ok_or(FileReadSourceError::Arithmetic)?;
+        Ok(Some(chunk))
+    }
+
+    /// Consume the source and prove that EOF occurs exactly at the verified
+    /// count. A byte beyond that point reports growth/count disagreement; an
+    /// error while probing remains a source read failure.
+    pub async fn verify_eof(mut self) -> Result<(), FileReadSourceError> {
+        if self.cursor != self.expected_bytes {
+            return Err(FileReadSourceError::Incomplete {
+                expected: self.expected_bytes,
+                observed: self.cursor,
+            });
+        }
+        let mut probe = [0_u8; 1];
+        match self.reader.read(&mut probe).await {
+            Ok(0) => Ok(()),
+            Ok(_) => Err(FileReadSourceError::Grew),
+            Err(error) => Err(FileReadSourceError::ReadFailed(error)),
+        }
+    }
+
+    #[cfg(test)]
+    fn from_test_reader(
+        reader: impl AsyncRead + Send + Unpin + 'static,
+        expected_bytes: u64,
+    ) -> Self {
+        Self {
+            reader: Box::new(reader),
+            expected_bytes,
+            cursor: 0,
+        }
+    }
 }
 
 /// Whether `op` is in the record's **`op_id`-deduplicated** class: the
@@ -265,6 +473,24 @@ impl Engine {
             name: file.name,
             declared_content_type: file.mime,
             bytes: file.bytes,
+        })
+    }
+
+    /// Validate and authorize one protocol-v2 `file.read`, resolve its local
+    /// copy once, and return terminal metadata plus an opaque unopened source.
+    ///
+    /// Keeping the source unopened lets the connection runtime reserve its
+    /// transfer count and logical-byte capacity, and start the absolute
+    /// deadline, before source setup. Opening consumes the source and exposes
+    /// no filesystem path.
+    pub async fn prepare_file_read(&self, req: &FileRead) -> Result<PreparedFileRead, ApiError> {
+        let (out, local) = typed::prepare_file_read(&self.supervisor, req).await?;
+        Ok(PreparedFileRead {
+            source: FileReadSource {
+                path: local.path,
+                expected_bytes: local.bytes,
+            },
+            out,
         })
     }
 
@@ -736,7 +962,33 @@ async fn typed_peer_rows(engine: &Engine, room_id: &iroh_rooms::room::RoomId) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use tempfile::TempDir;
+    use tokio::io::ReadBuf;
+
+    struct FailingReader;
+
+    impl AsyncRead for FailingReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::other("injected read failure")))
+        }
+    }
+
+    fn nonzero(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test read bound is nonzero")
+    }
+
+    async fn open_source(source: FileReadSource) -> OpenFileReadSource {
+        match source.open().await {
+            Ok(source) => source,
+            Err(error) => panic!("source should open: {error}"),
+        }
+    }
 
     fn test_engine(dir: &TempDir) -> Arc<Engine> {
         let (shutdown_tx, _shutdown_rx) = mpsc::channel(4);
@@ -763,6 +1015,211 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn file_read_source_handles_zero_one_and_bounded_multiple_chunks() {
+        let dir = TempDir::new().expect("tempdir");
+
+        let zero_path = dir.path().join("zero.bin");
+        std::fs::write(&zero_path, []).expect("write zero-byte source");
+        let mut zero = open_source(FileReadSource {
+            path: zero_path,
+            expected_bytes: 0,
+        })
+        .await;
+        assert!(zero
+            .read_chunk(nonzero(1))
+            .await
+            .expect("zero read")
+            .is_none());
+        zero.verify_eof().await.expect("zero-byte exact EOF");
+
+        let one_path = dir.path().join("one.bin");
+        std::fs::write(&one_path, [0x7a]).expect("write one-byte source");
+        let mut one = open_source(FileReadSource {
+            path: one_path,
+            expected_bytes: 1,
+        })
+        .await;
+        assert_eq!(
+            one.read_chunk(nonzero(FILE_READ_CHUNK_MAX))
+                .await
+                .expect("one-byte read")
+                .expect("one-byte chunk"),
+            vec![0x7a]
+        );
+        assert!(one
+            .read_chunk(nonzero(1))
+            .await
+            .expect("one-byte completion")
+            .is_none());
+        one.verify_eof().await.expect("one-byte exact EOF");
+
+        let payload: Vec<u8> = (0..FILE_READ_CHUNK_MAX + 17)
+            .map(|offset| (offset % 251) as u8)
+            .collect();
+        let multi_path = dir.path().join("multi.bin");
+        std::fs::write(&multi_path, &payload).expect("write multi-chunk source");
+        let mut multi = open_source(FileReadSource {
+            path: multi_path,
+            expected_bytes: payload.len() as u64,
+        })
+        .await;
+        let first = multi
+            .read_chunk(nonzero(usize::MAX))
+            .await
+            .expect("first bounded read")
+            .expect("first chunk");
+        assert_eq!(first.len(), FILE_READ_CHUNK_MAX);
+        assert_eq!(first, payload[..FILE_READ_CHUNK_MAX]);
+        let second = multi
+            .read_chunk(nonzero(usize::MAX))
+            .await
+            .expect("second bounded read")
+            .expect("second chunk");
+        assert_eq!(second, payload[FILE_READ_CHUNK_MAX..]);
+        assert!(multi
+            .read_chunk(nonzero(usize::MAX))
+            .await
+            .expect("multi completion")
+            .is_none());
+        multi.verify_eof().await.expect("multi exact EOF");
+    }
+
+    #[tokio::test]
+    async fn file_read_source_revalidates_opened_type_and_count() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("changed.bin");
+        std::fs::write(&path, b"three").expect("write source");
+        let size_error = match (FileReadSource {
+            path: path.clone(),
+            expected_bytes: 4,
+        })
+        .open()
+        .await
+        {
+            Ok(_) => panic!("a changed count must fail open"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            size_error,
+            FileReadSourceError::SizeChanged {
+                expected: 4,
+                observed: 5
+            }
+        ));
+
+        std::fs::remove_file(&path).expect("remove source before open");
+        let open_error = match (FileReadSource {
+            path,
+            expected_bytes: 5,
+        })
+        .open()
+        .await
+        {
+            Ok(_) => panic!("a missing source must fail open"),
+            Err(error) => error,
+        };
+        assert!(matches!(open_error, FileReadSourceError::OpenFailed(_)));
+
+        let directory_error = match (FileReadSource {
+            path: dir.path().to_path_buf(),
+            expected_bytes: 0,
+        })
+        .open()
+        .await
+        {
+            Ok(_) => panic!("a directory must not become a file source"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            directory_error,
+            FileReadSourceError::NotAFile | FileReadSourceError::OpenFailed(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn file_read_source_detects_truncation_growth_and_read_failure() {
+        let dir = TempDir::new().expect("tempdir");
+
+        let truncated_path = dir.path().join("truncated.bin");
+        std::fs::write(&truncated_path, b"12345678").expect("write source");
+        let mut truncated = open_source(FileReadSource {
+            path: truncated_path.clone(),
+            expected_bytes: 8,
+        })
+        .await;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&truncated_path)
+            .expect("open source for truncation")
+            .set_len(3)
+            .expect("truncate source");
+        let error = truncated
+            .read_chunk(nonzero(8))
+            .await
+            .expect_err("early EOF is truncation");
+        assert!(matches!(error, FileReadSourceError::Truncated));
+
+        let grown_path = dir.path().join("grown.bin");
+        std::fs::write(&grown_path, b"abc").expect("write source");
+        let mut grown = open_source(FileReadSource {
+            path: grown_path.clone(),
+            expected_bytes: 3,
+        })
+        .await;
+        assert_eq!(
+            grown
+                .read_chunk(nonzero(3))
+                .await
+                .expect("read verified bytes")
+                .expect("verified chunk"),
+            b"abc"
+        );
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&grown_path)
+            .expect("open source for growth")
+            .write_all(b"d")
+            .expect("grow source");
+        let error = grown
+            .verify_eof()
+            .await
+            .expect_err("a byte past the count is growth");
+        assert!(matches!(error, FileReadSourceError::Grew));
+
+        let mut failing = OpenFileReadSource::from_test_reader(FailingReader, 1);
+        let error = failing
+            .read_chunk(nonzero(1))
+            .await
+            .expect_err("injected failure must surface");
+        assert!(matches!(error, FileReadSourceError::ReadFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn file_read_source_checks_cursor_and_consuming_completion() {
+        let mut inconsistent = OpenFileReadSource::from_test_reader(tokio::io::empty(), 0);
+        inconsistent.cursor = 1;
+        let error = inconsistent
+            .read_chunk(nonzero(1))
+            .await
+            .expect_err("cursor subtraction must not wrap");
+        assert!(matches!(error, FileReadSourceError::Arithmetic));
+
+        let incomplete = OpenFileReadSource::from_test_reader(tokio::io::empty(), 1);
+        let error = incomplete
+            .verify_eof()
+            .await
+            .expect_err("completion before the verified count must fail");
+        assert!(matches!(
+            error,
+            FileReadSourceError::Incomplete {
+                expected: 1,
+                observed: 0
+            }
+        ));
+    }
+
+    #[tokio::test]
     async fn room_list_before_identity_is_subject_absent() {
         let dir = TempDir::new().expect("tempdir");
         let engine = test_engine(&dir);
@@ -785,6 +1242,98 @@ mod tests {
             .reply
             .expect("subject.ensure");
         engine
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepared_file_read_matches_metadata_dispatch_and_preserves_host_file_api() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let created = engine
+            .execute(TypedCall::RoomCreate(jeliya_api::RoomCreate {
+                name: "Prepared read".into(),
+            }))
+            .await
+            .reply
+            .expect("room.create");
+        let TypedReply::RoomCreate(created) = created else {
+            panic!("wrong room.create reply");
+        };
+        engine
+            .supervisor
+            .open_room(created.room_id.as_str(), &[])
+            .await
+            .expect("open room for host-staged share");
+
+        let bytes = b"prepared bytes";
+        let staged_path = dir.path().join("payload.bin");
+        std::fs::write(&staged_path, bytes).expect("write staged bytes");
+        let shared = engine
+            .supervisor
+            .share_file(
+                created.room_id.as_str(),
+                staged_path.to_str().expect("utf-8 temp path"),
+                Some("payload.bin"),
+                Some("text/plain"),
+            )
+            .await
+            .expect("host-staged share");
+        let downloads = dir.path().join("downloads");
+        std::fs::create_dir_all(&downloads).expect("create downloads");
+        let local_path = downloads.join("payload.bin");
+        std::fs::write(&local_path, bytes).expect("write local verified copy");
+
+        let request = FileRead {
+            room_id: created.room_id.clone(),
+            file_id: jeliya_api::FileId::new(shared.file_id),
+        };
+        let ordinary = engine
+            .execute(TypedCall::FileRead(request.clone()))
+            .await
+            .reply
+            .expect("ordinary metadata-only file.read");
+        let TypedReply::FileRead(ordinary) = ordinary else {
+            panic!("wrong file.read reply");
+        };
+        let prepared = engine
+            .prepare_file_read(&request)
+            .await
+            .expect("prepare file.read");
+        assert_eq!(prepared.out, ordinary);
+        assert_eq!(prepared.out.bytes, bytes.len() as u64);
+        assert_eq!(prepared.out.declared_content_type, "text/plain");
+
+        let mut source = open_source(prepared.source).await;
+        assert_eq!(
+            source
+                .read_chunk(nonzero(4))
+                .await
+                .expect("first incremental read")
+                .expect("first source chunk"),
+            &bytes[..4]
+        );
+        assert_eq!(
+            source
+                .read_chunk(nonzero(usize::MAX))
+                .await
+                .expect("remaining incremental read")
+                .expect("remaining source chunk"),
+            &bytes[4..]
+        );
+        source.verify_eof().await.expect("exact source EOF");
+
+        let host_file = engine
+            .local_file(&request)
+            .await
+            .expect("existing host local_file API remains available");
+        assert_eq!(host_file.path, local_path);
+        assert_eq!(host_file.name, "payload.bin");
+        assert_eq!(host_file.declared_content_type, "text/plain");
+        assert_eq!(host_file.bytes, bytes.len() as u64);
+        engine
+            .supervisor
+            .close_room(created.room_id.as_str())
+            .await
+            .expect("close room");
     }
 
     #[tokio::test]

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -2620,10 +2620,26 @@ impl RoomSupervisor {
                 format!("no such file {file_id_str} in room {room_id}"),
             ));
         };
-        let file_id_handle = file_handle(&file_id);
+        self.local_file_for_shared(&room_id, &file_id, file_id_str, &shared)
+    }
+
+    /// Resolve the local copy for a signed `file.shared` fact after the caller
+    /// has already passed room authorization and looked that fact up.
+    ///
+    /// This is the shared no-second-scan seam used by protocol `file.read`.
+    /// The outer [`Self::local_file`] wrapper retains its established parsing
+    /// and authorization behavior for host-controlled HTTP responses.
+    pub(crate) fn local_file_for_shared(
+        &self,
+        room_id: &RoomId,
+        file_id: &[u8; SHORT_ID_LEN],
+        file_id_str: &str,
+        shared: &iroh_rooms::files::FileShared,
+    ) -> CoreResult<LocalFile> {
+        let file_id_handle = file_handle(file_id);
         let room_id_key = room_id.to_string();
         let Some(local) = localstate::fetched_file(&self.data_dir, &room_id_key, &file_id_handle)
-            .or_else(|| self.downloaded_file_meta(&file_id, &shared.name, shared.size_bytes))
+            .or_else(|| self.downloaded_file_meta(file_id, &shared.name, shared.size_bytes))
         else {
             return Err(CoreError::new(
                 ErrorKind::FileUnavailable,
@@ -2633,8 +2649,8 @@ impl RoomSupervisor {
         };
         Ok(LocalFile {
             path: local.path,
-            name: shared.name,
-            mime: shared.mime_type,
+            name: shared.name.clone(),
+            mime: shared.mime_type.clone(),
             bytes: local.bytes,
         })
     }
@@ -6310,6 +6326,24 @@ mod tests {
 
         let err = sup.fetch_file(&room_id, &file_id, None).await.unwrap_err();
         assert_eq!(err.kind, ErrorKind::FileUnavailable);
+
+        // The host-facing local-file API historically preserved the caller's
+        // valid spelling in its diagnostic, including a bare uppercase id.
+        // The shared resolver used by protocol file.read must not canonicalize
+        // that externally visible text.
+        let original_file_id = file_id
+            .strip_prefix("file_")
+            .expect("shared ids use the file_ prefix")
+            .to_uppercase();
+        let err = sup
+            .local_file(&room_id, &original_file_id)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind, ErrorKind::FileUnavailable);
+        assert_eq!(
+            err.message,
+            format!("file {original_file_id} has not been fetched on this daemon")
+        );
 
         let downloads = dir.path().join(super::DOWNLOADS_DIR);
         std::fs::create_dir_all(&downloads).unwrap();

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -80,7 +80,7 @@ use iroh_rooms::room::{MembershipSnapshot, RoomId as IrohRoomId};
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
 use crate::projection::{self as proj, file_handle, Departures};
-use crate::supervisor::{RemoveMemberOutcome, RoomSupervisor};
+use crate::supervisor::{LocalFile as ResolvedLocalFile, RemoveMemberOutcome, RoomSupervisor};
 
 /// The daemon's served limits, surfaced in `hello`/`VersionInfo` and enforced
 /// here. Values are the record's served-limits object; the shared-file maximum
@@ -1683,29 +1683,41 @@ impl<'a> TypedSupervisor<'a> {
         ctx: &RoomContext,
         req: &FileRead,
     ) -> Result<FileReadOut, ApiError> {
+        self.resolve_file_read(ctx, req).map(|(out, _local)| out)
+    }
+
+    /// Resolve one authorized `file.read` into its protocol metadata and its
+    /// host-private local source in a single signed-index/local-state pass.
+    fn resolve_file_read(
+        &self,
+        ctx: &RoomContext,
+        req: &FileRead,
+    ) -> Result<(FileReadOut, ResolvedLocalFile), ApiError> {
         let unknown = || ApiError::FileUnknown {
             file_id: req.file_id.clone(),
         };
         let file_id = Self::parse_file(&req.file_id).map_err(|_| unknown())?;
-        {
+        let shared = {
             let store = self
                 .sup
                 .open_store()
                 .map_err(|_| ApiError::FileIndexUnreadable)?;
-            let shared = store
+            store
                 .by_type(&ctx.room_id, EventType::FileShared)
                 .map_err(|_| ApiError::FileIndexUnreadable)?
                 .iter()
                 .filter_map(|se| SignedEvent::decode(&se.wire.signed).ok())
-                .any(|ev| matches!(ev.content, Content::FileShared(f) if f.file_id == file_id));
-            if !shared {
-                return Err(unknown());
-            }
-        }
+                .find_map(|ev| match ev.content {
+                    Content::FileShared(file) if file.file_id == file_id => Some(file),
+                    _ => None,
+                })
+        };
+        let Some(shared) = shared else {
+            return Err(unknown());
+        };
         let local = self
             .sup
-            .local_file(req.room_id.as_ref(), req.file_id.as_str())
-            .await
+            .local_file_for_shared(&ctx.room_id, &file_id, req.file_id.as_str(), &shared)
             .map_err(|error| match error.kind {
                 // The share exists, so the only remaining cause is that this
                 // daemon holds no bytes for it.
@@ -1714,12 +1726,13 @@ impl<'a> TypedSupervisor<'a> {
                 },
                 _ => core_to_api_room(error, &req.room_id),
             })?;
-        Ok(FileReadOut {
+        let out = FileReadOut {
             room_id: req.room_id.clone(),
             file_id: req.file_id.clone(),
             bytes: local.bytes,
-            declared_content_type: local.mime,
-        })
+            declared_content_type: local.mime.clone(),
+        };
+        Ok((out, local))
     }
 
     /// `transfer.cancel` — cancel a transfer by the `op_id` that started it.
@@ -2797,9 +2810,58 @@ fn requires_authority(call: &TypedCall) -> bool {
     )
 }
 
+/// Run the shared validation-order stages that precede one operation's
+/// semantics and resolve its optional room context.
+async fn validated_context(
+    t: &TypedSupervisor<'_>,
+    call: &TypedCall,
+) -> Result<Option<RoomContext>, ApiError> {
+    // Step 1 — structural decode and bounds, for every operation.
+    validate_structure(call)?;
+
+    // Step 2 — subject precondition. `subject_absent` outranks
+    // `room_not_available` and every later stage, so a subject-less caller can
+    // never use error-code selection as a room probe.
+    //
+    // `subject.ensure` skips the stage because it exists to create a subject.
+    // `daemon.stop` also skips it because the engine sequences its effect
+    // before dispatch and a refusal that still stopped the daemon would lie.
+    let skips_subject = matches!(call, TypedCall::SubjectEnsure(_) | TypedCall::DaemonStop(_));
+    if !skips_subject && !t.subject_present()? {
+        return Err(ApiError::SubjectAbsent);
+    }
+
+    // Step 3 — dedup lives in `Engine::execute_with`. `file.read` is not in
+    // that class, so its preparation path proceeds directly to room access.
+
+    // Steps 4, 5, and 6 — room index, standing, role — in that order.
+    match request_room(call) {
+        Some(api_room) => Ok(Some(
+            t.room_context(api_room, standing_exempt(call), requires_authority(call))
+                .await?,
+        )),
+        None => Ok(None),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // The typed dispatch table (the engine's v2 surface)
 // ---------------------------------------------------------------------------
+
+/// Prepare one `file.read` through the same validation and authorization path
+/// as ordinary typed dispatch, returning metadata and one private local source.
+pub(crate) async fn prepare_file_read(
+    sup: &RoomSupervisor,
+    req: &FileRead,
+) -> Result<(FileReadOut, ResolvedLocalFile), ApiError> {
+    let call = TypedCall::FileRead(req.clone());
+    let t = TypedSupervisor::new(sup);
+    let ctx = validated_context(&t, &call).await?;
+    let room = ctx
+        .as_ref()
+        .expect("file.read always resolves one room context");
+    t.resolve_file_read(room, req)
+}
 
 /// One typed operation in, its typed output out, or a typed error. This is
 /// the engine's v2 dispatch seam: the codec hands a decoded [`Call`] here and
@@ -2813,47 +2875,7 @@ pub(crate) async fn dispatch(
     call: TypedCall,
 ) -> Result<TypedReply, ApiError> {
     let t = TypedSupervisor::new(sup);
-
-    // Step 1 — structural decode and bounds, for every operation.
-    validate_structure(&call)?;
-
-    // Step 2 — subject precondition. `subject_absent` outranks
-    // `room_not_available` and every later stage, so a subject-less caller can
-    // never use error-code selection as a room probe.
-    //
-    // Two operations skip it, and the stage table's own rule is why: a stage
-    // "runs only where its precondition is meaningful". `subject.ensure` skips
-    // it because it exists to create the subject. `daemon.stop` skips it
-    // because its precondition is a running daemon, not a local subject — it
-    // reads and writes no subject state, and `daemon_stop_does_not_require_a_
-    // subject` in the corpus settles that it must succeed on a fresh daemon.
-    //
-    // Refusing it here would also be a **refusal that still acts**: the stop is
-    // sequenced by `Engine::execute_with` before dispatch runs (the reply must
-    // flush before teardown), so a step-2 refusal would tell the client the
-    // operation failed while the daemon exited anyway. The record's stage table
-    // names only `subject.ensure`, and this second exemption is recorded as a
-    // divergence on #165 rather than left as a contradiction between the reply
-    // and the effect.
-    let skips_subject = matches!(call, TypedCall::SubjectEnsure(_) | TypedCall::DaemonStop(_));
-    if !skips_subject && !t.subject_present()? {
-        return Err(ApiError::SubjectAbsent);
-    }
-
-    // Step 3 — dedup. It lives in `Engine::execute_with`, which consults the
-    // ledger after running steps 1 and 2 and before calling this function, so a
-    // structurally invalid or subject-less request never binds an `op_id` to a
-    // refusal a corrected retry would then replay.
-
-    // Steps 4, 5, and 6 — room index, standing, role — for every operation
-    // whose `in` carries a `room_id`, in one place with one ordering.
-    let ctx = match request_room(&call) {
-        Some(api_room) => Some(
-            t.room_context(api_room, standing_exempt(&call), requires_authority(&call))
-                .await?,
-        ),
-        None => None,
-    };
+    let ctx = validated_context(&t, &call).await?;
     // Every room-bearing arm below unwraps this; `request_room` and the match
     // are the same total enumeration, so the two cannot drift apart without a
     // compile error in `request_room`'s exhaustive match.

--- a/crates/jeliyad/Cargo.toml
+++ b/crates/jeliyad/Cargo.toml
@@ -47,6 +47,8 @@ url = "2"
 # Sidecar lifecycle: single-instance data-dir lock, WS auth token, rolling log.
 fd-lock = "4"
 getrandom = "0.4"
+# Keyed permutation for unpredictable, connection-local protocol-v2 stream ids.
+blake3 = "1"
 hex = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -54,6 +56,7 @@ tracing-appender = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/jeliyad/src/file_read.rs
+++ b/crates/jeliyad/src/file_read.rs
@@ -1,0 +1,5372 @@
+//! Connection-local protocol-v2 `file.read` producer runtime.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::num::NonZeroUsize;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
+    Arc, Mutex,
+};
+
+use jeliya_api::{ApiError, ByteTotal, FileRead, FileReadOut, StreamAbortReason};
+use jeliya_codec::{
+    decode_stream_identity, decode_stream_kind, decode_stream_record, encode_stream_record,
+    BinaryAbortReason, CodecBounds, StreamCodecError, StreamIdentity, StreamRecord,
+    StreamRecordBody, StreamRecordKind, STREAM_HEADER_BYTES,
+};
+use jeliya_core::engine::Engine;
+use tokio::sync::watch;
+use tokio::sync::Notify;
+use tokio::time::{Duration, Instant};
+
+use crate::outbound::{Outbound, PendingWrite, WriteReceipt};
+use crate::transfer::{RuntimeLimits, StreamIdGenerator, TransferPool, TransferReservation};
+
+const CONTROL_ATTEMPT_QUEUED: u8 = 0;
+const CONTROL_ATTEMPT_STARTED: u8 = 1;
+const CONTROL_ATTEMPT_CANCELLED: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientAbortAckCancel {
+    Committed,
+    ProtocolFault,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientAbortAckOutcome {
+    Sent,
+    ProtocolFaultBeforeSent,
+    ProtocolFaultAfterSent,
+    Failed,
+}
+
+/// Admission result for one connection-local request identifier.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum RequestAdmissionError {
+    /// The client reused an identifier whose terminal Text reply is pending.
+    Duplicate,
+    /// The served request-capacity limit is already consumed.
+    Exhausted(ApiError),
+}
+
+/// Connection-local outstanding request identifiers.
+#[derive(Clone)]
+pub(crate) struct RequestTracker {
+    inner: Arc<RequestTrackerInner>,
+}
+
+struct RequestTrackerInner {
+    limit: u64,
+    ids: Mutex<HashSet<u64>>,
+}
+
+/// RAII ownership of one outstanding request identifier.
+pub(crate) struct RequestPermit {
+    tracker: Arc<RequestTrackerInner>,
+    id: u64,
+}
+
+#[derive(Clone)]
+struct RequestLease {
+    permit: Arc<Mutex<Option<RequestPermit>>>,
+}
+
+impl RequestLease {
+    fn new(permit: RequestPermit) -> Self {
+        Self {
+            permit: Arc::new(Mutex::new(Some(permit))),
+        }
+    }
+
+    fn release(&self) {
+        drop(self.permit.lock().expect("request lease poisoned").take());
+    }
+}
+
+impl RequestTracker {
+    pub(crate) fn new(limit: u64) -> Self {
+        Self {
+            inner: Arc::new(RequestTrackerInner {
+                limit,
+                ids: Mutex::new(HashSet::new()),
+            }),
+        }
+    }
+
+    pub(crate) fn acquire(&self, id: u64) -> Result<RequestPermit, RequestAdmissionError> {
+        let mut ids = self.inner.ids.lock().expect("request tracker poisoned");
+        if ids.contains(&id) {
+            return Err(RequestAdmissionError::Duplicate);
+        }
+        let used = u64::try_from(ids.len()).unwrap_or(u64::MAX);
+        if used >= self.inner.limit {
+            return Err(RequestAdmissionError::Exhausted(
+                ApiError::ResourceExhausted {
+                    resource: "max_inflight_requests".into(),
+                    limit: self.inner.limit,
+                },
+            ));
+        }
+        ids.insert(id);
+        drop(ids);
+        Ok(RequestPermit {
+            tracker: self.inner.clone(),
+            id,
+        })
+    }
+
+    pub(crate) fn is_outstanding(&self, id: u64) -> bool {
+        self.inner
+            .ids
+            .lock()
+            .expect("request tracker poisoned")
+            .contains(&id)
+    }
+}
+
+impl Drop for RequestPermit {
+    fn drop(&mut self) {
+        self.tracker
+            .ids
+            .lock()
+            .expect("request tracker poisoned")
+            .remove(&self.id);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum BindingPhase {
+    Opening = 0,
+    Active = 1,
+    DaemonAbortQueued = 2,
+    DaemonAbortWaitAck = 3,
+    AckPending = 4,
+    ClientAbortPending = 5,
+    ClientAbortAckCommitted = 6,
+    ClientAbortAckSent = 7,
+    Finalizing = 8,
+    Retired = 9,
+}
+
+impl BindingPhase {
+    fn load(value: &AtomicU8) -> Self {
+        match value.load(Ordering::Acquire) {
+            0 => Self::Opening,
+            1 => Self::Active,
+            2 => Self::DaemonAbortQueued,
+            3 => Self::DaemonAbortWaitAck,
+            4 => Self::AckPending,
+            5 => Self::ClientAbortPending,
+            6 => Self::ClientAbortAckCommitted,
+            7 => Self::ClientAbortAckSent,
+            8 => Self::Finalizing,
+            _ => Self::Retired,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum MailboxEventBody {
+    Record(StreamRecordBody),
+    Malformed,
+}
+
+#[derive(Debug)]
+struct MailboxEvent {
+    received_at: Instant,
+    body: MailboxEventBody,
+}
+
+type PendingCredit = (u128, Instant, u64, u64);
+
+#[derive(Default)]
+struct MailboxState {
+    // At most one DATA record can be in flight. Consequently a valid pending
+    // CREDIT batch has at most two accepted-through values: the prior
+    // high-water mark and that DATA record's end. Same-accepted send-window
+    // advances coalesce into their group without replacing the timestamp of
+    // the accepted change. A third accepted change is necessarily malformed.
+    credits: VecDeque<PendingCredit>,
+    last_credit: Option<(u64, u64)>,
+    terminal_events: VecDeque<(u128, MailboxEvent)>,
+    abort_seen: bool,
+    ack_seen: bool,
+    fault_seen: bool,
+    fault: Option<(u128, Instant)>,
+    fault_abort: Option<(Instant, u64, BinaryAbortReason)>,
+    first_terminal_sequence: Option<u128>,
+    closed: bool,
+    next_sequence: u128,
+}
+
+struct InboundMailbox {
+    state: Mutex<MailboxState>,
+    ready: Notify,
+}
+
+impl InboundMailbox {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(MailboxState::default()),
+            ready: Notify::new(),
+        }
+    }
+
+    fn malformed(&self) {
+        let received_at = Instant::now();
+        let mut state = self.state.lock().expect("stream mailbox poisoned");
+        let changed = Self::record_fault(&mut state, received_at);
+        drop(state);
+        if changed {
+            self.ready.notify_one();
+        }
+    }
+
+    fn push(&self, body: StreamRecordBody, allow_crossed_abort: bool) {
+        let received_at = Instant::now();
+        let mut state = self.state.lock().expect("stream mailbox poisoned");
+        let Some(sequence) = Self::next_sequence(&mut state) else {
+            drop(state);
+            self.ready.notify_one();
+            return;
+        };
+        let changed = match body {
+            StreamRecordBody::Credit { .. } if state.abort_seen || state.ack_seen => {
+                Self::record_fault_at(&mut state, sequence, received_at)
+            }
+            StreamRecordBody::Credit { .. } if state.fault_seen => false,
+            StreamRecordBody::Credit {
+                accepted_through,
+                send_through,
+            } => {
+                let previous = state.last_credit;
+                if accepted_through > send_through
+                    || previous.is_some_and(|(old_accepted, old_send)| {
+                        accepted_through < old_accepted || send_through < old_send
+                    })
+                {
+                    Self::record_fault_at(&mut state, sequence, received_at)
+                } else if previous == Some((accepted_through, send_through)) {
+                    false
+                } else {
+                    state.last_credit = Some((accepted_through, send_through));
+                    if let Some((_, _, pending_accepted, pending_send)) = state.credits.back_mut() {
+                        if *pending_accepted == accepted_through {
+                            // Only the cumulative send window changed. Keep
+                            // the accepted group's original sequence/time so
+                            // a later non-progress update cannot move actual
+                            // progress across a stall boundary.
+                            *pending_send = send_through;
+                            false
+                        } else if state.credits.len() < 2 {
+                            state.credits.push_back((
+                                sequence,
+                                received_at,
+                                accepted_through,
+                                send_through,
+                            ));
+                            true
+                        } else {
+                            Self::record_fault_at(&mut state, sequence, received_at)
+                        }
+                    } else {
+                        state.credits.push_back((
+                            sequence,
+                            received_at,
+                            accepted_through,
+                            send_through,
+                        ));
+                        true
+                    }
+                }
+            }
+            terminal @ (StreamRecordBody::Abort { .. } | StreamRecordBody::Ack { .. }) => {
+                let is_abort = matches!(&terminal, StreamRecordBody::Abort { .. });
+                let is_ack = matches!(&terminal, StreamRecordBody::Ack { .. });
+                let allowed = (is_abort && !state.abort_seen && !state.ack_seen)
+                    || (is_ack && !state.ack_seen && (!state.abort_seen || allow_crossed_abort));
+                if allowed {
+                    state.abort_seen |= is_abort;
+                    state.ack_seen |= is_ack;
+                    state.first_terminal_sequence.get_or_insert(sequence);
+                    state.terminal_events.push_back((
+                        sequence,
+                        MailboxEvent {
+                            received_at,
+                            body: MailboxEventBody::Record(terminal),
+                        },
+                    ));
+                    true
+                } else {
+                    // Terminal latches survive dequeue. Repeating a terminal
+                    // is therefore rejected even if the actor already
+                    // observed the first one. The only two-record exception
+                    // is crossed client ABORT then daemon-ABORT ACK.
+                    Self::record_fault_at(&mut state, sequence, received_at)
+                }
+            }
+            _ if state.fault_seen => false,
+            _ => Self::record_fault_at(&mut state, sequence, received_at),
+        };
+        drop(state);
+        if changed {
+            self.ready.notify_one();
+        }
+    }
+
+    fn record_fault(state: &mut MailboxState, received_at: Instant) -> bool {
+        let Some(sequence) = Self::next_sequence(state) else {
+            return true;
+        };
+        Self::record_fault_at(state, sequence, received_at)
+    }
+
+    fn record_fault_at(state: &mut MailboxState, sequence: u128, received_at: Instant) -> bool {
+        if state.fault_seen {
+            return false;
+        }
+        state.fault_seen = true;
+        // A duplicate/invalid record buffered behind an unconsumed terminal
+        // invalidates that terminal batch, but never erases earlier CREDIT.
+        // Replacing the batch at its first sequence preserves wire order.
+        if state.fault_abort.is_none() {
+            state.fault_abort =
+                state
+                    .terminal_events
+                    .iter()
+                    .find_map(|(_, event)| match &event.body {
+                        MailboxEventBody::Record(StreamRecordBody::Abort {
+                            accepted_through,
+                            reason,
+                        }) => Some((event.received_at, *accepted_through, *reason)),
+                        _ => None,
+                    });
+        }
+        let fault_sequence = state.first_terminal_sequence.unwrap_or(sequence);
+        state.terminal_events.clear();
+        state.fault = Some((fault_sequence, received_at));
+        true
+    }
+
+    fn next_sequence(state: &mut MailboxState) -> Option<u128> {
+        let sequence = state.next_sequence;
+        let Some(next) = sequence.checked_add(1) else {
+            // Although unreachable at any physical message rate, keep even
+            // internal ordering arithmetic checked. A priority protocol fault
+            // is the only safe behavior if the counter cannot advance.
+            state.fault_seen = true;
+            state.fault = Some((sequence, Instant::now()));
+            return None;
+        };
+        state.next_sequence = next;
+        Some(sequence)
+    }
+
+    fn take_locked(state: &mut MailboxState) -> Option<MailboxEvent> {
+        let credit_sequence = state.credits.front().map(|(sequence, _, _, _)| *sequence);
+        let terminal_sequence = state.terminal_events.front().map(|(sequence, _)| *sequence);
+        let fault_sequence = state.fault.map(|(sequence, _)| sequence);
+        let next = [credit_sequence, terminal_sequence, fault_sequence]
+            .into_iter()
+            .flatten()
+            .min()?;
+        if credit_sequence == Some(next) {
+            return state.credits.pop_front().map(
+                |(_, received_at, accepted_through, send_through)| MailboxEvent {
+                    received_at,
+                    body: MailboxEventBody::Record(StreamRecordBody::Credit {
+                        accepted_through,
+                        send_through,
+                    }),
+                },
+            );
+        }
+        if terminal_sequence == Some(next) {
+            return state.terminal_events.pop_front().map(|(_, event)| event);
+        }
+        state.fault.take().map(|(_, received_at)| {
+            // The fault has now made its terminal decision. Subsequent input
+            // belongs to the daemon-ABORT handshake and must be validated in
+            // that state rather than silently discarded behind a stale latch.
+            state.fault_seen = false;
+            if state.terminal_events.is_empty() {
+                state.first_terminal_sequence = None;
+            }
+            MailboxEvent {
+                received_at,
+                body: MailboxEventBody::Malformed,
+            }
+        })
+    }
+
+    fn try_recv(&self) -> Option<MailboxEvent> {
+        Self::take_locked(&mut self.state.lock().expect("stream mailbox poisoned"))
+    }
+
+    fn has_pending(&self) -> bool {
+        let state = self.state.lock().expect("stream mailbox poisoned");
+        state.closed
+            || state.fault.is_some()
+            || !state.credits.is_empty()
+            || !state.terminal_events.is_empty()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.state.lock().expect("stream mailbox poisoned").closed
+    }
+
+    fn take_fault_abort(&self) -> Option<(Instant, u64, BinaryAbortReason)> {
+        self.state
+            .lock()
+            .expect("stream mailbox poisoned")
+            .fault_abort
+            .take()
+    }
+
+    async fn wait_ready(&self) {
+        self.ready.notified().await;
+    }
+
+    fn close(&self) {
+        self.state.lock().expect("stream mailbox poisoned").closed = true;
+        self.ready.notify_waiters();
+        self.ready.notify_one();
+    }
+}
+
+struct StreamIngress {
+    mailbox: InboundMailbox,
+    sequencing: Mutex<()>,
+    phase: AtomicU8,
+    data_live: Arc<AtomicBool>,
+    opening_fatal: AtomicBool,
+    final_through: AtomicU64,
+}
+
+impl StreamIngress {
+    fn new() -> Self {
+        Self {
+            mailbox: InboundMailbox::new(),
+            sequencing: Mutex::new(()),
+            phase: AtomicU8::new(BindingPhase::Opening as u8),
+            data_live: Arc::new(AtomicBool::new(true)),
+            opening_fatal: AtomicBool::new(false),
+            final_through: AtomicU64::new(0),
+        }
+    }
+
+    fn set_phase(&self, phase: BindingPhase) {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        self.set_phase_locked(phase);
+    }
+
+    fn set_phase_locked(&self, phase: BindingPhase) {
+        self.phase.store(phase as u8, Ordering::Release);
+        if !matches!(phase, BindingPhase::Opening | BindingPhase::Active) {
+            self.data_live.store(false, Ordering::Release);
+        }
+    }
+
+    fn try_sequence_open(&self, attempt_live: &AtomicBool, absolute_deadline: Instant) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if !attempt_live.load(Ordering::Acquire)
+            || BindingPhase::load(&self.phase) != BindingPhase::Opening
+            || !self.data_live.load(Ordering::Acquire)
+            || Instant::now() >= absolute_deadline
+        {
+            return false;
+        }
+        self.set_phase_locked(BindingPhase::Active);
+        true
+    }
+
+    fn cancel_open_attempt(&self, attempt_live: &AtomicBool) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        attempt_live.store(false, Ordering::Release);
+        let committed = BindingPhase::load(&self.phase) == BindingPhase::Active;
+        self.data_live.store(false, Ordering::Release);
+        committed
+    }
+
+    fn try_sequence_end(
+        &self,
+        attempt_live: &AtomicBool,
+        absolute_deadline: Instant,
+        stall_deadline: Instant,
+        final_through: u64,
+    ) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        let now = Instant::now();
+        if !attempt_live.load(Ordering::Acquire)
+            || BindingPhase::load(&self.phase) != BindingPhase::Active
+            || !self.data_live.load(Ordering::Acquire)
+            || self.mailbox.has_pending()
+            || now >= absolute_deadline
+            || now >= stall_deadline
+        {
+            return false;
+        }
+        self.final_through.store(final_through, Ordering::Release);
+        self.set_phase_locked(BindingPhase::Finalizing);
+        true
+    }
+
+    fn try_sequence_client_abort_ack(&self, attempt_live: &AtomicBool, deadline: Instant) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if !attempt_live.load(Ordering::Acquire)
+            || BindingPhase::load(&self.phase) != BindingPhase::ClientAbortPending
+            || self.mailbox.has_pending()
+            || Instant::now() >= deadline
+        {
+            return false;
+        }
+        self.set_phase_locked(BindingPhase::ClientAbortAckCommitted);
+        true
+    }
+
+    fn cancel_client_abort_ack_attempt(&self, attempt_live: &AtomicBool) -> ClientAbortAckCancel {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        attempt_live.store(false, Ordering::Release);
+        match BindingPhase::load(&self.phase) {
+            BindingPhase::ClientAbortAckCommitted => ClientAbortAckCancel::Committed,
+            BindingPhase::ClientAbortPending if self.mailbox.has_pending() => {
+                ClientAbortAckCancel::ProtocolFault
+            }
+            _ => ClientAbortAckCancel::Cancelled,
+        }
+    }
+
+    fn classify_client_abort_ack_discard(&self) -> ClientAbortAckOutcome {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if BindingPhase::load(&self.phase) == BindingPhase::ClientAbortPending
+            && self.mailbox.has_pending()
+        {
+            ClientAbortAckOutcome::ProtocolFaultBeforeSent
+        } else {
+            ClientAbortAckOutcome::Failed
+        }
+    }
+
+    fn classify_client_abort_ack_sent(&self) -> ClientAbortAckOutcome {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if BindingPhase::load(&self.phase) == BindingPhase::ClientAbortAckSent {
+            ClientAbortAckOutcome::ProtocolFaultAfterSent
+        } else {
+            ClientAbortAckOutcome::Sent
+        }
+    }
+
+    fn try_sequence_daemon_abort(&self, attempt_live: &AtomicBool, deadline: Instant) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if !attempt_live.load(Ordering::Acquire)
+            || BindingPhase::load(&self.phase) != BindingPhase::DaemonAbortQueued
+            || Instant::now() >= deadline
+        {
+            return false;
+        }
+        self.set_phase_locked(BindingPhase::DaemonAbortWaitAck);
+        true
+    }
+
+    fn cancel_daemon_abort_attempt(&self, attempt_live: &AtomicBool) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        attempt_live.store(false, Ordering::Release);
+        BindingPhase::load(&self.phase) == BindingPhase::DaemonAbortWaitAck
+    }
+
+    fn cancel_end_attempt(&self, attempt_live: &AtomicBool) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        attempt_live.store(false, Ordering::Release);
+        BindingPhase::load(&self.phase) == BindingPhase::Finalizing
+    }
+
+    fn stop_active_data(&self) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        if BindingPhase::load(&self.phase) != BindingPhase::Active {
+            return false;
+        }
+        self.data_live.store(false, Ordering::Release);
+        true
+    }
+
+    fn try_start_data(&self, absolute_deadline: Instant, stall_deadline: Instant) -> bool {
+        let _sequencing = self.sequencing.lock().expect("stream sequencing poisoned");
+        let now = Instant::now();
+        BindingPhase::load(&self.phase) == BindingPhase::Active
+            && self.data_live.load(Ordering::Acquire)
+            && !self.mailbox.has_pending()
+            && now < absolute_deadline
+            && now < stall_deadline
+    }
+
+    fn protocol_fault(&self) {
+        self.data_live.store(false, Ordering::Release);
+        self.mailbox.malformed();
+    }
+}
+
+/// Result of routing one complete inbound Binary message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BinaryRoute {
+    /// The record was delivered or coalesced for its exact active pair.
+    Delivered,
+    /// Complete-message size takes the unparsed `4005` path.
+    CloseTooLarge,
+    /// No trustworthy exact binding exists; close `4007`.
+    CloseMalformed,
+}
+
+/// Exact-pair bindings for one WebSocket connection.
+#[derive(Clone)]
+pub(crate) struct StreamRegistry {
+    inner: Arc<Mutex<StreamRegistryState>>,
+}
+
+struct StreamRegistryState {
+    accepting: bool,
+    bindings: HashMap<StreamIdentity, Arc<StreamIngress>>,
+}
+
+/// Single owner for a connection-fatal WebSocket Close.
+///
+/// Claiming a Close is synchronous: it first invalidates every stream and
+/// queued non-Close write, then wakes the connection reader. The sole Close
+/// write runs in an independent task so cancelling a request actor cannot
+/// strand it, and a completion watch lets connection teardown preserve its
+/// bounded flush opportunity before stopping the writer.
+#[derive(Clone)]
+pub(crate) struct ConnectionCloser {
+    inner: Arc<ConnectionCloserInner>,
+}
+
+struct ConnectionCloserInner {
+    claimed: AtomicBool,
+    registry: StreamRegistry,
+    outbound: Outbound,
+    requested: watch::Sender<bool>,
+    completed: watch::Sender<bool>,
+}
+
+impl ConnectionCloser {
+    pub(crate) fn new(
+        registry: StreamRegistry,
+        outbound: Outbound,
+    ) -> (Self, watch::Receiver<bool>, watch::Receiver<bool>) {
+        let (requested, requested_rx) = watch::channel(false);
+        let (completed, completed_rx) = watch::channel(false);
+        (
+            Self {
+                inner: Arc::new(ConnectionCloserInner {
+                    claimed: AtomicBool::new(false),
+                    registry,
+                    outbound,
+                    requested,
+                    completed,
+                }),
+            },
+            requested_rx,
+            completed_rx,
+        )
+    }
+
+    /// Claims the connection's one fatal Close. The first caller owns its
+    /// code/reason; later callers only observe the already-invalidated state.
+    pub(crate) fn request(
+        &self,
+        frame: tokio_tungstenite::tungstenite::protocol::CloseFrame,
+    ) -> bool {
+        if self
+            .inner
+            .claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        self.inner.registry.invalidate_connection();
+        self.inner.outbound.invalidate_connection();
+
+        let outbound = self.inner.outbound.clone();
+        let completed = self.inner.completed.clone();
+        tokio::spawn(async move {
+            let _ = outbound.close(frame).await;
+            let _ = completed.send(true);
+        });
+        let _ = self.inner.requested.send(true);
+        true
+    }
+
+    pub(crate) fn malformed(&self) -> bool {
+        self.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+            code: 4007.into(),
+            reason: "malformed_frame".into(),
+        })
+    }
+
+    pub(crate) fn is_requested(&self) -> bool {
+        self.inner.claimed.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct StreamBinding {
+    registry: StreamRegistry,
+    identity: StreamIdentity,
+    ingress: Arc<StreamIngress>,
+}
+
+#[derive(Clone)]
+struct StreamRetirement {
+    registry: StreamRegistry,
+    identity: StreamIdentity,
+    ingress: Arc<StreamIngress>,
+}
+
+impl StreamRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(StreamRegistryState {
+                accepting: true,
+                bindings: HashMap::new(),
+            })),
+        }
+    }
+
+    fn bind(&self, identity: StreamIdentity) -> Option<StreamBinding> {
+        let ingress = Arc::new(StreamIngress::new());
+        let mut registry = self.inner.lock().expect("stream registry poisoned");
+        if !registry.accepting {
+            return None;
+        }
+        match registry.bindings.entry(identity) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(ingress.clone());
+            }
+            std::collections::hash_map::Entry::Occupied(_) => return None,
+        }
+        Some(StreamBinding {
+            registry: self.clone(),
+            identity,
+            ingress,
+        })
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        !self
+            .inner
+            .lock()
+            .expect("stream registry poisoned")
+            .bindings
+            .is_empty()
+    }
+
+    /// Atomically makes every current or future stream on this connection
+    /// unstartable before a connection-fatal Close is queued. The registry
+    /// lock is acquired before each stream sequencing lock, matching
+    /// retirement, so an OPEN writer start cannot slip between invalidation
+    /// and the Close merely because the FIFO control queue is congested.
+    pub(crate) fn invalidate_connection(&self) {
+        let mut registry = self.inner.lock().expect("stream registry poisoned");
+        registry.accepting = false;
+        for ingress in registry.bindings.values() {
+            let _sequencing = ingress
+                .sequencing
+                .lock()
+                .expect("stream sequencing poisoned");
+            ingress.opening_fatal.store(true, Ordering::Release);
+            ingress.set_phase_locked(BindingPhase::Retired);
+            ingress.mailbox.close();
+            ingress.data_live.store(false, Ordering::Release);
+        }
+        registry.bindings.clear();
+    }
+
+    pub(crate) fn route_binary(&self, bytes: &[u8], bounds: &CodecBounds) -> BinaryRoute {
+        if bytes.len() > bounds.max_frame_bytes {
+            return BinaryRoute::CloseTooLarge;
+        }
+        let identity = match decode_stream_identity(bytes, bounds) {
+            Ok(identity) => identity,
+            Err(StreamCodecError::FrameTooLarge { .. }) => return BinaryRoute::CloseTooLarge,
+            Err(_) => return BinaryRoute::CloseMalformed,
+        };
+        let ingress = {
+            self.inner
+                .lock()
+                .expect("stream registry poisoned")
+                .bindings
+                .get(&identity)
+                .cloned()
+        };
+        let Some(ingress) = ingress else {
+            return BinaryRoute::CloseMalformed;
+        };
+
+        Self::route_bound(&ingress, bytes, bounds)
+    }
+
+    fn route_bound(
+        ingress: &Arc<StreamIngress>,
+        bytes: &[u8],
+        bounds: &CodecBounds,
+    ) -> BinaryRoute {
+        let _sequencing = ingress
+            .sequencing
+            .lock()
+            .expect("stream sequencing poisoned");
+        let phase = BindingPhase::load(&ingress.phase);
+        if phase == BindingPhase::Opening {
+            // Until the sole writer commits OPEN, the pair is private runtime
+            // state rather than a trustworthy peer-visible binding. Cancel a
+            // queued OPEN under the same sequencing lock before asking the
+            // connection owner to close 4007.
+            ingress.opening_fatal.store(true, Ordering::Release);
+            ingress.data_live.store(false, Ordering::Release);
+            return BinaryRoute::CloseMalformed;
+        }
+        if matches!(phase, BindingPhase::AckPending | BindingPhase::Retired) {
+            return BinaryRoute::CloseMalformed;
+        }
+        // The exact active pair is trustworthy before kind/direction. This
+        // staged helper performs no DATA allocation.
+        let kind = match decode_stream_kind(bytes, bounds) {
+            Ok(kind) => kind,
+            Err(_) => {
+                ingress.protocol_fault();
+                return BinaryRoute::Delivered;
+            }
+        };
+        let direction_ok = match phase {
+            BindingPhase::Opening => unreachable!("opening returned above"),
+            BindingPhase::Active => {
+                matches!(kind, StreamRecordKind::Credit | StreamRecordKind::Abort)
+            }
+            BindingPhase::DaemonAbortQueued => {
+                matches!(kind, StreamRecordKind::Credit | StreamRecordKind::Abort)
+            }
+            BindingPhase::DaemonAbortWaitAck => matches!(
+                kind,
+                StreamRecordKind::Credit | StreamRecordKind::Abort | StreamRecordKind::Ack
+            ),
+            BindingPhase::ClientAbortPending => {
+                matches!(kind, StreamRecordKind::Credit | StreamRecordKind::Abort)
+            }
+            BindingPhase::ClientAbortAckCommitted | BindingPhase::ClientAbortAckSent => {
+                matches!(kind, StreamRecordKind::Credit | StreamRecordKind::Abort)
+            }
+            BindingPhase::Finalizing => {
+                matches!(kind, StreamRecordKind::Credit | StreamRecordKind::Abort)
+            }
+            BindingPhase::AckPending | BindingPhase::Retired => {
+                unreachable!("terminal phases returned above")
+            }
+        };
+        if !direction_ok {
+            if phase == BindingPhase::Finalizing {
+                return BinaryRoute::CloseMalformed;
+            }
+            ingress.protocol_fault();
+            return BinaryRoute::Delivered;
+        }
+
+        let record = match decode_stream_record(bytes, bounds) {
+            Ok(record) => record,
+            Err(_) => {
+                if phase == BindingPhase::Finalizing {
+                    return BinaryRoute::CloseMalformed;
+                }
+                ingress.protocol_fault();
+                return BinaryRoute::Delivered;
+            }
+        };
+        if phase == BindingPhase::Finalizing {
+            let final_through = ingress.final_through.load(Ordering::Acquire);
+            let valid_late_control = match record.body {
+                StreamRecordBody::Credit {
+                    accepted_through,
+                    send_through,
+                } => accepted_through == final_through && send_through == final_through,
+                StreamRecordBody::Abort {
+                    accepted_through,
+                    reason,
+                } => {
+                    accepted_through == final_through
+                        && matches!(
+                            reason,
+                            BinaryAbortReason::Cancelled
+                                | BinaryAbortReason::SinkFailed
+                                | BinaryAbortReason::ProtocolError
+                        )
+                }
+                _ => false,
+            };
+            // END already committed the authoritative result. A valid late
+            // receiver control cannot alter it; an invalid one cannot be
+            // answered with a second correlated terminal and is therefore a
+            // fatal malformed terminal/binding failure.
+            return if valid_late_control {
+                BinaryRoute::Delivered
+            } else {
+                BinaryRoute::CloseMalformed
+            };
+        }
+        if kind == StreamRecordKind::Abort {
+            // Once the peer has sequenced a terminal control, queued source
+            // DATA must not pass it. A write already in progress remains the
+            // older in-flight message and naturally precedes the ACK.
+            ingress.data_live.store(false, Ordering::Release);
+        }
+        if phase == BindingPhase::DaemonAbortWaitAck && kind == StreamRecordKind::Ack {
+            // Latch the first structurally valid ACK before exposing it to the
+            // actor. Until semantic validation and retirement finish, any
+            // later record for this pair is an unambiguous 4007 rather than a
+            // duplicate terminal racing the mailbox consumer.
+            ingress.set_phase_locked(BindingPhase::AckPending);
+        }
+        ingress
+            .mailbox
+            .push(record.body, phase == BindingPhase::DaemonAbortWaitAck);
+        BinaryRoute::Delivered
+    }
+}
+
+impl StreamBinding {
+    fn identity(&self) -> StreamIdentity {
+        self.identity
+    }
+
+    fn set_phase(&self, phase: BindingPhase) {
+        self.ingress.set_phase(phase);
+    }
+
+    fn phase(&self) -> BindingPhase {
+        BindingPhase::load(&self.ingress.phase)
+    }
+
+    fn retirement(&self) -> StreamRetirement {
+        StreamRetirement {
+            registry: self.registry.clone(),
+            identity: self.identity,
+            ingress: self.ingress.clone(),
+        }
+    }
+
+    fn retire(&self) {
+        self.retirement().retire();
+    }
+}
+
+impl StreamRetirement {
+    /// Completes a client-ABORT ACK at the socket acknowledgement boundary.
+    /// Routing uses the same sequencing lock: if a second exact-pair record
+    /// won before the ACK flush, keep the binding request-local for the actor
+    /// to promote into a daemon protocol ABORT. Otherwise retire it before a
+    /// later record can still name the pair.
+    fn retire_client_abort_ack(&self) {
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        let _sequencing = self
+            .ingress
+            .sequencing
+            .lock()
+            .expect("stream sequencing poisoned");
+        if BindingPhase::load(&self.ingress.phase) == BindingPhase::ClientAbortAckCommitted
+            && self.ingress.mailbox.has_pending()
+        {
+            self.ingress
+                .set_phase_locked(BindingPhase::ClientAbortAckSent);
+            return;
+        }
+        self.ingress.set_phase_locked(BindingPhase::Retired);
+        self.ingress.mailbox.close();
+        self.ingress.data_live.store(false, Ordering::Release);
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| Arc::ptr_eq(current, &self.ingress))
+        {
+            registry.bindings.remove(&self.identity);
+        }
+    }
+
+    fn retire(&self) {
+        // Keep lock order identical to connection invalidation. No code may
+        // hold a stream sequencing lock while acquiring the registry lock.
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        let _sequencing = self
+            .ingress
+            .sequencing
+            .lock()
+            .expect("stream sequencing poisoned");
+        self.ingress.set_phase_locked(BindingPhase::Retired);
+        self.ingress.mailbox.close();
+        self.ingress.data_live.store(false, Ordering::Release);
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| Arc::ptr_eq(current, &self.ingress))
+        {
+            registry.bindings.remove(&self.identity);
+        }
+    }
+}
+
+impl Drop for StreamBinding {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CreditEffect {
+    Repeated,
+    Advanced { accepted: bool },
+}
+
+#[derive(Debug, Clone)]
+struct ProducerState {
+    total: u64,
+    accepted: u64,
+    send_through: u64,
+    sent: u64,
+    credit_seen: bool,
+}
+
+impl ProducerState {
+    fn new(total: u64) -> Self {
+        Self {
+            total,
+            accepted: 0,
+            send_through: 0,
+            sent: 0,
+            credit_seen: false,
+        }
+    }
+
+    fn credit(&mut self, accepted: u64, send: u64) -> Result<CreditEffect, ()> {
+        if accepted > send
+            || accepted < self.accepted
+            || send < self.send_through
+            || send > self.total
+            || accepted > self.sent
+            || (accepted != self.accepted && accepted != self.sent)
+        {
+            return Err(());
+        }
+        let repeated = self.credit_seen && accepted == self.accepted && send == self.send_through;
+        let accepted_advanced = accepted > self.accepted;
+        self.credit_seen = true;
+        self.accepted = accepted;
+        self.send_through = send;
+        if repeated {
+            Ok(CreditEffect::Repeated)
+        } else {
+            Ok(CreditEffect::Advanced {
+                accepted: accepted_advanced,
+            })
+        }
+    }
+
+    fn next_payload(&self, max_payload: usize) -> Option<usize> {
+        if !self.credit_seen
+            || self.accepted != self.sent
+            || self.sent >= self.send_through
+            || self.sent >= self.total
+        {
+            return None;
+        }
+        let permitted = self
+            .send_through
+            .checked_sub(self.sent)?
+            .min(self.total.checked_sub(self.sent)?);
+        usize::try_from(permitted)
+            .ok()
+            .map(|bytes| bytes.min(max_payload))
+            .filter(|bytes| *bytes > 0)
+    }
+
+    fn data_sent(&mut self, payload_bytes: usize) -> Result<(), ()> {
+        let payload = u64::try_from(payload_bytes).map_err(|_| ())?;
+        let end = self.sent.checked_add(payload).ok_or(())?;
+        if payload == 0 || self.accepted != self.sent || end > self.send_through || end > self.total
+        {
+            return Err(());
+        }
+        self.sent = end;
+        Ok(())
+    }
+
+    fn valid_receiver_terminal(&self, accepted: u64) -> bool {
+        accepted >= self.accepted
+            && accepted <= self.sent
+            && (accepted == self.accepted || accepted == self.sent)
+    }
+
+    fn ready_for_end(&self) -> bool {
+        self.credit_seen && self.sent == self.total && self.accepted == self.total
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaemonFailure {
+    Source,
+    Protocol,
+    Deadline { budget_ms: u64 },
+    Stall,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveStop {
+    ClientAbort {
+        accepted: u64,
+        reason: StreamAbortReason,
+    },
+    Daemon(DaemonFailure),
+    TransportLost,
+}
+
+fn known_total(total: u64) -> ByteTotal {
+    ByteTotal::Known { bytes: total }
+}
+
+fn apply_active_event(
+    state: &mut ProducerState,
+    event: MailboxEvent,
+    stall_deadline: &mut Instant,
+    limits: RuntimeLimits,
+) -> Result<(), ActiveStop> {
+    let MailboxEvent { received_at, body } = event;
+    match body {
+        MailboxEventBody::Malformed => Err(ActiveStop::Daemon(DaemonFailure::Protocol)),
+        MailboxEventBody::Record(StreamRecordBody::Credit {
+            accepted_through,
+            send_through,
+        }) => match state.credit(accepted_through, send_through) {
+            Ok(CreditEffect::Advanced { accepted: true }) => {
+                *stall_deadline = limits
+                    .stall_deadline(received_at)
+                    .map_err(|_| ActiveStop::Daemon(DaemonFailure::Protocol))?;
+                Ok(())
+            }
+            Ok(CreditEffect::Advanced { accepted: false } | CreditEffect::Repeated) => Ok(()),
+            Err(()) => Err(ActiveStop::Daemon(DaemonFailure::Protocol)),
+        },
+        MailboxEventBody::Record(StreamRecordBody::Abort {
+            accepted_through,
+            reason,
+        }) => {
+            let reason = match reason {
+                BinaryAbortReason::Cancelled => StreamAbortReason::Cancelled,
+                BinaryAbortReason::SinkFailed => StreamAbortReason::SinkFailed,
+                BinaryAbortReason::ProtocolError => StreamAbortReason::ProtocolError,
+                // The client is the receiver. `source_failed` describes the
+                // producer's local failure, and operation_error is daemon-only.
+                BinaryAbortReason::SourceFailed | BinaryAbortReason::OperationError => {
+                    return Err(ActiveStop::Daemon(DaemonFailure::Protocol));
+                }
+            };
+            if !state.valid_receiver_terminal(accepted_through) {
+                return Err(ActiveStop::Daemon(DaemonFailure::Protocol));
+            }
+            Err(ActiveStop::ClientAbort {
+                accepted: accepted_through,
+                reason,
+            })
+        }
+        MailboxEventBody::Record(_) => Err(ActiveStop::Daemon(DaemonFailure::Protocol)),
+    }
+}
+
+fn timer_stop_at_event(
+    timing: ActiveTiming,
+    stall_deadline: Instant,
+    received_at: Instant,
+    event_wins_tie: bool,
+) -> Option<ActiveStop> {
+    let deadline_expired = if event_wins_tie {
+        received_at > timing.absolute_deadline
+    } else {
+        received_at >= timing.absolute_deadline
+    };
+    if deadline_expired {
+        return Some(ActiveStop::Daemon(DaemonFailure::Deadline {
+            budget_ms: timing.budget_ms,
+        }));
+    }
+    let stall_expired = if event_wins_tie {
+        received_at > stall_deadline
+    } else {
+        received_at >= stall_deadline
+    };
+    stall_expired.then_some(ActiveStop::Daemon(DaemonFailure::Stall))
+}
+
+fn timer_stop(timing: ActiveTiming, stall_deadline: Instant, now: Instant) -> Option<ActiveStop> {
+    if now >= timing.absolute_deadline {
+        Some(ActiveStop::Daemon(DaemonFailure::Deadline {
+            budget_ms: timing.budget_ms,
+        }))
+    } else if now >= stall_deadline {
+        Some(ActiveStop::Daemon(DaemonFailure::Stall))
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivePoll {
+    Event,
+    Idle,
+}
+
+fn sequence_active_stop_locked(ingress: &StreamIngress, stop: ActiveStop) {
+    match stop {
+        ActiveStop::ClientAbort { .. } => {
+            ingress.set_phase_locked(BindingPhase::ClientAbortPending)
+        }
+        ActiveStop::Daemon(_) => ingress.set_phase_locked(BindingPhase::DaemonAbortQueued),
+        ActiveStop::TransportLost => ingress.data_live.store(false, Ordering::Release),
+    }
+}
+
+/// Atomically observes the next routed record or claims an expired timer.
+/// Routing, OPEN/DATA/END writer starts, and this decision all use the same
+/// sequencing lock, so a progress CREDIT or valid client ABORT cannot be
+/// hidden merely because the actor was descheduled at the boundary.
+fn poll_active(
+    binding: &StreamBinding,
+    state: &mut ProducerState,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> Result<ActivePoll, ActiveStop> {
+    let _sequencing = binding
+        .ingress
+        .sequencing
+        .lock()
+        .expect("stream sequencing poisoned");
+    if let Some(event) = binding.ingress.mailbox.try_recv() {
+        match apply_active_event_with_timers(state, event, stall_deadline, timing) {
+            Ok(()) => return Ok(ActivePoll::Event),
+            Err(stop) => {
+                sequence_active_stop_locked(&binding.ingress, stop);
+                return Err(stop);
+            }
+        }
+    }
+    if binding.ingress.mailbox.is_closed() {
+        let stop = ActiveStop::TransportLost;
+        sequence_active_stop_locked(&binding.ingress, stop);
+        return Err(stop);
+    }
+    if let Some(stop) = timer_stop(timing, *stall_deadline, Instant::now()) {
+        sequence_active_stop_locked(&binding.ingress, stop);
+        return Err(stop);
+    }
+    Ok(ActivePoll::Idle)
+}
+
+/// Sequences a non-timer local failure after giving every already-routed
+/// record its deterministic earlier opportunity. Source/codec failures do not
+/// become a scheduling shortcut around a client ABORT that already arrived.
+fn claim_local_stop(
+    binding: &StreamBinding,
+    state: &mut ProducerState,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+    candidate: ActiveStop,
+) -> ActiveStop {
+    let _sequencing = binding
+        .ingress
+        .sequencing
+        .lock()
+        .expect("stream sequencing poisoned");
+    if BindingPhase::load(&binding.ingress.phase) != BindingPhase::Active {
+        return candidate;
+    }
+    while let Some(event) = binding.ingress.mailbox.try_recv() {
+        if let Err(stop) = apply_active_event_with_timers(state, event, stall_deadline, timing) {
+            sequence_active_stop_locked(&binding.ingress, stop);
+            return stop;
+        }
+    }
+    sequence_active_stop_locked(&binding.ingress, candidate);
+    candidate
+}
+
+fn apply_active_event_with_timers(
+    state: &mut ProducerState,
+    event: MailboxEvent,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> Result<(), ActiveStop> {
+    // Only a semantically valid peer ABORT wins a timer tie. Merely carrying
+    // the ABORT kind is insufficient: an invalid reason or high-water mark is
+    // malformed input, so deadline then stall retains priority over it.
+    let received_at = event.received_at;
+    if matches!(
+        &event.body,
+        MailboxEventBody::Record(StreamRecordBody::Abort { .. })
+    ) {
+        let result = apply_active_event(state, event, stall_deadline, timing.limits);
+        let valid_client_abort = matches!(result, Err(ActiveStop::ClientAbort { .. }));
+        if let Some(stop) =
+            timer_stop_at_event(timing, *stall_deadline, received_at, valid_client_abort)
+        {
+            return Err(stop);
+        }
+        return result;
+    }
+    if let Some(stop) = timer_stop_at_event(timing, *stall_deadline, received_at, false) {
+        return Err(stop);
+    }
+    apply_active_event(state, event, stall_deadline, timing.limits)
+}
+
+async fn await_active<F, T>(
+    operation: F,
+    binding: &StreamBinding,
+    state: &mut ProducerState,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> Result<T, ActiveStop>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::pin!(operation);
+    loop {
+        match poll_active(binding, state, stall_deadline, timing)? {
+            ActivePoll::Event => continue,
+            ActivePoll::Idle => {}
+        }
+        tokio::select! {
+            biased;
+            () = binding.ingress.mailbox.wait_ready() => {}
+            () = tokio::time::sleep_until(timing.absolute_deadline) => {}
+            () = tokio::time::sleep_until(*stall_deadline) => {}
+            output = &mut operation => return Ok(output),
+        }
+    }
+}
+
+async fn await_active_stop(
+    binding: &StreamBinding,
+    state: &mut ProducerState,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> ActiveStop {
+    match await_active(
+        std::future::pending::<()>(),
+        binding,
+        state,
+        stall_deadline,
+        timing,
+    )
+    .await
+    {
+        Err(stop) => stop,
+        Ok(()) => unreachable!("a pending operation cannot complete"),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ActiveTiming {
+    absolute_deadline: Instant,
+    budget_ms: u64,
+    limits: RuntimeLimits,
+}
+
+async fn await_data_write(
+    receipt: PendingWrite,
+    binding: &StreamBinding,
+    state: &mut ProducerState,
+    payload_bytes: usize,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> Result<WriteReceipt, ActiveStop> {
+    let cancellation = receipt.cancellation();
+    let receipt = receipt.wait();
+    tokio::pin!(receipt);
+    // Do not dequeue CREDIT/ABORT until the older DATA write is reconciled.
+    // A peer can observe and acknowledge DATA while the local sink flush is
+    // still pending; validating that acknowledgement against the old `sent`
+    // high-water mark would be a false protocol fault. ABORT/fault routing
+    // still lowers `data_live` immediately, so DATA not yet started is
+    // discarded. The writer owns an independent finite send watchdog, making
+    // this receipt wait bounded even if the socket sink stops draining.
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut receipt => {
+                if result == WriteReceipt::Sent {
+                    state
+                        .data_sent(payload_bytes)
+                        .map_err(|()| ActiveStop::Daemon(DaemonFailure::Protocol))?;
+                }
+                return Ok(result);
+            }
+            () = binding.ingress.mailbox.wait_ready() => {
+                if !binding.ingress.data_live.load(Ordering::Acquire) {
+                    if cancellation.cancel_before_start() {
+                        return Ok(WriteReceipt::Discarded);
+                    }
+                    // Writer start won. Its independently bounded receipt is
+                    // the only proof whether this older DATA became visible;
+                    // reconcile it before applying the terminal record.
+                    let result = (&mut receipt).await;
+                    if result == WriteReceipt::Sent {
+                        state
+                            .data_sent(payload_bytes)
+                            .map_err(|()| ActiveStop::Daemon(DaemonFailure::Protocol))?;
+                    }
+                    return Ok(result);
+                }
+            }
+            () = tokio::time::sleep_until(timing.absolute_deadline) => {
+                binding.ingress.stop_active_data();
+                if cancellation.cancel_before_start() {
+                    return Ok(WriteReceipt::Discarded);
+                }
+                // A DATA whose writer start preceded the deadline is older
+                // than the terminal decision and must drain. The main actor
+                // then applies timestamped ABORT/CREDIT before choosing the
+                // deadline result.
+                let result = (&mut receipt).await;
+                if result == WriteReceipt::Sent {
+                    state
+                        .data_sent(payload_bytes)
+                        .map_err(|()| ActiveStop::Daemon(DaemonFailure::Protocol))?;
+                }
+                return Ok(result);
+            }
+            () = tokio::time::sleep_until(*stall_deadline) => {
+                if cancellation.cancel_before_start() {
+                    return Ok(WriteReceipt::Discarded);
+                }
+                // If writer start already won, a client may have observed and
+                // acknowledged this DATA just before the stall boundary.
+                // Reconcile the write, then let ingress timestamps decide.
+                let result = (&mut receipt).await;
+                if result == WriteReceipt::Sent {
+                    state
+                        .data_sent(payload_bytes)
+                        .map_err(|()| ActiveStop::Daemon(DaemonFailure::Protocol))?;
+                }
+                return Ok(result);
+            }
+        }
+    }
+}
+
+struct StreamTerminalContext<'a> {
+    outbound: &'a Outbound,
+    binding: &'a StreamBinding,
+    bounds: &'a CodecBounds,
+    closer: &'a ConnectionCloser,
+}
+
+async fn send_stream_control_until(
+    context: &StreamTerminalContext<'_>,
+    bytes: Vec<u8>,
+    deadline: Instant,
+) -> WriteReceipt {
+    let write_live = Arc::new(AtomicBool::new(true));
+    let attempt = Arc::new(AtomicU8::new(CONTROL_ATTEMPT_QUEUED));
+    let start_attempt = attempt.clone();
+    let write = context
+        .outbound
+        .binary_control_with_start(bytes, write_live.clone(), move || {
+            start_attempt
+                .compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_STARTED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+        });
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => receipt,
+        () = tokio::time::sleep_until(deadline) => {
+            if attempt.compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ).is_ok() {
+                write_live.store(false, Ordering::Release);
+                WriteReceipt::Closed
+            } else {
+                // Writer start won, so this control may be peer-visible. Its
+                // independent writer watchdog bounds the reconciliation.
+                write.await
+            }
+        }
+    }
+}
+
+async fn send_client_abort_ack_until(
+    context: &StreamTerminalContext<'_>,
+    bytes: Vec<u8>,
+    deadline: Instant,
+    retirement: StreamRetirement,
+) -> ClientAbortAckOutcome {
+    let attempt_live = Arc::new(AtomicBool::new(true));
+    let commit_live = attempt_live.clone();
+    let ingress = context.binding.ingress.clone();
+    let cancel_ingress = context.binding.ingress.clone();
+    let cancel_live = attempt_live.clone();
+    let write = context.outbound.binary_control_with_hooks(
+        bytes,
+        attempt_live,
+        move || ingress.try_sequence_client_abort_ack(&commit_live, deadline),
+        move || retirement.retire_client_abort_ack(),
+    );
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => match receipt {
+            WriteReceipt::Sent => cancel_ingress.classify_client_abort_ack_sent(),
+            WriteReceipt::Discarded => cancel_ingress.classify_client_abort_ack_discard(),
+            WriteReceipt::Closed => ClientAbortAckOutcome::Failed,
+        },
+        () = tokio::time::sleep_until(deadline) => {
+            match cancel_ingress.cancel_client_abort_ack_attempt(&cancel_live) {
+                ClientAbortAckCancel::Committed => {
+                    if write.await == WriteReceipt::Sent {
+                        cancel_ingress.classify_client_abort_ack_sent()
+                    } else {
+                        ClientAbortAckOutcome::Failed
+                    }
+                }
+                ClientAbortAckCancel::ProtocolFault => {
+                    ClientAbortAckOutcome::ProtocolFaultBeforeSent
+                }
+                ClientAbortAckCancel::Cancelled => ClientAbortAckOutcome::Failed,
+            }
+        }
+    }
+}
+
+async fn send_phase_control_until(
+    context: &StreamTerminalContext<'_>,
+    bytes: Vec<u8>,
+    deadline: Instant,
+) -> WriteReceipt {
+    let attempt_live = Arc::new(AtomicBool::new(true));
+    let commit_live = attempt_live.clone();
+    let ingress = context.binding.ingress.clone();
+    let cancel_ingress = context.binding.ingress.clone();
+    let cancel_live = attempt_live.clone();
+    let write = context
+        .outbound
+        .binary_control_with_start(bytes, attempt_live, move || {
+            ingress.try_sequence_open(&commit_live, deadline)
+        });
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => receipt,
+        () = tokio::time::sleep_until(deadline) => {
+            if cancel_ingress.cancel_open_attempt(&cancel_live) {
+                // OPEN won the atomic writer-start race. Reconcile its bounded
+                // socket receipt; the caller then runs the admitted stream's
+                // deadline ABORT path rather than a pre-OPEN refusal.
+                write.await
+            } else {
+                WriteReceipt::Discarded
+            }
+        }
+    }
+}
+
+async fn send_daemon_abort_until(
+    context: &StreamTerminalContext<'_>,
+    bytes: Vec<u8>,
+    deadline: Instant,
+) -> WriteReceipt {
+    let attempt_live = Arc::new(AtomicBool::new(true));
+    let commit_live = attempt_live.clone();
+    let ingress = context.binding.ingress.clone();
+    let cancel_ingress = context.binding.ingress.clone();
+    let cancel_live = attempt_live.clone();
+    let write = context
+        .outbound
+        .binary_control_with_start(bytes, attempt_live, move || {
+            ingress.try_sequence_daemon_abort(&commit_live, deadline)
+        });
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => receipt,
+        () = tokio::time::sleep_until(deadline) => {
+            if cancel_ingress.cancel_daemon_abort_attempt(&cancel_live) {
+                // Writer start won atomically. Reconcile the bounded socket
+                // receipt; ACK is trustworthy only after this transition.
+                write.await
+            } else {
+                WriteReceipt::Discarded
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_end_while_active(
+    context: &StreamTerminalContext<'_>,
+    bytes: Vec<u8>,
+    state: &mut ProducerState,
+    reservation: Arc<Mutex<Option<TransferReservation>>>,
+    stall_deadline: &mut Instant,
+    timing: ActiveTiming,
+) -> Result<WriteReceipt, ActiveStop> {
+    'attempt: loop {
+        match poll_active(context.binding, state, stall_deadline, timing)? {
+            ActivePoll::Event => continue,
+            ActivePoll::Idle => {}
+        }
+
+        let attempt_live = Arc::new(AtomicBool::new(true));
+        let commit_live = attempt_live.clone();
+        let ingress = context.binding.ingress.clone();
+        let release_on_commit = reservation.clone();
+        let end_stall_deadline = *stall_deadline;
+        let absolute_deadline = timing.absolute_deadline;
+        let final_through = state.accepted;
+        let write = context.outbound.binary_control_with_start(
+            bytes.clone(),
+            attempt_live.clone(),
+            move || {
+                if !ingress.try_sequence_end(
+                    &commit_live,
+                    absolute_deadline,
+                    end_stall_deadline,
+                    final_through,
+                ) {
+                    return false;
+                }
+                drop(
+                    release_on_commit
+                        .lock()
+                        .expect("transfer reservation poisoned")
+                        .take(),
+                );
+                true
+            },
+        );
+        tokio::pin!(write);
+
+        loop {
+            tokio::select! {
+                biased;
+                receipt = &mut write => {
+                    if receipt == WriteReceipt::Discarded {
+                        if context.binding.phase() == BindingPhase::Active
+                            && context.binding.ingress.data_live.load(Ordering::Acquire)
+                        {
+                            // A record was queued under ACTIVE before the writer
+                            // could commit END. Drain and validate it first; an
+                            // idempotent CREDIT permits a fresh END attempt.
+                            continue 'attempt;
+                        }
+                        // An earlier terminal lowered `data_live`; consume its
+                        // sequenced event to choose the exact terminal result.
+                        return Err(
+                            await_active_stop(context.binding, state, stall_deadline, timing).await,
+                        );
+                    }
+                    return Ok(receipt);
+                }
+                () = context.binding.ingress.mailbox.wait_ready() => {
+                    // Coalesced/identical CREDIT deliberately creates no new
+                    // event, but a stale Notify permit can remain after the
+                    // pre-attempt drain. It must not cancel a valid END.
+                    if !context.binding.ingress.mailbox.has_pending() {
+                        continue;
+                    }
+                    if context.binding.ingress.cancel_end_attempt(&attempt_live) {
+                        return Ok(write.await);
+                    }
+                    continue 'attempt;
+                }
+                () = tokio::time::sleep_until(timing.absolute_deadline) => {
+                    if context.binding.ingress.cancel_end_attempt(&attempt_live) {
+                        return Ok(write.await);
+                    }
+                    continue 'attempt;
+                }
+                () = tokio::time::sleep_until(*stall_deadline) => {
+                    if context.binding.ingress.cancel_end_attempt(&attempt_live) {
+                        return Ok(write.await);
+                    }
+                    continue 'attempt;
+                }
+            }
+        }
+    }
+}
+
+fn stream_record(
+    identity: StreamIdentity,
+    body: StreamRecordBody,
+    bounds: &CodecBounds,
+) -> Option<Vec<u8>> {
+    encode_stream_record(&StreamRecord { identity, body }, bounds).ok()
+}
+
+fn reply_bytes(id: u64, result: Result<&FileReadOut, ApiError>) -> Vec<u8> {
+    let reply = match result {
+        Ok(out) => jeliya_codec::Reply {
+            id,
+            ok: true,
+            out: serde_json::to_value(out).ok(),
+            err: None,
+        },
+        Err(err) => jeliya_codec::Reply {
+            id,
+            ok: false,
+            out: None,
+            err: Some(err),
+        },
+    };
+    reply.to_bytes()
+}
+
+async fn send_reply(
+    outbound: &Outbound,
+    id: u64,
+    result: Result<&FileReadOut, ApiError>,
+    request: &RequestLease,
+) -> bool {
+    let release = request.clone();
+    outbound
+        .text_with_on_sent(reply_bytes(id, result), move || release.release())
+        .await
+        == WriteReceipt::Sent
+}
+
+async fn send_reply_until(
+    outbound: &Outbound,
+    id: u64,
+    result: Result<&FileReadOut, ApiError>,
+    deadline: Instant,
+    request: &RequestLease,
+    retirement: Option<StreamRetirement>,
+) -> bool {
+    let write_live = Arc::new(AtomicBool::new(true));
+    let attempt = Arc::new(AtomicU8::new(CONTROL_ATTEMPT_QUEUED));
+    let start_attempt = attempt.clone();
+    let release = request.clone();
+    let write = outbound.text_with_hooks(
+        reply_bytes(id, result),
+        write_live.clone(),
+        move || {
+            start_attempt
+                .compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_STARTED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+        },
+        move || {
+            if let Some(retirement) = retirement {
+                retirement.retire();
+            }
+            release.release();
+        },
+    );
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => {
+            receipt == WriteReceipt::Sent
+        }
+        () = tokio::time::sleep_until(deadline) => {
+            if attempt.compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ).is_ok() {
+                write_live.store(false, Ordering::Release);
+                false
+            } else {
+                write.await == WriteReceipt::Sent
+            }
+        }
+    }
+}
+
+fn daemon_error(failure: DaemonFailure, transferred: u64, total: u64) -> ApiError {
+    match failure {
+        DaemonFailure::Source => ApiError::StreamAborted {
+            transferred_bytes: transferred,
+            total: known_total(total),
+            reason: StreamAbortReason::SourceFailed,
+        },
+        DaemonFailure::Protocol => ApiError::MalformedFrame,
+        DaemonFailure::Deadline { budget_ms } => ApiError::TransferDeadlineExceeded {
+            transferred_bytes: transferred,
+            total: known_total(total),
+            budget_ms,
+        },
+        DaemonFailure::Stall => ApiError::TransferStalled {
+            transferred_bytes: transferred,
+            total: known_total(total),
+        },
+    }
+}
+
+fn daemon_abort_reason(failure: DaemonFailure) -> BinaryAbortReason {
+    match failure {
+        DaemonFailure::Source => BinaryAbortReason::SourceFailed,
+        DaemonFailure::Protocol => BinaryAbortReason::ProtocolError,
+        DaemonFailure::Deadline { .. } | DaemonFailure::Stall => BinaryAbortReason::OperationError,
+    }
+}
+
+fn signal_transport_close(closer: &ConnectionCloser) {
+    closer.malformed();
+}
+
+async fn finish_client_abort(
+    context: StreamTerminalContext<'_>,
+    id: u64,
+    request: &RequestLease,
+    state: &ProducerState,
+    accepted: u64,
+    reason: StreamAbortReason,
+    write_timeout: Duration,
+) -> bool {
+    let Some(ack) = stream_record(
+        context.binding.identity(),
+        StreamRecordBody::Ack {
+            accepted_through: accepted,
+        },
+        context.bounds,
+    ) else {
+        return false;
+    };
+    let ack_deadline = Instant::now()
+        .checked_add(write_timeout)
+        .expect("served stall duration was validated");
+    let retirement = context.binding.retirement();
+    match send_client_abort_ack_until(&context, ack, ack_deadline, retirement).await {
+        ClientAbortAckOutcome::Sent => {}
+        ClientAbortAckOutcome::ProtocolFaultBeforeSent => {
+            // A second ABORT, CREDIT, or malformed record followed the first
+            // client ABORT before its ACK committed. Consume that latched
+            // fault, promote to a crossed daemon protocol ABORT, and still
+            // satisfy the ACK owed for the first client terminal.
+            while context.binding.ingress.mailbox.try_recv().is_some() {}
+            return finish_daemon_abort(
+                context,
+                id,
+                request,
+                state,
+                DaemonFailure::Protocol,
+                write_timeout,
+                Some(accepted),
+            )
+            .await;
+        }
+        ClientAbortAckOutcome::ProtocolFaultAfterSent => {
+            // The first client ABORT's ACK is already peer-visible, but the
+            // exact pair stayed bound while that ACK flushed. Promote the
+            // latched follow-up record without emitting a duplicate ACK.
+            while context.binding.ingress.mailbox.try_recv().is_some() {}
+            return finish_daemon_abort(
+                context,
+                id,
+                request,
+                state,
+                DaemonFailure::Protocol,
+                write_timeout,
+                None,
+            )
+            .await;
+        }
+        ClientAbortAckOutcome::Failed => {
+            signal_transport_close(context.closer);
+            return false;
+        }
+    }
+    let reply_deadline = Instant::now()
+        .checked_add(write_timeout)
+        .expect("served stall duration was validated");
+    let replied = send_reply_until(
+        context.outbound,
+        id,
+        Err(ApiError::StreamAborted {
+            transferred_bytes: accepted,
+            total: known_total(state.total),
+            reason,
+        }),
+        reply_deadline,
+        request,
+        None,
+    )
+    .await;
+    if !replied {
+        signal_transport_close(context.closer);
+    }
+    replied
+}
+
+enum DaemonAckPoll {
+    Event(MailboxEvent),
+    Idle,
+    TimedOut,
+    Closed,
+}
+
+/// Atomically chooses the next daemon-ABORT handshake record or its timeout.
+/// Inbound routing uses this same sequencing lock, so an ACK cannot be
+/// timestamped in time between an empty mailbox observation and a separate
+/// timeout decision.
+fn poll_daemon_ack(binding: &StreamBinding, ack_deadline: Instant) -> DaemonAckPoll {
+    let _sequencing = binding
+        .ingress
+        .sequencing
+        .lock()
+        .expect("stream sequencing poisoned");
+    if let Some(event) = binding.ingress.mailbox.try_recv() {
+        return DaemonAckPoll::Event(event);
+    }
+    if binding.ingress.mailbox.is_closed() {
+        return DaemonAckPoll::Closed;
+    }
+    if Instant::now() >= ack_deadline {
+        return DaemonAckPoll::TimedOut;
+    }
+    DaemonAckPoll::Idle
+}
+
+async fn send_receiver_abort_ack(
+    context: &StreamTerminalContext<'_>,
+    accepted_through: u64,
+    ack_deadline: Instant,
+) -> bool {
+    let Some(ack) = stream_record(
+        context.binding.identity(),
+        StreamRecordBody::Ack { accepted_through },
+        context.bounds,
+    ) else {
+        return false;
+    };
+    send_stream_control_until(context, ack, ack_deadline).await == WriteReceipt::Sent
+}
+
+/// A later malformed/duplicate record may collapse a queued crossed ABORT
+/// into one mailbox fault. Preserve and discharge that first terminal's ACK
+/// obligation before ending the daemon-ABORT handshake.
+async fn acknowledge_retained_fault_abort(
+    context: &StreamTerminalContext<'_>,
+    state: &ProducerState,
+    ack_deadline: Instant,
+) -> bool {
+    let Some((received_at, accepted_through, reason)) =
+        context.binding.ingress.mailbox.take_fault_abort()
+    else {
+        return true;
+    };
+    if received_at > ack_deadline
+        || !matches!(
+            reason,
+            BinaryAbortReason::Cancelled
+                | BinaryAbortReason::SinkFailed
+                | BinaryAbortReason::ProtocolError
+        )
+        || !state.valid_receiver_terminal(accepted_through)
+    {
+        return true;
+    }
+    send_receiver_abort_ack(context, accepted_through, ack_deadline).await
+}
+
+async fn finish_daemon_abort(
+    context: StreamTerminalContext<'_>,
+    id: u64,
+    request: &RequestLease,
+    state: &ProducerState,
+    failure: DaemonFailure,
+    ack_timeout: Duration,
+    crossed_client_abort: Option<u64>,
+) -> bool {
+    context.binding.set_phase(BindingPhase::DaemonAbortQueued);
+    let Some(abort) = stream_record(
+        context.binding.identity(),
+        StreamRecordBody::Abort {
+            accepted_through: state.accepted,
+            reason: daemon_abort_reason(failure),
+        },
+        context.bounds,
+    ) else {
+        return false;
+    };
+    let abort_deadline = Instant::now()
+        .checked_add(ack_timeout)
+        .expect("served stall duration was validated");
+    if send_daemon_abort_until(&context, abort, abort_deadline).await != WriteReceipt::Sent {
+        signal_transport_close(context.closer);
+        return false;
+    }
+
+    let ack_deadline = Instant::now()
+        .checked_add(ack_timeout)
+        .expect("served stall duration was validated");
+    if let Some(accepted_through) = crossed_client_abort {
+        if !send_receiver_abort_ack(&context, accepted_through, ack_deadline).await {
+            signal_transport_close(context.closer);
+            return false;
+        }
+    } else if !acknowledge_retained_fault_abort(&context, state, ack_deadline).await {
+        signal_transport_close(context.closer);
+        return false;
+    }
+    let mut terminal_state = state.clone();
+    let mut transferred = None;
+    loop {
+        match poll_daemon_ack(context.binding, ack_deadline) {
+            DaemonAckPoll::Event(event) => {
+                let received_in_time = event.received_at <= ack_deadline;
+                match event.body {
+                    MailboxEventBody::Record(StreamRecordBody::Ack { accepted_through })
+                        if received_in_time
+                            && terminal_state.valid_receiver_terminal(accepted_through) =>
+                    {
+                        transferred = Some(accepted_through);
+                        break;
+                    }
+                    MailboxEventBody::Record(StreamRecordBody::Abort {
+                        accepted_through,
+                        reason,
+                    }) if received_in_time
+                        && matches!(
+                            reason,
+                            BinaryAbortReason::Cancelled
+                                | BinaryAbortReason::SinkFailed
+                                | BinaryAbortReason::ProtocolError
+                        )
+                        && terminal_state.valid_receiver_terminal(accepted_through) =>
+                    {
+                        // Crossed ABORT: the daemon's already-chosen terminal is
+                        // authoritative, but the peer's ABORT still gets its own
+                        // explicit ACK before we continue waiting for ours.
+                        if !send_receiver_abort_ack(&context, accepted_through, ack_deadline).await
+                        {
+                            break;
+                        }
+                    }
+                    MailboxEventBody::Record(StreamRecordBody::Credit {
+                        accepted_through,
+                        send_through,
+                    }) if received_in_time
+                        && terminal_state
+                            .credit(accepted_through, send_through)
+                            .is_ok() => {}
+                    MailboxEventBody::Malformed => {
+                        let _ = acknowledge_retained_fault_abort(
+                            &context,
+                            &terminal_state,
+                            ack_deadline,
+                        )
+                        .await;
+                        break;
+                    }
+                    _ => break,
+                }
+                continue;
+            }
+            DaemonAckPoll::TimedOut | DaemonAckPoll::Closed => break,
+            DaemonAckPoll::Idle => {}
+        }
+        tokio::select! {
+            biased;
+            () = context.binding.ingress.mailbox.wait_ready() => {}
+            () = tokio::time::sleep_until(ack_deadline) => {}
+        }
+    }
+
+    let acknowledged = transferred.is_some();
+    let transferred = transferred.unwrap_or(terminal_state.accepted);
+    // ACK (or its bounded timeout) is the binding retirement point. The
+    // request id remains separately outstanding through the Text reply.
+    context.binding.retire();
+    let reply_deadline = Instant::now()
+        .checked_add(ack_timeout)
+        .expect("served stall duration was validated");
+    let replied = send_reply_until(
+        context.outbound,
+        id,
+        Err(daemon_error(failure, transferred, state.total)),
+        reply_deadline,
+        request,
+        None,
+    )
+    .await;
+    if !acknowledged || !replied {
+        signal_transport_close(context.closer);
+    }
+    replied
+}
+
+/// Execute one complete producer-direction `file.read` request.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_file_read(
+    engine: Arc<Engine>,
+    request: FileRead,
+    id: u64,
+    request_permit: RequestPermit,
+    outbound: Outbound,
+    registry: StreamRegistry,
+    stream_ids: Arc<Mutex<StreamIdGenerator>>,
+    transfer_pool: TransferPool,
+    limits: RuntimeLimits,
+    closer: ConnectionCloser,
+) -> bool {
+    let request_lease = RequestLease::new(request_permit);
+    let prepared = match engine.prepare_file_read(&request).await {
+        Ok(prepared) => prepared,
+        Err(error) => return send_reply(&outbound, id, Err(error), &request_lease).await,
+    };
+    let metadata = prepared.out;
+    let total = metadata.bytes;
+
+    // Successful reservation is the transfer's admission instant. Source
+    // setup follows it and is charged to the checked absolute budget.
+    let admitted_at = Instant::now();
+    let reservation = match transfer_pool.reserve(total) {
+        Ok(reservation) => reservation,
+        Err(error) => return send_reply(&outbound, id, Err(error), &request_lease).await,
+    };
+    let mut reservation = Some(reservation);
+    let (absolute_deadline, budget_ms) = match limits.deadline(admitted_at, total) {
+        Ok(deadline) => deadline,
+        Err(_) => {
+            drop(reservation.take());
+            return send_reply(&outbound, id, Err(ApiError::NotReady), &request_lease).await;
+        }
+    };
+
+    let source = tokio::select! {
+        biased;
+        () = tokio::time::sleep_until(absolute_deadline) => {
+            drop(reservation.take());
+            return send_reply(
+                &outbound,
+                id,
+                Err(ApiError::TransferDeadlineExceeded {
+                    transferred_bytes: 0,
+                    total: known_total(total),
+                    budget_ms,
+                }),
+                &request_lease,
+            )
+            .await;
+        }
+        opened = prepared.source.open() => match opened {
+            Ok(source) => source,
+            Err(_) => {
+                drop(reservation.take());
+                return send_reply(
+                    &outbound,
+                    id,
+                    Err(ApiError::FileNotFetched {
+                        file_id: request.file_id.clone(),
+                    }),
+                    &request_lease,
+                )
+                .await;
+            }
+        }
+    };
+
+    let identity_result = {
+        let mut generator = stream_ids.lock().expect("stream id generator poisoned");
+        generator.next(id)
+    };
+    let identity = match identity_result {
+        Ok(identity) => identity,
+        Err(_) => {
+            drop(source);
+            drop(reservation.take());
+            return send_reply(&outbound, id, Err(ApiError::NotReady), &request_lease).await;
+        }
+    };
+    let Some(binding) = registry.bind(identity) else {
+        drop(source);
+        drop(reservation.take());
+        return send_reply(&outbound, id, Err(ApiError::NotReady), &request_lease).await;
+    };
+    let bounds = CodecBounds {
+        max_frame_bytes: limits.max_frame_bytes(),
+        ..CodecBounds::default()
+    };
+    let Some(open) = stream_record(identity, StreamRecordBody::Open { total }, &bounds) else {
+        binding.retire();
+        drop(source);
+        drop(reservation.take());
+        return send_reply(&outbound, id, Err(ApiError::NotReady), &request_lease).await;
+    };
+    if Instant::now() >= absolute_deadline {
+        binding.ingress.data_live.store(false, Ordering::Release);
+        binding.retire();
+        drop(source);
+        drop(reservation.take());
+        let reply_deadline = limits
+            .stall_deadline(Instant::now())
+            .expect("served stall duration was validated");
+        return send_reply_until(
+            &outbound,
+            id,
+            Err(ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 0,
+                total: known_total(total),
+                budget_ms,
+            }),
+            reply_deadline,
+            &request_lease,
+            None,
+        )
+        .await;
+    }
+    let open_result = send_phase_control_until(
+        &StreamTerminalContext {
+            outbound: &outbound,
+            binding: &binding,
+            bounds: &bounds,
+            closer: &closer,
+        },
+        open,
+        absolute_deadline,
+    )
+    .await;
+    match open_result {
+        WriteReceipt::Sent => debug_assert_eq!(binding.phase(), BindingPhase::Active),
+        WriteReceipt::Discarded if binding.phase() == BindingPhase::Opening => {
+            let opening_fatal = binding.ingress.opening_fatal.load(Ordering::Acquire);
+            binding.retire();
+            drop(source);
+            drop(reservation.take());
+            if opening_fatal {
+                // The connection owner has already selected the mandatory
+                // uncorrelated 4007 path. Do not race it with a Text reply.
+                closer.malformed();
+                return false;
+            }
+            let reply_deadline = limits
+                .stall_deadline(Instant::now())
+                .expect("served stall duration was validated");
+            let replied = send_reply_until(
+                &outbound,
+                id,
+                Err(ApiError::TransferDeadlineExceeded {
+                    transferred_bytes: 0,
+                    total: known_total(total),
+                    budget_ms,
+                }),
+                reply_deadline,
+                &request_lease,
+                None,
+            )
+            .await;
+            if !replied {
+                signal_transport_close(&closer);
+            }
+            return replied;
+        }
+        WriteReceipt::Discarded | WriteReceipt::Closed => {
+            closer.malformed();
+            return false;
+        }
+    }
+
+    let mut source = Some(source);
+    let reservation = Arc::new(Mutex::new(reservation));
+    let mut state = ProducerState::new(total);
+    let mut stall_deadline = limits
+        .stall_deadline(Instant::now())
+        .expect("served stall duration was validated");
+    let timing = ActiveTiming {
+        absolute_deadline,
+        budget_ms,
+        limits,
+    };
+
+    let stop = 'active: loop {
+        match poll_active(&binding, &mut state, &mut stall_deadline, timing) {
+            Ok(ActivePoll::Event) => continue,
+            Ok(ActivePoll::Idle) => {}
+            Err(stop) => break stop,
+        }
+
+        if state.ready_for_end() {
+            let verify = source
+                .take()
+                .expect("active stream owns its source")
+                .verify_eof();
+            match await_active(verify, &binding, &mut state, &mut stall_deadline, timing).await {
+                Ok(Ok(())) => {
+                    let Some(end) =
+                        stream_record(identity, StreamRecordBody::End { total }, &bounds)
+                    else {
+                        return false;
+                    };
+                    match send_end_while_active(
+                        &StreamTerminalContext {
+                            outbound: &outbound,
+                            binding: &binding,
+                            bounds: &bounds,
+                            closer: &closer,
+                        },
+                        end,
+                        &mut state,
+                        reservation.clone(),
+                        &mut stall_deadline,
+                        timing,
+                    )
+                    .await
+                    {
+                        Ok(WriteReceipt::Sent) => {}
+                        Ok(WriteReceipt::Closed) | Err(ActiveStop::TransportLost) => {
+                            closer.malformed();
+                            return false;
+                        }
+                        Ok(WriteReceipt::Discarded) => {
+                            unreachable!("discarded END resolves to its active stop")
+                        }
+                        Err(stop) => break stop,
+                    }
+                    // END's writer acknowledgement is the ordering barrier:
+                    // only now may the terminal success Text reply be queued.
+                    let reply_deadline = limits
+                        .stall_deadline(Instant::now())
+                        .expect("served stall duration was validated");
+                    let replied = send_reply_until(
+                        &outbound,
+                        id,
+                        Ok(&metadata),
+                        reply_deadline,
+                        &request_lease,
+                        Some(binding.retirement()),
+                    )
+                    .await;
+                    if !replied {
+                        signal_transport_close(&closer);
+                    }
+                    return replied;
+                }
+                Ok(Err(_)) => break ActiveStop::Daemon(DaemonFailure::Source),
+                Err(stop) => break stop,
+            }
+        }
+
+        if let Some(payload_bytes) = state.next_payload(limits.max_data_payload_bytes()) {
+            let Some(record_bytes) = STREAM_HEADER_BYTES.checked_add(payload_bytes) else {
+                break ActiveStop::Daemon(DaemonFailure::Protocol);
+            };
+            let Some(data_reservation) = outbound.reserve_data(record_bytes) else {
+                // Runtime configuration reserves one complete DATA record per
+                // admitted nonempty stream; failure here indicates transport
+                // teardown rather than permission to read ahead.
+                closer.malformed();
+                return false;
+            };
+            let read = source
+                .as_mut()
+                .expect("active stream owns its source")
+                .read_chunk(NonZeroUsize::new(payload_bytes).expect("positive payload"));
+            let payload =
+                match await_active(read, &binding, &mut state, &mut stall_deadline, timing).await {
+                    Ok(Ok(Some(payload))) if payload.len() == payload_bytes => payload,
+                    Ok(Ok(_)) | Ok(Err(_)) => break ActiveStop::Daemon(DaemonFailure::Source),
+                    Err(stop) => break stop,
+                };
+
+            let offset = state.sent;
+            let payload_len = payload.len();
+            let Some(data) = stream_record(
+                identity,
+                StreamRecordBody::Data { offset, payload },
+                &bounds,
+            ) else {
+                break ActiveStop::Daemon(DaemonFailure::Protocol);
+            };
+            let data = tokio_tungstenite::tungstenite::Bytes::from(data);
+            'data: loop {
+                let data_ingress = binding.ingress.clone();
+                let data_absolute_deadline = timing.absolute_deadline;
+                let data_stall_deadline = stall_deadline;
+                let Some(receipt) = outbound.queue_data_with_start(
+                    data_reservation.clone(),
+                    data.clone(),
+                    binding.ingress.data_live.clone(),
+                    move || {
+                        data_ingress.try_start_data(data_absolute_deadline, data_stall_deadline)
+                    },
+                ) else {
+                    closer.malformed();
+                    return false;
+                };
+                match await_data_write(
+                    receipt,
+                    &binding,
+                    &mut state,
+                    payload_len,
+                    &mut stall_deadline,
+                    timing,
+                )
+                .await
+                {
+                    Ok(WriteReceipt::Sent) => continue 'active,
+                    Ok(WriteReceipt::Discarded) => {
+                        // DATA bytes and their byte permit remain retained in
+                        // this bounded actor slot. Drain every earlier inbound
+                        // record, then retry the exact same bytes and offset;
+                        // the source cursor is never advanced twice.
+                        loop {
+                            match poll_active(&binding, &mut state, &mut stall_deadline, timing) {
+                                Ok(ActivePoll::Event) => continue,
+                                Ok(ActivePoll::Idle) => break,
+                                Err(stop) => break 'active stop,
+                            }
+                        }
+                        if binding.phase() == BindingPhase::Active
+                            && binding.ingress.data_live.load(Ordering::Acquire)
+                        {
+                            continue 'data;
+                        }
+                        break 'active await_active_stop(
+                            &binding,
+                            &mut state,
+                            &mut stall_deadline,
+                            timing,
+                        )
+                        .await;
+                    }
+                    Ok(WriteReceipt::Closed) | Err(ActiveStop::TransportLost) => {
+                        closer.malformed();
+                        return false;
+                    }
+                    Err(stop) => break 'active stop,
+                }
+            }
+        }
+
+        // Correct credit pause: only transfer deadline/stall and inbound
+        // records govern it. The ordinary connection idle timer is suppressed
+        // while the registry retains this binding.
+        tokio::select! {
+            biased;
+            () = binding.ingress.mailbox.wait_ready() => {}
+            () = tokio::time::sleep_until(timing.absolute_deadline) => {}
+            () = tokio::time::sleep_until(stall_deadline) => {}
+        }
+    };
+
+    let stop = claim_local_stop(&binding, &mut state, &mut stall_deadline, timing, stop);
+
+    // The local terminal decision releases source and both admission
+    // resources before any ABORT acknowledgement wait.
+    binding.ingress.stop_active_data();
+    drop(source.take());
+    drop(
+        reservation
+            .lock()
+            .expect("transfer reservation poisoned")
+            .take(),
+    );
+    match stop {
+        ActiveStop::ClientAbort { accepted, reason } => {
+            finish_client_abort(
+                StreamTerminalContext {
+                    outbound: &outbound,
+                    binding: &binding,
+                    bounds: &bounds,
+                    closer: &closer,
+                },
+                id,
+                &request_lease,
+                &state,
+                accepted,
+                reason,
+                timing.limits.transfer_stall(),
+            )
+            .await
+        }
+        ActiveStop::Daemon(failure) => {
+            finish_daemon_abort(
+                StreamTerminalContext {
+                    outbound: &outbound,
+                    binding: &binding,
+                    bounds: &bounds,
+                    closer: &closer,
+                },
+                id,
+                &request_lease,
+                &state,
+                failure,
+                timing.limits.transfer_stall(),
+                None,
+            )
+            .await
+        }
+        ActiveStop::TransportLost => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+
+    use futures_util::Sink;
+    use tempfile::TempDir;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use super::*;
+
+    const REQUEST_ID: u64 = 17;
+    const STREAM_ID: u128 = 0x1111_2222_3333_4444_5555_6666_7777_8888;
+
+    fn bounds(max_frame_bytes: usize) -> CodecBounds {
+        CodecBounds {
+            max_frame_bytes,
+            ..CodecBounds::default()
+        }
+    }
+
+    /// Spec-authored raw record constructor, deliberately independent of the
+    /// implementation encoder under test.
+    fn wire(
+        kind: u8,
+        request_id: u64,
+        stream_id: u128,
+        offset: u64,
+        value: u64,
+        payload: &[u8],
+    ) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(STREAM_HEADER_BYTES + payload.len());
+        bytes.extend_from_slice(b"JBS2");
+        bytes.push(kind);
+        bytes.extend_from_slice(&[0, 0, 0]);
+        bytes.extend_from_slice(&request_id.to_be_bytes());
+        bytes.extend_from_slice(&stream_id.to_be_bytes());
+        bytes.extend_from_slice(&offset.to_be_bytes());
+        bytes.extend_from_slice(&value.to_be_bytes());
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    #[derive(Debug, Clone, Copy, Default)]
+    struct StreamedDataSummary {
+        through: u64,
+        records: usize,
+        max_payload: usize,
+        identity: Option<[u8; 24]>,
+    }
+
+    #[derive(Default)]
+    struct StreamedDataState {
+        summary: StreamedDataSummary,
+        error: Option<String>,
+    }
+
+    impl StreamedDataState {
+        fn accept(&mut self, bytes: &[u8]) -> Result<(), String> {
+            if bytes.len() <= STREAM_HEADER_BYTES {
+                return Err(format!("DATA record was too short: {}", bytes.len()));
+            }
+            if &bytes[..4] != b"JBS2" || bytes[4] != 0x02 {
+                return Err("discarded message was not a JBS2 DATA record".into());
+            }
+            if bytes[5..8] != [0, 0, 0] {
+                return Err("DATA reserved bytes were nonzero".into());
+            }
+            let identity: [u8; 24] = bytes[8..32]
+                .try_into()
+                .expect("fixed stream identity slice");
+            if self
+                .summary
+                .identity
+                .is_some_and(|expected| expected != identity)
+            {
+                return Err("DATA changed stream identity".into());
+            }
+            let offset =
+                u64::from_be_bytes(bytes[32..40].try_into().expect("fixed DATA offset slice"));
+            if offset != self.summary.through {
+                return Err(format!(
+                    "noncontiguous DATA offset {offset}, expected {}",
+                    self.summary.through
+                ));
+            }
+            if bytes[40..48] != [0; 8] {
+                return Err("DATA value field was nonzero".into());
+            }
+            let payload = &bytes[STREAM_HEADER_BYTES..];
+            if payload.iter().any(|byte| *byte != 0) {
+                return Err("sparse zero source produced a nonzero DATA byte".into());
+            }
+            let payload_len = u64::try_from(payload.len())
+                .map_err(|_| "DATA payload count was not representable".to_owned())?;
+            self.summary.through = self
+                .summary
+                .through
+                .checked_add(payload_len)
+                .ok_or_else(|| "DATA byte count overflowed".to_owned())?;
+            self.summary.records = self
+                .summary
+                .records
+                .checked_add(1)
+                .ok_or_else(|| "DATA record count overflowed".to_owned())?;
+            self.summary.max_payload = self.summary.max_payload.max(payload.len());
+            self.summary.identity = Some(identity);
+            Ok(())
+        }
+    }
+
+    struct FlushGate {
+        block_next: AtomicBool,
+        blocked: AtomicBool,
+        released: AtomicBool,
+        waker: Mutex<Option<Waker>>,
+        changed: Notify,
+    }
+
+    impl Default for FlushGate {
+        fn default() -> Self {
+            Self {
+                block_next: AtomicBool::new(false),
+                blocked: AtomicBool::new(false),
+                released: AtomicBool::new(true),
+                waker: Mutex::new(None),
+                changed: Notify::new(),
+            }
+        }
+    }
+
+    impl FlushGate {
+        fn arm(&self) {
+            assert!(!self.blocked.load(Ordering::Acquire));
+            self.released.store(false, Ordering::Release);
+            self.block_next.store(true, Ordering::Release);
+        }
+
+        fn message_started(&self) {
+            if self.block_next.swap(false, Ordering::AcqRel) {
+                self.blocked.store(true, Ordering::Release);
+                self.changed.notify_waiters();
+                self.changed.notify_one();
+            }
+        }
+
+        fn poll_flush(&self, cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+            if !self.blocked.load(Ordering::Acquire) {
+                return Poll::Ready(Ok(()));
+            }
+            if self.released.load(Ordering::Acquire) {
+                self.blocked.store(false, Ordering::Release);
+                return Poll::Ready(Ok(()));
+            }
+            *self.waker.lock().expect("flush gate poisoned") = Some(cx.waker().clone());
+            if self.released.load(Ordering::Acquire) {
+                self.blocked.store(false, Ordering::Release);
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        }
+
+        async fn wait_blocked(&self) {
+            loop {
+                let notified = self.changed.notified();
+                if self.blocked.load(Ordering::Acquire) {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        fn release(&self) {
+            self.released.store(true, Ordering::Release);
+            if let Some(waker) = self.waker.lock().expect("flush gate poisoned").take() {
+                waker.wake();
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingSink {
+        messages: Arc<Mutex<Vec<Message>>>,
+        changed: Arc<Notify>,
+        streamed_data: Option<Arc<Mutex<StreamedDataState>>>,
+        flush_gate: Arc<FlushGate>,
+    }
+
+    impl Sink<Message> for RecordingSink {
+        type Error = Infallible;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            if let (Some(streamed_data), Message::Binary(bytes)) = (&self.streamed_data, &item) {
+                if bytes.get(4) == Some(&0x02) {
+                    let mut state = streamed_data.lock().expect("streaming sink poisoned");
+                    if state.error.is_none() {
+                        if let Err(error) = state.accept(bytes) {
+                            state.error = Some(error);
+                        }
+                    }
+                    drop(state);
+                    self.changed.notify_waiters();
+                    return Ok(());
+                }
+            }
+            self.messages
+                .lock()
+                .expect("recording sink poisoned")
+                .push(item);
+            self.changed.notify_waiters();
+            self.flush_gate.message_started();
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.flush_gate.poll_flush(_cx)
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl RecordingSink {
+        fn discarding_zero_data() -> Self {
+            Self {
+                streamed_data: Some(Arc::new(Mutex::new(StreamedDataState::default()))),
+                ..Self::default()
+            }
+        }
+
+        async fn message(&self, index: usize) -> Message {
+            loop {
+                let notified = self.changed.notified();
+                if let Some(message) = self
+                    .messages
+                    .lock()
+                    .expect("recording sink poisoned")
+                    .get(index)
+                    .cloned()
+                {
+                    return message;
+                }
+                notified.await;
+            }
+        }
+
+        fn block_next_flush(&self) {
+            self.flush_gate.arm();
+        }
+
+        async fn wait_flush_blocked(&self) {
+            self.flush_gate.wait_blocked().await;
+        }
+
+        fn release_flush(&self) {
+            self.flush_gate.release();
+        }
+
+        async fn assert_no_message(&self, index: usize) {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(20), self.message(index))
+                    .await
+                    .is_err(),
+                "unexpected outbound message at index {index}"
+            );
+        }
+
+        async fn streamed_through(&self, previous: u64) -> u64 {
+            let streamed_data = self
+                .streamed_data
+                .as_ref()
+                .expect("streaming DATA capture was not configured");
+            loop {
+                let notified = self.changed.notified();
+                let through = {
+                    let state = streamed_data.lock().expect("streaming sink poisoned");
+                    if let Some(error) = &state.error {
+                        panic!("invalid streamed DATA: {error}");
+                    }
+                    state.summary.through
+                };
+                if through > previous {
+                    return through;
+                }
+                notified.await;
+            }
+        }
+
+        fn streamed_summary(&self) -> StreamedDataSummary {
+            let state = self
+                .streamed_data
+                .as_ref()
+                .expect("streaming DATA capture was not configured")
+                .lock()
+                .expect("streaming sink poisoned");
+            if let Some(error) = &state.error {
+                panic!("invalid streamed DATA: {error}");
+            }
+            state.summary
+        }
+
+        fn retained_payload_bytes(&self) -> usize {
+            self.messages
+                .lock()
+                .expect("recording sink poisoned")
+                .iter()
+                .map(|message| match message {
+                    Message::Text(text) => text.len(),
+                    Message::Binary(bytes) | Message::Ping(bytes) | Message::Pong(bytes) => {
+                        bytes.len()
+                    }
+                    Message::Close(Some(frame)) => frame.reason.len().saturating_add(2),
+                    Message::Close(None) | Message::Frame(_) => 0,
+                })
+                .sum()
+        }
+    }
+
+    struct RuntimeHarness {
+        _dir: TempDir,
+        engine: Arc<Engine>,
+        request: FileRead,
+        source_path: std::path::PathBuf,
+        limits: RuntimeLimits,
+        pool: TransferPool,
+        registry: StreamRegistry,
+        tracker: RequestTracker,
+        stream_ids: Arc<Mutex<StreamIdGenerator>>,
+        outbound: Outbound,
+        sink: RecordingSink,
+        writer: tokio::task::JoinHandle<()>,
+        closer: ConnectionCloser,
+        close_rx: watch::Receiver<bool>,
+        _close_completed_rx: watch::Receiver<bool>,
+    }
+
+    impl RuntimeHarness {
+        async fn new(payload: &[u8], max_frame_bytes: u64) -> Self {
+            Self::new_with_timers(payload, max_frame_bytes, 1_000, 1_000, 8_192).await
+        }
+
+        async fn new_sparse_zero(total: u64, max_frame_bytes: u64) -> Self {
+            Self::new_configured(None, total, max_frame_bytes, 10_000, 1_000, 8_192, true).await
+        }
+
+        async fn new_with_timers(
+            payload: &[u8],
+            max_frame_bytes: u64,
+            stall_ms: u64,
+            connect_ms: u64,
+            floor_bps: u64,
+        ) -> Self {
+            Self::new_configured(
+                Some(payload),
+                payload.len() as u64,
+                max_frame_bytes,
+                stall_ms,
+                connect_ms,
+                floor_bps,
+                false,
+            )
+            .await
+        }
+
+        async fn new_configured(
+            payload: Option<&[u8]>,
+            source_bytes: u64,
+            max_frame_bytes: u64,
+            stall_ms: u64,
+            connect_ms: u64,
+            floor_bps: u64,
+            discard_data: bool,
+        ) -> Self {
+            let dir = TempDir::new().expect("runtime tempdir");
+            let (shutdown_tx, _shutdown_rx) = tokio::sync::mpsc::channel(1);
+            let engine = Engine::new(
+                dir.path().to_path_buf(),
+                true,
+                jeliya_core::engine::EngineConfig {
+                    port: 0,
+                    version: "test".into(),
+                    shutdown_tx,
+                },
+            )
+            .expect("test engine");
+            engine
+                .execute(jeliya_core::typed::TypedCall::SubjectEnsure(
+                    jeliya_api::SubjectEnsure {},
+                ))
+                .await
+                .reply
+                .expect("subject.ensure");
+            let created = engine
+                .execute(jeliya_core::typed::TypedCall::RoomCreate(
+                    jeliya_api::RoomCreate {
+                        name: "stream runtime".into(),
+                    },
+                ))
+                .await
+                .reply
+                .expect("room.create");
+            let jeliya_core::typed::TypedReply::RoomCreate(created) = created else {
+                panic!("wrong room.create reply");
+            };
+            engine
+                .execute(jeliya_core::typed::TypedCall::RoomActivate(
+                    jeliya_api::RoomActivate {
+                        room_id: created.room_id.clone(),
+                    },
+                ))
+                .await
+                .reply
+                .expect("room.activate");
+            let staged = dir.path().join("stream-source.bin");
+            match payload {
+                Some(payload) => {
+                    assert_eq!(payload.len() as u64, source_bytes);
+                    std::fs::write(&staged, payload).expect("write staged source");
+                }
+                None => std::fs::File::create(&staged)
+                    .and_then(|file| file.set_len(source_bytes))
+                    .expect("create sparse staged source"),
+            }
+            let shared = engine
+                .share_staged_file(
+                    &jeliya_api::FileShare {
+                        room_id: created.room_id.clone(),
+                        name: "stream-source.bin".into(),
+                        declared_bytes: source_bytes,
+                        declared_content_type: "application/octet-stream".into(),
+                    },
+                    &staged,
+                )
+                .await
+                .expect("host-staged share");
+            // Fixture setup marks the staged bytes as a verified local fetch.
+            // This writes core's existing private state format only in the
+            // daemon test; the production streaming API still exposes no path.
+            let state_path = dir.path().join("state.json");
+            let mut local_state: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&state_path).expect("read local state"))
+                    .expect("decode local state");
+            local_state["rooms"][created.room_id.as_str()]["fetched_files"]
+                [shared.file_id.as_str()] = serde_json::json!({
+                "path": staged.clone(),
+                "bytes": source_bytes,
+                "fetched_at_ms": 0,
+            });
+            std::fs::write(
+                &state_path,
+                serde_json::to_vec_pretty(&local_state).expect("encode local state"),
+            )
+            .expect("write local state");
+            let request = FileRead {
+                room_id: created.room_id,
+                file_id: shared.file_id,
+            };
+
+            let mut served = engine.limits();
+            served.max_frame_bytes = max_frame_bytes;
+            served.max_concurrent_transfers = 2;
+            served.max_transfer_bytes_inflight = source_bytes.max(2 * 1024 * 1024);
+            served.transfer_stall_ms = stall_ms;
+            served.transfer_connect_allowance_ms = connect_ms;
+            served.transfer_floor_bits_per_second = floor_bps;
+            let limits = RuntimeLimits::from_served(&served).expect("test runtime limits");
+            let pool = TransferPool::from_runtime(&limits);
+            let registry = StreamRegistry::new();
+            let tracker = RequestTracker::new(4);
+            let stream_ids = Arc::new(Mutex::new(StreamIdGenerator::new()));
+            let (outbound, queues) = Outbound::new(
+                16,
+                2,
+                limits.control_queue_capacity_bytes(),
+                limits.data_queue_capacity_bytes(),
+                limits.max_frame_bytes(),
+            );
+            let sink = if discard_data {
+                RecordingSink::discarding_zero_data()
+            } else {
+                RecordingSink::default()
+            };
+            let writer_sink = sink.clone();
+            let writer = tokio::spawn(async move {
+                let result = queues.run(writer_sink, limits.transfer_stall()).await;
+                assert!(result.is_ok());
+            });
+            let (closer, close_rx, close_completed_rx) =
+                ConnectionCloser::new(registry.clone(), outbound.clone());
+            Self {
+                _dir: dir,
+                engine,
+                request,
+                source_path: staged,
+                limits,
+                pool,
+                registry,
+                tracker,
+                stream_ids,
+                outbound,
+                sink,
+                writer,
+                closer,
+                close_rx,
+                _close_completed_rx: close_completed_rx,
+            }
+        }
+
+        fn spawn_read(&self, id: u64) -> tokio::task::JoinHandle<bool> {
+            let permit = self.tracker.acquire(id).expect("request permit");
+            tokio::spawn(run_file_read(
+                self.engine.clone(),
+                self.request.clone(),
+                id,
+                permit,
+                self.outbound.clone(),
+                self.registry.clone(),
+                self.stream_ids.clone(),
+                self.pool.clone(),
+                self.limits,
+                self.closer.clone(),
+            ))
+        }
+
+        async fn shutdown(self) {
+            let Self {
+                outbound,
+                closer,
+                writer,
+                ..
+            } = self;
+            drop(closer);
+            drop(outbound);
+            writer.await.expect("writer join");
+        }
+    }
+
+    fn binary(message: Message) -> Vec<u8> {
+        let Message::Binary(bytes) = message else {
+            panic!("expected Binary stream record, got {message:?}");
+        };
+        bytes.to_vec()
+    }
+
+    fn text_reply(message: Message) -> jeliya_codec::Reply {
+        let Message::Text(text) = message else {
+            panic!("expected Text reply");
+        };
+        serde_json::from_str(&text).expect("typed reply JSON")
+    }
+
+    async fn assert_success_flow(payload: Vec<u8>, max_frame_bytes: u64) {
+        let harness = RuntimeHarness::new(&payload, max_frame_bytes).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let open = decode_stream_record(
+            &binary(harness.sink.message(0).await),
+            &bounds(max_frame_bytes as usize),
+        )
+        .expect("OPEN record");
+        assert_eq!(
+            open.body,
+            StreamRecordBody::Open {
+                total: payload.len() as u64
+            }
+        );
+        let identity = open.identity;
+        assert_eq!(identity.request_id().get(), REQUEST_ID);
+        assert_ne!(identity.stream_id().get(), 0);
+
+        let total = payload.len() as u64;
+        let initial = wire(0x03, REQUEST_ID, identity.stream_id().get(), 0, total, &[]);
+        assert_eq!(
+            harness
+                .registry
+                .route_binary(&initial, &bounds(max_frame_bytes as usize)),
+            BinaryRoute::Delivered
+        );
+
+        let mut accepted = 0_u64;
+        let mut observed = Vec::new();
+        let mut index = 1;
+        loop {
+            let record = decode_stream_record(
+                &binary(harness.sink.message(index).await),
+                &bounds(max_frame_bytes as usize),
+            )
+            .expect("outbound stream record");
+            index += 1;
+            assert_eq!(record.identity, identity);
+            match record.body {
+                StreamRecordBody::Data { offset, payload } => {
+                    assert_eq!(offset, accepted);
+                    assert!(!payload.is_empty());
+                    assert!(payload.len() <= max_frame_bytes as usize - STREAM_HEADER_BYTES);
+                    accepted += payload.len() as u64;
+                    observed.extend_from_slice(&payload);
+                    let credit = wire(
+                        0x03,
+                        REQUEST_ID,
+                        identity.stream_id().get(),
+                        accepted,
+                        total,
+                        &[],
+                    );
+                    assert_eq!(
+                        harness
+                            .registry
+                            .route_binary(&credit, &bounds(max_frame_bytes as usize)),
+                        BinaryRoute::Delivered
+                    );
+                }
+                StreamRecordBody::End { total: ended } => {
+                    assert_eq!(ended, total);
+                    assert_eq!(accepted, total);
+                    break;
+                }
+                other => panic!("unexpected producer record: {other:?}"),
+            }
+        }
+        assert_eq!(observed, payload);
+        let reply = text_reply(harness.sink.message(index).await);
+        assert!(reply.ok);
+        assert_eq!(reply.id, REQUEST_ID);
+        assert_eq!(
+            reply.out.as_ref().and_then(|out| out["bytes"].as_u64()),
+            Some(total)
+        );
+        for _ in 0..20 {
+            if !harness.tracker.is_outstanding(REQUEST_ID) && !harness.registry.is_active() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !harness.tracker.is_outstanding(REQUEST_ID),
+            "terminal Text send releases the request id before actor return"
+        );
+        assert!(
+            !harness.registry.is_active(),
+            "terminal success Text send retires the exact pair"
+        );
+        drop(
+            harness
+                .tracker
+                .acquire(REQUEST_ID)
+                .expect("peer-visible reply makes the request id reusable"),
+        );
+        assert_eq!(
+            harness.registry.route_binary(
+                &wire(
+                    0x03,
+                    REQUEST_ID,
+                    identity.stream_id().get(),
+                    total,
+                    total,
+                    &[],
+                ),
+                &bounds(max_frame_bytes as usize),
+            ),
+            BinaryRoute::CloseMalformed,
+            "completed downloads retain no resumable binding"
+        );
+        assert!(actor.await.expect("file.read actor"));
+        harness.shutdown().await;
+    }
+
+    async fn opened_identity(harness: &RuntimeHarness, id: u64) -> StreamIdentity {
+        let open = decode_stream_record(
+            &binary(harness.sink.message(0).await),
+            &bounds(harness.limits.max_frame_bytes()),
+        )
+        .expect("OPEN record");
+        assert!(matches!(open.body, StreamRecordBody::Open { .. }));
+        assert_eq!(open.identity.request_id().get(), id);
+        open.identity
+    }
+
+    fn route_body(
+        harness: &RuntimeHarness,
+        identity: StreamIdentity,
+        body: StreamRecordBody,
+    ) -> BinaryRoute {
+        let (kind, offset, value) = match body {
+            StreamRecordBody::Credit {
+                accepted_through,
+                send_through,
+            } => (0x03, accepted_through, send_through),
+            StreamRecordBody::Abort {
+                accepted_through,
+                reason,
+            } => {
+                let reason = match reason {
+                    BinaryAbortReason::Cancelled => 0x01,
+                    BinaryAbortReason::SourceFailed => 0x02,
+                    BinaryAbortReason::SinkFailed => 0x03,
+                    BinaryAbortReason::ProtocolError => 0x04,
+                    BinaryAbortReason::OperationError => 0x05,
+                };
+                (0x05, accepted_through, reason)
+            }
+            StreamRecordBody::Ack { accepted_through } => (0x06, accepted_through, 0x05),
+            other => panic!("test helper only constructs receiver controls: {other:?}"),
+        };
+        let record = wire(
+            kind,
+            identity.request_id().get(),
+            identity.stream_id().get(),
+            offset,
+            value,
+            &[],
+        );
+        harness
+            .registry
+            .route_binary(&record, &bounds(harness.limits.max_frame_bytes()))
+    }
+
+    #[tokio::test]
+    async fn zero_one_multi_and_payload_boundary_reads_follow_open_credit_data_end_reply() {
+        assert_success_flow(Vec::new(), 256).await;
+        assert_success_flow(vec![0x7a], 256).await;
+        assert_success_flow((0..300).map(|i| (i % 251) as u8).collect(), 256).await;
+        let payload_limit = 256 - STREAM_HEADER_BYTES;
+        assert_success_flow(vec![0x5a; payload_limit], 256).await;
+        assert_success_flow(vec![0x5a; payload_limit + 1], 256).await;
+    }
+
+    #[tokio::test]
+    async fn pending_credit_retries_the_same_bounded_data_without_rereading_source() {
+        let harness = RuntimeHarness::new(&[0x11, 0x22, 0x33], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        harness.sink.block_next_flush();
+        let ordinary_out = harness.outbound.clone();
+        let ordinary =
+            tokio::spawn(
+                async move { ordinary_out.text(br#"{"id":99,"ok":true}"#.to_vec()).await },
+            );
+        harness.sink.wait_flush_blocked().await;
+
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 2,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        let full_capacity = harness.limits.data_queue_capacity_bytes();
+        for _ in 0..100 {
+            if harness.outbound.available_data_bytes() < full_capacity {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            harness.outbound.available_data_bytes() < full_capacity,
+            "the first DATA was read only after retaining its byte permit"
+        );
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 3,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+
+        harness.sink.release_flush();
+        assert_eq!(ordinary.await.unwrap(), WriteReceipt::Sent);
+        let first = decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256))
+            .expect("first DATA after retry");
+        assert_eq!(
+            first.body,
+            StreamRecordBody::Data {
+                offset: 0,
+                payload: vec![0x11, 0x22],
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 2,
+                send_through: 3,
+            },
+        );
+        let second = decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256))
+            .expect("second DATA");
+        assert_eq!(
+            second.body,
+            StreamRecordBody::Data {
+                offset: 2,
+                payload: vec![0x33],
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 3,
+                send_through: 3,
+            },
+        );
+        assert!(matches!(
+            decode_stream_record(&binary(harness.sink.message(4).await), &bounds(256))
+                .unwrap()
+                .body,
+            StreamRecordBody::End { total: 3 }
+        ));
+        assert!(text_reply(harness.sink.message(5).await).ok);
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn progress_while_data_flushes_is_reconciled_before_stall() {
+        let harness = RuntimeHarness::new_with_timers(&[0x7a], 256, 10, 1_000, 8_192).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        tokio::time::advance(Duration::from_millis(5)).await;
+
+        harness.sink.block_next_flush();
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            },
+        );
+        let data = decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+            .expect("started DATA");
+        assert!(matches!(
+            data.body,
+            StreamRecordBody::Data { offset: 0, .. }
+        ));
+        harness.sink.wait_flush_blocked().await;
+
+        tokio::time::advance(Duration::from_millis(4)).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 1,
+            },
+        );
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        harness.sink.release_flush();
+        tokio::task::yield_now().await;
+
+        assert!(matches!(
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256))
+                .unwrap()
+                .body,
+            StreamRecordBody::End { total: 1 }
+        ));
+        assert!(text_reply(harness.sink.message(3).await).ok);
+        assert!(actor.await.unwrap());
+        assert!(!*harness.close_rx.borrow());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn exact_input_before_open_commit_closes_without_a_terminal_text_reply() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        harness.sink.block_next_flush();
+        let ordinary_out = harness.outbound.clone();
+        let ordinary =
+            tokio::spawn(
+                async move { ordinary_out.text(br#"{"id":99,"ok":true}"#.to_vec()).await },
+            );
+        harness.sink.wait_flush_blocked().await;
+
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = loop {
+            if let Some(identity) = harness
+                .registry
+                .inner
+                .lock()
+                .expect("stream registry poisoned")
+                .bindings
+                .keys()
+                .next()
+                .copied()
+            {
+                break identity;
+            }
+            tokio::task::yield_now().await;
+        };
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 1,
+                },
+            ),
+            BinaryRoute::CloseMalformed
+        );
+        harness.sink.release_flush();
+        assert_eq!(ordinary.await.unwrap(), WriteReceipt::Sent);
+        assert!(!actor.await.unwrap());
+        let Message::Close(Some(close)) = harness.sink.message(1).await else {
+            panic!("pre-OPEN exact input must produce the uncorrelated Close");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        harness.sink.assert_no_message(2).await;
+        assert!(*harness.close_rx.borrow());
+        assert!(!harness.registry.is_active());
+        assert!(!harness.tracker.is_outstanding(REQUEST_ID));
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn connection_fatal_invalidation_discards_a_queued_open_before_close() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        harness.sink.block_next_flush();
+        let ordinary_out = harness.outbound.clone();
+        let ordinary =
+            tokio::spawn(
+                async move { ordinary_out.text(br#"{"id":99,"ok":true}"#.to_vec()).await },
+            );
+        harness.sink.wait_flush_blocked().await;
+
+        let actor = harness.spawn_read(REQUEST_ID);
+        loop {
+            if harness.registry.is_active() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        // The connection owner atomically invalidates every stream writer
+        // start and ordinary output before its sole Close task is launched.
+        assert!(harness.closer.malformed());
+        assert!(!harness.closer.malformed(), "Close ownership is single-use");
+
+        harness.sink.release_flush();
+        assert_eq!(ordinary.await.unwrap(), WriteReceipt::Sent);
+        let Message::Close(Some(frame)) = harness.sink.message(1).await else {
+            panic!("fatal invalidation must send Close after the older started message");
+        };
+        assert_eq!(u16::from(frame.code), 4007);
+        assert!(*harness.close_rx.borrow());
+        assert!(!actor.await.unwrap());
+        harness.sink.assert_no_message(2).await;
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn maximum_size_read_completes_without_retaining_the_file_in_the_sink() {
+        const TOTAL: u64 = 104_857_600;
+        const FRAME_BYTES: u64 = (STREAM_HEADER_BYTES + 65_536) as u64;
+
+        // A sparse zero file exercises the complete configured file-size
+        // maximum without allocating a 100 MiB input fixture. The sink below
+        // validates each DATA record in place and drops it immediately.
+        let harness = RuntimeHarness::new_sparse_zero(TOTAL, FRAME_BYTES).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let open = decode_stream_record(
+            &binary(harness.sink.message(0).await),
+            &bounds(FRAME_BYTES as usize),
+        )
+        .expect("maximum-size OPEN record");
+        assert_eq!(open.body, StreamRecordBody::Open { total: TOTAL });
+        let identity = open.identity;
+
+        let initial = wire(0x03, REQUEST_ID, identity.stream_id().get(), 0, TOTAL, &[]);
+        assert_eq!(
+            harness
+                .registry
+                .route_binary(&initial, &bounds(FRAME_BYTES as usize)),
+            BinaryRoute::Delivered
+        );
+
+        let mut accepted = 0_u64;
+        while accepted < TOTAL {
+            accepted = harness.sink.streamed_through(accepted).await;
+            assert!(accepted <= TOTAL);
+            let credit = wire(
+                0x03,
+                REQUEST_ID,
+                identity.stream_id().get(),
+                accepted,
+                TOTAL,
+                &[],
+            );
+            assert_eq!(
+                harness
+                    .registry
+                    .route_binary(&credit, &bounds(FRAME_BYTES as usize)),
+                BinaryRoute::Delivered
+            );
+        }
+
+        let summary = harness.sink.streamed_summary();
+        let mut identity_wire = [0_u8; 24];
+        identity_wire[..8].copy_from_slice(&REQUEST_ID.to_be_bytes());
+        identity_wire[8..].copy_from_slice(&identity.stream_id().get().to_be_bytes());
+        assert_eq!(summary.through, TOTAL);
+        assert_eq!(summary.records, 1_600);
+        assert_eq!(summary.max_payload, 65_536);
+        assert_eq!(summary.identity, Some(identity_wire));
+
+        let end = decode_stream_record(
+            &binary(harness.sink.message(1).await),
+            &bounds(FRAME_BYTES as usize),
+        )
+        .expect("maximum-size END record");
+        assert_eq!(end.identity, identity);
+        assert_eq!(end.body, StreamRecordBody::End { total: TOTAL });
+        let reply = text_reply(harness.sink.message(2).await);
+        assert!(reply.ok);
+        assert_eq!(reply.id, REQUEST_ID);
+        assert_eq!(
+            reply.out.as_ref().and_then(|out| out["bytes"].as_u64()),
+            Some(TOTAL)
+        );
+        assert!(
+            harness.sink.retained_payload_bytes() < 4_096,
+            "the streaming test sink must retain only OPEN, END, and reply"
+        );
+        assert!(actor.await.expect("maximum-size file.read actor"));
+        assert!(!harness.tracker.is_outstanding(REQUEST_ID));
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn runtime_never_reads_or_sends_beyond_credit_and_waits_for_final_ack() {
+        let harness = RuntimeHarness::new(&[1, 2, 3, 4, 5], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        harness.sink.assert_no_message(1).await;
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 2,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        let first = decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+            .expect("first DATA");
+        assert_eq!(
+            first.body,
+            StreamRecordBody::Data {
+                offset: 0,
+                payload: vec![1, 2],
+            }
+        );
+        harness.sink.assert_no_message(2).await;
+
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 2,
+                send_through: 5,
+            },
+        );
+        let second = decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256))
+            .expect("second DATA");
+        assert_eq!(
+            second.body,
+            StreamRecordBody::Data {
+                offset: 2,
+                payload: vec![3, 4, 5],
+            }
+        );
+
+        // Advancing only the send window is not final acknowledgement: no END
+        // and no success reply may become observable.
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 2,
+                send_through: 5,
+            },
+        );
+        harness.sink.assert_no_message(3).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 5,
+                send_through: 5,
+            },
+        );
+        let end = decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256))
+            .expect("END");
+        assert_eq!(end.body, StreamRecordBody::End { total: 5 });
+        assert!(text_reply(harness.sink.message(4).await).ok);
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn transfer_count_and_byte_exhaustion_reply_before_open() {
+        let count = RuntimeHarness::new(&[1], 256).await;
+        let first = count.pool.reserve(0).expect("first count slot");
+        let second = count.pool.reserve(0).expect("second count slot");
+        let actor = count.spawn_read(REQUEST_ID);
+        let reply = text_reply(count.sink.message(0).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::ResourceExhausted {
+                resource: "max_concurrent_transfers".into(),
+                limit: 2,
+            })
+        );
+        assert!(actor.await.unwrap());
+        assert!(!count.registry.is_active());
+        assert!(!count.tracker.is_outstanding(REQUEST_ID));
+        drop((first, second));
+        assert_eq!(count.pool.usage(), (0, 0));
+        count.shutdown().await;
+
+        let bytes = RuntimeHarness::new(&[1], 256).await;
+        let held = bytes
+            .pool
+            .reserve(2 * 1024 * 1024)
+            .expect("entire byte capacity");
+        let actor = bytes.spawn_read(REQUEST_ID);
+        let reply = text_reply(bytes.sink.message(0).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::ResourceExhausted {
+                resource: "max_transfer_bytes_inflight".into(),
+                limit: 2 * 1024 * 1024,
+            })
+        );
+        assert!(actor.await.unwrap());
+        assert!(!bytes.registry.is_active());
+        assert!(!bytes.tracker.is_outstanding(REQUEST_ID));
+        drop(held);
+        assert_eq!(bytes.pool.usage(), (0, 0));
+        bytes.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn client_abort_is_acked_before_stream_aborted_reply() {
+        let harness = RuntimeHarness::new(&[1, 2, 3], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 3,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        let data =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert!(matches!(data.body, StreamRecordBody::Data { .. }));
+
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Abort {
+                    accepted_through: 0,
+                    reason: BinaryAbortReason::Cancelled,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        let ack =
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+        assert_eq!(
+            ack.body,
+            StreamRecordBody::Ack {
+                accepted_through: 0
+            }
+        );
+        for _ in 0..20 {
+            if !harness.registry.is_active() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !harness.registry.is_active(),
+            "the daemon ACK send retires the client-aborted pair"
+        );
+        let reply = text_reply(harness.sink.message(3).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::StreamAborted {
+                transferred_bytes: 0,
+                total: known_total(3),
+                reason: StreamAbortReason::Cancelled,
+            })
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn source_open_failure_after_admission_releases_every_reservation_without_open() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        std::fs::remove_file(&harness.source_path).expect("remove prepared source before open");
+        let actor = harness.spawn_read(REQUEST_ID);
+
+        let reply = text_reply(harness.sink.message(0).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::FileNotFetched {
+                file_id: harness.request.file_id.clone(),
+            })
+        );
+        assert!(actor.await.unwrap());
+        assert_eq!(harness.pool.usage(), (0, 0));
+        assert!(!harness.registry.is_active());
+        assert!(!harness.tracker.is_outstanding(REQUEST_ID));
+        harness.sink.assert_no_message(1).await;
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn buffered_duplicate_abort_becomes_correlated_protocol_failure() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        let abort = StreamRecordBody::Abort {
+            accepted_through: 0,
+            reason: BinaryAbortReason::Cancelled,
+        };
+        assert_eq!(
+            route_body(&harness, identity, abort.clone()),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            route_body(&harness, identity, abort),
+            BinaryRoute::Delivered
+        );
+
+        let daemon_abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            daemon_abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::ProtocolError,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        let crossed_ack =
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+        assert_eq!(
+            crossed_ack.body,
+            StreamRecordBody::Ack {
+                accepted_through: 0
+            }
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(3).await).err,
+            Some(ApiError::MalformedFrame)
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn post_client_abort_credit_or_duplicate_abort_promotes_to_crossed_protocol_abort() {
+        for trailing in [
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 0,
+            },
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+        ] {
+            let harness = RuntimeHarness::new(&[1], 256).await;
+            let actor = harness.spawn_read(REQUEST_ID);
+            let identity = opened_identity(&harness, REQUEST_ID).await;
+
+            harness.sink.block_next_flush();
+            let ordinary_out = harness.outbound.clone();
+            let ordinary =
+                tokio::spawn(
+                    async move { ordinary_out.text(br#"{"id":99,"ok":true}"#.to_vec()).await },
+                );
+            harness.sink.wait_flush_blocked().await;
+            assert_eq!(
+                route_body(
+                    &harness,
+                    identity,
+                    StreamRecordBody::Abort {
+                        accepted_through: 0,
+                        reason: BinaryAbortReason::Cancelled,
+                    },
+                ),
+                BinaryRoute::Delivered
+            );
+
+            let ingress = loop {
+                let ingress = harness
+                    .registry
+                    .inner
+                    .lock()
+                    .expect("stream registry poisoned")
+                    .bindings
+                    .get(&identity)
+                    .cloned()
+                    .expect("client-aborted pair remains bound");
+                if BindingPhase::load(&ingress.phase) == BindingPhase::ClientAbortPending {
+                    break ingress;
+                }
+                tokio::task::yield_now().await;
+            };
+            assert_eq!(
+                route_body(&harness, identity, trailing),
+                BinaryRoute::Delivered
+            );
+            assert!(ingress.mailbox.has_pending());
+
+            harness.sink.release_flush();
+            assert_eq!(ordinary.await.unwrap(), WriteReceipt::Sent);
+            let daemon_abort =
+                decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+            assert_eq!(
+                daemon_abort.body,
+                StreamRecordBody::Abort {
+                    accepted_through: 0,
+                    reason: BinaryAbortReason::ProtocolError,
+                }
+            );
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            );
+            let client_abort_ack =
+                decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256)).unwrap();
+            assert_eq!(
+                client_abort_ack.body,
+                StreamRecordBody::Ack {
+                    accepted_through: 0
+                }
+            );
+            assert_eq!(
+                text_reply(harness.sink.message(4).await).err,
+                Some(ApiError::MalformedFrame)
+            );
+            assert!(actor.await.unwrap());
+            assert!(!*harness.close_rx.borrow());
+            harness.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_pair_stays_request_local_while_client_abort_ack_flushes() {
+        for trailing in [
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 0,
+            },
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+        ] {
+            let harness = RuntimeHarness::new(&[1], 256).await;
+            let actor = harness.spawn_read(REQUEST_ID);
+            let identity = opened_identity(&harness, REQUEST_ID).await;
+
+            // Block the client-ABORT ACK after writer start. Its exact pair is
+            // still trustworthy until that peer-visible write is reconciled.
+            harness.sink.block_next_flush();
+            assert_eq!(
+                route_body(
+                    &harness,
+                    identity,
+                    StreamRecordBody::Abort {
+                        accepted_through: 0,
+                        reason: BinaryAbortReason::Cancelled,
+                    },
+                ),
+                BinaryRoute::Delivered
+            );
+            harness.sink.wait_flush_blocked().await;
+            let ingress = harness
+                .registry
+                .inner
+                .lock()
+                .expect("stream registry poisoned")
+                .bindings
+                .get(&identity)
+                .cloned()
+                .expect("ACK-in-flight pair remains bound");
+            assert_eq!(
+                BindingPhase::load(&ingress.phase),
+                BindingPhase::ClientAbortAckCommitted
+            );
+            assert_eq!(
+                route_body(&harness, identity, trailing),
+                BinaryRoute::Delivered,
+                "an exact-pair fault during ACK flush is request-local"
+            );
+
+            harness.sink.release_flush();
+            let first_ack =
+                decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+            assert_eq!(
+                first_ack.body,
+                StreamRecordBody::Ack {
+                    accepted_through: 0
+                }
+            );
+            let daemon_abort =
+                decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+            assert_eq!(
+                daemon_abort.body,
+                StreamRecordBody::Abort {
+                    accepted_through: 0,
+                    reason: BinaryAbortReason::ProtocolError,
+                }
+            );
+            assert_eq!(
+                route_body(
+                    &harness,
+                    identity,
+                    StreamRecordBody::Ack {
+                        accepted_through: 0,
+                    },
+                ),
+                BinaryRoute::Delivered
+            );
+            assert_eq!(
+                text_reply(harness.sink.message(3).await).err,
+                Some(ApiError::MalformedFrame)
+            );
+            assert!(actor.await.unwrap());
+            assert!(!*harness.close_rx.borrow());
+            harness.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn bound_protocol_fault_aborts_only_stream_and_waits_for_ack() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        // Client-to-daemon DATA is the wrong direction for a download. The
+        // exact pair makes this stream-local rather than a 4007 close.
+        assert_eq!(
+            harness.registry.route_binary(
+                &wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0, &[0xaa],),
+                &bounds(256),
+            ),
+            BinaryRoute::Delivered
+        );
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::ProtocolError,
+            }
+        );
+        assert_eq!(harness.pool.usage(), (0, 0));
+        assert!(harness.registry.is_active(), "binding waits for ACK");
+        assert!(harness.tracker.is_outstanding(REQUEST_ID));
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::CloseMalformed,
+            "the first ACK latches retirement against duplicate terminals"
+        );
+        let reply = text_reply(harness.sink.message(2).await);
+        assert_eq!(reply.err, Some(ApiError::MalformedFrame));
+        assert!(actor.await.unwrap());
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::CloseMalformed,
+            "ACK retires the exact binding before the Text reply completes"
+        );
+        assert!(!*harness.close_rx.borrow());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ack_before_daemon_abort_writer_start_is_not_accepted() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        harness.sink.block_next_flush();
+        let ordinary_out = harness.outbound.clone();
+        let ordinary =
+            tokio::spawn(
+                async move { ordinary_out.text(br#"{"id":99,"ok":true}"#.to_vec()).await },
+            );
+        harness.sink.wait_flush_blocked().await;
+        assert_eq!(
+            harness.registry.route_binary(
+                &wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0, &[0xaa]),
+                &bounds(256),
+            ),
+            BinaryRoute::Delivered
+        );
+
+        let ingress = loop {
+            let ingress = harness
+                .registry
+                .inner
+                .lock()
+                .expect("stream registry poisoned")
+                .bindings
+                .get(&identity)
+                .cloned()
+                .expect("active exact pair");
+            if BindingPhase::load(&ingress.phase) == BindingPhase::DaemonAbortQueued {
+                break ingress;
+            }
+            tokio::task::yield_now().await;
+        };
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::Delivered,
+            "the exact pair makes premature ACK a correlated protocol fault"
+        );
+        assert_eq!(
+            BindingPhase::load(&ingress.phase),
+            BindingPhase::DaemonAbortQueued,
+            "ACK is not trustworthy before daemon ABORT writer start"
+        );
+
+        harness.sink.release_flush();
+        assert_eq!(ordinary.await.unwrap(), WriteReceipt::Sent);
+        let abort = decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256))
+            .expect("daemon ABORT");
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::ProtocolError,
+            }
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(3).await).err,
+            Some(ApiError::MalformedFrame)
+        );
+        let Message::Close(Some(close)) = harness.sink.message(4).await else {
+            panic!("premature ACK fault must close after the terminal reply");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn overflowing_credit_drives_correlated_protocol_abort() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: u64::MAX,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::ProtocolError,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(2).await).err,
+            Some(ApiError::MalformedFrame)
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn invalid_credit_during_daemon_abort_ack_wait_is_not_ignored() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        // Wrong-direction DATA chooses the daemon's correlated protocol
+        // ABORT. CREDIT remains structurally routable while its ACK is in
+        // flight, but its cumulative values are still semantically checked.
+        assert_eq!(
+            harness.registry.route_binary(
+                &wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0, &[0xaa]),
+                &bounds(256),
+            ),
+            BinaryRoute::Delivered
+        );
+        let abort = decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+            .expect("daemon protocol ABORT");
+        assert!(matches!(abort.body, StreamRecordBody::Abort { .. }));
+
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 2,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(2).await).err,
+            Some(ApiError::MalformedFrame)
+        );
+        let Message::Close(Some(close)) = harness.sink.message(3).await else {
+            panic!("invalid terminal-handshake CREDIT must close after the chosen reply");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        assert!(actor.await.unwrap());
+        assert!(*harness.close_rx.borrow());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn collapsed_crossed_abort_is_acked_before_malformed_handshake_closes() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        assert_eq!(
+            harness.registry.route_binary(
+                &wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0, &[0xaa]),
+                &bounds(256),
+            ),
+            BinaryRoute::Delivered
+        );
+        let daemon_abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert!(matches!(daemon_abort.body, StreamRecordBody::Abort { .. }));
+
+        // Prove the actor has passed its one-time pre-loop reconciliation by
+        // making it consume a valid handshake CREDIT first.
+        let ingress = harness
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned")
+            .bindings
+            .get(&identity)
+            .cloned()
+            .expect("daemon-ABORT pair remains bound");
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 0,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+        while ingress.mailbox.has_pending() {
+            tokio::task::yield_now().await;
+        }
+
+        // These synchronous routes cannot be interleaved with the actor. The
+        // duplicate collapses the first crossed ABORT into a Malformed event;
+        // the retained first terminal must still receive its ACK.
+        let crossed = StreamRecordBody::Abort {
+            accepted_through: 0,
+            reason: BinaryAbortReason::Cancelled,
+        };
+        assert_eq!(
+            route_body(&harness, identity, crossed.clone()),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            route_body(&harness, identity, crossed),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: 0,
+                },
+            ),
+            BinaryRoute::Delivered
+        );
+
+        let crossed_ack =
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+        assert_eq!(
+            crossed_ack.body,
+            StreamRecordBody::Ack {
+                accepted_through: 0
+            }
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(3).await).err,
+            Some(ApiError::MalformedFrame)
+        );
+        let Message::Close(Some(close)) = harness.sink.message(4).await else {
+            panic!("malformed terminal batch must close after its correlated reply");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        assert!(actor.await.unwrap());
+        assert!(*harness.close_rx.borrow());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn crossed_abort_completes_both_ack_obligations_with_daemon_result_authoritative() {
+        let harness = RuntimeHarness::new(&[1], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        harness.registry.route_binary(
+            &wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0, &[0xaa]),
+            &bounds(256),
+        );
+        let daemon_abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert!(matches!(daemon_abort.body, StreamRecordBody::Abort { .. }));
+
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        let crossed_ack =
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256)).unwrap();
+        assert_eq!(
+            crossed_ack.body,
+            StreamRecordBody::Ack {
+                accepted_through: 0
+            }
+        );
+        let reply = text_reply(harness.sink.message(3).await);
+        assert_eq!(reply.err, Some(ApiError::MalformedFrame));
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn truncation_and_growth_become_source_failed_abort_before_any_success() {
+        for grow in [false, true] {
+            let harness = RuntimeHarness::new(&[1, 2, 3], 256).await;
+            let actor = harness.spawn_read(REQUEST_ID);
+            let identity = opened_identity(&harness, REQUEST_ID).await;
+            if !grow {
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&harness.source_path)
+                    .unwrap()
+                    .set_len(0)
+                    .unwrap();
+            }
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 3,
+                },
+            );
+
+            let abort_index = if grow {
+                let data =
+                    decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+                        .unwrap();
+                assert!(matches!(data.body, StreamRecordBody::Data { .. }));
+                use std::io::Write as _;
+                std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&harness.source_path)
+                    .unwrap()
+                    .write_all(&[4])
+                    .unwrap();
+                route_body(
+                    &harness,
+                    identity,
+                    StreamRecordBody::Credit {
+                        accepted_through: 3,
+                        send_through: 3,
+                    },
+                );
+                2
+            } else {
+                1
+            };
+            let abort = decode_stream_record(
+                &binary(harness.sink.message(abort_index).await),
+                &bounds(256),
+            )
+            .unwrap();
+            assert_eq!(
+                abort.body,
+                StreamRecordBody::Abort {
+                    accepted_through: if grow { 3 } else { 0 },
+                    reason: BinaryAbortReason::SourceFailed,
+                }
+            );
+            route_body(
+                &harness,
+                identity,
+                StreamRecordBody::Ack {
+                    accepted_through: if grow { 3 } else { 0 },
+                },
+            );
+            let reply = text_reply(harness.sink.message(abort_index + 1).await);
+            assert_eq!(
+                reply.err,
+                Some(ApiError::StreamAborted {
+                    transferred_bytes: if grow { 3 } else { 0 },
+                    total: known_total(3),
+                    reason: StreamAbortReason::SourceFailed,
+                })
+            );
+            assert!(actor.await.unwrap());
+            harness.shutdown().await;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn source_read_error_emits_abort_then_waits_for_ack_before_reply() {
+        let harness = RuntimeHarness::new(&[], 256).await;
+        let state_path = harness._dir.path().join("state.json");
+        let mut local_state: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_path).expect("read local state"))
+                .expect("decode local state");
+        local_state["rooms"][harness.request.room_id.as_str()]["fetched_files"]
+            [harness.request.file_id.as_str()]["path"] = serde_json::json!("/proc/self/mem");
+        std::fs::write(
+            &state_path,
+            serde_json::to_vec_pretty(&local_state).expect("encode local state"),
+        )
+        .expect("install an exact-size source whose EOF probe returns EIO");
+
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 0,
+            },
+        );
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::SourceFailed,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(2).await).err,
+            Some(ApiError::StreamAborted {
+                transferred_bytes: 0,
+                total: known_total(0),
+                reason: StreamAbortReason::SourceFailed,
+            })
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn stall_ignores_repeated_credit_then_abort_ack_timeout_replies_and_closes() {
+        let harness = RuntimeHarness::new_with_timers(&[1], 256, 10, 1_000, 8_192).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        for _ in 0..4 {
+            assert_eq!(
+                route_body(
+                    &harness,
+                    identity,
+                    StreamRecordBody::Credit {
+                        accepted_through: 0,
+                        send_through: 0,
+                    },
+                ),
+                BinaryRoute::Delivered
+            );
+        }
+
+        tokio::time::advance(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::OperationError,
+            }
+        );
+
+        tokio::time::advance(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+        let reply = text_reply(harness.sink.message(2).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::TransferStalled {
+                transferred_bytes: 0,
+                total: known_total(1),
+            })
+        );
+        let Message::Close(Some(close)) = harness.sink.message(3).await else {
+            panic!("expected close after ACK timeout");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        assert!(actor.await.unwrap());
+        assert!(*harness.close_rx.borrow());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sent_unacknowledged_data_and_pong_do_not_reset_stall() {
+        let harness = RuntimeHarness::new_with_timers(&[1], 256, 10, 1_000, 8_192).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            },
+        );
+        let data = decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+            .expect("one credited DATA record");
+        assert!(matches!(data.body, StreamRecordBody::Data { .. }));
+
+        assert!(
+            harness
+                .outbound
+                .pong(tokio_tungstenite::tungstenite::Bytes::from_static(
+                    b"still-alive"
+                ))
+                .await
+        );
+        assert!(matches!(harness.sink.message(2).await, Message::Pong(_)));
+
+        tokio::time::advance(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+        let abort = decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256))
+            .expect("stall ABORT");
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::OperationError,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        assert_eq!(
+            text_reply(harness.sink.message(4).await).err,
+            Some(ApiError::TransferStalled {
+                transferred_bytes: 0,
+                total: known_total(1),
+            })
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn absolute_deadline_aborts_even_while_correctly_credit_paused() {
+        let harness = RuntimeHarness::new_with_timers(&[1], 256, 100, 0, u64::MAX).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        // Initial zero-window CREDIT is correct receiver backpressure. It does
+        // not stop the size-aware absolute budget.
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 0,
+            },
+        );
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::OperationError,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            },
+        );
+        let reply = text_reply(harness.sink.message(2).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 0,
+                total: known_total(1),
+                budget_ms: 1,
+            })
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn accepted_progress_resets_stall_but_cannot_extend_absolute_deadline() {
+        let harness = RuntimeHarness::new_with_timers(&[1, 2, 3], 256, 10, 0, 1_200).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            },
+        );
+        assert!(matches!(
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256))
+                .unwrap()
+                .body,
+            StreamRecordBody::Data { offset: 0, .. }
+        ));
+
+        tokio::time::advance(Duration::from_millis(9)).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            },
+        );
+        assert!(matches!(
+            decode_stream_record(&binary(harness.sink.message(2).await), &bounds(256))
+                .unwrap()
+                .body,
+            StreamRecordBody::Data { offset: 1, .. }
+        ));
+        tokio::time::advance(Duration::from_millis(9)).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Credit {
+                accepted_through: 2,
+                send_through: 3,
+            },
+        );
+        assert!(matches!(
+            decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256))
+                .unwrap()
+                .body,
+            StreamRecordBody::Data { offset: 2, .. }
+        ));
+
+        tokio::time::advance(Duration::from_millis(2)).await;
+        tokio::task::yield_now().await;
+        let abort =
+            decode_stream_record(&binary(harness.sink.message(4).await), &bounds(256)).unwrap();
+        assert_eq!(
+            abort.body,
+            StreamRecordBody::Abort {
+                accepted_through: 2,
+                reason: BinaryAbortReason::OperationError,
+            }
+        );
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Ack {
+                accepted_through: 2,
+            },
+        );
+        let reply = text_reply(harness.sink.message(5).await);
+        assert_eq!(
+            reply.err,
+            Some(ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 2,
+                total: known_total(3),
+                budget_ms: 20,
+            })
+        );
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn client_abort_wins_an_exact_stall_timer_tie() {
+        let harness = RuntimeHarness::new_with_timers(&[1], 256, 10, 1_000, 8_192).await;
+        tokio::time::pause();
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+        tokio::time::advance(Duration::from_millis(10)).await;
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+        );
+        tokio::task::yield_now().await;
+        let ack =
+            decode_stream_record(&binary(harness.sink.message(1).await), &bounds(256)).unwrap();
+        assert_eq!(
+            ack.body,
+            StreamRecordBody::Ack {
+                accepted_through: 0,
+            }
+        );
+        let reply = text_reply(harness.sink.message(2).await);
+        assert!(matches!(
+            reply.err,
+            Some(ApiError::StreamAborted {
+                reason: StreamAbortReason::Cancelled,
+                ..
+            })
+        ));
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn disconnect_task_abort_drops_binding_source_request_and_reservations() {
+        let harness = RuntimeHarness::new(&[1, 2, 3], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let _identity = opened_identity(&harness, REQUEST_ID).await;
+        assert!(harness.registry.is_active());
+        assert_eq!(harness.pool.usage(), (1, 3));
+        assert!(harness.tracker.is_outstanding(REQUEST_ID));
+
+        actor.abort();
+        assert!(actor.await.unwrap_err().is_cancelled());
+        tokio::task::yield_now().await;
+        assert!(!harness.registry.is_active());
+        assert_eq!(harness.pool.usage(), (0, 0));
+        assert!(!harness.tracker.is_outstanding(REQUEST_ID));
+        assert_eq!(
+            harness.outbound.available_data_bytes(),
+            harness.limits.data_queue_capacity_bytes()
+        );
+        harness.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn ordinary_reply_and_push_interleave_while_download_waits_for_credit() {
+        let harness = RuntimeHarness::new(&[1, 2, 3], 256).await;
+        let actor = harness.spawn_read(REQUEST_ID);
+        let identity = opened_identity(&harness, REQUEST_ID).await;
+
+        let ordinary = jeliya_codec::Reply {
+            id: 99,
+            ok: true,
+            out: Some(serde_json::json!({"rooms": []})),
+            err: None,
+        };
+        assert_eq!(
+            harness.outbound.text(ordinary.to_bytes()).await,
+            WriteReceipt::Sent
+        );
+        let push = jeliya_api::Push::Transfer {
+            transfer_op_id: jeliya_api::OpId::new("other-transfer"),
+            transferred_bytes: 7,
+            total: known_total(9),
+        };
+        assert_eq!(
+            harness
+                .outbound
+                .text(jeliya_codec::push_to_bytes(&push))
+                .await,
+            WriteReceipt::Sent
+        );
+        assert!(matches!(harness.sink.message(1).await, Message::Text(_)));
+        assert!(matches!(harness.sink.message(2).await, Message::Text(_)));
+        assert!(harness.registry.is_active());
+
+        route_body(
+            &harness,
+            identity,
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+        );
+        let ack =
+            decode_stream_record(&binary(harness.sink.message(3).await), &bounds(256)).unwrap();
+        assert!(matches!(ack.body, StreamRecordBody::Ack { .. }));
+        let aborted = text_reply(harness.sink.message(4).await);
+        assert!(matches!(aborted.err, Some(ApiError::StreamAborted { .. })));
+        assert!(actor.await.unwrap());
+        harness.shutdown().await;
+    }
+
+    #[test]
+    fn request_ids_remain_outstanding_until_raii_terminal_release() {
+        let tracker = RequestTracker::new(2);
+        let first = tracker.acquire(1).expect("first request");
+        assert!(tracker.is_outstanding(1));
+        assert_eq!(
+            tracker.acquire(1).err(),
+            Some(RequestAdmissionError::Duplicate)
+        );
+        let second = tracker.acquire(2).expect("second request");
+        assert_eq!(
+            tracker.acquire(3).err(),
+            Some(RequestAdmissionError::Exhausted(
+                ApiError::ResourceExhausted {
+                    resource: "max_inflight_requests".into(),
+                    limit: 2,
+                }
+            ))
+        );
+        drop(first);
+        assert!(!tracker.is_outstanding(1));
+        assert!(tracker.acquire(1).is_ok());
+        drop(second);
+    }
+
+    #[test]
+    fn credit_is_cumulative_monotonic_bounded_and_boundary_exact() {
+        let mut state = ProducerState::new(10);
+        assert_eq!(state.next_payload(4), None, "no DATA before initial credit");
+        assert_eq!(
+            state.credit(0, 0),
+            Ok(CreditEffect::Advanced { accepted: false })
+        );
+        assert_eq!(state.credit(0, 0), Ok(CreditEffect::Repeated));
+        assert_eq!(
+            state.credit(0, 4),
+            Ok(CreditEffect::Advanced { accepted: false })
+        );
+        assert_eq!(state.next_payload(64), Some(4));
+        state.data_sent(4).expect("first DATA boundary");
+
+        assert_eq!(
+            state.credit(4, 8),
+            Ok(CreditEffect::Advanced { accepted: true })
+        );
+        state.data_sent(4).expect("second DATA boundary");
+        for invalid in [(3, 8), (4, 7), (9, 9), (8, 11)] {
+            assert_eq!(state.credit(invalid.0, invalid.1), Err(()), "{invalid:?}");
+        }
+        // Atomic DATA acceptance forbids acknowledging the middle of a record.
+        assert_eq!(state.credit(6, 8), Err(()));
+    }
+
+    #[test]
+    fn checked_data_and_credit_edges_never_wrap_or_cross_credit() {
+        let mut state = ProducerState::new(u64::MAX);
+        state.credit_seen = true;
+        state.send_through = u64::MAX;
+        state.sent = u64::MAX;
+        assert_eq!(state.data_sent(1), Err(()));
+
+        let mut bounded = ProducerState::new(5);
+        bounded.credit(0, 1).unwrap();
+        assert_eq!(bounded.data_sent(2), Err(()), "DATA may not exceed credit");
+        bounded.data_sent(1).unwrap();
+        assert_eq!(bounded.next_payload(65_536), None);
+        assert_eq!(bounded.credit(2, 2), Err(()), "cannot ACK unsent bytes");
+    }
+
+    #[test]
+    fn zero_one_multi_and_maximum_totals_segment_without_whole_file_state() {
+        let zero = ProducerState::new(0);
+        assert!(!zero.ready_for_end(), "zero still requires initial CREDIT");
+
+        let mut one = ProducerState::new(1);
+        one.credit(0, 1).unwrap();
+        assert_eq!(one.next_payload(65_536), Some(1));
+        one.data_sent(1).unwrap();
+        one.credit(1, 1).unwrap();
+        assert!(one.ready_for_end());
+
+        let total = 104_857_600_u64;
+        let mut maximum = ProducerState::new(total);
+        maximum.credit(0, total).unwrap();
+        let mut records = 0_usize;
+        while let Some(bytes) = maximum.next_payload(65_536) {
+            assert!((1..=65_536).contains(&bytes));
+            maximum.data_sent(bytes).unwrap();
+            records += 1;
+            maximum.credit(maximum.sent, total).unwrap();
+        }
+        assert_eq!(maximum.sent, total);
+        assert_eq!(records, 1_600);
+        assert!(maximum.ready_for_end());
+
+        // Adversarial one-byte credit cannot accumulate one boundary per byte:
+        // the producer keeps exactly one atomic DATA record outstanding.
+        let mut tiny_windows = ProducerState::new(100_000);
+        for end in 1..=100_000 {
+            tiny_windows.credit(tiny_windows.accepted, end).unwrap();
+            assert_eq!(tiny_windows.next_payload(65_536), Some(1));
+            tiny_windows.data_sent(1).unwrap();
+            assert_eq!(tiny_windows.next_payload(65_536), None);
+            tiny_windows.credit(end, end).unwrap();
+        }
+        assert!(tiny_windows.ready_for_end());
+    }
+
+    #[test]
+    fn binary_routing_checks_size_then_full_pair_then_direction_and_structure() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).expect("fresh pair");
+        binding.set_phase(BindingPhase::Active);
+        let limits = bounds(64);
+
+        let oversized_bad_magic = vec![0; 65];
+        assert_eq!(
+            registry.route_binary(&oversized_bad_magic, &limits),
+            BinaryRoute::CloseTooLarge
+        );
+        assert_eq!(
+            registry.route_binary(b"JBS2", &limits),
+            BinaryRoute::CloseMalformed
+        );
+        let mut bad_magic = wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]);
+        bad_magic[0] = b'X';
+        assert_eq!(
+            registry.route_binary(&bad_magic, &limits),
+            BinaryRoute::CloseMalformed
+        );
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID + 1, STREAM_ID, 0, 1, &[]), &limits,),
+            BinaryRoute::CloseMalformed,
+            "wrong request id cannot half-bind"
+        );
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID + 1, 0, 1, &[]), &limits,),
+            BinaryRoute::CloseMalformed,
+            "wrong stream id cannot half-bind"
+        );
+
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]), &limits,),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 1
+                }),
+                ..
+            })
+        ));
+
+        // DATA is structurally plausible but the client is the receiver. Kind
+        // and direction reject it before the full decoder can allocate payload.
+        assert_eq!(
+            registry.route_binary(&wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[0xaa]), &limits,),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Malformed,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn records_before_writer_commits_open_have_no_trustworthy_binding() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).expect("opening pair");
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 0, &[]), &bounds(64),),
+            BinaryRoute::CloseMalformed
+        );
+        assert!(binding.ingress.mailbox.try_recv().is_none());
+    }
+
+    #[test]
+    fn malformed_bound_record_is_local_but_unbound_malformed_is_connection_fatal() {
+        let registry = StreamRegistry::new();
+        let one = StreamIdentity::new(1, 11).unwrap();
+        let two = StreamIdentity::new(2, 22).unwrap();
+        let one_binding = registry.bind(one).unwrap();
+        let two_binding = registry.bind(two).unwrap();
+        one_binding.set_phase(BindingPhase::Active);
+        two_binding.set_phase(BindingPhase::Active);
+        let limits = bounds(64);
+
+        let mut bound_bad_reserved = wire(0x03, 1, 11, 0, 1, &[]);
+        bound_bad_reserved[5] = 1;
+        assert_eq!(
+            registry.route_binary(&bound_bad_reserved, &limits),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            one_binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Malformed,
+                ..
+            })
+        ));
+
+        // The unrelated exact pair remains fully usable.
+        assert_eq!(
+            registry.route_binary(&wire(0x03, 2, 22, 0, 1, &[]), &limits),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            two_binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit { .. }),
+                ..
+            })
+        ));
+
+        let mut unbound_bad_reserved = wire(0x03, 3, 33, 0, 1, &[]);
+        unbound_bad_reserved[5] = 1;
+        assert_eq!(
+            registry.route_binary(&unbound_bad_reserved, &limits),
+            BinaryRoute::CloseMalformed
+        );
+    }
+
+    #[test]
+    fn duplicate_terminal_is_a_bound_stream_protocol_fault() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::Active);
+        let abort = wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]);
+
+        assert_eq!(
+            registry.route_binary(&abort, &bounds(64)),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            registry.route_binary(&abort, &bounds(64)),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Malformed,
+                ..
+            })
+        ));
+        assert!(binding.ingress.mailbox.try_recv().is_none());
+    }
+
+    #[test]
+    fn coalesced_credit_keeps_wire_order_ahead_of_later_abort() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::Active);
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]), &bounds(64),),
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            registry.route_binary(&wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &bounds(64),),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit { .. }),
+                ..
+            })
+        ));
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Abort { .. }),
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn credit_coalescing_preserves_progress_time_and_invalid_intermediate_values() {
+        tokio::time::pause();
+        let mailbox = InboundMailbox::new();
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 0,
+            },
+            false,
+        );
+        let progress_at = Instant::now();
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 4,
+                send_through: 4,
+            },
+            false,
+        );
+        tokio::time::advance(Duration::from_millis(9)).await;
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 4,
+                send_through: 8,
+            },
+            false,
+        );
+
+        assert!(matches!(
+            mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 0,
+                }),
+                ..
+            })
+        ));
+        let progress = mailbox
+            .try_recv()
+            .expect("accepted progress remains visible");
+        assert_eq!(progress.received_at, progress_at);
+        assert!(matches!(
+            progress.body,
+            MailboxEventBody::Record(StreamRecordBody::Credit {
+                accepted_through: 4,
+                send_through: 8,
+            })
+        ));
+
+        let mailbox = InboundMailbox::new();
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 2,
+                send_through: 4,
+            },
+            false,
+        );
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 4,
+                send_through: 4,
+            },
+            false,
+        );
+        let mut producer = ProducerState::new(4);
+        producer.credit(0, 4).unwrap();
+        producer.data_sent(4).unwrap();
+        let partial = mailbox.try_recv().expect("partial ACK is retained");
+        let MailboxEventBody::Record(StreamRecordBody::Credit {
+            accepted_through,
+            send_through,
+        }) = partial.body
+        else {
+            panic!("expected retained CREDIT");
+        };
+        assert_eq!(producer.credit(accepted_through, send_through), Err(()));
+    }
+
+    #[test]
+    fn terminal_fault_preserves_earlier_credit_order() {
+        let mailbox = InboundMailbox::new();
+        mailbox.push(
+            StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            },
+            false,
+        );
+        mailbox.push(
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+            false,
+        );
+        mailbox.push(
+            StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: BinaryAbortReason::Cancelled,
+            },
+            false,
+        );
+        assert!(matches!(
+            mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit { .. }),
+                ..
+            })
+        ));
+        assert!(matches!(
+            mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Malformed,
+                ..
+            })
+        ));
+        assert!(mailbox.try_recv().is_none());
+    }
+
+    #[test]
+    fn duplicate_bind_does_not_replace_the_live_ingress() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::Active);
+        assert!(registry.bind(identity).is_none());
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 0, &[]), &bounds(64),),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            binding.ingress.mailbox.try_recv(),
+            Some(MailboxEvent {
+                body: MailboxEventBody::Record(StreamRecordBody::Credit { .. }),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn stale_routing_clone_cannot_deliver_after_retirement() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::Active);
+        let stale = binding.ingress.clone();
+        binding.retire();
+        assert_eq!(BindingPhase::load(&stale.phase), BindingPhase::Retired);
+        assert_eq!(
+            StreamRegistry::route_bound(
+                &stale,
+                &wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]),
+                &bounds(64),
+            ),
+            BinaryRoute::CloseMalformed
+        );
+        assert!(stale.mailbox.try_recv().is_none());
+    }
+
+    #[tokio::test]
+    async fn timely_ack_at_the_daemon_abort_deadline_wins_the_atomic_poll() {
+        tokio::time::pause();
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::DaemonAbortWaitAck);
+        let deadline = Instant::now() + Duration::from_millis(10);
+
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert_eq!(
+            registry.route_binary(
+                &wire(0x06, REQUEST_ID, STREAM_ID, 0, 0x05, &[]),
+                &bounds(64),
+            ),
+            BinaryRoute::Delivered
+        );
+        let DaemonAckPoll::Event(event) = poll_daemon_ack(&binding, deadline) else {
+            panic!("an ACK sequenced at the deadline must be observed before timeout");
+        };
+        assert!(event.received_at <= deadline);
+        assert!(matches!(
+            event.body,
+            MailboxEventBody::Record(StreamRecordBody::Ack {
+                accepted_through: 0
+            })
+        ));
+    }
+
+    #[test]
+    fn end_finalizing_ignores_only_valid_late_controls_and_retains_no_resume_state() {
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let binding = registry.bind(identity).unwrap();
+        binding.set_phase(BindingPhase::Finalizing);
+        let abort = wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]);
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 0, &[]), &bounds(64),),
+            BinaryRoute::Delivered,
+            "the final repeated CREDIT cannot alter committed END"
+        );
+        assert_eq!(
+            registry.route_binary(&abort, &bounds(64)),
+            BinaryRoute::Delivered
+        );
+        assert!(binding.ingress.mailbox.try_recv().is_none());
+        assert_eq!(
+            registry.route_binary(&wire(0x03, REQUEST_ID, STREAM_ID, 0, 1, &[]), &bounds(64),),
+            BinaryRoute::CloseMalformed,
+            "one-past late CREDIT is validated rather than silently dropped"
+        );
+        assert_eq!(
+            registry.route_binary(
+                &wire(0x06, REQUEST_ID, STREAM_ID, 0, 0x05, &[]),
+                &bounds(64),
+            ),
+            BinaryRoute::CloseMalformed,
+            "unsolicited ACK has no valid FINALIZING transition"
+        );
+        drop(binding);
+        assert!(!registry.is_active());
+        assert_eq!(
+            registry.route_binary(&abort, &bounds(64)),
+            BinaryRoute::CloseMalformed,
+            "a retired pair is never resumable or tombstoned as active"
+        );
+    }
+}

--- a/crates/jeliyad/src/main.rs
+++ b/crates/jeliyad/src/main.rs
@@ -13,8 +13,11 @@
 //! and the WS auth token, graceful teardown on SIGTERM/SIGINT, and
 //! `--supervised` mode that exits when the parent closes stdin.
 
+mod file_read;
 mod lifecycle;
+mod outbound;
 mod serve;
+mod transfer;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
@@ -96,6 +99,10 @@ pub(crate) struct AppState {
     pub(crate) connect_tickets: Arc<std::sync::Mutex<std::collections::HashMap<String, u64>>>,
     /// Live WebSocket connections, for the `max_connections` gate.
     pub(crate) connections: Arc<std::sync::atomic::AtomicU64>,
+    /// Host-checked framing, queue, stall, and absolute-deadline limits.
+    pub(crate) runtime_limits: transfer::RuntimeLimits,
+    /// Daemon-global transfer count and logical-byte admission pool.
+    pub(crate) transfer_pool: transfer::TransferPool,
 }
 
 #[tokio::main]
@@ -192,6 +199,14 @@ async fn main() {
         }
     };
     let engine_limits = engine.limits();
+    let runtime_limits = match transfer::RuntimeLimits::from_served(&engine_limits) {
+        Ok(limits) => limits,
+        Err(err) => {
+            error!("invalid served transfer limits: {err}");
+            std::process::exit(1);
+        }
+    };
+    let transfer_pool = transfer::TransferPool::from_runtime(&runtime_limits);
     let state = AppState {
         data_dir: data_dir.clone(),
         engine,
@@ -199,6 +214,8 @@ async fn main() {
         port: addr.port(),
         connect_tickets: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        runtime_limits,
+        transfer_pool,
     };
 
     let portfile = lifecycle::Portfile {

--- a/crates/jeliyad/src/outbound.rs
+++ b/crates/jeliyad/src/outbound.rs
@@ -1,0 +1,811 @@
+//! Byte-bounded, priority-aware WebSocket output.
+//!
+//! JSON and stream-control records use the priority queue. DATA uses a
+//! separate queue whose complete record bytes are reserved before the file is
+//! read and released only after the socket writer has acknowledged the
+//! message. This keeps source read-ahead and queued DATA independently bounded
+//! from the logical transfer reservation.
+
+use std::sync::{
+    atomic::{AtomicBool, AtomicU8, Ordering},
+    Arc,
+};
+
+use futures_util::{Sink, SinkExt};
+use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
+use tokio::time::Duration;
+use tokio_tungstenite::tungstenite::{Bytes, Message};
+
+/// Result of one command at the single socket writer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteReceipt {
+    /// The complete WebSocket message was accepted by the sink.
+    Sent,
+    /// A queued DATA record was invalidated by a stream terminal decision.
+    Discarded,
+    /// The socket writer was already gone or its sink failed.
+    Closed,
+}
+
+struct WriterCommand {
+    message: Message,
+    receipt: Option<oneshot::Sender<WriteReceipt>>,
+    byte_permit: Arc<OwnedSemaphorePermit>,
+    connection_live: Option<Arc<AtomicBool>>,
+    stream_live: Option<Arc<AtomicBool>>,
+    on_start: Option<Box<dyn FnOnce() -> bool + Send>>,
+    on_sent: Option<Box<dyn FnOnce() + Send>>,
+    pending_state: Option<Arc<AtomicU8>>,
+}
+
+const WRITE_QUEUED: u8 = 0;
+const WRITE_STARTED: u8 = 1;
+const WRITE_DONE: u8 = 2;
+const WRITE_CANCELLED: u8 = 3;
+
+/// The receiving halves owned by the connection's sole socket writer.
+pub(crate) struct WriterQueues {
+    control_rx: mpsc::Receiver<WriterCommand>,
+    data_rx: mpsc::Receiver<WriterCommand>,
+}
+
+/// Cloneable output handle shared by request and transfer actors.
+#[derive(Clone)]
+pub(crate) struct Outbound {
+    control_tx: mpsc::Sender<WriterCommand>,
+    data_tx: mpsc::Sender<WriterCommand>,
+    control_bytes: Arc<Semaphore>,
+    data_bytes: Arc<Semaphore>,
+    max_message_bytes: usize,
+    connection_live: Arc<AtomicBool>,
+}
+
+/// Complete-record byte capacity acquired before a source read.
+#[derive(Clone)]
+pub(crate) struct DataReservation {
+    permit: Arc<OwnedSemaphorePermit>,
+    bytes: usize,
+}
+
+/// A queued message whose result is acknowledged by the sole socket writer.
+pub(crate) struct PendingWrite {
+    receipt: oneshot::Receiver<WriteReceipt>,
+    state: Arc<AtomicU8>,
+}
+
+/// Cloneable cancellation side for a queued DATA write.
+#[derive(Clone)]
+pub(crate) struct PendingWriteCancel {
+    state: Arc<AtomicU8>,
+}
+
+fn message_payload_len(message: &Message) -> usize {
+    match message {
+        Message::Text(text) => text.len(),
+        Message::Binary(bytes) | Message::Ping(bytes) | Message::Pong(bytes) => bytes.len(),
+        Message::Close(Some(frame)) => frame.reason.len().saturating_add(2),
+        Message::Close(None) | Message::Frame(_) => 0,
+    }
+}
+
+impl PendingWrite {
+    pub(crate) async fn wait(self) -> WriteReceipt {
+        self.receipt.await.unwrap_or(WriteReceipt::Closed)
+    }
+
+    /// Cancels a DATA command only while it is still queued. Once the sole
+    /// writer has claimed the command, its bounded sink receipt must be
+    /// reconciled because the message may already be peer-visible.
+    pub(crate) fn cancellation(&self) -> PendingWriteCancel {
+        PendingWriteCancel {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl PendingWriteCancel {
+    pub(crate) fn cancel_before_start(&self) -> bool {
+        self.state
+            .compare_exchange(
+                WRITE_QUEUED,
+                WRITE_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+}
+
+impl Outbound {
+    /// Constructs independently bounded control and DATA queues.
+    pub(crate) fn new(
+        control_messages: usize,
+        data_messages: usize,
+        control_bytes: usize,
+        data_bytes: usize,
+        max_message_bytes: usize,
+    ) -> (Self, WriterQueues) {
+        let (control_tx, control_rx) = mpsc::channel(control_messages.max(1));
+        let (data_tx, data_rx) = mpsc::channel(data_messages.max(1));
+        (
+            Self {
+                control_tx,
+                data_tx,
+                control_bytes: Arc::new(Semaphore::new(control_bytes)),
+                data_bytes: Arc::new(Semaphore::new(data_bytes)),
+                max_message_bytes,
+                connection_live: Arc::new(AtomicBool::new(true)),
+            },
+            WriterQueues {
+                control_rx,
+                data_rx,
+            },
+        )
+    }
+
+    /// Enqueues one JSON Text message and returns a socket-write receipt.
+    pub(crate) async fn text(&self, bytes: Vec<u8>) -> WriteReceipt {
+        let text = String::from_utf8(bytes).expect("serialized JSON is UTF-8");
+        self.control_wait(Message::Text(text.into())).await
+    }
+
+    /// Enqueues Text and runs `on_sent` after the sink accepts the message but
+    /// before any waiter is notified. This is the peer-visible retirement
+    /// boundary for request identifiers and completed stream bindings.
+    pub(crate) async fn text_with_on_sent<F>(&self, bytes: Vec<u8>, on_sent: F) -> WriteReceipt
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let text = String::from_utf8(bytes).expect("serialized JSON is UTF-8");
+        self.control_wait_with_hooks(
+            Message::Text(text.into()),
+            true,
+            None,
+            None,
+            Some(Box::new(on_sent)),
+        )
+        .await
+    }
+
+    /// Enqueues terminal Text with atomic writer-start and successful-send
+    /// hooks, mirroring the stream-control sequencing surface.
+    pub(crate) async fn text_with_hooks<F, G>(
+        &self,
+        bytes: Vec<u8>,
+        stream_live: Arc<AtomicBool>,
+        on_start: F,
+        on_sent: G,
+    ) -> WriteReceipt
+    where
+        F: FnOnce() -> bool + Send + 'static,
+        G: FnOnce() + Send + 'static,
+    {
+        let text = String::from_utf8(bytes).expect("serialized JSON is UTF-8");
+        self.control_wait_with_hooks(
+            Message::Text(text.into()),
+            true,
+            Some(stream_live),
+            Some(Box::new(on_start)),
+            Some(Box::new(on_sent)),
+        )
+        .await
+    }
+
+    /// Enqueues a Pong without waiting behind DATA.
+    pub(crate) async fn pong(&self, payload: tokio_tungstenite::tungstenite::Bytes) -> bool {
+        self.control_nowait(Message::Pong(payload)).await
+    }
+
+    /// Enqueues a Close without waiting behind DATA.
+    pub(crate) async fn close(
+        &self,
+        frame: tokio_tungstenite::tungstenite::protocol::CloseFrame,
+    ) -> bool {
+        let write_live = Arc::new(AtomicBool::new(true));
+        tokio::select! {
+            biased;
+            receipt = self.control_wait_with_hooks(
+                Message::Close(Some(frame)),
+                false,
+                Some(write_live.clone()),
+                None,
+                None,
+            ) => receipt == WriteReceipt::Sent,
+            () = tokio::time::sleep(Duration::from_secs(1)) => {
+                write_live.store(false, Ordering::Release);
+                false
+            }
+        }
+    }
+
+    async fn control_wait(&self, message: Message) -> WriteReceipt {
+        self.control_wait_with_hooks(message, true, None, None, None)
+            .await
+    }
+
+    async fn control_wait_with_hooks(
+        &self,
+        message: Message,
+        connection_bound: bool,
+        stream_live: Option<Arc<AtomicBool>>,
+        on_start: Option<Box<dyn FnOnce() -> bool + Send>>,
+        on_sent: Option<Box<dyn FnOnce() + Send>>,
+    ) -> WriteReceipt {
+        let Some(byte_permit) = self.reserve_control(message_payload_len(&message)).await else {
+            return WriteReceipt::Closed;
+        };
+        let (receipt_tx, receipt_rx) = oneshot::channel();
+        let command = WriterCommand {
+            message,
+            receipt: Some(receipt_tx),
+            byte_permit: Arc::new(byte_permit),
+            connection_live: connection_bound.then(|| self.connection_live.clone()),
+            stream_live,
+            on_start,
+            on_sent,
+            pending_state: None,
+        };
+        if self.control_tx.send(command).await.is_err() {
+            return WriteReceipt::Closed;
+        }
+        receipt_rx.await.unwrap_or(WriteReceipt::Closed)
+    }
+
+    async fn control_nowait(&self, message: Message) -> bool {
+        let Some(byte_permit) = self.reserve_control(message_payload_len(&message)).await else {
+            return false;
+        };
+        self.control_tx
+            .send(WriterCommand {
+                message,
+                receipt: None,
+                byte_permit: Arc::new(byte_permit),
+                connection_live: Some(self.connection_live.clone()),
+                stream_live: None,
+                on_start: None,
+                on_sent: None,
+                pending_state: None,
+            })
+            .await
+            .is_ok()
+    }
+
+    async fn reserve_control(&self, bytes: usize) -> Option<OwnedSemaphorePermit> {
+        if bytes > self.max_message_bytes {
+            return None;
+        }
+        let permits = u32::try_from(bytes.max(1)).ok()?;
+        self.control_bytes
+            .clone()
+            .acquire_many_owned(permits)
+            .await
+            .ok()
+    }
+
+    /// Acquires complete-record byte capacity without waiting or reading.
+    ///
+    /// Runtime configuration keeps every individual record and the aggregate
+    /// DATA queue within `u32`, the permit unit accepted by Tokio's semaphore.
+    pub(crate) fn reserve_data(&self, record_bytes: usize) -> Option<DataReservation> {
+        if record_bytes == 0 || record_bytes > self.max_message_bytes {
+            return None;
+        }
+        let permits = u32::try_from(record_bytes).ok()?;
+        let permit = self
+            .data_bytes
+            .clone()
+            .try_acquire_many_owned(permits)
+            .ok()?;
+        Some(DataReservation {
+            permit: Arc::new(permit),
+            bytes: record_bytes,
+        })
+    }
+
+    /// Enqueues one already-reserved DATA record and waits for writer
+    /// acknowledgement. The permit remains owned by the command through the
+    /// sink write (or cancellation discard).
+    #[cfg(test)]
+    pub(crate) async fn data(
+        &self,
+        reservation: DataReservation,
+        bytes: Vec<u8>,
+        stream_live: Arc<AtomicBool>,
+    ) -> WriteReceipt {
+        if bytes.len() != reservation.bytes {
+            return WriteReceipt::Closed;
+        }
+        let (receipt_tx, receipt_rx) = oneshot::channel();
+        let command = WriterCommand {
+            message: Message::Binary(bytes.into()),
+            receipt: Some(receipt_tx),
+            byte_permit: reservation.permit,
+            connection_live: Some(self.connection_live.clone()),
+            stream_live: Some(stream_live),
+            on_start: None,
+            on_sent: None,
+            pending_state: None,
+        };
+        if self.data_tx.send(command).await.is_err() {
+            return WriteReceipt::Closed;
+        }
+        receipt_rx.await.unwrap_or(WriteReceipt::Closed)
+    }
+
+    /// Queues one reserved DATA record without awaiting the socket writer.
+    /// The runtime uses the returned receipt in the same select loop as its
+    /// deadline, stall timer, and terminal controls.
+    pub(crate) fn queue_data_with_start<F>(
+        &self,
+        reservation: DataReservation,
+        bytes: Bytes,
+        stream_live: Arc<AtomicBool>,
+        on_start: F,
+    ) -> Option<PendingWrite>
+    where
+        F: FnOnce() -> bool + Send + 'static,
+    {
+        if bytes.len() != reservation.bytes {
+            return None;
+        }
+        let (receipt_tx, receipt) = oneshot::channel();
+        let state = Arc::new(AtomicU8::new(WRITE_QUEUED));
+        self.data_tx
+            .try_send(WriterCommand {
+                message: Message::Binary(bytes),
+                receipt: Some(receipt_tx),
+                byte_permit: reservation.permit,
+                connection_live: Some(self.connection_live.clone()),
+                stream_live: Some(stream_live),
+                on_start: Some(Box::new(on_start)),
+                on_sent: None,
+                pending_state: Some(state.clone()),
+            })
+            .ok()?;
+        Some(PendingWrite { receipt, state })
+    }
+
+    /// Enqueues stream control whose state transition is committed by the
+    /// sole writer immediately before it starts the WebSocket message. A
+    /// `false` callback result discards the command, allowing an inbound
+    /// terminal or timer that won first to prevent a late OPEN/END.
+    pub(crate) async fn binary_control_with_start<F>(
+        &self,
+        bytes: Vec<u8>,
+        stream_live: Arc<AtomicBool>,
+        on_start: F,
+    ) -> WriteReceipt
+    where
+        F: FnOnce() -> bool + Send + 'static,
+    {
+        self.control_wait_with_hooks(
+            Message::Binary(bytes.into()),
+            true,
+            Some(stream_live),
+            Some(Box::new(on_start)),
+            None,
+        )
+        .await
+    }
+
+    /// Enqueues stream control with atomic writer-start and successful-send
+    /// hooks. The latter runs before the receipt becomes observable.
+    pub(crate) async fn binary_control_with_hooks<F, G>(
+        &self,
+        bytes: Vec<u8>,
+        stream_live: Arc<AtomicBool>,
+        on_start: F,
+        on_sent: G,
+    ) -> WriteReceipt
+    where
+        F: FnOnce() -> bool + Send + 'static,
+        G: FnOnce() + Send + 'static,
+    {
+        self.control_wait_with_hooks(
+            Message::Binary(bytes.into()),
+            true,
+            Some(stream_live),
+            Some(Box::new(on_start)),
+            Some(Box::new(on_sent)),
+        )
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn available_data_bytes(&self) -> usize {
+        self.data_bytes.available_permits()
+    }
+
+    #[cfg(test)]
+    fn available_control_bytes(&self) -> usize {
+        self.control_bytes.available_permits()
+    }
+
+    /// Prevents every queued or future non-Close message from starting. A
+    /// connection-fatal path calls this before it queues the Close itself.
+    pub(crate) fn invalidate_connection(&self) {
+        self.connection_live.store(false, Ordering::Release);
+    }
+}
+
+impl WriterQueues {
+    /// Runs the connection's sole socket writer. The biased selection is
+    /// deliberate: each DATA write is one bounded record, then queued JSON,
+    /// terminal stream control, Pong, or Close gets first opportunity.
+    pub(crate) async fn run<S, E>(mut self, mut sink: S, write_timeout: Duration) -> Result<(), E>
+    where
+        S: Sink<Message, Error = E> + Unpin,
+    {
+        loop {
+            let command = tokio::select! {
+                biased;
+                Some(command) = self.control_rx.recv() => command,
+                Some(command) = self.data_rx.recv() => command,
+                else => break,
+            };
+
+            if let Some(state) = &command.pending_state {
+                if state
+                    .compare_exchange(
+                        WRITE_QUEUED,
+                        WRITE_STARTED,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .is_err()
+                {
+                    state.store(WRITE_DONE, Ordering::Release);
+                    if let Some(receipt) = command.receipt {
+                        let _ = receipt.send(WriteReceipt::Discarded);
+                    }
+                    continue;
+                }
+            }
+
+            let discarded = command
+                .connection_live
+                .as_ref()
+                .is_some_and(|live| !live.load(Ordering::Acquire))
+                || command
+                    .stream_live
+                    .as_ref()
+                    .is_some_and(|live| !live.load(Ordering::Acquire));
+            if discarded {
+                if let Some(state) = &command.pending_state {
+                    state.store(WRITE_DONE, Ordering::Release);
+                }
+                if let Some(receipt) = command.receipt {
+                    let _ = receipt.send(WriteReceipt::Discarded);
+                }
+                // Dropping the command here releases its DATA permit.
+                continue;
+            }
+
+            let WriterCommand {
+                message,
+                receipt,
+                byte_permit,
+                connection_live: _,
+                stream_live: _,
+                on_start,
+                on_sent,
+                pending_state,
+            } = command;
+            if on_start.is_some_and(|commit| !commit()) {
+                if let Some(state) = &pending_state {
+                    state.store(WRITE_DONE, Ordering::Release);
+                }
+                if let Some(receipt) = receipt {
+                    let _ = receipt.send(WriteReceipt::Discarded);
+                }
+                continue;
+            }
+            // This watchdog is owned by the writer itself, independently of
+            // the socket reader. Consequently a sink stalled in DATA cannot
+            // also strand a Pong, push, Close, or transfer terminal while the
+            // reader is awaiting that control receipt.
+            let result = tokio::time::timeout(write_timeout, sink.send(message)).await;
+            // A permit represents bytes retained through the sink await. The
+            // drop is the writer acknowledgement for byte-capacity purposes.
+            drop(byte_permit);
+            if let Some(state) = &pending_state {
+                state.store(WRITE_DONE, Ordering::Release);
+            }
+            match result {
+                Ok(Ok(())) => {
+                    if let Some(on_sent) = on_sent {
+                        on_sent();
+                    }
+                    if let Some(receipt) = receipt {
+                        let _ = receipt.send(WriteReceipt::Sent);
+                    }
+                }
+                Ok(Err(error)) => {
+                    if let Some(receipt) = receipt {
+                        let _ = receipt.send(WriteReceipt::Closed);
+                    }
+                    return Err(error);
+                }
+                Err(_) => {
+                    if let Some(receipt) = receipt {
+                        let _ = receipt.send(WriteReceipt::Closed);
+                    }
+                    // Dropping the sink closes the connection. The owner task
+                    // independently notifies the reader through `close_tx`.
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::pin::Pin;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    };
+    use std::task::{Context, Poll};
+
+    use futures_util::Sink;
+    use tokio::sync::Notify;
+    use tokio::time::Duration;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use super::{Outbound, WriteReceipt};
+
+    #[derive(Clone, Default)]
+    struct RecordingSink {
+        messages: Arc<Mutex<Vec<Message>>>,
+    }
+
+    impl Sink<Message> for RecordingSink {
+        type Error = Infallible;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.messages
+                .lock()
+                .expect("recording sink poisoned")
+                .push(item);
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct StalledSink {
+        started: Arc<Notify>,
+    }
+
+    impl Sink<Message> for StalledSink {
+        type Error = Infallible;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            self.started.notify_one();
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Pending
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn data_bytes_remain_reserved_until_writer_acknowledges() {
+        let (out, queues) = Outbound::new(2, 1, 64, 64, 64);
+        let reservation = out.reserve_data(64).expect("exact capacity");
+        assert_eq!(out.available_data_bytes(), 0);
+        assert!(out.reserve_data(1).is_none());
+
+        let sink = RecordingSink::default();
+        let written = sink.messages.clone();
+        let writer = tokio::spawn(queues.run(sink, Duration::from_secs(1)));
+        let live = Arc::new(AtomicBool::new(true));
+        assert_eq!(
+            out.data(reservation, vec![7; 64], live).await,
+            WriteReceipt::Sent
+        );
+        assert_eq!(out.available_data_bytes(), 64);
+        assert!(matches!(
+            written.lock().expect("recording sink poisoned").as_slice(),
+            [Message::Binary(_)]
+        ));
+        drop(out);
+        assert!(writer.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn on_sent_runs_only_after_a_successful_sink_send() {
+        let (out, queues) = Outbound::new(2, 1, 64, 64, 64);
+        let sink = RecordingSink::default();
+        let writer = tokio::spawn(queues.run(sink, Duration::from_secs(1)));
+        let sent = Arc::new(AtomicBool::new(false));
+        let mark_sent = sent.clone();
+        assert_eq!(
+            out.text_with_on_sent(vec![b'x'], move || {
+                mark_sent.store(true, Ordering::Release);
+            })
+            .await,
+            WriteReceipt::Sent
+        );
+        assert!(sent.load(Ordering::Acquire));
+
+        let live = Arc::new(AtomicBool::new(false));
+        let discarded_hook = Arc::new(AtomicBool::new(false));
+        let mark_discarded = discarded_hook.clone();
+        assert_eq!(
+            out.binary_control_with_hooks(
+                vec![0; 1],
+                live,
+                || true,
+                move || mark_discarded.store(true, Ordering::Release),
+            )
+            .await,
+            WriteReceipt::Discarded
+        );
+        assert!(!discarded_hook.load(Ordering::Acquire));
+        drop(out);
+        assert!(writer.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn data_reservation_must_exactly_match_the_queued_record() {
+        let (out, _queues) = Outbound::new(2, 1, 64, 64, 64);
+        let reservation = out.reserve_data(64).expect("exact capacity");
+        assert_eq!(
+            out.data(reservation, vec![7; 63], Arc::new(AtomicBool::new(true)),)
+                .await,
+            WriteReceipt::Closed
+        );
+        assert_eq!(out.available_data_bytes(), 64);
+    }
+
+    #[tokio::test]
+    async fn writer_watchdog_unblocks_data_and_control_when_sink_flush_stalls() {
+        tokio::time::pause();
+        let (out, queues) = Outbound::new(2, 1, 64, 64, 64);
+        let sink = StalledSink::default();
+        let started = sink.started.clone();
+        let writer = tokio::spawn(queues.run(sink, Duration::from_millis(10)));
+
+        let reservation = out.reserve_data(64).expect("exact capacity");
+        let data_out = out.clone();
+        let data = tokio::spawn(async move {
+            data_out
+                .data(reservation, vec![7; 64], Arc::new(AtomicBool::new(true)))
+                .await
+        });
+        started.notified().await;
+        let control_out = out.clone();
+        let control_sent = Arc::new(AtomicBool::new(false));
+        let control_sent_task = control_sent.clone();
+        let control = tokio::spawn(async move {
+            control_out
+                .text_with_hooks(
+                    vec![b'x'; 64],
+                    Arc::new(AtomicBool::new(true)),
+                    || true,
+                    move || control_sent_task.store(true, Ordering::Release),
+                )
+                .await
+        });
+
+        tokio::time::advance(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(data.await.unwrap(), WriteReceipt::Closed);
+        assert_eq!(control.await.unwrap(), WriteReceipt::Closed);
+        assert!(!control_sent.load(Ordering::Acquire));
+        assert!(writer.await.unwrap().is_ok());
+        assert_eq!(out.available_data_bytes(), 64);
+        assert_eq!(out.available_control_bytes(), 64);
+    }
+
+    #[tokio::test]
+    async fn control_overtakes_live_queued_data() {
+        let (out, queues) = Outbound::new(2, 1, 64, 64, 64);
+        let reservation = out.reserve_data(64).unwrap();
+        let live = Arc::new(AtomicBool::new(true));
+
+        // Fill both queues before the writer starts. The live DATA remains
+        // sendable, so observed order proves the biased control selection.
+        let data_out = out.clone();
+        let data_live = live.clone();
+        let data =
+            tokio::spawn(async move { data_out.data(reservation, vec![9; 64], data_live).await });
+        tokio::task::yield_now().await;
+        let control_out = out.clone();
+        let control =
+            tokio::spawn(async move { control_out.text(br#"{"id":1,"ok":true}"#.to_vec()).await });
+        tokio::task::yield_now().await;
+
+        let sink = RecordingSink::default();
+        let written = sink.messages.clone();
+        let writer = tokio::spawn(queues.run(sink, Duration::from_secs(1)));
+        assert_eq!(control.await.unwrap(), WriteReceipt::Sent);
+        assert_eq!(data.await.unwrap(), WriteReceipt::Sent);
+        assert!(matches!(
+            written.lock().expect("recording sink poisoned").as_slice(),
+            [Message::Text(_), Message::Binary(_)]
+        ));
+        assert_eq!(out.available_data_bytes(), 64);
+        drop(out);
+        assert!(writer.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn terminal_latch_discards_queued_data_and_control_bytes_are_bounded() {
+        let (out, queues) = Outbound::new(2, 1, 64, 64, 64);
+        let reservation = out.reserve_data(64).unwrap();
+        let live = Arc::new(AtomicBool::new(true));
+        let data_out = out.clone();
+        let data_live = live.clone();
+        let data =
+            tokio::spawn(async move { data_out.data(reservation, vec![9; 64], data_live).await });
+        tokio::task::yield_now().await;
+        live.store(false, Ordering::Release);
+
+        let control_out = out.clone();
+        let control = tokio::spawn(async move { control_out.text(vec![b'x'; 64]).await });
+        tokio::task::yield_now().await;
+        assert_eq!(out.available_control_bytes(), 0);
+        assert_eq!(
+            out.text(vec![b'x'; 65]).await,
+            WriteReceipt::Closed,
+            "one-past complete messages are refused before enqueue"
+        );
+
+        let sink = RecordingSink::default();
+        let written = sink.messages.clone();
+        let writer = tokio::spawn(queues.run(sink, Duration::from_secs(1)));
+        assert_eq!(control.await.unwrap(), WriteReceipt::Sent);
+        assert_eq!(data.await.unwrap(), WriteReceipt::Discarded);
+        assert!(matches!(
+            written.lock().expect("recording sink poisoned").as_slice(),
+            [Message::Text(_)]
+        ));
+        assert_eq!(out.available_control_bytes(), 64);
+        assert_eq!(out.available_data_bytes(), 64);
+        drop(out);
+        assert!(writer.await.unwrap().is_ok());
+    }
+}

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -11,7 +11,7 @@ use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::StreamExt;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::{
@@ -489,7 +489,23 @@ fn ws_upgrade(req: &mut Request<Incoming>, state: AppState) -> Response<Full<Byt
             "expected a websocket upgrade; connect to /ws",
         );
     }
-    match hyper_tungstenite::upgrade(req, None) {
+    let max_frame_bytes = state.runtime_limits.max_frame_bytes();
+    let max_encoded_message_bytes = max_frame_bytes
+        .checked_add(14)
+        .expect("validated frame bound leaves WebSocket header headroom");
+    let websocket_config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default()
+        // Jeliya checks the complete-message payload itself. Align both
+        // tungstenite guards with the served bound so its 64/16 MiB defaults
+        // cannot reject a conforming 128 MiB message below the application.
+        .max_message_size(Some(max_frame_bytes))
+        .max_frame_size(Some(max_frame_bytes))
+        // Each message is flushed eagerly; the runtime's own queue owns the
+        // explicit DATA byte permits and writer acknowledgement. Tungstenite's
+        // write buffer counts the encoded frame, so retain the maximum RFC
+        // 6455 header in addition to the application payload bound.
+        .write_buffer_size(0)
+        .max_write_buffer_size(max_encoded_message_bytes);
+    match hyper_tungstenite::upgrade(req, Some(websocket_config)) {
         Ok((response, websocket)) => {
             tokio::spawn(async move {
                 if let Ok(ws) = websocket.await {
@@ -905,12 +921,12 @@ fn serve_static(path: &str, ui: &UiSource) -> Response<Full<Bytes>> {
     text(StatusCode::NOT_FOUND, "not found")
 }
 
-/// One v2 WebSocket connection. The daemon's first frame is exactly one
-/// `hello`; thereafter each inbound text frame is decoded by the codec into a
+/// One v2 WebSocket connection. The daemon's first message is exactly one
+/// `hello`; thereafter each inbound Text message is decoded by the codec into a
 /// typed call, executed by the engine, and its typed reply encoded back —
-/// interleaved with typed pushes. A frame over the limit closes `4005`; a
-/// frame whose `id` cannot be recovered closes `4007`; any other malformed
-/// frame gets a correlated error reply so one bad request never strands the
+/// interleaved with typed pushes. A complete message over the limit closes
+/// `4005`; a message whose `id` cannot be recovered closes `4007`; any other
+/// malformed message gets a correlated error reply so one bad request never strands the
 /// others in flight. A lagged push receiver is told to resync (the one
 /// resync path), never silently continued.
 pub async fn serve_ws<S>(
@@ -922,9 +938,13 @@ pub async fn serve_ws<S>(
     // can own the socket and engine handles across threads.
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    let (mut sink, mut messages) = ws.split();
+    let (sink, mut messages) = ws.split();
     let mut push_rx = state.engine.subscribe_pushes();
-    let bounds = jeliya_codec::CodecBounds::default();
+    let bounds = jeliya_codec::CodecBounds {
+        max_frame_bytes: state.runtime_limits.max_frame_bytes(),
+        ..jeliya_codec::CodecBounds::default()
+    };
+    let served = state.engine.limits();
 
     // The authenticated session principal rendered as one ledger key:
     // `(credential, client_id)`. An omitted `client_id` yields a fresh
@@ -944,18 +964,29 @@ pub async fn serve_ws<S>(
         ),
     };
 
-    // All outbound frames flow through ONE writer task over an mpsc channel,
-    // so a slow request's execution never head-of-line blocks a push, a ping,
-    // or another request's reply. Replies may complete out of order — the
-    // record allows that and the client correlates by `id`.
-    let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Message>(256);
-    let writer = tokio::spawn(async move {
-        while let Some(msg) = out_rx.recv().await {
-            if sink.send(msg).await.is_err() {
-                break;
-            }
-        }
+    // One writer owns the sink. Its control queue is independent from the
+    // byte-permitted DATA queue and is selected first between bounded DATA
+    // records, so JSON, terminal control, Pong, and Close cannot sit behind a
+    // file-sized message-count backlog.
+    let (outbound, writer_queues) = crate::outbound::Outbound::new(
+        state.runtime_limits.control_queue_capacity_messages(),
+        state.runtime_limits.data_queue_capacity_messages(),
+        state.runtime_limits.control_queue_capacity_bytes(),
+        state.runtime_limits.data_queue_capacity_bytes(),
+        state.runtime_limits.max_frame_bytes(),
+    );
+    let (writer_done_tx, mut writer_done_rx) = tokio::sync::watch::channel(false);
+    let writer_timeout = state.runtime_limits.transfer_stall();
+    let mut writer = tokio::spawn(async move {
+        let _ = writer_queues.run(sink, writer_timeout).await;
+        let _ = writer_done_tx.send(true);
     });
+
+    let streams = crate::file_read::StreamRegistry::new();
+    let requests = crate::file_read::RequestTracker::new(served.max_inflight_requests);
+    let stream_ids = std::sync::Arc::new(std::sync::Mutex::new(
+        crate::transfer::StreamIdGenerator::new(),
+    ));
 
     // This connection's room subscriptions: `stream.subscribe` adds a room
     // with the position the client's stream begins at; `stream.unsubscribe`
@@ -975,15 +1006,14 @@ pub async fn serve_ws<S>(
     let subject = match state.engine.subject_state() {
         Ok(s) => s,
         Err(_) => {
-            let _ = out_tx
-                .send(Message::Close(Some(
-                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                        code: 4003.into(),
-                        reason: "not_ready".into(),
-                    },
-                )))
+            let _ = outbound
+                .close(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                    code: 4003.into(),
+                    reason: "not_ready".into(),
+                })
                 .await;
-            writer.abort();
+            drop(outbound);
+            let _ = writer.await;
             return;
         }
     };
@@ -996,16 +1026,21 @@ pub async fn serve_ws<S>(
     };
     match serde_json::to_vec(&hello) {
         Ok(bytes) => {
-            if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
-                writer.abort();
+            if outbound.text(bytes).await != crate::outbound::WriteReceipt::Sent {
+                drop(outbound);
+                let _ = writer.await;
                 return;
             }
         }
         Err(_) => {
-            writer.abort();
+            drop(outbound);
+            let _ = writer.await;
             return;
         }
     }
+
+    let (closer, mut close_requested_rx, mut close_completed_rx) =
+        crate::file_read::ConnectionCloser::new(streams.clone(), outbound.clone());
 
     // Track in-flight request tasks so the loop never serializes on a slow
     // operation; a finished task's result is reaped without blocking.
@@ -1016,41 +1051,118 @@ pub async fn serve_ws<S>(
     let idle_ms = state.engine.limits().idle_timeout_ms;
     let idle_deadline = tokio::time::sleep(tokio::time::Duration::from_millis(idle_ms));
     tokio::pin!(idle_deadline);
+    let mut force_writer_abort = false;
 
     loop {
+        if closer.is_requested() {
+            break;
+        }
         tokio::select! {
+            biased;
+            changed = close_requested_rx.changed() => {
+                if changed.is_err() || *close_requested_rx.borrow() {
+                    break;
+                }
+            }
+            changed = writer_done_rx.changed() => {
+                if changed.is_err() || *writer_done_rx.borrow() {
+                    force_writer_abort = true;
+                    break;
+                }
+            }
             msg = messages.next() => match msg {
-                Some(Ok(Message::Text(text))) => {
+                Some(Ok(message)) => {
+                    // The Close owner publishes `claimed` before it may need
+                    // to wait on a stream sequencing lock. Linearize reader
+                    // admission here, after the socket future resolves: a
+                    // message that became ready in that interval must not be
+                    // parsed or allowed to spawn a mutating request.
+                    if closer.is_requested() {
+                        break;
+                    }
                     idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
-                    if !dispatch_inbound(text.as_bytes(), &state, &bounds, &subscriptions, &out_tx, &mut inflight, &principal_key).await {
+                    // Complete-message size wins before Text/Binary class or
+                    // any JSON/header/magic/binding inspection.
+                    if complete_data_message_len(&message).is_some_and(|len| len > bounds.max_frame_bytes) {
+                        closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                            code: 4005.into(),
+                            reason: "frame_too_large".into(),
+                        });
                         break;
                     }
-                }
-                Some(Ok(Message::Binary(bytes))) => {
-                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
-                    if !dispatch_inbound(&bytes, &state, &bounds, &subscriptions, &out_tx, &mut inflight, &principal_key).await {
-                        break;
+                    match message {
+                        Message::Text(text) => {
+                            if !dispatch_text(
+                                text.as_bytes(),
+                                &state,
+                                &bounds,
+                                &subscriptions,
+                                &outbound,
+                                &requests,
+                                &streams,
+                                &stream_ids,
+                                &closer,
+                                &mut inflight,
+                                &principal_key,
+                            ).await {
+                                break;
+                            }
+                        }
+                        Message::Binary(bytes) => match streams.route_binary(&bytes, &bounds) {
+                            crate::file_read::BinaryRoute::Delivered => {}
+                            crate::file_read::BinaryRoute::CloseTooLarge => {
+                                closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                                    code: 4005.into(),
+                                    reason: "frame_too_large".into(),
+                                });
+                                break;
+                            }
+                            crate::file_read::BinaryRoute::CloseMalformed => {
+                                closer.malformed();
+                                break;
+                            }
+                        },
+                        Message::Ping(payload) => {
+                            if !outbound.pong(payload).await {
+                                break;
+                            }
+                        }
+                        Message::Close(_) => {
+                            force_writer_abort = true;
+                            break;
+                        }
+                        Message::Pong(_) | Message::Frame(_) => {}
                     }
                 }
-                Some(Ok(Message::Ping(payload))) => {
-                    if out_tx.send(Message::Pong(payload)).await.is_err() {
-                        break;
-                    }
+                Some(Err(tokio_tungstenite::tungstenite::Error::Capacity(
+                    tokio_tungstenite::tungstenite::error::CapacityError::MessageTooLong { .. },
+                ))) => {
+                    // The transport rejected an oversized reassembled message
+                    // before exposing its class/content; preserve the same
+                    // application close as the explicit complete-message gate.
+                    closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: 4005.into(),
+                        reason: "frame_too_large".into(),
+                    });
+                    break;
                 }
-                Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
-                Some(Ok(_)) => {} // pong frames: ignored
+                Some(Err(_)) | None => {
+                    force_writer_abort = true;
+                    break;
+                }
             },
             () = &mut idle_deadline => {
-                // No inbound activity for the served idle window: close 4004.
-                let _ = out_tx
-                    .send(Message::Close(Some(
-                        tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                            code: 4004.into(),
-                            reason: "idle_timeout".into(),
-                        },
-                    )))
-                    .await;
-                break;
+                if streams.is_active() {
+                    // A correctly credit-paused transfer remains governed by
+                    // its stall and absolute timers, never ordinary idle.
+                    idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
+                } else {
+                    closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: 4004.into(),
+                        reason: "idle_timeout".into(),
+                    });
+                    break;
+                }
             }
             push = push_rx.recv() => match push {
                 Ok(push) => {
@@ -1075,7 +1187,7 @@ pub async fn serve_ws<S>(
                     };
                     if subscribed {
                         let bytes = jeliya_codec::push_to_bytes(&push);
-                        if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
+                        if outbound.text(bytes).await != crate::outbound::WriteReceipt::Sent {
                             break;
                         }
                     }
@@ -1107,7 +1219,7 @@ pub async fn serve_ws<S>(
                             reason: jeliya_api::GapReason::Backpressure,
                         };
                         let bytes = jeliya_codec::push_to_bytes(&gap);
-                        if out_tx.send(Message::Binary(bytes.into())).await.is_err() {
+                        if outbound.text(bytes).await != crate::outbound::WriteReceipt::Sent {
                             break;
                         }
                     }
@@ -1115,15 +1227,55 @@ pub async fn serve_ws<S>(
                 Err(broadcast::error::RecvError::Closed) => break,
             },
             // Reap finished request tasks without blocking the loop.
-            Some(_) = inflight.join_next() => {}
+            Some(_) = inflight.join_next() => {
+                // Completion of a transfer counts as connection activity;
+                // restart ordinary idle after its binding/request retires.
+                idle_deadline.as_mut().reset(tokio::time::Instant::now() + tokio::time::Duration::from_millis(idle_ms));
+            }
         }
     }
 
     // Teardown: stop accepting new work, drain in-flight replies, then drop
     // the writer task.
+    streams.invalidate_connection();
+    outbound.invalidate_connection();
     inflight.abort_all();
-    drop(out_tx);
-    let _ = writer.await;
+    while inflight.join_next().await.is_some() {}
+    let close_requested = closer.is_requested();
+    if close_requested && !*close_completed_rx.borrow() {
+        let wait_for_close = async {
+            while !*close_completed_rx.borrow() {
+                if close_completed_rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        };
+        let _ =
+            tokio::time::timeout(tokio::time::Duration::from_millis(1_100), wait_for_close).await;
+    }
+    drop(closer);
+    drop(outbound);
+    if force_writer_abort && !close_requested {
+        writer.abort();
+        let _ = writer.await;
+    } else if tokio::time::timeout(tokio::time::Duration::from_secs(1), &mut writer)
+        .await
+        .is_err()
+    {
+        // A peer can keep TCP open while refusing to drain its receive
+        // window. Give a queued Close a short flush grace, then cancel the
+        // sole sink owner so connection teardown cannot hang indefinitely.
+        writer.abort();
+        let _ = writer.await;
+    }
+}
+
+fn complete_data_message_len(message: &Message) -> Option<usize> {
+    match message {
+        Message::Text(text) => Some(text.len()),
+        Message::Binary(bytes) => Some(bytes.len()),
+        Message::Ping(_) | Message::Pong(_) | Message::Close(_) | Message::Frame(_) => None,
+    }
 }
 
 /// The room a push is scoped to, for subscription gating. `transfer` frames
@@ -1164,7 +1316,7 @@ struct SubscriptionState {
 /// Naturally idempotent; exceeding the served limit is
 /// `subscription_limit_reached`, never a silent drop.
 async fn handle_stream_subscribe(
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    out_tx: &crate::outbound::Outbound,
     state: &AppState,
     request: &jeliya_codec::Request,
     subscriptions: &std::sync::Arc<
@@ -1264,7 +1416,7 @@ async fn handle_stream_subscribe(
 
 /// `stream.unsubscribe` — remove the room from this connection's set.
 async fn handle_stream_unsubscribe(
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    out_tx: &crate::outbound::Outbound,
     state: &AppState,
     request: &jeliya_codec::Request,
     subscriptions: &std::sync::Arc<
@@ -1332,7 +1484,7 @@ async fn handle_stream_unsubscribe(
 /// `stream.resync` — the authoritative recovery: events since `from_pos`, or
 /// `resync_required` naming a position to discard back to.
 async fn handle_stream_resync(
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    out_tx: &crate::outbound::Outbound,
     state: &AppState,
     request: &jeliya_codec::Request,
 ) -> bool {
@@ -1457,7 +1609,7 @@ fn stream_start_position(last_committed: Option<u64>) -> u64 {
 }
 
 /// Encode a typed output as a reply frame and send it.
-async fn send_typed<O>(out_tx: &tokio::sync::mpsc::Sender<Message>, id: u64, out: &O) -> bool
+async fn send_typed<O>(out_tx: &crate::outbound::Outbound, id: u64, out: &O) -> bool
 where
     O: serde::Serialize,
 {
@@ -1467,15 +1619,12 @@ where
         out: serde_json::to_value(out).ok(),
         err: None,
     };
-    out_tx
-        .send(Message::Binary(reply.to_bytes().into()))
-        .await
-        .is_ok()
+    out_tx.text(reply.to_bytes()).await == crate::outbound::WriteReceipt::Sent
 }
 
 /// Encode a typed API error as a reply frame and send it.
 async fn send_api_err(
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    out_tx: &crate::outbound::Outbound,
     id: u64,
     err: jeliya_api::ApiError,
 ) -> bool {
@@ -1485,10 +1634,7 @@ async fn send_api_err(
         out: None,
         err: Some(err),
     };
-    out_tx
-        .send(Message::Binary(reply.to_bytes().into()))
-        .await
-        .is_ok()
+    out_tx.text(reply.to_bytes()).await == crate::outbound::WriteReceipt::Sent
 }
 
 /// Decode one inbound frame and route it. Connection-terminating frames (over
@@ -1496,48 +1642,49 @@ async fn send_api_err(
 /// well-formed requests are executed on a spawned task so a slow operation
 /// never head-of-line blocks the push fan-out or other requests. Returns
 /// `false` when the connection must close.
-async fn dispatch_inbound(
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_text(
     bytes: &[u8],
     state: &AppState,
     bounds: &jeliya_codec::CodecBounds,
     subscriptions: &std::sync::Arc<
         tokio::sync::Mutex<std::collections::HashMap<String, SubscriptionState>>,
     >,
-    out_tx: &tokio::sync::mpsc::Sender<Message>,
+    out_tx: &crate::outbound::Outbound,
+    requests: &crate::file_read::RequestTracker,
+    streams: &crate::file_read::StreamRegistry,
+    stream_ids: &std::sync::Arc<std::sync::Mutex<crate::transfer::StreamIdGenerator>>,
+    closer: &crate::file_read::ConnectionCloser,
     inflight: &mut tokio::task::JoinSet<bool>,
     principal_key: &str,
 ) -> bool {
+    // This is the final request-admission linearization point. If it wins
+    // before a concurrent Close claim, the request was already in flight and
+    // teardown will cancel it; if the Close claim wins, no operation starts.
+    if closer.is_requested() {
+        return false;
+    }
     use jeliya_codec::CodecError;
     let frame = match jeliya_codec::decode(bytes, bounds) {
         Ok(frame) => frame,
         Err(CodecError::FrameTooLarge { .. }) => {
-            let _ = out_tx
-                .send(Message::Close(Some(
-                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                        code: 4005.into(),
-                        reason: "frame_too_large".into(),
-                    },
-                )))
-                .await;
+            closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                code: 4005.into(),
+                reason: "frame_too_large".into(),
+            });
             return false;
         }
         Err(CodecError::UnrecoverableId(_)) => {
-            let _ = out_tx
-                .send(Message::Close(Some(
-                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                        code: 4007.into(),
-                        reason: "malformed_frame".into(),
-                    },
-                )))
-                .await;
+            closer.malformed();
             return false;
         }
         Err(CodecError::Malformed { id, error }) => {
+            if requests.is_outstanding(id) {
+                closer.malformed();
+                return false;
+            }
             let reply = jeliya_codec::Reply::from_result::<jeliya_api::RoomList>(id, Err(error));
-            return out_tx
-                .send(Message::Binary(reply.to_bytes().into()))
-                .await
-                .is_ok();
+            return out_tx.text(reply.to_bytes()).await == crate::outbound::WriteReceipt::Sent;
         }
         Err(CodecError::GateRefused(_)) => {
             return false;
@@ -1549,20 +1696,75 @@ async fn dispatch_inbound(
         return true;
     };
 
+    let request_permit = match requests.acquire(request.id) {
+        Ok(permit) => permit,
+        Err(crate::file_read::RequestAdmissionError::Duplicate) => {
+            // Reusing an outstanding correlation id makes either reply
+            // ambiguous, so there is no trustworthy request to answer.
+            closer.malformed();
+            return false;
+        }
+        Err(crate::file_read::RequestAdmissionError::Exhausted(error)) => {
+            return send_api_err(out_tx, request.id, error).await;
+        }
+    };
+
     // The three stream operations are connection-scoped: they read and mutate
     // THIS connection's subscription set, never the supervisor. They are fast
     // (map ops plus one engine read), so run them inline.
     match request.call.op {
         "stream.subscribe" => {
+            let _request_permit = request_permit;
             return handle_stream_subscribe(out_tx, state, &request, subscriptions).await;
         }
         "stream.unsubscribe" => {
+            let _request_permit = request_permit;
             return handle_stream_unsubscribe(out_tx, state, &request, subscriptions).await;
         }
         "stream.resync" => {
+            let _request_permit = request_permit;
             return handle_stream_resync(out_tx, state, &request).await;
         }
         _ => {}
+    }
+
+    // `file.read` is the one producer-direction stream in this slice. Its
+    // request remains outstanding inside the actor through END/ABORT and the
+    // terminal Text writer acknowledgement. `file.share` deliberately stays
+    // on the ordinary engine path and continues returning `not_ready`.
+    if request.call.op == "file.read" {
+        let Some(file_read) = request
+            .call
+            .input_any()
+            .downcast_ref::<jeliya_api::FileRead>()
+            .cloned()
+        else {
+            return send_api_err(out_tx, request.id, jeliya_api::ApiError::MalformedFrame).await;
+        };
+        let engine = state.engine.clone();
+        let outbound = out_tx.clone();
+        let registry = streams.clone();
+        let stream_ids = stream_ids.clone();
+        let transfer_pool = state.transfer_pool.clone();
+        let limits = state.runtime_limits;
+        let closer = closer.clone();
+        let id = request.id;
+        inflight.spawn(async move {
+            crate::file_read::run_file_read(
+                engine,
+                file_read,
+                id,
+                request_permit,
+                outbound,
+                registry,
+                stream_ids,
+                transfer_pool,
+                limits,
+                closer,
+            )
+            .await
+        });
+        return true;
     }
 
     let Some(call) = jeliya_core::typed::resolve_call(request.call.op, request.call.input_any())
@@ -1571,10 +1773,7 @@ async fn dispatch_inbound(
             request.id,
             Err(jeliya_api::ApiError::MalformedFrame),
         );
-        return out_tx
-            .send(Message::Binary(reply.to_bytes().into()))
-            .await
-            .is_ok();
+        return out_tx.text(reply.to_bytes()).await == crate::outbound::WriteReceipt::Sent;
     };
 
     // Execute on a spawned task so a slow op (file.fetch, pipe.connect) does
@@ -1587,6 +1786,7 @@ async fn dispatch_inbound(
     let engine = state.engine.clone();
     let out_tx = out_tx.clone();
     inflight.spawn(async move {
+        let _request_permit = request_permit;
         let executed = engine.execute_with(call, op_id, &principal_key).await;
         let reply = match executed.reply {
             Ok(out) => jeliya_codec::Reply {
@@ -1602,10 +1802,7 @@ async fn dispatch_inbound(
                 err: Some(err),
             },
         };
-        out_tx
-            .send(Message::Binary(reply.to_bytes().into()))
-            .await
-            .is_ok()
+        out_tx.text(reply.to_bytes()).await == crate::outbound::WriteReceipt::Sent
     });
     true
 }
@@ -1667,8 +1864,174 @@ fn text(status: StatusCode, body: &'static str) -> Response<Full<Bytes>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{constant_time_eq, gate_refusal, safe_download_mime, stream_start_position};
+    use std::sync::Arc;
+
+    use futures_util::{SinkExt, StreamExt};
     use hyper::{header::CONTENT_TYPE, StatusCode};
+    use tempfile::TempDir;
+    use tokio_tungstenite::tungstenite::{protocol::Role, Message};
+    use tokio_tungstenite::WebSocketStream;
+
+    use super::{
+        complete_data_message_len, constant_time_eq, gate_refusal, safe_download_mime, serve_ws,
+        stream_start_position,
+    };
+
+    const SOCKET_FRAME_BYTES: usize = 4_096;
+
+    fn test_state(max_frame_bytes: u64) -> (TempDir, crate::AppState) {
+        let dir = TempDir::new().expect("server tempdir");
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::mpsc::channel(1);
+        let engine = jeliya_core::engine::Engine::new(
+            dir.path().to_path_buf(),
+            true,
+            jeliya_core::engine::EngineConfig {
+                port: 0,
+                version: "test".into(),
+                shutdown_tx,
+            },
+        )
+        .expect("test engine");
+        let mut limits = engine.limits();
+        limits.max_frame_bytes = max_frame_bytes;
+        let runtime_limits =
+            crate::transfer::RuntimeLimits::from_served(&limits).expect("test runtime limits");
+        let transfer_pool = crate::transfer::TransferPool::from_runtime(&runtime_limits);
+        let state = crate::AppState {
+            data_dir: dir.path().to_path_buf(),
+            engine,
+            auth_token: Arc::new("test-token".into()),
+            port: 0,
+            connect_tickets: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            runtime_limits,
+            transfer_pool,
+        };
+        (dir, state)
+    }
+
+    async fn socket_pair(
+        state: crate::AppState,
+    ) -> (
+        WebSocketStream<tokio::io::DuplexStream>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (server_io, client_io) = tokio::io::duplex(1 << 20);
+        let server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let task = tokio::spawn(serve_ws(
+            server,
+            state,
+            jeliya_codec::SessionPrincipal {
+                credential: "test-token".into(),
+                client_id: Some("serve-test".into()),
+            },
+        ));
+        (client, task)
+    }
+
+    async fn file_state(
+        payload: &[u8],
+        max_frame_bytes: u64,
+    ) -> (TempDir, crate::AppState, jeliya_api::FileRead) {
+        let (dir, state) = test_state(max_frame_bytes);
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::SubjectEnsure(
+                jeliya_api::SubjectEnsure {},
+            ))
+            .await
+            .reply
+            .expect("subject.ensure");
+        let created = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomCreate(
+                jeliya_api::RoomCreate {
+                    name: "socket file read".into(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.create");
+        let jeliya_core::typed::TypedReply::RoomCreate(created) = created else {
+            panic!("wrong room.create reply");
+        };
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomActivate(
+                jeliya_api::RoomActivate {
+                    room_id: created.room_id.clone(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.activate");
+        let staged = dir.path().join("socket-source.bin");
+        std::fs::write(&staged, payload).expect("write socket source");
+        let shared = state
+            .engine
+            .share_staged_file(
+                &jeliya_api::FileShare {
+                    room_id: created.room_id.clone(),
+                    name: "socket-source.bin".into(),
+                    declared_bytes: payload.len() as u64,
+                    declared_content_type: "application/octet-stream".into(),
+                },
+                &staged,
+            )
+            .await
+            .expect("host-staged share");
+        let state_path = dir.path().join("state.json");
+        let mut local_state: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&state_path).expect("read local state"))
+                .expect("decode local state");
+        local_state["rooms"][created.room_id.as_str()]["fetched_files"][shared.file_id.as_str()] = serde_json::json!({
+            "path": staged,
+            "bytes": payload.len(),
+            "fetched_at_ms": 0,
+        });
+        std::fs::write(
+            state_path,
+            serde_json::to_vec_pretty(&local_state).expect("encode local state"),
+        )
+        .expect("write local state");
+        let request = jeliya_api::FileRead {
+            room_id: created.room_id,
+            file_id: shared.file_id,
+        };
+        (dir, state, request)
+    }
+
+    fn stream_wire(kind: u8, request_id: u64, stream_id: u128, offset: u64, value: u64) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(jeliya_codec::STREAM_HEADER_BYTES);
+        bytes.extend_from_slice(b"JBS2");
+        bytes.push(kind);
+        bytes.extend_from_slice(&[0, 0, 0]);
+        bytes.extend_from_slice(&request_id.to_be_bytes());
+        bytes.extend_from_slice(&stream_id.to_be_bytes());
+        bytes.extend_from_slice(&offset.to_be_bytes());
+        bytes.extend_from_slice(&value.to_be_bytes());
+        bytes
+    }
+
+    async fn send_file_read(
+        client: &mut WebSocketStream<tokio::io::DuplexStream>,
+        id: u64,
+        request: &jeliya_api::FileRead,
+    ) {
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": id,
+                    "op": "file.read",
+                    "in": request,
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("send file.read");
+    }
 
     #[test]
     fn gate_refusal_is_bare_json_with_the_exact_media_type() {
@@ -1727,5 +2090,295 @@ mod tests {
             safe_download_mime("text/plain; charset=utf-8"),
             "text/plain"
         );
+    }
+
+    #[test]
+    fn complete_message_size_is_class_agnostic_and_excludes_controls() {
+        assert_eq!(
+            complete_data_message_len(&Message::Text("123".into())),
+            Some(3)
+        );
+        assert_eq!(
+            complete_data_message_len(&Message::Binary(vec![0; 4].into())),
+            Some(4)
+        );
+        assert_eq!(
+            complete_data_message_len(&Message::Ping(vec![0; 8].into())),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_enforces_text_json_binary_stream_and_size_before_parse() {
+        let (_dir, state) = test_state(SOCKET_FRAME_BYTES as u64);
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        client
+            .send(Message::Text(
+                r#"{"id":1,"op":"subject.ensure","in":{}}"#.into(),
+            ))
+            .await
+            .unwrap();
+        let reply = client.next().await.expect("reply").expect("valid reply");
+        let Message::Text(reply) = reply else {
+            panic!("JSON reply must be Text");
+        };
+        let reply: jeliya_codec::Reply = serde_json::from_str(&reply).unwrap();
+        assert!(reply.ok);
+
+        // Valid JSON in Binary is never offered to the JSON decoder. It is
+        // shorter than JBS2's header and therefore closes unbound with 4007.
+        client
+            .send(Message::Binary(
+                br#"{"id":2,"op":"room.list","in":{}}"#.to_vec().into(),
+            ))
+            .await
+            .unwrap();
+        let close = client.next().await.expect("close").expect("close frame");
+        let Message::Close(Some(close)) = close else {
+            panic!("Binary JSON must close");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        let _ = server.await;
+
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        // Oversized and bad-magic: the complete-message bound wins without
+        // attempting header, magic, identity, or class-specific parsing.
+        client
+            .send(Message::Binary(vec![0; SOCKET_FRAME_BYTES + 1].into()))
+            .await
+            .unwrap();
+        let close = client.next().await.expect("close").expect("close frame");
+        let Message::Close(Some(close)) = close else {
+            panic!("oversized Binary must close");
+        };
+        assert_eq!(u16::from(close.code), 4005);
+        let _ = server.await;
+
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text("x".repeat(SOCKET_FRAME_BYTES + 1).into()))
+            .await
+            .unwrap();
+        let close = client.next().await.expect("close").expect("close frame");
+        let Message::Close(Some(close)) = close else {
+            panic!("oversized malformed Text must close");
+        };
+        assert_eq!(u16::from(close.code), 4005);
+        let _ = server.await;
+
+        let (mut client, server) = socket_pair(state).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        let mut stream_as_text = Vec::new();
+        stream_as_text.extend_from_slice(b"JBS2");
+        stream_as_text.resize(48, 0);
+        stream_as_text[31] = 1; // structurally nonzero stream id, still UTF-8
+        client
+            .send(Message::Text(
+                String::from_utf8(stream_as_text).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let close = client.next().await.expect("close").expect("close frame");
+        let Message::Close(Some(close)) = close else {
+            panic!("Text stream record must close");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn websocket_file_read_disconnects_cleanly_and_restarts_from_zero() {
+        let payload: Vec<u8> = (0..300).map(|value| (value % 251) as u8).collect();
+        let (_dir, state, request) = file_state(&payload, SOCKET_FRAME_BYTES as u64).await;
+
+        let (mut first, first_server) = socket_pair(state.clone()).await;
+        assert!(matches!(first.next().await, Some(Ok(Message::Text(_)))));
+        send_file_read(&mut first, 7, &request).await;
+        let Message::Binary(open) = first.next().await.unwrap().unwrap() else {
+            panic!("file.read must begin with Binary OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(
+            &open,
+            &jeliya_codec::CodecBounds {
+                max_frame_bytes: SOCKET_FRAME_BYTES,
+                ..jeliya_codec::CodecBounds::default()
+            },
+        )
+        .expect("decode first OPEN");
+        assert_eq!(
+            open.body,
+            jeliya_codec::StreamRecordBody::Open { total: 300 }
+        );
+
+        // The socket reader remains usable for ordinary Text requests while
+        // the download is correctly paused before initial CREDIT.
+        first
+            .send(Message::Text(r#"{"id":8,"op":"room.list","in":{}}"#.into()))
+            .await
+            .unwrap();
+        let Message::Text(ordinary) = first.next().await.unwrap().unwrap() else {
+            panic!("ordinary reply must interleave as Text");
+        };
+        let ordinary: jeliya_codec::Reply = serde_json::from_str(&ordinary).unwrap();
+        assert_eq!(ordinary.id, 8);
+        drop(first);
+        tokio::time::timeout(std::time::Duration::from_secs(1), first_server)
+            .await
+            .expect("disconnect teardown must finish")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        let (mut second, second_server) = socket_pair(state.clone()).await;
+        assert!(matches!(second.next().await, Some(Ok(Message::Text(_)))));
+        send_file_read(&mut second, 7, &request).await;
+        let Message::Binary(open_again) = second.next().await.unwrap().unwrap() else {
+            panic!("retry must begin with a fresh OPEN");
+        };
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let open_again = jeliya_codec::decode_stream_record(&open_again, &bounds).unwrap();
+        assert!(matches!(
+            open_again.body,
+            jeliya_codec::StreamRecordBody::Open { total: 300 }
+        ));
+        assert_ne!(
+            open_again.identity.stream_id(),
+            open.identity.stream_id(),
+            "reconnect never resumes or reuses the prior stream"
+        );
+        let stream_id = open_again.identity.stream_id().get();
+        second
+            .send(Message::Binary(
+                stream_wire(0x03, 7, stream_id, 0, payload.len() as u64).into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut accepted = 0_u64;
+        loop {
+            match second.next().await.unwrap().unwrap() {
+                Message::Binary(record) => {
+                    let record = jeliya_codec::decode_stream_record(&record, &bounds).unwrap();
+                    match record.body {
+                        jeliya_codec::StreamRecordBody::Data {
+                            offset,
+                            payload: data,
+                        } => {
+                            assert_eq!(offset, accepted);
+                            assert_eq!(
+                                data,
+                                payload[accepted as usize..accepted as usize + data.len()]
+                            );
+                            accepted += data.len() as u64;
+                            second
+                                .send(Message::Binary(
+                                    stream_wire(0x03, 7, stream_id, accepted, payload.len() as u64)
+                                        .into(),
+                                ))
+                                .await
+                                .unwrap();
+                        }
+                        jeliya_codec::StreamRecordBody::End { total } => {
+                            assert_eq!(total, payload.len() as u64);
+                            assert_eq!(accepted, total);
+                            break;
+                        }
+                        other => panic!("unexpected producer record: {other:?}"),
+                    }
+                }
+                other => panic!("success reply preceded END: {other:?}"),
+            }
+        }
+        let Message::Text(reply) = second.next().await.unwrap().unwrap() else {
+            panic!("terminal success must be Text");
+        };
+        let reply: jeliya_codec::Reply = serde_json::from_str(&reply).unwrap();
+        assert!(reply.ok);
+        assert_eq!(reply.id, 7);
+
+        second
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 9,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": request.room_id,
+                        "name": "still-not-streamed.bin",
+                        "declared_bytes": 0,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(share_reply) = second.next().await.unwrap().unwrap() else {
+            panic!("file.share refusal must remain an ordinary Text reply");
+        };
+        let share_reply: jeliya_codec::Reply = serde_json::from_str(&share_reply).unwrap();
+        assert_eq!(share_reply.err, Some(jeliya_api::ApiError::NotReady));
+        second.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), second_server)
+            .await
+            .expect("completed connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn active_credit_pause_is_not_closed_by_ordinary_idle_timeout() {
+        let (_dir, mut state, request) = file_state(&[1], SOCKET_FRAME_BYTES as u64).await;
+        let mut limits = state.engine.limits();
+        limits.max_frame_bytes = SOCKET_FRAME_BYTES as u64;
+        limits.transfer_connect_allowance_ms = 700_000;
+        limits.transfer_stall_ms = 700_000;
+        state.runtime_limits = crate::transfer::RuntimeLimits::from_served(&limits).unwrap();
+        state.transfer_pool = crate::transfer::TransferPool::from_runtime(&state.runtime_limits);
+
+        tokio::time::pause();
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        send_file_read(&mut client, 11, &request).await;
+        let Message::Binary(open) = client.next().await.unwrap().unwrap() else {
+            panic!("expected OPEN");
+        };
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        client
+            .send(Message::Binary(
+                stream_wire(0x03, 11, open.identity.stream_id().get(), 0, 0).into(),
+            ))
+            .await
+            .unwrap();
+
+        tokio::time::advance(std::time::Duration::from_millis(600_000)).await;
+        tokio::task::yield_now().await;
+        client
+            .send(Message::Text(
+                r#"{"id":12,"op":"room.list","in":{}}"#.into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(reply) = client.next().await.unwrap().unwrap() else {
+            panic!("active transfer lost to ordinary idle timeout");
+        };
+        let reply: jeliya_codec::Reply = serde_json::from_str(&reply).unwrap();
+        assert_eq!(reply.id, 12);
+        drop(client);
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("disconnect cleanup")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
     }
 }

--- a/crates/jeliyad/src/transfer.rs
+++ b/crates/jeliyad/src/transfer.rs
@@ -1,0 +1,1085 @@
+//! Daemon-wide byte-transfer admission and checked runtime limits.
+//!
+//! The logical reservation in this module is deliberately separate from the
+//! outbound writer's byte permits: it bounds the number and aggregate declared
+//! size of admitted transfers, while the writer bound limits bytes actually
+//! resident in memory. Reservations are RAII so every task-abort and disconnect
+//! path releases capacity without a bespoke cleanup call.
+
+use std::error::Error;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use jeliya_api::{ApiError, Envelope, FileId, FileRead, FileShare, Limits, RoomId};
+use jeliya_codec::{max_stream_data_bytes, StreamIdentity, STREAM_HEADER_BYTES};
+use tokio::sync::Semaphore;
+use tokio::time::Instant;
+
+const CONTROL_QUEUE_ALLOWANCE: usize = 32;
+// Tokio stores aggregate semaphore capacity in `usize`, but one
+// `acquire_many_owned` request is a `u32`. A complete control message consumes
+// one acquisition, so readiness must enforce the smaller bound.
+const MAX_CONTROL_BYTE_PERMITS: usize = if Semaphore::MAX_PERMITS < u32::MAX as usize {
+    Semaphore::MAX_PERMITS
+} else {
+    u32::MAX as usize
+};
+
+const STREAM_ID_FEISTEL_ROUNDS: u8 = 8;
+const STREAM_ID_DOMAIN: &[u8] = b"jeliya.protocol-v2.stream-id.feistel";
+
+/// Checked, host-representable limits used by the WebSocket transfer runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RuntimeLimits {
+    max_frame_bytes: usize,
+    max_data_payload_bytes: usize,
+    data_queue_capacity_bytes: usize,
+    control_queue_capacity_messages: usize,
+    data_queue_capacity_messages: usize,
+    max_concurrent_transfers: u64,
+    max_transfer_bytes_inflight: u64,
+    transfer_connect_allowance_ms: u64,
+    transfer_floor_bits_per_second: u64,
+    transfer_stall_ms: u64,
+    transfer_stall: Duration,
+}
+
+impl RuntimeLimits {
+    /// Validate the served limits before the daemon announces readiness.
+    pub(crate) fn from_served(limits: &Limits) -> Result<Self, RuntimeConfigError> {
+        let max_frame_bytes = usize::try_from(limits.max_frame_bytes).map_err(|_| {
+            RuntimeConfigError::MaxFrameBytesNotRepresentable {
+                max_frame_bytes: limits.max_frame_bytes,
+            }
+        })?;
+        let max_data_payload_bytes = max_stream_data_bytes(max_frame_bytes).map_err(|_| {
+            RuntimeConfigError::FrameCannotCarryData {
+                max_frame_bytes,
+                minimum_bytes: STREAM_HEADER_BYTES + 1,
+            }
+        })?;
+
+        let minimum_request_bytes = minimum_stream_request_bytes();
+        if max_frame_bytes < minimum_request_bytes {
+            return Err(RuntimeConfigError::FrameCannotCarryStreamRequest {
+                max_frame_bytes,
+                minimum_bytes: minimum_request_bytes,
+            });
+        }
+        if max_frame_bytes > MAX_CONTROL_BYTE_PERMITS {
+            return Err(RuntimeConfigError::ControlQueueCapacityTooLarge {
+                capacity_bytes: max_frame_bytes,
+                maximum: MAX_CONTROL_BYTE_PERMITS,
+            });
+        }
+
+        let data_queue_capacity_bytes = data_queue_capacity(
+            limits.max_concurrent_transfers,
+            limits.max_transfer_bytes_inflight,
+            max_data_payload_bytes,
+        )?;
+        let control_queue_capacity_messages = writer_queue_capacity(
+            "control",
+            limits.max_inflight_requests,
+            CONTROL_QUEUE_ALLOWANCE,
+            1,
+        )?;
+        let data_queue_capacity_messages =
+            writer_queue_capacity("DATA", limits.max_concurrent_transfers, 0, 1)?;
+
+        if limits.transfer_floor_bits_per_second == 0 {
+            return Err(RuntimeConfigError::ZeroTransferFloor);
+        }
+
+        let checked = Self {
+            max_frame_bytes,
+            max_data_payload_bytes,
+            data_queue_capacity_bytes,
+            control_queue_capacity_messages,
+            data_queue_capacity_messages,
+            max_concurrent_transfers: limits.max_concurrent_transfers,
+            max_transfer_bytes_inflight: limits.max_transfer_bytes_inflight,
+            transfer_connect_allowance_ms: limits.transfer_connect_allowance_ms,
+            transfer_floor_bits_per_second: limits.transfer_floor_bits_per_second,
+            transfer_stall_ms: limits.transfer_stall_ms,
+            transfer_stall: Duration::from_millis(limits.transfer_stall_ms),
+        };
+
+        // One transfer can consume the entire aggregate byte reservation. If
+        // its deadline cannot be represented, the served configuration is not
+        // executable and must fail before readiness rather than at admission.
+        let now = Instant::now();
+        checked.stall_deadline(now)?;
+        checked.deadline(now, limits.max_transfer_bytes_inflight)?;
+        Ok(checked)
+    }
+
+    /// Maximum payload bytes in one complete Text or Binary data message.
+    pub(crate) const fn max_frame_bytes(self) -> usize {
+        self.max_frame_bytes
+    }
+
+    /// Effective `min(65_536, max_frame_bytes - 48)` DATA payload bound.
+    pub(crate) const fn max_data_payload_bytes(self) -> usize {
+        self.max_data_payload_bytes
+    }
+
+    /// Byte permits reserved for at most one queued DATA record per transfer.
+    pub(crate) const fn data_queue_capacity_bytes(self) -> usize {
+        self.data_queue_capacity_bytes
+    }
+
+    /// Aggregate queued Text/control bytes. One maximum-size message always
+    /// fits, while concurrent producers wait for writer acknowledgement.
+    pub(crate) const fn control_queue_capacity_bytes(self) -> usize {
+        self.max_frame_bytes
+    }
+
+    /// Bounded priority-writer queue slots, including control headroom.
+    pub(crate) const fn control_queue_capacity_messages(self) -> usize {
+        self.control_queue_capacity_messages
+    }
+
+    /// Bounded DATA-writer queue slots (one per configured transfer, floored at one).
+    pub(crate) const fn data_queue_capacity_messages(self) -> usize {
+        self.data_queue_capacity_messages
+    }
+
+    /// Zero-forward-progress interval.
+    pub(crate) const fn transfer_stall(self) -> Duration {
+        self.transfer_stall
+    }
+
+    /// Checked forward-progress deadline for the supplied progress instant.
+    pub(crate) fn stall_deadline(self, start: Instant) -> Result<Instant, RuntimeConfigError> {
+        start
+            .checked_add(self.transfer_stall)
+            .ok_or(RuntimeConfigError::StallDeadlineNotFinite {
+                stall_ms: self.transfer_stall_ms,
+            })
+    }
+
+    /// Absolute deadline and the exact budget reported in a typed error.
+    pub(crate) fn deadline(
+        self,
+        start: Instant,
+        total_bytes: u64,
+    ) -> Result<(Instant, u64), RuntimeConfigError> {
+        let budget_ms = deadline_budget_ms(
+            self.transfer_connect_allowance_ms,
+            self.transfer_floor_bits_per_second,
+            total_bytes,
+        )?;
+        let deadline = start
+            .checked_add(Duration::from_millis(budget_ms))
+            .ok_or(RuntimeConfigError::DeadlineNotFinite { budget_ms })?;
+        Ok((deadline, budget_ms))
+    }
+}
+
+/// A daemon-global admission pool shared by every cloned [`crate::AppState`].
+#[derive(Debug, Clone)]
+pub(crate) struct TransferPool {
+    inner: Arc<TransferPoolInner>,
+}
+
+#[derive(Debug)]
+struct TransferPoolInner {
+    max_concurrent_transfers: u64,
+    max_transfer_bytes_inflight: u64,
+    state: Mutex<TransferPoolState>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct TransferPoolState {
+    active_transfers: u64,
+    reserved_bytes: u64,
+}
+
+impl TransferPool {
+    /// Construct a pool over the two independently served transfer resources.
+    pub(crate) fn new(max_concurrent_transfers: u64, max_transfer_bytes_inflight: u64) -> Self {
+        Self {
+            inner: Arc::new(TransferPoolInner {
+                max_concurrent_transfers,
+                max_transfer_bytes_inflight,
+                state: Mutex::new(TransferPoolState::default()),
+            }),
+        }
+    }
+
+    /// Construct the daemon-global pool from validated runtime limits.
+    pub(crate) fn from_runtime(limits: &RuntimeLimits) -> Self {
+        Self::new(
+            limits.max_concurrent_transfers,
+            limits.max_transfer_bytes_inflight,
+        )
+    }
+
+    /// Atomically reserve one transfer and its complete logical byte total.
+    ///
+    /// Count is checked first, then checked byte arithmetic and the byte limit,
+    /// matching the deterministic admission order. No state changes on error.
+    pub(crate) fn reserve(&self, total_bytes: u64) -> Result<TransferReservation, ApiError> {
+        let mut state = lock_unpoisoned(&self.inner.state);
+        if state.active_transfers >= self.inner.max_concurrent_transfers {
+            return Err(resource_exhausted(
+                "max_concurrent_transfers",
+                self.inner.max_concurrent_transfers,
+            ));
+        }
+
+        let Some(next_bytes) = state.reserved_bytes.checked_add(total_bytes) else {
+            return Err(resource_exhausted(
+                "max_transfer_bytes_inflight",
+                self.inner.max_transfer_bytes_inflight,
+            ));
+        };
+        if next_bytes > self.inner.max_transfer_bytes_inflight {
+            return Err(resource_exhausted(
+                "max_transfer_bytes_inflight",
+                self.inner.max_transfer_bytes_inflight,
+            ));
+        }
+
+        // `active_transfers < max`; therefore the increment cannot overflow
+        // even when the configured maximum is u64::MAX.
+        state.active_transfers += 1;
+        state.reserved_bytes = next_bytes;
+        drop(state);
+
+        Ok(TransferReservation {
+            inner: Arc::clone(&self.inner),
+            total_bytes,
+        })
+    }
+
+    #[cfg(test)]
+    fn state(&self) -> TransferPoolState {
+        *lock_unpoisoned(&self.inner.state)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn usage(&self) -> (u64, u64) {
+        let state = self.state();
+        (state.active_transfers, state.reserved_bytes)
+    }
+}
+
+/// One non-cloneable transfer admission; dropping it releases both resources.
+#[derive(Debug)]
+pub(crate) struct TransferReservation {
+    inner: Arc<TransferPoolInner>,
+    total_bytes: u64,
+}
+
+impl Drop for TransferReservation {
+    fn drop(&mut self) {
+        let mut state = lock_unpoisoned(&self.inner.state);
+        // These subtractions are guaranteed by construction: state is mutated
+        // only while holding this mutex, and a reservation cannot be cloned or
+        // dropped twice. Avoid a panicking destructor even if a future edit
+        // violates that internal invariant.
+        debug_assert!(state.active_transfers > 0);
+        debug_assert!(state.reserved_bytes >= self.total_bytes);
+        state.active_transfers = state.active_transfers.saturating_sub(1);
+        state.reserved_bytes = state.reserved_bytes.saturating_sub(self.total_bytes);
+    }
+}
+
+/// Constant-space generator for unpredictable, never-reused stream ids.
+pub(crate) struct StreamIdGenerator {
+    key: Option<[u8; 32]>,
+    last_sequence: u128,
+}
+
+impl StreamIdGenerator {
+    /// Start a fresh connection-local id sequence.
+    pub(crate) const fn new() -> Self {
+        Self {
+            key: None,
+            last_sequence: 0,
+        }
+    }
+
+    /// Generate one full identity for an outstanding request.
+    ///
+    /// A connection-secret keyed Feistel permutation maps a checked 128-bit
+    /// counter onto the full 128-bit wire domain. The permutation makes every
+    /// counter value structurally unique without retaining an ever-growing set,
+    /// while its keyed round function keeps the counter and future ids hidden
+    /// from an observer. The sole counter whose permutation is zero is skipped.
+    pub(crate) fn next(&mut self, request_id: u64) -> Result<StreamIdentity, StreamIdError> {
+        if request_id > jeliya_codec::MAX_REQUEST_ID {
+            return Err(StreamIdError::RequestIdOutOfRange { request_id });
+        }
+        let key = self.connection_key()?;
+        loop {
+            let sequence = self
+                .last_sequence
+                .checked_add(1)
+                .ok_or(StreamIdError::SequenceExhausted)?;
+            self.last_sequence = sequence;
+
+            let stream_id = permute_stream_counter(&key, sequence);
+            if stream_id != 0 {
+                return StreamIdentity::new(request_id, stream_id)
+                    .map_err(StreamIdError::InvalidIdentity);
+            }
+            // A permutation has exactly one zero preimage. The next distinct
+            // counter therefore cannot also map to zero.
+        }
+    }
+
+    fn connection_key(&mut self) -> Result<[u8; 32], StreamIdError> {
+        if let Some(key) = self.key {
+            return Ok(key);
+        }
+        let mut key = [0_u8; 32];
+        getrandom::fill(&mut key).map_err(StreamIdError::RandomUnavailable)?;
+        self.key = Some(key);
+        Ok(key)
+    }
+
+    #[cfg(test)]
+    const fn with_test_key(key: [u8; 32]) -> Self {
+        Self {
+            key: Some(key),
+            last_sequence: 0,
+        }
+    }
+}
+
+impl Default for StreamIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for StreamIdGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StreamIdGenerator")
+            .field("key_initialized", &self.key.is_some())
+            .field("last_sequence", &self.last_sequence)
+            .finish()
+    }
+}
+
+fn permute_stream_counter(key: &[u8; 32], counter: u128) -> u128 {
+    let counter = counter.to_be_bytes();
+    let mut left = u64::from_be_bytes(counter[..8].try_into().expect("fixed left half"));
+    let mut right = u64::from_be_bytes(counter[8..].try_into().expect("fixed right half"));
+    for round in 0..STREAM_ID_FEISTEL_ROUNDS {
+        let next_left = right;
+        let next_right = left ^ stream_id_round(key, round, right);
+        left = next_left;
+        right = next_right;
+    }
+    (u128::from(left) << 64) | u128::from(right)
+}
+
+fn stream_id_round(key: &[u8; 32], round: u8, right: u64) -> u64 {
+    let mut hasher = blake3::Hasher::new_keyed(key);
+    hasher.update(STREAM_ID_DOMAIN);
+    hasher.update(&[round]);
+    hasher.update(&right.to_be_bytes());
+    let output = hasher.finalize();
+    u64::from_be_bytes(
+        output.as_bytes()[..8]
+            .try_into()
+            .expect("BLAKE3 output has a fixed first word"),
+    )
+}
+
+/// Invalid served transfer configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeConfigError {
+    /// The wire `u64` frame limit cannot be represented by this host.
+    MaxFrameBytesNotRepresentable { max_frame_bytes: u64 },
+    /// No nonempty DATA record fits.
+    FrameCannotCarryData {
+        max_frame_bytes: usize,
+        minimum_bytes: usize,
+    },
+    /// The frame bound cannot carry a shortest streaming Text request.
+    FrameCannotCarryStreamRequest {
+        max_frame_bytes: usize,
+        minimum_bytes: usize,
+    },
+    /// The bounded one-record-per-transfer DATA queue is not representable.
+    DataQueueCapacityNotRepresentable,
+    /// Tokio's byte semaphore cannot represent the calculated queue bound.
+    DataQueueCapacityTooLarge {
+        capacity_bytes: usize,
+        maximum: usize,
+    },
+    /// The advertised complete-message bound cannot back a byte semaphore.
+    ControlQueueCapacityTooLarge {
+        capacity_bytes: usize,
+        maximum: usize,
+    },
+    /// A served writer message bound cannot be converted or added on this host.
+    WriterQueueCapacityNotRepresentable {
+        queue: &'static str,
+        configured: u64,
+    },
+    /// Tokio's bounded channel cannot represent a calculated message count.
+    WriterQueueCapacityTooLarge {
+        queue: &'static str,
+        capacity_messages: usize,
+        maximum: usize,
+    },
+    /// Deadline division by zero is an invalid served configuration.
+    ZeroTransferFloor,
+    /// The forward-progress interval cannot be represented by the host timer.
+    StallDeadlineNotFinite { stall_ms: u64 },
+    /// The size-aware deadline budget does not fit the served `u64` field.
+    DeadlineBudgetOverflow { total_bytes: u64 },
+    /// The host timer cannot represent the otherwise valid budget.
+    DeadlineNotFinite { budget_ms: u64 },
+}
+
+impl fmt::Display for RuntimeConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MaxFrameBytesNotRepresentable { max_frame_bytes } => write!(
+                f,
+                "max_frame_bytes {max_frame_bytes} is not representable on this host"
+            ),
+            Self::FrameCannotCarryData {
+                max_frame_bytes,
+                minimum_bytes,
+            } => write!(
+                f,
+                "max_frame_bytes {max_frame_bytes} cannot carry a DATA record (minimum {minimum_bytes})"
+            ),
+            Self::FrameCannotCarryStreamRequest {
+                max_frame_bytes,
+                minimum_bytes,
+            } => write!(
+                f,
+                "max_frame_bytes {max_frame_bytes} cannot carry the shortest stream request (minimum {minimum_bytes})"
+            ),
+            Self::DataQueueCapacityNotRepresentable => {
+                f.write_str("the bounded DATA queue capacity is not representable")
+            }
+            Self::DataQueueCapacityTooLarge {
+                capacity_bytes,
+                maximum,
+            } => write!(
+                f,
+                "DATA queue capacity {capacity_bytes} exceeds semaphore maximum {maximum}"
+            ),
+            Self::ControlQueueCapacityTooLarge {
+                capacity_bytes,
+                maximum,
+            } => write!(
+                f,
+                "control queue capacity {capacity_bytes} exceeds semaphore maximum {maximum}"
+            ),
+            Self::WriterQueueCapacityNotRepresentable { queue, configured } => write!(
+                f,
+                "{queue} writer queue capacity derived from {configured} is not representable"
+            ),
+            Self::WriterQueueCapacityTooLarge {
+                queue,
+                capacity_messages,
+                maximum,
+            } => write!(
+                f,
+                "{queue} writer queue capacity {capacity_messages} exceeds channel maximum {maximum}"
+            ),
+            Self::ZeroTransferFloor => {
+                f.write_str("transfer_floor_bits_per_second must be nonzero")
+            }
+            Self::StallDeadlineNotFinite { stall_ms } => write!(
+                f,
+                "transfer stall interval {stall_ms}ms is not representable by the host timer"
+            ),
+            Self::DeadlineBudgetOverflow { total_bytes } => write!(
+                f,
+                "deadline budget for {total_bytes} bytes is not representable as u64 milliseconds"
+            ),
+            Self::DeadlineNotFinite { budget_ms } => write!(
+                f,
+                "deadline budget {budget_ms}ms is not representable by the host timer"
+            ),
+        }
+    }
+}
+
+impl Error for RuntimeConfigError {}
+
+/// Failure to create a fresh connection-local stream id.
+#[derive(Debug)]
+pub(crate) enum StreamIdError {
+    /// The request id is outside the browser-safe JSON range.
+    RequestIdOutOfRange { request_id: u64 },
+    /// Every representable connection-local counter value has been consumed.
+    SequenceExhausted,
+    /// The OS CSPRNG was unavailable.
+    RandomUnavailable(getrandom::Error),
+    /// Defensive conversion failure after the checks above.
+    InvalidIdentity(jeliya_codec::StreamCodecError),
+}
+
+impl fmt::Display for StreamIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RequestIdOutOfRange { request_id } => {
+                write!(
+                    f,
+                    "request id {request_id} is outside the browser-safe range"
+                )
+            }
+            Self::SequenceExhausted => f.write_str("connection-local stream id space exhausted"),
+            Self::RandomUnavailable(error) => write!(f, "OS CSPRNG unavailable: {error}"),
+            Self::InvalidIdentity(error) => write!(f, "invalid generated stream identity: {error}"),
+        }
+    }
+}
+
+impl Error for StreamIdError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::RandomUnavailable(error) => Some(error),
+            Self::InvalidIdentity(error) => Some(error),
+            Self::RequestIdOutOfRange { .. } | Self::SequenceExhausted => None,
+        }
+    }
+}
+
+fn resource_exhausted(resource: &str, limit: u64) -> ApiError {
+    ApiError::ResourceExhausted {
+        resource: resource.to_owned(),
+        limit,
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn minimum_stream_request_bytes() -> usize {
+    let read = Envelope::new(
+        0,
+        None,
+        FileRead {
+            room_id: RoomId::new(""),
+            file_id: FileId::new(""),
+        },
+    )
+    .expect("zero is a valid request id");
+    let share = Envelope::new(
+        0,
+        None,
+        FileShare {
+            room_id: RoomId::new(""),
+            name: String::new(),
+            declared_bytes: 0,
+            declared_content_type: String::new(),
+        },
+    )
+    .expect("zero is a valid request id");
+    let read_bytes = serde_json::to_vec(&read)
+        .expect("the shortest file.read envelope serializes")
+        .len();
+    let share_bytes = serde_json::to_vec(&share)
+        .expect("the shortest file.share envelope serializes")
+        .len();
+    read_bytes.max(share_bytes)
+}
+
+fn writer_queue_capacity(
+    queue: &'static str,
+    configured: u64,
+    additional: usize,
+    minimum: usize,
+) -> Result<usize, RuntimeConfigError> {
+    let configured_capacity = usize::try_from(configured).map_err(|_| {
+        RuntimeConfigError::WriterQueueCapacityNotRepresentable { queue, configured }
+    })?;
+    let capacity_messages = configured_capacity
+        .checked_add(additional)
+        .ok_or(RuntimeConfigError::WriterQueueCapacityNotRepresentable { queue, configured })?;
+    let capacity_messages = capacity_messages.max(minimum);
+    if capacity_messages > Semaphore::MAX_PERMITS {
+        return Err(RuntimeConfigError::WriterQueueCapacityTooLarge {
+            queue,
+            capacity_messages,
+            maximum: Semaphore::MAX_PERMITS,
+        });
+    }
+    Ok(capacity_messages)
+}
+
+fn data_queue_capacity(
+    max_concurrent_transfers: u64,
+    max_transfer_bytes_inflight: u64,
+    max_data_payload_bytes: usize,
+) -> Result<usize, RuntimeConfigError> {
+    // A transfer that can emit DATA reserves at least one logical byte. Zero
+    // byte transfers need no DATA queue slot, so do not charge header space for
+    // more streams than the byte budget can make nonempty.
+    let data_streams = max_concurrent_transfers.min(max_transfer_bytes_inflight);
+    let payload_capacity = u128::from(data_streams)
+        .checked_mul(max_data_payload_bytes as u128)
+        .ok_or(RuntimeConfigError::DataQueueCapacityNotRepresentable)?
+        .min(u128::from(max_transfer_bytes_inflight));
+    let header_capacity = u128::from(data_streams)
+        .checked_mul(STREAM_HEADER_BYTES as u128)
+        .ok_or(RuntimeConfigError::DataQueueCapacityNotRepresentable)?;
+    let capacity = payload_capacity
+        .checked_add(header_capacity)
+        .ok_or(RuntimeConfigError::DataQueueCapacityNotRepresentable)?;
+    let capacity_bytes = usize::try_from(capacity)
+        .map_err(|_| RuntimeConfigError::DataQueueCapacityNotRepresentable)?;
+    if capacity_bytes > Semaphore::MAX_PERMITS {
+        return Err(RuntimeConfigError::DataQueueCapacityTooLarge {
+            capacity_bytes,
+            maximum: Semaphore::MAX_PERMITS,
+        });
+    }
+    Ok(capacity_bytes)
+}
+
+fn deadline_budget_ms(
+    connect_allowance_ms: u64,
+    floor_bits_per_second: u64,
+    total_bytes: u64,
+) -> Result<u64, RuntimeConfigError> {
+    if floor_bits_per_second == 0 {
+        return Err(RuntimeConfigError::ZeroTransferFloor);
+    }
+    let numerator = u128::from(total_bytes)
+        .checked_mul(8)
+        .and_then(|value| value.checked_mul(1_000))
+        .ok_or(RuntimeConfigError::DeadlineBudgetOverflow { total_bytes })?;
+    let floor = u128::from(floor_bits_per_second);
+    let transfer_ms = numerator
+        .checked_add(floor - 1)
+        .ok_or(RuntimeConfigError::DeadlineBudgetOverflow { total_bytes })?
+        / floor;
+    let budget_ms = u128::from(connect_allowance_ms)
+        .checked_add(transfer_ms)
+        .ok_or(RuntimeConfigError::DeadlineBudgetOverflow { total_bytes })?;
+    u64::try_from(budget_ms).map_err(|_| RuntimeConfigError::DeadlineBudgetOverflow { total_bytes })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    fn served_limits() -> Limits {
+        jeliya_core::typed::limits()
+    }
+
+    fn assert_resource(error: ApiError, expected_resource: &str, expected_limit: u64) {
+        match error {
+            ApiError::ResourceExhausted { resource, limit } => {
+                assert_eq!(resource, expected_resource);
+                assert_eq!(limit, expected_limit);
+            }
+            other => panic!("expected resource_exhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transfer_count_accepts_exact_limit_and_refuses_one_past_first() {
+        let pool = TransferPool::new(2, 0);
+        let first = pool.reserve(0).expect("first count slot");
+        let second = pool.reserve(0).expect("exact count limit");
+        assert_eq!(
+            pool.state(),
+            TransferPoolState {
+                active_transfers: 2,
+                reserved_bytes: 0,
+            }
+        );
+
+        assert_resource(
+            pool.reserve(u64::MAX).unwrap_err(),
+            "max_concurrent_transfers",
+            2,
+        );
+        drop((first, second));
+        assert_eq!(pool.state(), TransferPoolState::default());
+    }
+
+    #[test]
+    fn transfer_bytes_accept_exact_limit_and_refuse_one_past() {
+        let pool = TransferPool::new(3, 10);
+        let six = pool.reserve(6).expect("six bytes");
+        let four = pool.reserve(4).expect("exact byte limit");
+        assert_resource(
+            pool.reserve(1).unwrap_err(),
+            "max_transfer_bytes_inflight",
+            10,
+        );
+        drop(six);
+        let one = pool.reserve(1).expect("released bytes are reusable");
+        drop((four, one));
+        assert_eq!(pool.state(), TransferPoolState::default());
+    }
+
+    #[test]
+    fn checked_byte_overflow_is_resource_exhaustion_without_mutation() {
+        let pool = TransferPool::new(2, u64::MAX);
+        let full = pool.reserve(u64::MAX).expect("full u64 reservation");
+        assert_resource(
+            pool.reserve(1).unwrap_err(),
+            "max_transfer_bytes_inflight",
+            u64::MAX,
+        );
+        assert_eq!(
+            pool.state(),
+            TransferPoolState {
+                active_transfers: 1,
+                reserved_bytes: u64::MAX,
+            }
+        );
+        drop(full);
+        assert_eq!(pool.state(), TransferPoolState::default());
+    }
+
+    #[test]
+    fn zero_byte_transfer_consumes_only_a_count_slot() {
+        let pool = TransferPool::new(1, 0);
+        let reservation = pool.reserve(0).expect("zero-byte transfer is admissible");
+        assert_eq!(pool.state().active_transfers, 1);
+        assert_eq!(pool.state().reserved_bytes, 0);
+        assert_resource(pool.reserve(0).unwrap_err(), "max_concurrent_transfers", 1);
+        drop(reservation);
+        assert!(pool.reserve(0).is_ok());
+    }
+
+    #[test]
+    fn concurrent_holders_are_counted_atomically_and_drop_releases_all() {
+        const WORKERS: usize = 4;
+        let pool = TransferPool::new(WORKERS as u64, WORKERS as u64);
+        let admitted = Arc::new(Barrier::new(WORKERS + 1));
+        let release = Arc::new(Barrier::new(WORKERS + 1));
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let pool = pool.clone();
+                let admitted = Arc::clone(&admitted);
+                let release = Arc::clone(&release);
+                std::thread::spawn(move || {
+                    let reservation = pool.reserve(1).expect("worker admission");
+                    admitted.wait();
+                    release.wait();
+                    drop(reservation);
+                })
+            })
+            .collect();
+
+        admitted.wait();
+        assert_eq!(
+            pool.state(),
+            TransferPoolState {
+                active_transfers: WORKERS as u64,
+                reserved_bytes: WORKERS as u64,
+            }
+        );
+        assert_resource(
+            pool.reserve(0).unwrap_err(),
+            "max_concurrent_transfers",
+            WORKERS as u64,
+        );
+        release.wait();
+        for handle in handles {
+            handle.join().expect("worker exits cleanly");
+        }
+        assert_eq!(pool.state(), TransferPoolState::default());
+    }
+
+    #[test]
+    fn runtime_limits_compute_frame_payload_and_bounded_data_queue() {
+        let mut limits = served_limits();
+        limits.max_frame_bytes = (STREAM_HEADER_BYTES + 65_536) as u64;
+        limits.max_concurrent_transfers = 2;
+        limits.max_transfer_bytes_inflight = 200_000;
+        let runtime = RuntimeLimits::from_served(&limits).expect("valid runtime limits");
+        assert_eq!(runtime.max_frame_bytes(), STREAM_HEADER_BYTES + 65_536);
+        assert_eq!(runtime.max_data_payload_bytes(), 65_536);
+        assert_eq!(
+            runtime.data_queue_capacity_bytes(),
+            2 * (STREAM_HEADER_BYTES + 65_536)
+        );
+        assert_eq!(
+            runtime.control_queue_capacity_messages(),
+            usize::try_from(limits.max_inflight_requests).unwrap() + CONTROL_QUEUE_ALLOWANCE
+        );
+        assert_eq!(runtime.data_queue_capacity_messages(), 2);
+        assert_eq!(runtime.transfer_stall(), Duration::from_secs(30));
+
+        limits.max_frame_bytes += 1;
+        let capped = RuntimeLimits::from_served(&limits).expect("protocol payload cap applies");
+        assert_eq!(capped.max_data_payload_bytes(), 65_536);
+    }
+
+    #[test]
+    fn data_queue_bound_accounts_only_for_possible_nonempty_streams() {
+        let mut limits = served_limits();
+        limits.max_concurrent_transfers = 8;
+        limits.max_transfer_bytes_inflight = 1;
+        let runtime = RuntimeLimits::from_served(&limits).expect("one-byte queue config");
+        assert_eq!(runtime.data_queue_capacity_bytes(), STREAM_HEADER_BYTES + 1);
+
+        limits.max_transfer_bytes_inflight = 0;
+        let zero = RuntimeLimits::from_served(&limits).expect("zero-byte-only config");
+        assert_eq!(zero.data_queue_capacity_bytes(), 0);
+        assert_eq!(zero.data_queue_capacity_messages(), 8);
+    }
+
+    #[test]
+    fn writer_and_frame_permit_bounds_refuse_conversion_overflow_and_tokio_panics() {
+        let mut limits = served_limits();
+        limits.max_inflight_requests = u64::MAX;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::WriterQueueCapacityNotRepresentable {
+                queue: "control",
+                configured: u64::MAX,
+            })
+        ));
+
+        limits = served_limits();
+        let maximum_control_bytes =
+            u64::try_from(MAX_CONTROL_BYTE_PERMITS).expect("control permit maximum fits u64");
+        limits.max_frame_bytes = maximum_control_bytes;
+        let exact_frame =
+            RuntimeLimits::from_served(&limits).expect("exact control permit maximum");
+        assert_eq!(
+            exact_frame.control_queue_capacity_bytes(),
+            MAX_CONTROL_BYTE_PERMITS
+        );
+
+        limits.max_frame_bytes = maximum_control_bytes + 1;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::ControlQueueCapacityTooLarge {
+                maximum: MAX_CONTROL_BYTE_PERMITS,
+                ..
+            })
+        ));
+
+        limits = served_limits();
+        let maximum = u64::try_from(Semaphore::MAX_PERMITS)
+            .expect("Tokio's semaphore maximum fits the wire u64");
+        let control_at_maximum = maximum
+            .checked_sub(u64::try_from(CONTROL_QUEUE_ALLOWANCE).unwrap())
+            .expect("Tokio permits more slots than the control allowance");
+        limits.max_inflight_requests = control_at_maximum;
+        let exact_control = RuntimeLimits::from_served(&limits).expect("exact channel maximum");
+        assert_eq!(
+            exact_control.control_queue_capacity_messages(),
+            Semaphore::MAX_PERMITS
+        );
+
+        limits.max_inflight_requests = maximum;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::WriterQueueCapacityTooLarge {
+                queue: "control",
+                maximum: Semaphore::MAX_PERMITS,
+                ..
+            })
+        ));
+
+        limits = served_limits();
+        limits.max_concurrent_transfers = maximum;
+        limits.max_transfer_bytes_inflight = 0;
+        let exact_data = RuntimeLimits::from_served(&limits).expect("exact channel maximum");
+        assert_eq!(
+            exact_data.data_queue_capacity_messages(),
+            Semaphore::MAX_PERMITS
+        );
+
+        let one_past_maximum = maximum
+            .checked_add(1)
+            .expect("Tokio reserves headroom below u64::MAX");
+        let one_past_maximum_usize = Semaphore::MAX_PERMITS
+            .checked_add(1)
+            .expect("Tokio reserves headroom below usize::MAX");
+        limits.max_concurrent_transfers = one_past_maximum;
+        limits.max_transfer_bytes_inflight = 0;
+        assert_eq!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::WriterQueueCapacityTooLarge {
+                queue: "DATA",
+                capacity_messages: one_past_maximum_usize,
+                maximum: Semaphore::MAX_PERMITS,
+            })
+        );
+    }
+
+    #[test]
+    fn frame_must_carry_data_and_the_shortest_stream_request() {
+        let mut limits = served_limits();
+        limits.max_frame_bytes = STREAM_HEADER_BYTES as u64;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::FrameCannotCarryData { .. })
+        ));
+
+        let minimum = minimum_stream_request_bytes();
+        assert_eq!(minimum, 102, "the spec-reviewed minimal envelope");
+        limits.max_frame_bytes = (minimum - 1) as u64;
+        assert_eq!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::FrameCannotCarryStreamRequest {
+                max_frame_bytes: minimum - 1,
+                minimum_bytes: minimum,
+            })
+        );
+        limits.max_frame_bytes = minimum as u64;
+        assert!(RuntimeLimits::from_served(&limits).is_ok());
+    }
+
+    #[test]
+    fn deadline_formula_uses_exact_ceiling_and_absolute_start() {
+        let mut limits = served_limits();
+        limits.transfer_connect_allowance_ms = 5_000;
+        limits.transfer_floor_bits_per_second = 8_192;
+        let runtime = RuntimeLimits::from_served(&limits).expect("valid deadlines");
+        let start = Instant::now();
+
+        let (one_deadline, one_budget) = runtime.deadline(start, 1).expect("one-byte deadline");
+        assert_eq!(one_budget, 5_001);
+        assert_eq!(
+            one_deadline.duration_since(start),
+            Duration::from_millis(5_001)
+        );
+
+        let (exact_deadline, exact_budget) = runtime
+            .deadline(start, 1_024)
+            .expect("exact division deadline");
+        assert_eq!(exact_budget, 6_000);
+        assert_eq!(
+            exact_deadline.duration_since(start),
+            Duration::from_millis(6_000)
+        );
+
+        assert_eq!(
+            runtime
+                .stall_deadline(start)
+                .expect("served stall interval is finite")
+                .duration_since(start),
+            Duration::from_millis(limits.transfer_stall_ms)
+        );
+    }
+
+    #[test]
+    fn served_stall_interval_is_checked_against_tokio_instant() {
+        let mut limits = served_limits();
+        limits.transfer_stall_ms = u64::MAX;
+        let representable =
+            Instant::now().checked_add(Duration::from_millis(limits.transfer_stall_ms));
+        let configured = RuntimeLimits::from_served(&limits);
+
+        if representable.is_some() {
+            let runtime = configured.expect("host timer represents every served stall value");
+            assert!(runtime.stall_deadline(Instant::now()).is_ok());
+        } else {
+            assert_eq!(
+                configured,
+                Err(RuntimeConfigError::StallDeadlineNotFinite { stall_ms: u64::MAX })
+            );
+        }
+    }
+
+    #[test]
+    fn zero_floor_and_worst_total_budget_overflow_refuse_configuration() {
+        let mut limits = served_limits();
+        limits.transfer_floor_bits_per_second = 0;
+        assert_eq!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::ZeroTransferFloor)
+        );
+
+        limits.transfer_floor_bits_per_second = 1;
+        limits.transfer_connect_allowance_ms = 0;
+        limits.max_transfer_bytes_inflight = u64::MAX;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::DataQueueCapacityTooLarge { .. })
+                | Err(RuntimeConfigError::DataQueueCapacityNotRepresentable)
+                | Err(RuntimeConfigError::DeadlineBudgetOverflow { .. })
+        ));
+
+        assert_eq!(
+            deadline_budget_ms(u64::MAX, 8_192, 1),
+            Err(RuntimeConfigError::DeadlineBudgetOverflow { total_bytes: 1 })
+        );
+    }
+
+    #[test]
+    fn generated_stream_ids_are_full_width_nonzero_unique_and_constant_space() {
+        let mut generator = StreamIdGenerator::with_test_key([0x42; 32]);
+        let mut ids = HashSet::new();
+        let mut high_halves = HashSet::new();
+        let mut low_halves = HashSet::new();
+        for expected_sequence in 1_u128..=256 {
+            let identity = generator.next(7).expect("fresh stream id");
+            let raw = identity.stream_id().get();
+            assert_ne!(raw, 0);
+            assert_ne!(raw, expected_sequence, "the counter leaked on the wire");
+            assert!(ids.insert(raw), "stream id was reused");
+            high_halves.insert(raw >> 64);
+            low_halves.insert(raw & u128::from(u64::MAX));
+            assert_eq!(identity.request_id().get(), 7);
+        }
+        assert_eq!(generator.last_sequence, 256);
+        assert!(
+            high_halves.len() > 250 && low_halves.len() > 250,
+            "both halves must vary pseudorandomly"
+        );
+        assert!(
+            std::mem::size_of::<StreamIdGenerator>() <= 64,
+            "generator state must remain constant and small"
+        );
+    }
+
+    #[test]
+    fn stream_id_permutation_crosses_u64_and_is_keyed() {
+        let mut first = StreamIdGenerator::with_test_key([0x11; 32]);
+        let mut second = StreamIdGenerator::with_test_key([0x22; 32]);
+        first.last_sequence = u128::from(u64::MAX) - 1;
+        second.last_sequence = first.last_sequence;
+
+        let before_boundary = first.next(1).unwrap().stream_id().get();
+        let after_boundary = first.next(2).unwrap().stream_id().get();
+        let other_key = second.next(1).unwrap().stream_id().get();
+        assert_ne!(before_boundary, after_boundary);
+        assert_ne!(before_boundary, other_key);
+        assert_eq!(first.last_sequence, u128::from(u64::MAX) + 1);
+    }
+
+    #[test]
+    fn stream_id_generator_checks_request_and_sequence_bounds() {
+        let mut generator = StreamIdGenerator::new();
+        assert!(matches!(
+            generator.next(jeliya_codec::MAX_REQUEST_ID + 1),
+            Err(StreamIdError::RequestIdOutOfRange { .. })
+        ));
+        assert_eq!(generator.last_sequence, 0, "invalid requests consume no id");
+        assert!(
+            generator.key.is_none(),
+            "invalid requests consume no entropy"
+        );
+
+        generator.last_sequence = u128::MAX;
+        assert!(matches!(
+            generator.next(0),
+            Err(StreamIdError::SequenceExhausted)
+        ));
+    }
+}


### PR DESCRIPTION
Implements the second implementation slice of #233: the protocol-v2 producer-direction `file.read` runtime.

Summary:
- corrects WebSocket message classes so JSON hello/replies/pushes are Text and Binary is reserved for bounded `JBS2` records
- adds staged stream header/kind validation and an opaque incremental core file source
- implements connection-local OPEN/CREDIT/DATA/END/reply and ABORT/ACK state machines with full-pair binding, checked deadlines, stall detection, and cleanup
- adds daemon-wide transfer reservations plus byte-bounded, priority-aware writer queues
- leaves `file.share` returning `not_ready` and does not change HTTP file routes or replay fixtures/harness behavior

Validation:
- `cargo +1.96.0 fmt --all --check`
- `cargo +1.96.0 build --locked --workspace`
- `cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings`
- `cargo +1.96.0 test --locked --workspace`
- `cargo +1.91.0 check --locked --workspace --all-targets`
- `node scripts/check-docs.mjs`
- `node scripts/check-v2-corpus.mjs`
- `git diff --check`