### PR TITLE
Implement protocol-v2 file.share upload runtime

### DIFF
--- a/crates/jeliya-codec/src/byte_stream.rs
+++ b/crates/jeliya-codec/src/byte_stream.rs
@@ -83,6 +83,28 @@ impl StreamRecord {
     }
 }
 
+/// A decoded byte-stream record borrowing any DATA payload from its input.
+///
+/// This is the stateful runtime's full structural-decode surface after it has
+/// validated the identity, bound the exact active pair, and checked the
+/// record's kind against stream state and endpoint direction. Unlike
+/// [`StreamRecord`], decoding this view never copies or allocates a DATA
+/// payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamRecordView<'a> {
+    /// The request-id/stream-id pair this record belongs to.
+    pub identity: StreamIdentity,
+    /// The record's kind-specific structural fields.
+    pub body: StreamRecordBodyView<'a>,
+}
+
+impl StreamRecordView<'_> {
+    /// Returns this record's closed kind.
+    pub fn kind(&self) -> StreamRecordKind {
+        self.body.kind()
+    }
+}
+
 /// The kind-specific body of a byte-stream record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StreamRecordBody {
@@ -133,6 +155,90 @@ impl StreamRecordBody {
             Self::End { .. } => StreamRecordKind::End,
             Self::Abort { .. } => StreamRecordKind::Abort,
             Self::Ack { .. } => StreamRecordKind::Ack,
+        }
+    }
+}
+
+/// The kind-specific body of a borrowed byte-stream record.
+///
+/// Every control record is represented by the same values as
+/// [`StreamRecordBody`]. DATA instead borrows its opaque bytes directly from
+/// the complete Binary message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRecordBodyView<'a> {
+    /// Admission, carrying the expected total byte count.
+    Open {
+        /// Expected total bytes for the admitted transfer.
+        total: u64,
+    },
+    /// A nonempty contiguous payload beginning at `offset`.
+    Data {
+        /// Zero-based offset of the payload's first byte.
+        offset: u64,
+        /// File bytes borrowed from the complete Binary message.
+        payload: &'a [u8],
+    },
+    /// Cumulative receiver credit.
+    Credit {
+        /// Exclusive end of bytes accepted by the receiver's sink.
+        accepted_through: u64,
+        /// Exclusive end through which the producer may send.
+        send_through: u64,
+    },
+    /// The producer's explicit end marker.
+    End {
+        /// Total bytes sent by the producer.
+        total: u64,
+    },
+    /// A stream abort.
+    Abort {
+        /// Sender's accepted-byte high-water mark.
+        accepted_through: u64,
+        /// The sender's local abort reason.
+        reason: BinaryAbortReason,
+    },
+    /// Acknowledgement of an ABORT.
+    Ack {
+        /// Final receiver-accepted byte count.
+        accepted_through: u64,
+    },
+}
+
+impl StreamRecordBodyView<'_> {
+    fn kind(&self) -> StreamRecordKind {
+        match self {
+            Self::Open { .. } => StreamRecordKind::Open,
+            Self::Data { .. } => StreamRecordKind::Data,
+            Self::Credit { .. } => StreamRecordKind::Credit,
+            Self::End { .. } => StreamRecordKind::End,
+            Self::Abort { .. } => StreamRecordKind::Abort,
+            Self::Ack { .. } => StreamRecordKind::Ack,
+        }
+    }
+
+    fn into_owned(self) -> StreamRecordBody {
+        match self {
+            Self::Open { total } => StreamRecordBody::Open { total },
+            Self::Data { offset, payload } => StreamRecordBody::Data {
+                offset,
+                payload: payload.to_vec(),
+            },
+            Self::Credit {
+                accepted_through,
+                send_through,
+            } => StreamRecordBody::Credit {
+                accepted_through,
+                send_through,
+            },
+            Self::End { total } => StreamRecordBody::End { total },
+            Self::Abort {
+                accepted_through,
+                reason,
+            } => StreamRecordBody::Abort {
+                accepted_through,
+                reason,
+            },
+            Self::Ack { accepted_through } => StreamRecordBody::Ack { accepted_through },
         }
     }
 }
@@ -372,18 +478,18 @@ pub fn decode_stream_kind(
     StreamRecordKind::from_wire(bytes[4])
 }
 
-/// Decodes one complete Binary message into a typed byte-stream record.
+/// Decodes one complete Binary message into a borrowed byte-stream record.
 ///
-/// No allocation occurs until every header field and payload bound has been
-/// validated. The only input-dependent allocation is a DATA payload capped at
-/// 65,536 bytes. Stateful runtimes must retain the result of
+/// No input-dependent allocation occurs. In particular, DATA payload bytes
+/// remain a slice of `bytes`. Stateful runtimes must retain the result of
 /// [`decode_stream_identity`], perform active binding lookup, call
 /// [`decode_stream_kind`] for direction/state validation, and only then call
-/// this full structural decoder.
-pub fn decode_stream_record(
-    bytes: &[u8],
+/// this full structural decoder. All fixed fields, payload bounds, and DATA
+/// offset arithmetic are checked before the view is returned.
+pub fn decode_stream_record_view<'a>(
+    bytes: &'a [u8],
     bounds: &CodecBounds,
-) -> Result<StreamRecord, StreamCodecError> {
+) -> Result<StreamRecordView<'a>, StreamCodecError> {
     let identity = decode_stream_identity(bytes, bounds)?;
     let max_payload = max_stream_data_bytes(bounds.max_frame_bytes)?;
 
@@ -400,7 +506,7 @@ pub fn decode_stream_record(
         StreamRecordKind::Open => {
             require_no_payload(kind, payload)?;
             require_field(kind, StreamHeaderField::Offset, offset, 0)?;
-            StreamRecordBody::Open { total: value }
+            StreamRecordBodyView::Open { total: value }
         }
         StreamRecordKind::Data => {
             require_field(kind, StreamHeaderField::Value, value, 0)?;
@@ -414,10 +520,7 @@ pub fn decode_stream_record(
                 });
             }
             checked_data_end(offset, payload.len())?;
-            StreamRecordBody::Data {
-                offset,
-                payload: payload.to_vec(),
-            }
+            StreamRecordBodyView::Data { offset, payload }
         }
         StreamRecordKind::Credit => {
             require_no_payload(kind, payload)?;
@@ -427,7 +530,7 @@ pub fn decode_stream_record(
                     send_through: value,
                 });
             }
-            StreamRecordBody::Credit {
+            StreamRecordBodyView::Credit {
                 accepted_through: offset,
                 send_through: value,
             }
@@ -435,12 +538,12 @@ pub fn decode_stream_record(
         StreamRecordKind::End => {
             require_field(kind, StreamHeaderField::Value, value, 0)?;
             require_no_payload(kind, payload)?;
-            StreamRecordBody::End { total: offset }
+            StreamRecordBodyView::End { total: offset }
         }
         StreamRecordKind::Abort => {
             let reason = BinaryAbortReason::from_wire(value)?;
             require_no_payload(kind, payload)?;
-            StreamRecordBody::Abort {
+            StreamRecordBodyView::Abort {
                 accepted_through: offset,
                 reason,
             }
@@ -448,13 +551,31 @@ pub fn decode_stream_record(
         StreamRecordKind::Ack => {
             require_field(kind, StreamHeaderField::Value, value, 0x05)?;
             require_no_payload(kind, payload)?;
-            StreamRecordBody::Ack {
+            StreamRecordBodyView::Ack {
                 accepted_through: offset,
             }
         }
     };
 
-    Ok(StreamRecord { identity, body })
+    Ok(StreamRecordView { identity, body })
+}
+
+/// Decodes one complete Binary message into an owned byte-stream record.
+///
+/// This uses [`decode_stream_record_view`] for all validation, then copies only
+/// a valid DATA payload. The only input-dependent allocation is therefore a
+/// DATA payload capped at 65,536 bytes. Stateful runtimes that can consume a
+/// payload before the complete message is released should prefer the borrowed
+/// decoder.
+pub fn decode_stream_record(
+    bytes: &[u8],
+    bounds: &CodecBounds,
+) -> Result<StreamRecord, StreamCodecError> {
+    let view = decode_stream_record_view(bytes, bounds)?;
+    Ok(StreamRecord {
+        identity: view.identity,
+        body: view.body.into_owned(),
+    })
 }
 
 /// Encodes one typed byte-stream record as one complete Binary message.

--- a/crates/jeliya-codec/src/lib.rs
+++ b/crates/jeliya-codec/src/lib.rs
@@ -51,9 +51,10 @@ mod gate;
 mod routing;
 
 pub use byte_stream::{
-    decode_stream_identity, decode_stream_kind, decode_stream_record, encode_stream_record,
-    max_stream_data_bytes, BinaryAbortReason, StreamCodecError, StreamHeaderField, StreamIdentity,
-    StreamRecord, StreamRecordBody, StreamRecordKind, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
+    decode_stream_identity, decode_stream_kind, decode_stream_record, decode_stream_record_view,
+    encode_stream_record, max_stream_data_bytes, BinaryAbortReason, StreamCodecError,
+    StreamHeaderField, StreamIdentity, StreamRecord, StreamRecordBody, StreamRecordBodyView,
+    StreamRecordKind, StreamRecordView, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
 };
 pub use error::{CodecError, GateRejection};
 pub use frame::push_to_bytes;

--- a/crates/jeliya-codec/tests/byte_stream.rs
+++ b/crates/jeliya-codec/tests/byte_stream.rs
@@ -1,10 +1,10 @@
 //! Spec-authored protocol-v2 Binary-record vectors and structural boundaries.
 
 use jeliya_codec::{
-    decode_stream_identity, decode_stream_kind, decode_stream_record, encode_stream_record,
-    max_stream_data_bytes, BinaryAbortReason, CodecBounds, StreamCodecError, StreamHeaderField,
-    StreamIdentity, StreamRecord, StreamRecordBody, StreamRecordKind, MAX_REQUEST_ID,
-    MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
+    decode_stream_identity, decode_stream_kind, decode_stream_record, decode_stream_record_view,
+    encode_stream_record, max_stream_data_bytes, BinaryAbortReason, CodecBounds, StreamCodecError,
+    StreamHeaderField, StreamIdentity, StreamRecord, StreamRecordBody, StreamRecordBodyView,
+    StreamRecordKind, StreamRecordView, MAX_REQUEST_ID, MAX_STREAM_DATA_BYTES, STREAM_HEADER_BYTES,
 };
 
 const REQUEST_ID: u64 = 0x0001_0203_0405_0607;
@@ -125,6 +125,291 @@ fn every_record_kind_matches_the_record_and_round_trips() {
             expected_record
         );
     }
+}
+
+#[test]
+fn borrowed_record_view_decodes_every_spec_authored_kind() {
+    let bounds = bounds(1024);
+    let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+
+    // These vectors are constructed directly from the normative kind table,
+    // not from `encode_stream_record` or an owned decode result.
+    let open = wire(0x01, REQUEST_ID, STREAM_ID, 0, 12, &[]);
+    assert_eq!(
+        decode_stream_record_view(&open, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::Open { total: 12 },
+        }
+    );
+
+    let data_payload = [0xde, 0xad, 0xbe, 0xef];
+    let data = wire(0x02, REQUEST_ID, STREAM_ID, 7, 0, &data_payload);
+    assert_eq!(
+        decode_stream_record_view(&data, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::Data {
+                offset: 7,
+                payload: &data_payload,
+            },
+        }
+    );
+
+    let credit = wire(0x03, REQUEST_ID, STREAM_ID, 8, 21, &[]);
+    assert_eq!(
+        decode_stream_record_view(&credit, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::Credit {
+                accepted_through: 8,
+                send_through: 21,
+            },
+        }
+    );
+
+    let end = wire(0x04, REQUEST_ID, STREAM_ID, 12, 0, &[]);
+    assert_eq!(
+        decode_stream_record_view(&end, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::End { total: 12 },
+        }
+    );
+
+    let abort = wire(0x05, REQUEST_ID, STREAM_ID, 8, 0x04, &[]);
+    assert_eq!(
+        decode_stream_record_view(&abort, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::Abort {
+                accepted_through: 8,
+                reason: BinaryAbortReason::ProtocolError,
+            },
+        }
+    );
+
+    let ack = wire(0x06, REQUEST_ID, STREAM_ID, 8, 0x05, &[]);
+    assert_eq!(
+        decode_stream_record_view(&ack, &bounds).unwrap(),
+        StreamRecordView {
+            identity,
+            body: StreamRecordBodyView::Ack {
+                accepted_through: 8,
+            },
+        }
+    );
+}
+
+#[test]
+fn borrowed_data_payload_is_the_exact_input_slice_and_owned_decode_matches() {
+    let expected_payload = [0x00, 0xff, 0x4a, 0x42, 0x53, 0x32, 0x7f];
+    let bytes = wire(
+        0x02,
+        REQUEST_ID,
+        STREAM_ID,
+        0x2021_2223_2425_2627,
+        0,
+        &expected_payload,
+    );
+    let bounds = bounds(bytes.len());
+    let view = decode_stream_record_view(&bytes, &bounds).unwrap();
+    assert_eq!(view.kind(), StreamRecordKind::Data);
+    let StreamRecordBodyView::Data { offset, payload } = view.body else {
+        panic!("raw DATA decoded as a control record");
+    };
+    assert_eq!(offset, 0x2021_2223_2425_2627);
+    assert_eq!(payload, expected_payload);
+    assert_eq!(payload.as_ptr(), bytes[STREAM_HEADER_BYTES..].as_ptr());
+    assert_eq!(payload.len(), bytes.len() - STREAM_HEADER_BYTES);
+
+    assert_eq!(
+        decode_stream_record(&bytes, &bounds).unwrap(),
+        StreamRecord {
+            identity: view.identity,
+            body: StreamRecordBody::Data {
+                offset,
+                payload: expected_payload.to_vec(),
+            },
+        }
+    );
+}
+
+#[test]
+fn borrowed_and_owned_decoders_have_identical_raw_wire_refusals() {
+    let ordinary = bounds(1024);
+    let protocol_payload_bounds = bounds(STREAM_HEADER_BYTES + MAX_STREAM_DATA_BYTES + 1);
+
+    let mut oversized_bad_magic = vec![0; 50];
+    oversized_bad_magic[..4].copy_from_slice(b"NOPE");
+    let mut bad_magic = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]);
+    bad_magic[..4].copy_from_slice(b"NOPE");
+    let mut bad_reserved = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]);
+    bad_reserved[6] = 1;
+
+    let cases = vec![
+        (
+            oversized_bad_magic,
+            bounds(49),
+            StreamCodecError::FrameTooLarge {
+                actual_bytes: 50,
+                limit_bytes: 49,
+            },
+        ),
+        (
+            b"JBS2".to_vec(),
+            ordinary,
+            StreamCodecError::HeaderTooShort { actual_bytes: 4 },
+        ),
+        (bad_magic, ordinary, StreamCodecError::BadMagic),
+        (
+            wire(0x02, MAX_REQUEST_ID + 1, STREAM_ID, 0, 0, &[1]),
+            ordinary,
+            StreamCodecError::RequestIdOutOfRange {
+                request_id: MAX_REQUEST_ID + 1,
+            },
+        ),
+        (
+            wire(0x02, REQUEST_ID, 0, 0, 0, &[1]),
+            ordinary,
+            StreamCodecError::ZeroStreamId,
+        ),
+        (
+            wire(0xff, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+            ordinary,
+            StreamCodecError::UnknownKind { kind: 0xff },
+        ),
+        (
+            bad_reserved,
+            ordinary,
+            StreamCodecError::ReservedBytesNonzero,
+        ),
+        (
+            wire(0x02, REQUEST_ID, STREAM_ID, 0, 1, &[1]),
+            ordinary,
+            StreamCodecError::InvalidField {
+                kind: StreamRecordKind::Data,
+                field: StreamHeaderField::Value,
+                value: 1,
+                expected: 0,
+            },
+        ),
+        (
+            wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+            ordinary,
+            StreamCodecError::EmptyData,
+        ),
+        (
+            wire(
+                0x02,
+                REQUEST_ID,
+                STREAM_ID,
+                0,
+                0,
+                &vec![0x5a; MAX_STREAM_DATA_BYTES + 1],
+            ),
+            protocol_payload_bounds,
+            StreamCodecError::DataTooLarge {
+                actual_bytes: MAX_STREAM_DATA_BYTES + 1,
+                limit_bytes: MAX_STREAM_DATA_BYTES,
+            },
+        ),
+        (
+            wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX, 0, &[1]),
+            ordinary,
+            StreamCodecError::OffsetOverflow {
+                offset: u64::MAX,
+                payload_bytes: 1,
+            },
+        ),
+        (
+            wire(0x01, REQUEST_ID, STREAM_ID, 0, 0, &[1]),
+            ordinary,
+            StreamCodecError::UnexpectedPayload {
+                kind: StreamRecordKind::Open,
+                payload_bytes: 1,
+            },
+        ),
+        (
+            wire(0x03, REQUEST_ID, STREAM_ID, 8, 7, &[]),
+            ordinary,
+            StreamCodecError::InvalidCredit {
+                accepted_through: 8,
+                send_through: 7,
+            },
+        ),
+        (
+            wire(0x05, REQUEST_ID, STREAM_ID, 0, 6, &[]),
+            ordinary,
+            StreamCodecError::InvalidAbortReason { value: 6 },
+        ),
+        (
+            wire(0x06, REQUEST_ID, STREAM_ID, 0, 4, &[]),
+            ordinary,
+            StreamCodecError::InvalidField {
+                kind: StreamRecordKind::Ack,
+                field: StreamHeaderField::Value,
+                value: 4,
+                expected: 5,
+            },
+        ),
+    ];
+
+    for (bytes, bounds, expected) in cases {
+        assert_eq!(
+            decode_stream_record_view(&bytes, &bounds),
+            Err(expected.clone())
+        );
+        assert_eq!(decode_stream_record(&bytes, &bounds), Err(expected));
+    }
+}
+
+#[test]
+fn borrowed_data_view_checks_payload_and_candidate_boundaries() {
+    let one_byte = wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX - 1, 0, &[0xaa]);
+    let view = decode_stream_record_view(&one_byte, &bounds(49)).unwrap();
+    let StreamRecordBodyView::Data { offset, payload } = view.body else {
+        panic!("boundary DATA decoded as control");
+    };
+    assert_eq!(offset, u64::MAX - 1);
+    assert_eq!(payload, [0xaa]);
+
+    let two_bytes = wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX - 2, 0, &[0xaa, 0xbb]);
+    let two_view = decode_stream_record_view(&two_bytes, &bounds(50)).unwrap();
+    let StreamRecordBodyView::Data { offset, payload } = two_view.body else {
+        panic!("boundary DATA decoded as control");
+    };
+    assert_eq!(offset, u64::MAX - 2);
+    assert_eq!(payload, [0xaa, 0xbb]);
+
+    let overflow = wire(0x02, REQUEST_ID, STREAM_ID, u64::MAX - 1, 0, &[0xaa, 0xbb]);
+    assert_eq!(
+        decode_stream_record_view(&overflow, &bounds(50)),
+        Err(StreamCodecError::OffsetOverflow {
+            offset: u64::MAX - 1,
+            payload_bytes: 2,
+        })
+    );
+
+    let maximum_payload = vec![0x5a; MAX_STREAM_DATA_BYTES];
+    let maximum = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &maximum_payload);
+    let maximum_bounds = bounds(STREAM_HEADER_BYTES + MAX_STREAM_DATA_BYTES);
+    let maximum_view = decode_stream_record_view(&maximum, &maximum_bounds).unwrap();
+    let StreamRecordBodyView::Data { payload, .. } = maximum_view.body else {
+        panic!("maximum DATA decoded as control");
+    };
+    assert_eq!(payload.len(), MAX_STREAM_DATA_BYTES);
+    assert_eq!(payload.as_ptr(), maximum[STREAM_HEADER_BYTES..].as_ptr());
+
+    let past_payload = vec![0x5a; MAX_STREAM_DATA_BYTES + 1];
+    let past = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &past_payload);
+    assert_eq!(
+        decode_stream_record_view(&past, &bounds(past.len())),
+        Err(StreamCodecError::DataTooLarge {
+            actual_bytes: MAX_STREAM_DATA_BYTES + 1,
+            limit_bytes: MAX_STREAM_DATA_BYTES,
+        })
+    );
 }
 
 #[test]

--- a/crates/jeliya-core/src/engine.rs
+++ b/crates/jeliya-core/src/engine.rs
@@ -19,13 +19,13 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use jeliya_api::{
-    ApiError, FileRead, FileReadOut, FileShare, FileShareOut, OpId, PeerRow, Push, RoomId,
-    SubjectState,
+    ApiError, ByteTotal, FileRead, FileReadOut, FileShare, FileShareOut, OpId, PeerRow, Push,
+    RoomId, StreamAbortReason, SubjectState,
 };
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::{broadcast, mpsc, watch};
@@ -35,6 +35,10 @@ use tracing::{info, warn};
 use crate::error::{CoreResult, ErrorKind};
 use crate::supervisor::RoomSupervisor;
 use crate::typed::{self, TypedCall, TypedReply};
+
+pub use crate::protocol_upload::{
+    FileShareFinalizer, FileShareSinkError, OpenFileShareSink, PreparedFileShare,
+};
 
 /// The protocol generation this engine serves. One generation at a time, no
 /// dual support: v2's generation. Part of the supervision contract — an app
@@ -323,6 +327,122 @@ fn is_dedup_op(op: &str) -> bool {
 /// execution and every faithful replay. Clone-cheap (`Arc`).
 type LedgerReply = Arc<Result<TypedReply, ApiError>>;
 
+/// A single-use publisher for one newly-owned deduplicated operation.
+///
+/// Keeping publication separate from operation execution lets ordinary typed
+/// calls and streamed operations share the same owner/join/replay ledger. A
+/// streamed owner can therefore retain this capability through byte transfer
+/// and publish only its eventual terminal result.
+struct LedgerOwner {
+    ledger: Arc<Mutex<DedupLedger>>,
+    key: (String, OpId),
+    body_hash: [u8; 32],
+    done: watch::Sender<Option<LedgerReply>>,
+    completed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileShareCancellation {
+    transferred_bytes: u64,
+    total_bytes: u64,
+}
+
+impl LedgerOwner {
+    fn complete(mut self, reply: Result<TypedReply, ApiError>) {
+        self.publish(Arc::new(reply));
+    }
+
+    fn record_file_share_cancellation(&self, cancellation: FileShareCancellation) {
+        let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
+        let entry = ledger
+            .entries
+            .get_mut(&self.key)
+            .expect("owned dedup entry remains present until publication");
+        match entry {
+            LedgerEntry::InFlight {
+                body_hash,
+                cancellation: recorded,
+                ..
+            } => {
+                assert_eq!(
+                    *body_hash, self.body_hash,
+                    "owned dedup fingerprint changed before publication"
+                );
+                assert!(
+                    recorded.is_none_or(|existing| existing == cancellation),
+                    "streamed cancellation result changed after selection"
+                );
+                *recorded = Some(cancellation);
+            }
+            LedgerEntry::Done { .. } => {
+                panic!("owned streamed operation completed before its owner")
+            }
+        }
+    }
+
+    fn publish(&mut self, reply: LedgerReply) {
+        if self.completed {
+            return;
+        }
+        self.completed = true;
+        let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
+        let cancellation = match ledger.entries.get(&self.key) {
+            Some(
+                LedgerEntry::InFlight { cancellation, .. } | LedgerEntry::Done { cancellation, .. },
+            ) => *cancellation,
+            None => None,
+        };
+        ledger.entries.insert(
+            self.key.clone(),
+            LedgerEntry::Done {
+                body_hash: self.body_hash,
+                reply: reply.clone(),
+                cancellation,
+            },
+        );
+        drop(ledger);
+        // Retain the terminal value even when the owner had no concurrent
+        // waiter.  A plain `send` discards it when the channel's initial
+        // receiver has already been dropped, which could strand a faithful
+        // replay that subscribed at the completion boundary.
+        let _ = self.done.send_replace(Some(reply));
+    }
+}
+
+impl Drop for LedgerOwner {
+    fn drop(&mut self) {
+        // Never strand faithful joiners if an owning task panics or is
+        // cancelled before it can choose a more exact terminal result.
+        if !self.completed {
+            self.publish(Arc::new(Err(ApiError::NotReady)));
+        }
+    }
+}
+
+struct LedgerWaiter {
+    done: watch::Receiver<Option<LedgerReply>>,
+}
+
+impl LedgerWaiter {
+    async fn wait(mut self) -> LedgerReply {
+        loop {
+            if let Some(reply) = self.done.borrow().clone() {
+                return reply;
+            }
+            if self.done.changed().await.is_err() {
+                return Arc::new(Err(ApiError::NotReady));
+            }
+        }
+    }
+}
+
+enum OperationGate {
+    Owner(LedgerOwner),
+    Await(LedgerWaiter),
+    Done(LedgerReply),
+    Conflict,
+}
+
 /// A dedup-ledger entry in one of two states. `InFlight` reserves the key
 /// BEFORE the effect runs and carries a [`watch`] the original execution
 /// publishes its reply into; a concurrent duplicate of the same key subscribes
@@ -335,16 +455,22 @@ enum LedgerEntry {
     InFlight {
         /// The request fingerprint (operation path + canonical body), to tell
         /// a faithful retry from a conflicting reuse of the same `op_id`.
-        body_hash: u64,
+        body_hash: [u8; 32],
         /// Publishes the reply the moment the original execution completes.
         done: watch::Sender<Option<LedgerReply>>,
+        /// Explicit daemon-selected streamed-upload cancellation provenance.
+        /// This is distinct from a client ABORT that happens to use the same
+        /// public terminal reason.
+        cancellation: Option<FileShareCancellation>,
     },
     /// The effect completed; the reply is recorded for faithful replays.
     Done {
         /// The request fingerprint.
-        body_hash: u64,
+        body_hash: [u8; 32],
         /// The recorded reply.
         reply: LedgerReply,
+        /// Cancellation provenance retained for `transfer.cancel` replay.
+        cancellation: Option<FileShareCancellation>,
     },
 }
 
@@ -394,13 +520,228 @@ pub struct Executed {
     pub stop_after_reply: bool,
 }
 
+/// Result of the pre-stream `file.share` ledger gate.
+///
+/// Only [`Self::Owner`] may prepare staging and emit OPEN. [`Self::Replay`]
+/// covers a faithful in-flight join, a completed replay, a divergent-body
+/// conflict, and validation refusals that precede the ledger.
+pub enum FileShareLedgerGate {
+    /// This request owns the one upload execution.
+    Owner(FileShareLedgerOwner),
+    /// Return this exact result without opening a byte stream.
+    Replay(Result<FileShareOut, ApiError>),
+}
+
+/// Single-use completion capability for an owned streamed `file.share`.
+///
+/// The capability is deliberately independent of a WebSocket task. Moving it
+/// into detached finalization guarantees the ledger can publish after a lost
+/// connection. Dropping it before an explicit terminal decision records the
+/// required pre-END `transport_lost` result for uploads carrying `op_id`.
+pub struct FileShareLedgerOwner {
+    publisher: Option<LedgerOwner>,
+    declared_bytes: u64,
+    accepted_bytes: Arc<AtomicU64>,
+    selected_cancellation: Option<FileShareCancellation>,
+    completed: bool,
+}
+
+/// Cloneable accepted-byte counter retained by a streamed ledger owner.
+///
+/// The upload sink advances this only after a complete DATA record is durably
+/// accepted. If connection teardown drops the owner before it can explicitly
+/// publish `transport_lost`, the owner's destructor still records the exact
+/// proven count rather than zero.
+#[derive(Clone)]
+pub struct FileShareLedgerProgress {
+    accepted_bytes: Arc<AtomicU64>,
+}
+
+impl FileShareLedgerProgress {
+    /// Advance the proven receiver-accepted high-water mark monotonically.
+    pub fn record_accepted(&self, accepted_bytes: u64) {
+        self.accepted_bytes
+            .fetch_max(accepted_bytes, Ordering::AcqRel);
+    }
+
+    /// Return the current proven receiver-accepted count.
+    #[must_use]
+    pub fn accepted_bytes(&self) -> u64 {
+        self.accepted_bytes.load(Ordering::Acquire)
+    }
+}
+
+impl FileShareLedgerOwner {
+    /// A progress handle for the bounded staging sink.
+    #[must_use]
+    pub fn progress(&self) -> FileShareLedgerProgress {
+        FileShareLedgerProgress {
+            accepted_bytes: self.accepted_bytes.clone(),
+        }
+    }
+
+    /// Publish and return one terminal upload result.
+    pub fn complete(
+        mut self,
+        result: Result<FileShareOut, ApiError>,
+    ) -> Result<FileShareOut, ApiError> {
+        let result = self
+            .selected_cancellation
+            .map(file_share_cancellation_error)
+            .unwrap_or(result);
+        if let Some(publisher) = self.publisher.take() {
+            publisher.complete(result.clone().map(TypedReply::FileShare));
+        }
+        self.completed = true;
+        result
+    }
+
+    /// Record the daemon's atomic ACTIVE cancellation selection.
+    ///
+    /// The compact annotation is stored on the existing dedup entry before
+    /// the transport removes its live target. Repeated `transfer.cancel`
+    /// requests can therefore return `already_cancelled` during ABORT/ACK and
+    /// after publication without a second permanent registry.
+    pub fn record_cancel_selected(&mut self, transferred_bytes: u64, total_bytes: u64) {
+        assert_eq!(
+            total_bytes, self.declared_bytes,
+            "streamed cancellation total disagrees with its owned declaration"
+        );
+        assert!(
+            transferred_bytes <= total_bytes,
+            "streamed cancellation progress exceeds its declaration"
+        );
+        let cancellation = FileShareCancellation {
+            transferred_bytes,
+            total_bytes,
+        };
+        assert!(
+            self.selected_cancellation
+                .is_none_or(|existing| existing == cancellation),
+            "streamed cancellation result changed after selection"
+        );
+        let publisher = self
+            .publisher
+            .as_ref()
+            .expect("only an op_id upload can be registered for cancellation");
+        publisher.record_file_share_cancellation(cancellation);
+        self.selected_cancellation = Some(cancellation);
+    }
+
+    /// Record the exact pre-END transport-loss result.
+    pub fn transport_lost(self, transferred_bytes: u64) -> Result<FileShareOut, ApiError> {
+        self.accepted_bytes
+            .fetch_max(transferred_bytes, Ordering::AcqRel);
+        let total = ByteTotal::Known {
+            bytes: self.declared_bytes,
+        };
+        let transferred_bytes = self.accepted_bytes.load(Ordering::Acquire);
+        self.complete(Err(ApiError::StreamAborted {
+            transferred_bytes,
+            total,
+            reason: StreamAbortReason::TransportLost,
+        }))
+    }
+}
+
+impl Drop for FileShareLedgerOwner {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        if let Some(publisher) = self.publisher.take() {
+            let result = self.selected_cancellation.map_or_else(
+                || {
+                    Err(ApiError::StreamAborted {
+                        transferred_bytes: self.accepted_bytes.load(Ordering::Acquire),
+                        total: ByteTotal::Known {
+                            bytes: self.declared_bytes,
+                        },
+                        reason: StreamAbortReason::TransportLost,
+                    })
+                },
+                file_share_cancellation_error,
+            );
+            publisher.complete(result.map(TypedReply::FileShare));
+        }
+        self.completed = true;
+    }
+}
+
+fn file_share_cancellation_error(
+    cancellation: FileShareCancellation,
+) -> Result<FileShareOut, ApiError> {
+    Err(ApiError::StreamAborted {
+        transferred_bytes: cancellation.transferred_bytes,
+        total: ByteTotal::Known {
+            bytes: cancellation.total_bytes,
+        },
+        reason: StreamAbortReason::Cancelled,
+    })
+}
+
 impl Engine {
+    fn gate_operation(
+        &self,
+        principal_key: &str,
+        op_id: OpId,
+        body_hash: [u8; 32],
+    ) -> OperationGate {
+        let key = (principal_key.to_owned(), op_id);
+        let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
+        match ledger.entries.get(&key) {
+            Some(LedgerEntry::Done {
+                body_hash: recorded,
+                reply,
+                ..
+            }) => {
+                if *recorded == body_hash {
+                    OperationGate::Done(reply.clone())
+                } else {
+                    OperationGate::Conflict
+                }
+            }
+            Some(LedgerEntry::InFlight {
+                body_hash: recorded,
+                done,
+                ..
+            }) => {
+                if *recorded == body_hash {
+                    OperationGate::Await(LedgerWaiter {
+                        done: done.subscribe(),
+                    })
+                } else {
+                    OperationGate::Conflict
+                }
+            }
+            None => {
+                let (done, _unused_rx) = watch::channel(None);
+                ledger.entries.insert(
+                    key.clone(),
+                    LedgerEntry::InFlight {
+                        body_hash,
+                        done: done.clone(),
+                        cancellation: None,
+                    },
+                );
+                OperationGate::Owner(LedgerOwner {
+                    ledger: self.ledger.clone(),
+                    key,
+                    body_hash,
+                    done,
+                    completed: false,
+                })
+            }
+        }
+    }
+
     /// Create an engine owning a fresh supervisor over `data_dir` (created if
     /// missing, then canonicalized). Synchronous; the engine never creates a
     /// runtime, it assumes an ambient one for its spawned work.
     pub fn new(data_dir: PathBuf, loopback: bool, config: EngineConfig) -> CoreResult<Arc<Self>> {
         crate::identity::ensure_dir(&data_dir)?;
         let data_dir = data_dir.canonicalize().unwrap_or(data_dir);
+        crate::protocol_upload::cleanup_abandoned_protocol_uploads(&data_dir)?;
         let supervisor = Arc::new(RoomSupervisor::new(data_dir, loopback)?);
         Ok(Self::with_supervisor(supervisor, config))
     }
@@ -494,12 +835,111 @@ impl Engine {
         })
     }
 
+    /// Reserve or join the streamed-operation ledger for `file.share`.
+    ///
+    /// Structural validation and the subject precondition run before this
+    /// method touches the ledger. Room/standing/role authorization and upload
+    /// semantics intentionally run only after it returns [`FileShareLedgerGate::Owner`],
+    /// so a faithful concurrent replay opens no second sink or stream.
+    pub async fn gate_file_share(
+        &self,
+        req: &FileShare,
+        op_id: Option<OpId>,
+        principal_key: &str,
+    ) -> FileShareLedgerGate {
+        let call = TypedCall::FileShare(req.clone());
+        if let Err(error) = typed::validate_structure(&call) {
+            return FileShareLedgerGate::Replay(Err(error));
+        }
+        let typed = typed::TypedSupervisor::new(&self.supervisor);
+        match typed.subject_present() {
+            Ok(true) => {}
+            Ok(false) => return FileShareLedgerGate::Replay(Err(ApiError::SubjectAbsent)),
+            Err(error) => return FileShareLedgerGate::Replay(Err(error)),
+        }
+
+        let Some(op_id) = op_id else {
+            return FileShareLedgerGate::Owner(FileShareLedgerOwner {
+                publisher: None,
+                declared_bytes: req.declared_bytes,
+                accepted_bytes: Arc::new(AtomicU64::new(0)),
+                selected_cancellation: None,
+                completed: false,
+            });
+        };
+        let result = match self.gate_operation(principal_key, op_id.clone(), call.body_hash()) {
+            OperationGate::Owner(publisher) => {
+                return FileShareLedgerGate::Owner(FileShareLedgerOwner {
+                    publisher: Some(publisher),
+                    declared_bytes: req.declared_bytes,
+                    accepted_bytes: Arc::new(AtomicU64::new(0)),
+                    selected_cancellation: None,
+                    completed: false,
+                });
+            }
+            OperationGate::Await(waiter) => waiter.wait().await,
+            OperationGate::Done(reply) => reply,
+            OperationGate::Conflict => {
+                return FileShareLedgerGate::Replay(Err(ApiError::OpIdConflict { op_id }));
+            }
+        };
+        FileShareLedgerGate::Replay(match (*result).clone() {
+            Ok(TypedReply::FileShare(out)) => Ok(out),
+            Err(error) => Err(error),
+            Ok(_) => Err(ApiError::NotReady),
+        })
+    }
+
+    /// Return the daemon-selected cancellation recorded for one streamed
+    /// upload, whether its original ABORT/ACK exchange is still in flight or
+    /// its terminal result has already been published.
+    #[must_use]
+    pub fn recorded_file_share_cancellation(
+        &self,
+        principal_key: &str,
+        op_id: &OpId,
+    ) -> Option<(u64, u64)> {
+        let ledger = self.ledger.lock().expect("dedup ledger poisoned");
+        let cancellation = match ledger
+            .entries
+            .get(&(principal_key.to_owned(), op_id.clone()))?
+        {
+            LedgerEntry::InFlight { cancellation, .. } | LedgerEntry::Done { cancellation, .. } => {
+                *cancellation
+            }
+        }?;
+        Some((cancellation.transferred_bytes, cancellation.total_bytes))
+    }
+
+    /// Run the owner-only post-ledger `file.share` validation and
+    /// authorization, without creating staging yet.
+    ///
+    /// The daemon reserves transfer count and declared logical bytes after
+    /// this returns, then calls [`PreparedFileShare::open_sink`] before OPEN.
+    pub async fn prepare_file_share_after_gate(
+        &self,
+        req: &FileShare,
+    ) -> Result<PreparedFileShare, ApiError> {
+        crate::protocol_upload::prepare_file_share_after_gate(self.supervisor.clone(), req).await
+    }
+
     /// The `hello` `subject` fact: present with ids, its stated absence, or
     /// `not_ready` when the subject store cannot be read (the connection must
     /// be refused rather than invited to run `subject.ensure` against
     /// unreadable existing state).
     pub fn subject_state(&self) -> Result<SubjectState, ApiError> {
         typed::TypedSupervisor::new(&self.supervisor).subject_state()
+    }
+
+    /// Apply the validation-order subject precondition for daemon-managed
+    /// `transfer.cancel` before the transport consults its principal-scoped
+    /// live upload registry. The codec has already performed structural
+    /// decoding, and the cancel request's own envelope `op_id` is ignored.
+    pub fn validate_transfer_cancel(&self) -> Result<(), ApiError> {
+        match typed::TypedSupervisor::new(&self.supervisor).subject_present()? {
+            true => Ok(()),
+            false => Err(ApiError::SubjectAbsent),
+        }
     }
 
     /// Execute one typed call with no request context. Equivalent to
@@ -594,87 +1034,28 @@ impl Engine {
             }
 
             let body_hash = call.body_hash();
-            let key = (principal_key.to_owned(), op_id.clone());
-            // Reserve or join under the lock; never held across the await.
-            enum Gate {
-                /// We own the effect: it is already spawned (below) and we
-                /// await its completion here.
-                Run(watch::Receiver<Option<LedgerReply>>),
-                /// A faithful replay: await the in-flight/recorded reply.
-                Await(watch::Receiver<Option<LedgerReply>>),
-                /// A recorded reply to return directly.
-                Done(LedgerReply),
-                /// The same `op_id` with a different body.
-                Conflict,
-            }
-            let gate = {
-                let mut ledger = self.ledger.lock().expect("dedup ledger poisoned");
-                match ledger.entries.get(&key) {
-                    Some(LedgerEntry::Done {
-                        body_hash: h,
-                        reply,
-                    }) => {
-                        if *h == body_hash {
-                            Gate::Done(reply.clone())
-                        } else {
-                            Gate::Conflict
-                        }
-                    }
-                    Some(LedgerEntry::InFlight { body_hash: h, done }) => {
-                        if *h == body_hash {
-                            Gate::Await(done.subscribe())
-                        } else {
-                            Gate::Conflict
-                        }
-                    }
-                    None => {
-                        // First sighting: reserve the key, then run the effect
-                        // in a DETACHED task so it completes and records the
-                        // reply even if this connection's reply task is
-                        // aborted on disconnect (the record's motivating case
-                        // is a reply lost to a dropped connection). Publish to
-                        // the watch, then mark Done.
-                        let (tx, rx) = watch::channel(None);
-                        ledger.entries.insert(
-                            key.clone(),
-                            LedgerEntry::InFlight {
-                                body_hash,
-                                done: tx.clone(),
-                            },
-                        );
-                        let sup = self.supervisor.clone();
-                        let ledger = self.ledger.clone();
-                        tokio::spawn(async move {
-                            let reply: LedgerReply = Arc::new(typed::dispatch(&sup, call).await);
-                            let _ = tx.send(Some(reply.clone()));
-                            let mut ledger = ledger.lock().expect("dedup ledger poisoned");
-                            ledger
-                                .entries
-                                .insert(key, LedgerEntry::Done { body_hash, reply });
-                        });
-                        Gate::Run(rx)
-                    }
-                }
-            };
-            let reply = match gate {
-                Gate::Done(reply) => reply,
-                Gate::Conflict => {
+            let reply = match self.gate_operation(principal_key, op_id.clone(), body_hash) {
+                OperationGate::Done(reply) => reply,
+                OperationGate::Conflict => {
                     return Executed {
                         reply: Err(ApiError::OpIdConflict { op_id }),
                         stop_after_reply: false,
                     };
                 }
-                Gate::Run(mut rx) | Gate::Await(mut rx) => loop {
-                    if let Some(reply) = rx.borrow().clone() {
-                        break reply;
-                    }
-                    if rx.changed().await.is_err() {
-                        // The publisher dropped without a reply (the spawned
-                        // effect panicked): report not_ready rather than hang
-                        // the caller forever.
-                        break Arc::new(Err(ApiError::NotReady));
-                    }
-                },
+                OperationGate::Await(waiter) => waiter.wait().await,
+                OperationGate::Owner(owner) => {
+                    // The effect is detached from the requesting connection:
+                    // a lost reply must still become a completed replay, and a
+                    // faithful concurrent request joins the same publisher.
+                    let waiter = LedgerWaiter {
+                        done: owner.done.subscribe(),
+                    };
+                    let sup = self.supervisor.clone();
+                    tokio::spawn(async move {
+                        owner.complete(typed::dispatch(&sup, call).await);
+                    });
+                    waiter.wait().await
+                }
             };
             return Executed {
                 reply: (*reply).clone(),
@@ -1398,6 +1779,232 @@ mod tests {
             .reply
             .expect_err("a divergent body conflicts");
         assert!(matches!(err, ApiError::OpIdConflict { .. }), "got {err:?}");
+    }
+
+    fn streamed_share(name: &str, declared_bytes: u64) -> FileShare {
+        FileShare {
+            room_id: RoomId::new("room-for-ledger-gate"),
+            name: name.into(),
+            declared_bytes,
+            declared_content_type: "application/octet-stream".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn streamed_share_gate_joins_and_replays_one_exact_result() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let request = streamed_share("one.bin", 7);
+        let op_id = OpId::new("streamed-share-owner");
+
+        let FileShareLedgerGate::Owner(owner) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("first execution must own the stream");
+        };
+        let progress = owner.progress();
+        progress.record_accepted(3);
+
+        let joining_engine = engine.clone();
+        let joining_request = request.clone();
+        let joining_op_id = op_id.clone();
+        let join = tokio::spawn(async move {
+            joining_engine
+                .gate_file_share(&joining_request, Some(joining_op_id), "principal:a")
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(!join.is_finished(), "faithful replay waits for its owner");
+
+        let terminal = ApiError::StreamAborted {
+            transferred_bytes: 3,
+            total: ByteTotal::Known { bytes: 7 },
+            reason: StreamAbortReason::TransportLost,
+        };
+        // Connection-task cancellation drops the owner; the detached progress
+        // handle makes that destructor publish the exact proven count.
+        drop(owner);
+
+        let FileShareLedgerGate::Replay(joined) = join.await.expect("join task") else {
+            panic!("join must never own a second stream");
+        };
+        assert_eq!(joined, Err(terminal.clone()));
+        let FileShareLedgerGate::Replay(replayed) = engine
+            .gate_file_share(&request, Some(op_id), "principal:a")
+            .await
+        else {
+            panic!("completed replay must not own a stream");
+        };
+        assert_eq!(replayed, Err(terminal));
+    }
+
+    #[tokio::test]
+    async fn streamed_share_cancellation_annotation_survives_join_publication_and_owner_drop() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let request = streamed_share("cancelled.bin", 7);
+        let op_id = OpId::new("streamed-share-cancelled");
+
+        let FileShareLedgerGate::Owner(mut owner) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("first execution must own the stream");
+        };
+        owner.record_cancel_selected(3, 7);
+        assert_eq!(
+            engine.recorded_file_share_cancellation("principal:a", &op_id),
+            Some((3, 7))
+        );
+        assert_eq!(
+            engine.recorded_file_share_cancellation("principal:b", &op_id),
+            None,
+            "cancellation annotations remain principal-scoped"
+        );
+
+        let joining_engine = engine.clone();
+        let joining_request = request.clone();
+        let joining_op_id = op_id.clone();
+        let join = tokio::spawn(async move {
+            joining_engine
+                .gate_file_share(&joining_request, Some(joining_op_id), "principal:a")
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !join.is_finished(),
+            "ledger annotation must not publish before ABORT/ACK completion"
+        );
+
+        // Even an unexpected owner drop after selection preserves the
+        // authoritative cancellation rather than synthesizing transport_lost.
+        drop(owner);
+        let terminal = ApiError::StreamAborted {
+            transferred_bytes: 3,
+            total: ByteTotal::Known { bytes: 7 },
+            reason: StreamAbortReason::Cancelled,
+        };
+        let FileShareLedgerGate::Replay(joined) = join.await.expect("join task") else {
+            panic!("faithful join must not own another stream");
+        };
+        assert_eq!(joined, Err(terminal.clone()));
+
+        let FileShareLedgerGate::Replay(replayed) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("completed cancellation must replay");
+        };
+        assert_eq!(replayed, Err(terminal));
+        assert_eq!(
+            engine.recorded_file_share_cancellation("principal:a", &op_id),
+            Some((3, 7)),
+            "publication retains the compact cancellation annotation"
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_share_completion_without_waiter_replays_exact_result() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let request = streamed_share("completion-boundary.bin", 0);
+        let op_id = OpId::new("streamed-share-no-initial-waiter");
+        let FileShareLedgerGate::Owner(owner) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("first execution must own the stream");
+        };
+        let terminal = ApiError::StreamAborted {
+            transferred_bytes: 0,
+            total: ByteTotal::Known { bytes: 0 },
+            reason: StreamAbortReason::Cancelled,
+        };
+        assert_eq!(owner.complete(Err(terminal.clone())), Err(terminal.clone()));
+
+        let FileShareLedgerGate::Replay(replayed) = engine
+            .gate_file_share(&request, Some(op_id), "principal:a")
+            .await
+        else {
+            panic!("completion-boundary replay must not own a second stream");
+        };
+        assert_eq!(replayed, Err(terminal));
+    }
+
+    #[tokio::test]
+    async fn streamed_share_gate_conflict_principal_and_omitted_key_are_isolated() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = engine_with_subject(&dir).await;
+        let request = streamed_share("one.bin", 1);
+        let op_id = OpId::new("streamed-share-scope");
+        let FileShareLedgerGate::Owner(owner) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("first execution must own");
+        };
+
+        let divergent = streamed_share("different.bin", 1);
+        let FileShareLedgerGate::Replay(conflict) = engine
+            .gate_file_share(&divergent, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("divergent body cannot own");
+        };
+        assert_eq!(
+            conflict,
+            Err(ApiError::OpIdConflict {
+                op_id: op_id.clone()
+            })
+        );
+
+        let FileShareLedgerGate::Owner(other_principal) = engine
+            .gate_file_share(&request, Some(op_id), "principal:b")
+            .await
+        else {
+            panic!("a different principal has an isolated keyspace");
+        };
+        let FileShareLedgerGate::Owner(untracked_one) =
+            engine.gate_file_share(&request, None, "principal:a").await
+        else {
+            panic!("an omitted op_id runs untracked");
+        };
+        let FileShareLedgerGate::Owner(untracked_two) =
+            engine.gate_file_share(&request, None, "principal:a").await
+        else {
+            panic!("each omitted op_id is a fresh owner");
+        };
+
+        drop((owner, other_principal, untracked_one, untracked_two));
+    }
+
+    #[tokio::test]
+    async fn streamed_share_preledger_refusal_does_not_consume_the_key() {
+        let dir = TempDir::new().expect("tempdir");
+        let engine = test_engine(&dir);
+        let request = streamed_share("one.bin", 0);
+        let op_id = OpId::new("preledger-share");
+        let FileShareLedgerGate::Replay(refused) = engine
+            .gate_file_share(&request, Some(op_id.clone()), "principal:a")
+            .await
+        else {
+            panic!("subject precondition must refuse before ownership");
+        };
+        assert_eq!(refused, Err(ApiError::SubjectAbsent));
+
+        engine
+            .execute(TypedCall::SubjectEnsure(jeliya_api::SubjectEnsure {}))
+            .await
+            .reply
+            .expect("subject.ensure");
+        let FileShareLedgerGate::Owner(owner) = engine
+            .gate_file_share(&request, Some(op_id), "principal:a")
+            .await
+        else {
+            panic!("the same key remains unused after a preledger refusal");
+        };
+        drop(owner);
     }
 
     #[tokio::test]

--- a/crates/jeliya-core/src/lib.rs
+++ b/crates/jeliya-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod localstate;
 #[cfg(test)]
 mod materializer;
 mod projection;
+mod protocol_upload;
 mod supervisor;
 pub mod typed;
 

--- a/crates/jeliya-core/src/protocol_upload.rs
+++ b/crates/jeliya-core/src/protocol_upload.rs
@@ -1,0 +1,1567 @@
+//! Opaque, bounded staging for protocol-v2 consumer-direction uploads.
+//!
+//! The wire runtime owns framing, credit, and terminal races. This module owns
+//! the filesystem boundary below it: an admitted share gets one unpredictable
+//! exclusive object in a protocol-only staging directory, accepts only
+//! contiguous complete records, and turns an exact END into one consuming
+//! import/event capability. No path, file, seek, or random-access handle is
+//! exposed through the public surface.
+
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use jeliya_api::{ApiError, ByteTotal, FileShare, FileShareOut, StreamAbortReason};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+use crate::error::{CoreError, CoreResult};
+use crate::supervisor::{
+    AuthorizedFileShare, FinalizeFileShareError, RoomSupervisor, FILE_UPLOAD_MAX_BYTES,
+};
+
+/// Dedicated to protocol streams. The HTTP route stages under `uploads`, and
+/// durable room content lives under `blobs`; cleanup never traverses either.
+const PROTOCOL_STAGING_DIR: &str = "protocol-v2-stream-staging";
+const STAGING_PREFIX: &str = "upload-";
+const STAGING_SUFFIX: &str = ".stage";
+const STAGING_NONCE_BYTES: usize = 24;
+const CREATE_ATTEMPTS: usize = 16;
+
+type BoxWriter = Pin<Box<dyn AsyncWrite + Send>>;
+#[cfg(test)]
+type BeforeImportHook = Box<dyn FnOnce(&Path) + Send>;
+
+/// A prepared upload whose protocol validation and authorization have already
+/// run, but whose staging object does not yet exist.
+///
+/// The connection runtime calls [`Self::open_sink`] only after it has reserved
+/// both transfer limits and started the absolute deadline.
+pub struct PreparedFileShare {
+    supervisor: Arc<RoomSupervisor>,
+    request: FileShare,
+    authorized: AuthorizedFileShare,
+}
+
+/// An exclusive, forward-only staging sink.
+///
+/// It has no path, file, seek, clone, or inner-writer accessor. Dropping it
+/// before exact END synchronously unlinks its private staging object.
+pub struct OpenFileShareSink {
+    parts: Option<PreparedParts>,
+    storage: Option<StageStorage>,
+    accepted_bytes: u64,
+    accepted_digest: blake3::Hasher,
+}
+
+/// The single-use capability produced by an exact END.
+///
+/// Consuming [`Self::finalize`] imports the staged bytes and authors one event.
+/// Dropping the capability instead authors nothing and removes the stage.
+pub struct FileShareFinalizer {
+    parts: Option<PreparedParts>,
+    sealed: Option<SealedStage>,
+    accepted_digest: [u8; 32],
+    #[cfg(test)]
+    before_import: Option<BeforeImportHook>,
+    #[cfg(test)]
+    fail_cleanup: bool,
+    #[cfg(test)]
+    fail_after_publish: bool,
+}
+
+struct PreparedParts {
+    supervisor: Arc<RoomSupervisor>,
+    request: FileShare,
+    authorized: AuthorizedFileShare,
+}
+
+struct StageStorage {
+    path: PathBuf,
+    writer: Option<BoxWriter>,
+    inspector: Option<tokio::fs::File>,
+    identity: FileIdentity,
+    cleanup_armed: bool,
+    #[cfg(test)]
+    fail_sync: bool,
+}
+
+struct SealedStage {
+    path: PathBuf,
+    inspector: Option<tokio::fs::File>,
+    identity: FileIdentity,
+    cleanup_armed: bool,
+}
+
+/// Owns a just-created name until [`StageStorage`] has installed its own
+/// unconditional cleanup guard.
+struct CreatedPathGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+#[derive(Clone, Copy)]
+struct FileIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+/// A staging refusal or local sink failure.
+#[derive(Debug)]
+pub enum FileShareSinkError {
+    /// `offset + payload_len` was not representable.
+    Arithmetic,
+    /// A DATA record carried no payload (END is the only empty terminator).
+    EmptyRecord,
+    /// Aggregate policy wins before declaration, continuity, and sink checks.
+    FileTooLarge {
+        /// Candidate exclusive end offset.
+        candidate: u64,
+        /// Served aggregate maximum.
+        limit: u64,
+    },
+    /// The candidate is inside aggregate policy but beyond the declaration.
+    DeclaredSizeMismatch {
+        /// Declared upload count.
+        declared: u64,
+        /// Candidate or END count observed.
+        observed: u64,
+    },
+    /// The DATA record was not contiguous with durable accepted storage.
+    OffsetMismatch {
+        /// Next required offset.
+        expected: u64,
+        /// Offset supplied by the record.
+        observed: u64,
+    },
+    /// The exclusive staging object or its containing directory could not be
+    /// created safely.
+    Create(io::Error),
+    /// A record write failed. `written` reports bytes written from this record
+    /// before the sink was poisoned and the entire stage discarded.
+    Write {
+        /// Bytes physically written before failure; never accepted storage.
+        written: u64,
+        /// Underlying failure.
+        source: io::Error,
+    },
+    /// A zero-length/short write prevented accepting the complete record.
+    PartialWrite {
+        /// Full record payload length.
+        expected: u64,
+        /// Bytes physically written before the sink was discarded.
+        written: u64,
+    },
+    /// Flushing the complete record failed before acceptance.
+    Flush(io::Error),
+    /// Durably syncing the complete record failed before acceptance.
+    Sync(io::Error),
+    /// Removing the private staging name failed. Publication must not begin
+    /// while the upload can still leave protocol staging residue.
+    Cleanup(io::Error),
+    /// The daemon-managed stage disappeared before it could be accepted or
+    /// finalized.
+    StagingDisappeared,
+    /// The private path no longer names the exclusive object that was opened.
+    StagingReplaced,
+    /// The opened object or its directory entry disagreed with the accepted
+    /// contiguous count.
+    CountDisagreement {
+        /// Count the sink had durably accepted.
+        expected: u64,
+        /// Count reported by the filesystem.
+        observed: u64,
+    },
+    /// The sink was already poisoned by an earlier local failure.
+    SinkClosed,
+}
+
+impl fmt::Display for FileShareSinkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Arithmetic => f.write_str("upload offset arithmetic overflowed"),
+            Self::EmptyRecord => f.write_str("an upload DATA record must not be empty"),
+            Self::FileTooLarge { candidate, limit } => write!(
+                f,
+                "upload candidate {candidate} exceeds the aggregate limit {limit}"
+            ),
+            Self::DeclaredSizeMismatch { declared, observed } => write!(
+                f,
+                "upload count disagrees with its declaration (declared {declared}, observed {observed})"
+            ),
+            Self::OffsetMismatch { expected, observed } => write!(
+                f,
+                "upload DATA is not contiguous (expected {expected}, observed {observed})"
+            ),
+            Self::Create(error) => write!(f, "could not create protocol upload staging: {error}"),
+            Self::Write { written, source } => write!(
+                f,
+                "protocol upload staging write failed after {written} record bytes: {source}"
+            ),
+            Self::PartialWrite { expected, written } => write!(
+                f,
+                "protocol upload staging accepted only {written} of {expected} record bytes"
+            ),
+            Self::Flush(error) => write!(f, "could not flush protocol upload staging: {error}"),
+            Self::Sync(error) => write!(f, "could not sync protocol upload staging: {error}"),
+            Self::Cleanup(error) => {
+                write!(f, "could not remove protocol upload staging: {error}")
+            }
+            Self::StagingDisappeared => {
+                f.write_str("protocol upload staging disappeared")
+            }
+            Self::StagingReplaced => {
+                f.write_str("protocol upload staging was replaced")
+            }
+            Self::CountDisagreement { expected, observed } => write!(
+                f,
+                "protocol upload staging count changed (expected {expected}, observed {observed})"
+            ),
+            Self::SinkClosed => f.write_str("protocol upload staging is already closed"),
+        }
+    }
+}
+
+impl std::error::Error for FileShareSinkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Create(error)
+            | Self::Flush(error)
+            | Self::Sync(error)
+            | Self::Cleanup(error)
+            | Self::Write { source: error, .. } => Some(error),
+            Self::Arithmetic
+            | Self::EmptyRecord
+            | Self::FileTooLarge { .. }
+            | Self::DeclaredSizeMismatch { .. }
+            | Self::OffsetMismatch { .. }
+            | Self::PartialWrite { .. }
+            | Self::StagingDisappeared
+            | Self::StagingReplaced
+            | Self::CountDisagreement { .. }
+            | Self::SinkClosed => None,
+        }
+    }
+}
+
+/// Run only the post-ledger half of streamed upload preparation.
+pub(crate) async fn prepare_file_share_after_gate(
+    supervisor: Arc<RoomSupervisor>,
+    request: &FileShare,
+) -> Result<PreparedFileShare, ApiError> {
+    let authorized = crate::typed::authorize_file_share_after_gate(&supervisor, request).await?;
+    Ok(PreparedFileShare {
+        supervisor,
+        request: request.clone(),
+        authorized,
+    })
+}
+
+impl PreparedFileShare {
+    /// Create the exclusive staging object. This is intentionally separate
+    /// from authorization so transfer reservations can be acquired first.
+    pub async fn open_sink(self) -> Result<OpenFileShareSink, FileShareSinkError> {
+        let storage = StageStorage::create(self.supervisor.data_dir()).await?;
+        Ok(OpenFileShareSink {
+            parts: Some(PreparedParts {
+                supervisor: self.supervisor,
+                request: self.request,
+                authorized: self.authorized,
+            }),
+            storage: Some(storage),
+            accepted_bytes: 0,
+            accepted_digest: blake3::Hasher::new(),
+        })
+    }
+
+    /// The declared logical total reserved for this upload.
+    #[must_use]
+    pub fn declared_bytes(&self) -> u64 {
+        self.request.declared_bytes
+    }
+}
+
+impl OpenFileShareSink {
+    /// The declared logical total reserved for this upload.
+    #[must_use]
+    pub fn declared_bytes(&self) -> u64 {
+        self.parts
+            .as_ref()
+            .map_or(0, |parts| parts.request.declared_bytes)
+    }
+
+    /// Bytes durably and contiguously accepted through complete DATA records.
+    #[must_use]
+    pub const fn accepted_bytes(&self) -> u64 {
+        self.accepted_bytes
+    }
+
+    /// Atomically accept one complete DATA payload at its exact offset.
+    ///
+    /// Policy and continuity are checked before the payload is passed to the
+    /// writer. Once any local write/flush/sync/count check fails, the sink is
+    /// poisoned and all staging is discarded; partial physical writes can
+    /// therefore never become accepted bytes or be resumed.
+    pub async fn accept(&mut self, offset: u64, payload: &[u8]) -> Result<u64, FileShareSinkError> {
+        if payload.is_empty() {
+            return Err(FileShareSinkError::EmptyRecord);
+        }
+        let payload_len =
+            u64::try_from(payload.len()).map_err(|_| FileShareSinkError::Arithmetic)?;
+        let candidate = offset
+            .checked_add(payload_len)
+            .ok_or(FileShareSinkError::Arithmetic)?;
+
+        // The record fixes this refusal order. These checks happen before the
+        // continuity check and before the writer sees a payload byte.
+        if candidate > FILE_UPLOAD_MAX_BYTES {
+            return Err(FileShareSinkError::FileTooLarge {
+                candidate,
+                limit: FILE_UPLOAD_MAX_BYTES,
+            });
+        }
+        let declared = self.declared_bytes();
+        if candidate > declared {
+            return Err(FileShareSinkError::DeclaredSizeMismatch {
+                declared,
+                observed: candidate,
+            });
+        }
+        if offset != self.accepted_bytes {
+            return Err(FileShareSinkError::OffsetMismatch {
+                expected: self.accepted_bytes,
+                observed: offset,
+            });
+        }
+
+        let Some(storage) = self.storage.as_mut() else {
+            return Err(FileShareSinkError::SinkClosed);
+        };
+        if let Err(error) = storage.verify(self.accepted_bytes).await {
+            self.discard().await;
+            return Err(error);
+        }
+
+        let mut written = 0usize;
+        while written < payload.len() {
+            let write_result = {
+                let writer = storage
+                    .writer
+                    .as_mut()
+                    .ok_or(FileShareSinkError::SinkClosed)?;
+                writer.write(&payload[written..]).await
+            };
+            match write_result {
+                Ok(0) => {
+                    let error = FileShareSinkError::PartialWrite {
+                        expected: payload_len,
+                        written: u64::try_from(written).unwrap_or(u64::MAX),
+                    };
+                    self.discard().await;
+                    return Err(error);
+                }
+                Ok(count) => {
+                    written = written
+                        .checked_add(count)
+                        .ok_or(FileShareSinkError::Arithmetic)?;
+                }
+                Err(source) => {
+                    let error = FileShareSinkError::Write {
+                        written: u64::try_from(written).unwrap_or(u64::MAX),
+                        source,
+                    };
+                    self.discard().await;
+                    return Err(error);
+                }
+            }
+        }
+
+        let flush_result = match storage.writer.as_mut() {
+            Some(writer) => writer.flush().await,
+            None => Err(io::Error::new(io::ErrorKind::BrokenPipe, "sink closed")),
+        };
+        if let Err(error) = flush_result {
+            self.discard().await;
+            return Err(FileShareSinkError::Flush(error));
+        }
+        let sync_result = storage.sync_data().await;
+        if let Err(error) = sync_result {
+            self.discard().await;
+            return Err(FileShareSinkError::Sync(error));
+        }
+        if let Err(error) = storage.verify(candidate).await {
+            self.discard().await;
+            return Err(error);
+        }
+        // Hash only a complete, durably accepted record. This keeps the
+        // digest aligned with the same atomic acceptance boundary used for
+        // credit and offsets, without retaining payloads after this call.
+        self.accepted_digest.update(payload);
+        self.accepted_bytes = candidate;
+        Ok(candidate)
+    }
+
+    /// Consume exact END and seal the stage into a one-use finalizer.
+    pub async fn finish(
+        mut self,
+        end_offset: u64,
+    ) -> Result<FileShareFinalizer, FileShareSinkError> {
+        let declared = self.declared_bytes();
+        if end_offset != declared || self.accepted_bytes != declared {
+            return Err(FileShareSinkError::DeclaredSizeMismatch {
+                declared,
+                observed: end_offset,
+            });
+        }
+        let Some(mut storage) = self.storage.take() else {
+            return Err(FileShareSinkError::SinkClosed);
+        };
+        if let Err(error) = storage.flush_sync_verify(self.accepted_bytes).await {
+            let _ = storage.cleanup().await;
+            return Err(error);
+        }
+        let sealed = storage.seal();
+        let parts = self.parts.take().ok_or(FileShareSinkError::SinkClosed)?;
+        Ok(FileShareFinalizer {
+            parts: Some(parts),
+            sealed: Some(sealed),
+            accepted_digest: *self.accepted_digest.finalize().as_bytes(),
+            #[cfg(test)]
+            before_import: None,
+            #[cfg(test)]
+            fail_cleanup: false,
+            #[cfg(test)]
+            fail_after_publish: false,
+        })
+    }
+
+    async fn discard(&mut self) {
+        if let Some(storage) = self.storage.take() {
+            let _ = storage.cleanup().await;
+        }
+    }
+}
+
+impl Drop for OpenFileShareSink {
+    fn drop(&mut self) {
+        if let Some(mut storage) = self.storage.take() {
+            storage.unlink_now();
+        }
+    }
+}
+
+impl FileShareFinalizer {
+    /// Import and author the one prepared share, then remove staging whether
+    /// the operation succeeds or fails. A cancellation of this future still
+    /// runs the synchronous unlink guard; the connection runtime is expected
+    /// to detach it after END so publication itself is not cancelled.
+    pub async fn finalize(mut self) -> Result<FileShareOut, ApiError> {
+        let PreparedParts {
+            supervisor,
+            request,
+            authorized,
+        } = self
+            .parts
+            .take()
+            .expect("file-share finalizer is single-use");
+        let mut sealed = self
+            .sealed
+            .take()
+            .expect("file-share finalizer is single-use");
+        let terminal = || sink_failed_terminal(request.declared_bytes);
+
+        // Exact END has already won. Every later filesystem/import failure is
+        // therefore one terminal sink failure, never a second stream ABORT or
+        // an operation error outside file.share's closed taxonomy.
+        if let Err(error) = sealed.verify(request.declared_bytes).await {
+            let cleanup = sealed.cleanup().await;
+            if cleanup.is_err() {
+                return Err(terminal());
+            }
+            return Err(match error {
+                FileShareSinkError::CountDisagreement { observed, .. }
+                | FileShareSinkError::DeclaredSizeMismatch { observed, .. } => {
+                    declared_size_mismatch(request.declared_bytes, observed)
+                }
+                _ => terminal(),
+            });
+        }
+
+        #[cfg(test)]
+        if let Some(before_import) = self.before_import.take() {
+            before_import(&sealed.path);
+        }
+
+        // `blob_import` reopens by path. Bind what it actually imported to the
+        // complete sequence durably accepted through DATA, so a same-length
+        // replacement in that gap cannot authorize different content.
+        let imported = match supervisor
+            .import_authorized_file_share(authorized, &sealed.path)
+            .await
+        {
+            Ok(imported) => imported,
+            Err(error) => {
+                let cleanup = sealed.cleanup().await;
+                if cleanup.is_err() {
+                    return Err(terminal());
+                }
+                return Err(match error {
+                    FinalizeFileShareError::CountDisagreement { observed_bytes } => {
+                        declared_size_mismatch(request.declared_bytes, observed_bytes)
+                    }
+                    FinalizeFileShareError::Core(_) => terminal(),
+                });
+            }
+        };
+        if imported.size_bytes() != request.declared_bytes {
+            let observed = imported.size_bytes();
+            if sealed.cleanup().await.is_err() {
+                return Err(terminal());
+            }
+            return Err(declared_size_mismatch(request.declared_bytes, observed));
+        }
+        if imported.hash() != self.accepted_digest {
+            let _ = sealed.cleanup().await;
+            return Err(terminal());
+        }
+
+        // No event may be authored until the private stage is gone. A cleanup
+        // refusal consumes this finalizer and leaves the imported blob
+        // unreferenced; Drop makes one synchronous best-effort retry.
+        #[cfg(test)]
+        let cleanup_result = if self.fail_cleanup {
+            Err(FileShareSinkError::Cleanup(io::Error::other(
+                "injected staging cleanup failure",
+            )))
+        } else {
+            sealed.cleanup().await
+        };
+        #[cfg(not(test))]
+        let cleanup_result = sealed.cleanup().await;
+        if cleanup_result.is_err() {
+            return Err(terminal());
+        }
+
+        let shared = match supervisor.publish_imported_file_share(imported).await {
+            Ok(shared) => shared,
+            Err(_) => return Err(terminal()),
+        };
+        #[cfg(test)]
+        if self.fail_after_publish {
+            return Err(terminal());
+        }
+        crate::typed::project_streamed_file_share(&supervisor, &request, shared)
+            .map_err(|_| terminal())
+    }
+}
+
+impl Drop for FileShareFinalizer {
+    fn drop(&mut self) {
+        if let Some(mut sealed) = self.sealed.take() {
+            sealed.unlink_now();
+        }
+    }
+}
+
+impl StageStorage {
+    async fn create(data_dir: &Path) -> Result<Self, FileShareSinkError> {
+        let directory = ensure_staging_dir(data_dir).map_err(FileShareSinkError::Create)?;
+        for _ in 0..CREATE_ATTEMPTS {
+            let mut nonce = [0_u8; STAGING_NONCE_BYTES];
+            getrandom::fill(&mut nonce).map_err(|error| {
+                FileShareSinkError::Create(io::Error::other(format!(
+                    "OS CSPRNG unavailable: {error}"
+                )))
+            })?;
+            let path = directory.join(format!(
+                "{STAGING_PREFIX}{}{STAGING_SUFFIX}",
+                hex::encode(nonce)
+            ));
+            // Declared before `file` so error unwinding closes the handle
+            // before this guard removes its name (required on Windows).
+            let mut created = CreatedPathGuard {
+                path: path.clone(),
+                armed: false,
+            };
+            let opened = open_exclusive(&path);
+            let file = match opened {
+                Ok(file) => {
+                    created.armed = true;
+                    file
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(FileShareSinkError::Create(error)),
+            };
+            let identity = FileIdentity::of(&file.metadata().map_err(FileShareSinkError::Create)?);
+            let inspector = file.try_clone().map_err(FileShareSinkError::Create)?;
+            let storage = Self {
+                path,
+                writer: Some(Box::pin(tokio::fs::File::from_std(file))),
+                inspector: Some(tokio::fs::File::from_std(inspector)),
+                identity,
+                cleanup_armed: true,
+                #[cfg(test)]
+                fail_sync: false,
+            };
+            created.armed = false;
+            return Ok(storage);
+        }
+        Err(FileShareSinkError::Create(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique protocol staging object",
+        )))
+    }
+
+    async fn verify(&mut self, expected: u64) -> Result<(), FileShareSinkError> {
+        let inspector = self
+            .inspector
+            .as_ref()
+            .ok_or(FileShareSinkError::SinkClosed)?;
+        let opened = inspector
+            .metadata()
+            .await
+            .map_err(|error| classify_metadata_error(&error))?;
+        let named = tokio::fs::symlink_metadata(&self.path)
+            .await
+            .map_err(|error| classify_metadata_error(&error))?;
+        if !opened.is_file() || !named.is_file() || named.file_type().is_symlink() {
+            return Err(FileShareSinkError::StagingReplaced);
+        }
+        if !self.identity.matches(&opened) || !self.identity.matches(&named) {
+            return Err(FileShareSinkError::StagingReplaced);
+        }
+        if opened.len() != expected {
+            return Err(FileShareSinkError::CountDisagreement {
+                expected,
+                observed: opened.len(),
+            });
+        }
+        if named.len() != expected {
+            return Err(FileShareSinkError::CountDisagreement {
+                expected,
+                observed: named.len(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn flush_sync_verify(&mut self, expected: u64) -> Result<(), FileShareSinkError> {
+        let writer = self.writer.as_mut().ok_or(FileShareSinkError::SinkClosed)?;
+        writer.flush().await.map_err(FileShareSinkError::Flush)?;
+        self.sync_data().await.map_err(FileShareSinkError::Sync)?;
+        self.verify(expected).await
+    }
+
+    async fn sync_data(&mut self) -> io::Result<()> {
+        #[cfg(test)]
+        if self.fail_sync {
+            return Err(io::Error::other("injected sync failure"));
+        }
+        match self.inspector.as_ref() {
+            Some(inspector) => inspector.sync_data().await,
+            None => Err(io::Error::new(io::ErrorKind::BrokenPipe, "sink closed")),
+        }
+    }
+
+    fn seal(mut self) -> SealedStage {
+        self.writer.take();
+        let sealed = SealedStage {
+            path: self.path.clone(),
+            inspector: self.inspector.take(),
+            identity: self.identity,
+            cleanup_armed: true,
+        };
+        self.cleanup_armed = false;
+        sealed
+    }
+
+    async fn cleanup(mut self) -> Result<(), FileShareSinkError> {
+        self.writer.take();
+        self.inspector.take();
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => {
+                self.cleanup_armed = false;
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.cleanup_armed = false;
+                Ok(())
+            }
+            Err(error) => Err(FileShareSinkError::Cleanup(error)),
+        }
+    }
+
+    fn unlink_now(&mut self) {
+        self.writer.take();
+        self.inspector.take();
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => self.cleanup_armed = false,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.cleanup_armed = false;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "could not remove dropped protocol upload staging residue"
+                );
+            }
+        }
+    }
+}
+
+impl SealedStage {
+    async fn verify(&mut self, expected: u64) -> Result<(), FileShareSinkError> {
+        let inspector = self
+            .inspector
+            .as_ref()
+            .ok_or(FileShareSinkError::SinkClosed)?;
+        let opened = inspector
+            .metadata()
+            .await
+            .map_err(|error| classify_metadata_error(&error))?;
+        let named = tokio::fs::symlink_metadata(&self.path)
+            .await
+            .map_err(|error| classify_metadata_error(&error))?;
+        if !opened.is_file()
+            || !named.is_file()
+            || named.file_type().is_symlink()
+            || !self.identity.matches(&opened)
+            || !self.identity.matches(&named)
+        {
+            return Err(FileShareSinkError::StagingReplaced);
+        }
+        if opened.len() != expected {
+            return Err(FileShareSinkError::CountDisagreement {
+                expected,
+                observed: opened.len(),
+            });
+        }
+        if named.len() != expected {
+            return Err(FileShareSinkError::CountDisagreement {
+                expected,
+                observed: named.len(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn cleanup(mut self) -> Result<(), FileShareSinkError> {
+        self.inspector.take();
+        match tokio::fs::remove_file(&self.path).await {
+            Ok(()) => {
+                self.cleanup_armed = false;
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.cleanup_armed = false;
+                Ok(())
+            }
+            Err(error) => Err(FileShareSinkError::Cleanup(error)),
+        }
+    }
+
+    fn unlink_now(&mut self) {
+        self.inspector.take();
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => self.cleanup_armed = false,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.cleanup_armed = false;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "could not remove dropped protocol upload finalizer residue"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for CreatedPathGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+impl Drop for StageStorage {
+    fn drop(&mut self) {
+        if self.cleanup_armed {
+            self.unlink_now();
+        }
+    }
+}
+
+impl Drop for SealedStage {
+    fn drop(&mut self) {
+        if self.cleanup_armed {
+            self.unlink_now();
+        }
+    }
+}
+
+impl FileIdentity {
+    fn of(metadata: &std::fs::Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Self {
+                device: metadata.dev(),
+                inode: metadata.ino(),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = metadata;
+            Self {}
+        }
+    }
+
+    fn matches(&self, metadata: &std::fs::Metadata) -> bool {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            self.device == metadata.dev() && self.inode == metadata.ino()
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = metadata;
+            true
+        }
+    }
+}
+
+fn classify_metadata_error(error: &io::Error) -> FileShareSinkError {
+    if error.kind() == io::ErrorKind::NotFound {
+        FileShareSinkError::StagingDisappeared
+    } else {
+        FileShareSinkError::Create(io::Error::new(error.kind(), error.to_string()))
+    }
+}
+
+fn sink_failed_terminal(declared_bytes: u64) -> ApiError {
+    ApiError::StreamAborted {
+        transferred_bytes: declared_bytes,
+        total: ByteTotal::Known {
+            bytes: declared_bytes,
+        },
+        reason: StreamAbortReason::SinkFailed,
+    }
+}
+
+fn declared_size_mismatch(declared_bytes: u64, observed_bytes: u64) -> ApiError {
+    ApiError::DeclaredSizeMismatch {
+        declared_bytes,
+        observed_bytes,
+    }
+}
+
+fn ensure_staging_dir(data_dir: &Path) -> io::Result<PathBuf> {
+    let root = std::fs::canonicalize(data_dir)?;
+    let directory = root.join(PROTOCOL_STAGING_DIR);
+    match std::fs::symlink_metadata(&directory) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "protocol staging root is not a private directory",
+                ));
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            match std::fs::create_dir(&directory) {
+                Ok(()) => {}
+                Err(raced) if raced.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(error) => return Err(error),
+    }
+    let metadata = std::fs::symlink_metadata(&directory)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "protocol staging root changed type",
+        ));
+    }
+    let resolved = std::fs::canonicalize(&directory)?;
+    if resolved.parent() != Some(root.as_path()) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "protocol staging root escaped the daemon data directory",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&resolved, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(resolved)
+}
+
+fn open_exclusive(path: &Path) -> io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create_new(true).write(true).read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+fn is_protocol_stage_name(name: &str) -> bool {
+    let Some(hex) = name
+        .strip_prefix(STAGING_PREFIX)
+        .and_then(|name| name.strip_suffix(STAGING_SUFFIX))
+    else {
+        return false;
+    };
+    hex.len() == STAGING_NONCE_BYTES * 2 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Remove abandoned protocol-stream stages at daemon startup.
+///
+/// The walk is deliberately one directory deep and recognizes only this
+/// module's unpredictable stage-name shape. It cannot enter the HTTP upload
+/// directory or any durable blob tree.
+pub(crate) fn cleanup_abandoned_protocol_uploads(data_dir: &Path) -> CoreResult<usize> {
+    let root = std::fs::canonicalize(data_dir).map_err(|error| {
+        CoreError::internal(format!("could not resolve the daemon data dir: {error}"))
+    })?;
+    let directory = root.join(PROTOCOL_STAGING_DIR);
+    let metadata = match std::fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => {
+            return Err(CoreError::internal(format!(
+                "could not inspect protocol staging at startup: {error}"
+            )))
+        }
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(CoreError::internal(
+            "protocol staging root is not a private directory",
+        ));
+    }
+    let resolved = std::fs::canonicalize(&directory).map_err(|error| {
+        CoreError::internal(format!("could not resolve protocol staging: {error}"))
+    })?;
+    if resolved.parent() != Some(root.as_path()) {
+        return Err(CoreError::internal(
+            "protocol staging root escaped the daemon data directory",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&resolved, std::fs::Permissions::from_mode(0o700)).map_err(
+            |error| {
+                CoreError::internal(format!(
+                    "could not make protocol staging private at startup: {error}"
+                ))
+            },
+        )?;
+    }
+
+    let entries = std::fs::read_dir(&resolved).map_err(|error| {
+        CoreError::internal(format!("could not scan protocol staging: {error}"))
+    })?;
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            CoreError::internal(format!("could not read protocol staging entry: {error}"))
+        })?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !is_protocol_stage_name(&name) {
+            continue;
+        }
+        let entry_type = entry.file_type().map_err(|error| {
+            CoreError::internal(format!("could not inspect protocol staging entry: {error}"))
+        })?;
+        if entry_type.is_dir() {
+            return Err(CoreError::internal(
+                "a protocol staging artifact unexpectedly became a directory",
+            ));
+        }
+        std::fs::remove_file(entry.path()).map_err(|error| {
+            CoreError::internal(format!(
+                "could not remove abandoned protocol stage: {error}"
+            ))
+        })?;
+        removed = removed.saturating_add(1);
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::task::{Context, Poll};
+
+    use iroh_rooms::events::EventType;
+    use jeliya_api::RoomId as ApiRoomId;
+    use tempfile::tempdir;
+
+    struct ScriptedWriter {
+        first: usize,
+        wrote: bool,
+        flush_fails: bool,
+    }
+
+    impl AsyncWrite for ScriptedWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            bytes: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            if self.wrote {
+                return Poll::Ready(Err(io::Error::other("injected write failure")));
+            }
+            self.wrote = true;
+            Poll::Ready(Ok(self.first.min(bytes.len())))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            if self.flush_fails {
+                Poll::Ready(Err(io::Error::other("injected flush failure")))
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    async fn setup_room(data_dir: &Path) -> (Arc<RoomSupervisor>, String) {
+        crate::identity::create(data_dir).unwrap();
+        let supervisor = Arc::new(RoomSupervisor::new(data_dir.to_path_buf(), true).unwrap());
+        let room_id = supervisor.create_room("stream staging").unwrap();
+        supervisor.open_room(&room_id, &[]).await.unwrap();
+        (supervisor, room_id)
+    }
+
+    fn request(room_id: &str, declared_bytes: u64) -> FileShare {
+        FileShare {
+            room_id: ApiRoomId::new(room_id),
+            name: "payload.bin".into(),
+            declared_bytes,
+            declared_content_type: "application/octet-stream".into(),
+        }
+    }
+
+    async fn open_sink(
+        supervisor: &Arc<RoomSupervisor>,
+        room_id: &str,
+        declared_bytes: u64,
+    ) -> OpenFileShareSink {
+        prepare_file_share_after_gate(supervisor.clone(), &request(room_id, declared_bytes))
+            .await
+            .unwrap()
+            .open_sink()
+            .await
+            .unwrap()
+    }
+
+    fn stage_path(sink: &OpenFileShareSink) -> PathBuf {
+        sink.storage.as_ref().unwrap().path.clone()
+    }
+
+    fn file_event_count(supervisor: &RoomSupervisor, room_id: &str) -> usize {
+        let room_id = room_id.parse().unwrap();
+        supervisor
+            .open_store()
+            .unwrap()
+            .by_type(&room_id, EventType::FileShared)
+            .unwrap()
+            .len()
+    }
+
+    #[test]
+    fn startup_cleanup_is_confined_to_protocol_artifacts() {
+        let dir = tempdir().unwrap();
+        crate::identity::ensure_dir(dir.path()).unwrap();
+        let protocol = dir.path().join(PROTOCOL_STAGING_DIR);
+        let http = dir.path().join("uploads");
+        let blobs = dir.path().join("blobs");
+        std::fs::create_dir_all(&protocol).unwrap();
+        std::fs::create_dir_all(&http).unwrap();
+        std::fs::create_dir_all(&blobs).unwrap();
+        let abandoned = protocol.join(format!(
+            "{STAGING_PREFIX}{}{STAGING_SUFFIX}",
+            "ab".repeat(STAGING_NONCE_BYTES)
+        ));
+        let unrelated = protocol.join("operator-note");
+        let http_stage = http.join("upload.bin");
+        let durable = blobs.join("durable.bin");
+        std::fs::write(&abandoned, b"partial").unwrap();
+        std::fs::write(&unrelated, b"keep").unwrap();
+        std::fs::write(&http_stage, b"http").unwrap();
+        std::fs::write(&durable, b"blob").unwrap();
+
+        assert_eq!(cleanup_abandoned_protocol_uploads(dir.path()).unwrap(), 1);
+        assert!(!abandoned.exists());
+        assert!(unrelated.exists());
+        assert!(http_stage.exists());
+        assert!(durable.exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&protocol).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_cleanup_repairs_existing_staging_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        crate::identity::ensure_dir(dir.path()).unwrap();
+        let protocol = dir.path().join(PROTOCOL_STAGING_DIR);
+        std::fs::create_dir(&protocol).unwrap();
+        std::fs::set_permissions(&protocol, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        assert_eq!(cleanup_abandoned_protocol_uploads(dir.path()).unwrap(), 0);
+        assert_eq!(
+            std::fs::metadata(protocol).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[tokio::test]
+    async fn exclusive_stage_is_unlinked_on_drop_and_disappearance_is_detected() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let sink = open_sink(&supervisor, &room_id, 1).await;
+        let guarded_path = stage_path(&sink);
+        let other = open_sink(&supervisor, &room_id, 1).await;
+        let other_path = stage_path(&other);
+        assert!(guarded_path.exists());
+        assert_ne!(guarded_path, other_path);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&guarded_path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        drop(other);
+        assert!(!other_path.exists());
+        drop(sink);
+        assert!(!guarded_path.exists());
+
+        let mut sink = open_sink(&supervisor, &room_id, 1).await;
+        let path = stage_path(&sink);
+        std::fs::remove_file(&path).unwrap();
+        assert!(matches!(
+            sink.accept(0, b"x").await,
+            Err(FileShareSinkError::StagingDisappeared)
+        ));
+        assert_eq!(sink.accepted_bytes(), 0);
+        assert!(!path.exists());
+        drop(sink);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn preparation_and_declared_policy_create_no_staging_object() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let staging = dir.path().join(PROTOCOL_STAGING_DIR);
+
+        let prepared = prepare_file_share_after_gate(
+            supervisor.clone(),
+            &request(&room_id, FILE_UPLOAD_MAX_BYTES),
+        )
+        .await
+        .unwrap();
+        assert!(!staging.exists());
+        drop(prepared);
+
+        let refused = prepare_file_share_after_gate(
+            supervisor.clone(),
+            &request(&room_id, FILE_UPLOAD_MAX_BYTES + 1),
+        )
+        .await;
+        assert!(matches!(
+            refused,
+            Err(ApiError::FileTooLarge {
+                declared_bytes,
+                limit_bytes: FILE_UPLOAD_MAX_BYTES,
+                enforced_at: jeliya_api::EnforcedAt::StageDeclared,
+            }) if declared_bytes == FILE_UPLOAD_MAX_BYTES + 1
+        ));
+        assert!(!staging.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn partial_write_and_flush_failure_are_detected_before_acceptance() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+
+        let mut partial = open_sink(&supervisor, &room_id, 4).await;
+        let partial_path = stage_path(&partial);
+        partial.storage.as_mut().unwrap().writer = Some(Box::pin(ScriptedWriter {
+            first: 2,
+            wrote: false,
+            flush_fails: false,
+        }));
+        let error = partial.accept(0, b"abcd").await.unwrap_err();
+        assert!(matches!(
+            error,
+            FileShareSinkError::Write { written: 2, .. }
+        ));
+        assert_eq!(partial.accepted_bytes(), 0);
+        assert!(!partial_path.exists());
+
+        let mut zero_write = open_sink(&supervisor, &room_id, 4).await;
+        let zero_path = stage_path(&zero_write);
+        zero_write.storage.as_mut().unwrap().writer = Some(Box::pin(ScriptedWriter {
+            first: 0,
+            wrote: false,
+            flush_fails: false,
+        }));
+        assert!(matches!(
+            zero_write.accept(0, b"abcd").await,
+            Err(FileShareSinkError::PartialWrite {
+                expected: 4,
+                written: 0
+            })
+        ));
+        assert_eq!(zero_write.accepted_bytes(), 0);
+        assert!(!zero_path.exists());
+
+        let mut flush = open_sink(&supervisor, &room_id, 4).await;
+        let flush_path = stage_path(&flush);
+        flush.storage.as_mut().unwrap().writer = Some(Box::pin(ScriptedWriter {
+            first: usize::MAX,
+            wrote: false,
+            flush_fails: true,
+        }));
+        assert!(matches!(
+            flush.accept(0, b"abcd").await,
+            Err(FileShareSinkError::Flush(_))
+        ));
+        assert_eq!(flush.accepted_bytes(), 0);
+        assert!(!flush_path.exists());
+
+        let mut sync = open_sink(&supervisor, &room_id, 4).await;
+        let sync_path = stage_path(&sync);
+        sync.storage.as_mut().unwrap().fail_sync = true;
+        assert!(matches!(
+            sync.accept(0, b"abcd").await,
+            Err(FileShareSinkError::Sync(_))
+        ));
+        assert_eq!(sync.accepted_bytes(), 0);
+        assert!(!sync_path.exists());
+
+        let mut finish_sync = open_sink(&supervisor, &room_id, 1).await;
+        finish_sync.accept(0, b"x").await.unwrap();
+        let finish_sync_path = stage_path(&finish_sync);
+        finish_sync.storage.as_mut().unwrap().fail_sync = true;
+        assert!(matches!(
+            finish_sync.finish(1).await,
+            Err(FileShareSinkError::Sync(_))
+        ));
+        assert!(!finish_sync_path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        drop((partial, zero_write, flush, sync));
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn policy_precedes_declaration_and_continuity_before_any_copy() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+
+        let mut aggregate = open_sink(&supervisor, &room_id, FILE_UPLOAD_MAX_BYTES).await;
+        let aggregate_path = stage_path(&aggregate);
+        assert!(matches!(
+            aggregate.accept(FILE_UPLOAD_MAX_BYTES, b"x").await,
+            Err(FileShareSinkError::FileTooLarge {
+                candidate,
+                limit: FILE_UPLOAD_MAX_BYTES
+            }) if candidate == FILE_UPLOAD_MAX_BYTES + 1
+        ));
+        assert_eq!(std::fs::metadata(&aggregate_path).unwrap().len(), 0);
+
+        let mut declaration = open_sink(&supervisor, &room_id, 1).await;
+        let declaration_path = stage_path(&declaration);
+        assert!(matches!(
+            declaration.accept(1, b"x").await,
+            Err(FileShareSinkError::DeclaredSizeMismatch {
+                declared: 1,
+                observed: 2
+            })
+        ));
+        assert_eq!(std::fs::metadata(&declaration_path).unwrap().len(), 0);
+
+        let mut arithmetic = open_sink(&supervisor, &room_id, 1).await;
+        let arithmetic_path = stage_path(&arithmetic);
+        assert!(matches!(
+            arithmetic.accept(u64::MAX, b"x").await,
+            Err(FileShareSinkError::Arithmetic)
+        ));
+        assert_eq!(std::fs::metadata(&arithmetic_path).unwrap().len(), 0);
+
+        let mut discontinuous = open_sink(&supervisor, &room_id, 2).await;
+        let discontinuous_path = stage_path(&discontinuous);
+        assert!(matches!(
+            discontinuous.accept(1, b"x").await,
+            Err(FileShareSinkError::OffsetMismatch {
+                expected: 0,
+                observed: 1
+            })
+        ));
+        assert_eq!(std::fs::metadata(&discontinuous_path).unwrap().len(), 0);
+        drop((aggregate, declaration, arithmetic, discontinuous));
+        assert!(!aggregate_path.exists());
+        assert!(!declaration_path.exists());
+        assert!(!arithmetic_path.exists());
+        assert!(!discontinuous_path.exists());
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn records_are_contiguous_durable_and_end_seals_exactly() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let mut sink = open_sink(&supervisor, &room_id, 5).await;
+        let path = stage_path(&sink);
+
+        assert_eq!(sink.accept(0, b"ab").await.unwrap(), 2);
+        assert_eq!(sink.accepted_bytes(), 2);
+        assert_eq!(std::fs::read(&path).unwrap(), b"ab");
+        assert!(matches!(
+            sink.accept(1, b"x").await,
+            Err(FileShareSinkError::OffsetMismatch {
+                expected: 2,
+                observed: 1
+            })
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), b"ab");
+        assert_eq!(sink.accept(2, b"cde").await.unwrap(), 5);
+        assert_eq!(std::fs::read(&path).unwrap(), b"abcde");
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+
+        let finalizer = sink.finish(5).await.unwrap();
+        assert!(path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        let output = finalizer.finalize().await.unwrap();
+        assert_eq!(output.bytes, 5);
+        assert_eq!(
+            output.digest,
+            iroh_rooms::files::HashRef::from_bytes(*blake3::hash(b"abcde").as_bytes()).to_string()
+        );
+        assert_eq!(file_event_count(&supervisor, &room_id), 1);
+        assert!(!path.exists());
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn zero_byte_finalize_and_below_end_cleanup() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+
+        let zero = open_sink(&supervisor, &room_id, 0).await;
+        let zero_path = stage_path(&zero);
+        let output = zero.finish(0).await.unwrap().finalize().await.unwrap();
+        assert_eq!(output.bytes, 0);
+        assert!(!zero_path.exists());
+
+        let mut below = open_sink(&supervisor, &room_id, 2).await;
+        let below_path = stage_path(&below);
+        below.accept(0, b"x").await.unwrap();
+        assert!(matches!(
+            below.finish(1).await,
+            Err(FileShareSinkError::DeclaredSizeMismatch {
+                declared: 2,
+                observed: 1
+            })
+        ));
+        assert!(!below_path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 1);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn count_replacement_and_post_end_disappearance_never_author() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+
+        let mut count = open_sink(&supervisor, &room_id, 1).await;
+        let count_path = stage_path(&count);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&count_path)
+            .unwrap()
+            .set_len(1)
+            .unwrap();
+        assert!(matches!(
+            count.accept(0, b"x").await,
+            Err(FileShareSinkError::CountDisagreement {
+                expected: 0,
+                observed: 1
+            })
+        ));
+        assert!(!count_path.exists());
+
+        let mut replaced = open_sink(&supervisor, &room_id, 1).await;
+        let replaced_path = stage_path(&replaced);
+        std::fs::remove_file(&replaced_path).unwrap();
+        std::fs::write(&replaced_path, b"").unwrap();
+        assert!(matches!(
+            replaced.accept(0, b"x").await,
+            Err(FileShareSinkError::StagingReplaced)
+        ));
+        assert!(!replaced_path.exists());
+
+        let mut finalizing = open_sink(&supervisor, &room_id, 1).await;
+        finalizing.accept(0, b"x").await.unwrap();
+        let finalizer = finalizing.finish(1).await.unwrap();
+        let final_path = finalizer.sealed.as_ref().unwrap().path.clone();
+        std::fs::remove_file(&final_path).unwrap();
+        assert_eq!(
+            finalizer.finalize().await,
+            Err(ApiError::StreamAborted {
+                transferred_bytes: 1,
+                total: ByteTotal::Known { bytes: 1 },
+                reason: StreamAbortReason::SinkFailed,
+            })
+        );
+        assert!(!final_path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        drop((count, replaced));
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn import_is_bound_to_the_incrementally_accepted_digest() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let mut sink = open_sink(&supervisor, &room_id, 4).await;
+        sink.accept(0, b"good").await.unwrap();
+        let mut finalizer = sink.finish(4).await.unwrap();
+        let path = finalizer.sealed.as_ref().unwrap().path.clone();
+        finalizer.before_import = Some(Box::new(|path| {
+            std::fs::remove_file(path).unwrap();
+            std::fs::write(path, b"evil").unwrap();
+        }));
+
+        assert_eq!(finalizer.finalize().await, Err(sink_failed_terminal(4)));
+        assert!(!path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn finalization_requires_cleanup_before_publication() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let mut sink = open_sink(&supervisor, &room_id, 1).await;
+        sink.accept(0, b"x").await.unwrap();
+        let mut finalizer = sink.finish(1).await.unwrap();
+        let path = finalizer.sealed.as_ref().unwrap().path.clone();
+        finalizer.fail_cleanup = true;
+
+        assert_eq!(finalizer.finalize().await, Err(sink_failed_terminal(1)));
+        assert!(!path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn post_end_count_change_and_dropped_finalizer_leave_no_event_or_stage() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+
+        let mut changed = open_sink(&supervisor, &room_id, 1).await;
+        changed.accept(0, b"x").await.unwrap();
+        let changed_finalizer = changed.finish(1).await.unwrap();
+        let changed_path = changed_finalizer.sealed.as_ref().unwrap().path.clone();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&changed_path)
+            .unwrap()
+            .set_len(2)
+            .unwrap();
+        assert_eq!(
+            changed_finalizer.finalize().await,
+            Err(declared_size_mismatch(1, 2))
+        );
+        assert!(!changed_path.exists());
+
+        let mut dropped = open_sink(&supervisor, &room_id, 1).await;
+        dropped.accept(0, b"y").await.unwrap();
+        let dropped_finalizer = dropped.finish(1).await.unwrap();
+        let dropped_path = dropped_finalizer.sealed.as_ref().unwrap().path.clone();
+        drop(dropped_finalizer);
+        assert!(!dropped_path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 0);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn post_publication_projection_failure_uses_legal_terminal_once() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let mut sink = open_sink(&supervisor, &room_id, 1).await;
+        sink.accept(0, b"x").await.unwrap();
+        let mut finalizer = sink.finish(1).await.unwrap();
+        let path = finalizer.sealed.as_ref().unwrap().path.clone();
+        finalizer.fail_after_publish = true;
+
+        assert_eq!(finalizer.finalize().await, Err(sink_failed_terminal(1)));
+        assert!(!path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 1);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn host_staged_api_still_preserves_its_path_and_typed_result() {
+        let dir = tempdir().unwrap();
+        let (supervisor, room_id) = setup_room(dir.path()).await;
+        let path = dir.path().join("host-upload.bin");
+        std::fs::write(&path, b"host").unwrap();
+        let req = request(&room_id, 4);
+
+        let output = crate::typed::TypedSupervisor::new(&supervisor)
+            .share_staged_file(&req, &path)
+            .await
+            .unwrap();
+        assert_eq!(output.bytes, 4);
+        assert!(path.exists(), "the host owns and retains its staged path");
+        assert_eq!(file_event_count(&supervisor, &room_id), 1);
+
+        let mismatch = request(&room_id, 3);
+        assert_eq!(
+            crate::typed::TypedSupervisor::new(&supervisor)
+                .share_staged_file(&mismatch, &path)
+                .await,
+            Err(declared_size_mismatch(3, 4))
+        );
+        assert!(path.exists());
+        assert_eq!(file_event_count(&supervisor, &room_id), 1);
+        supervisor.close_room(&room_id).await.unwrap();
+    }
+}

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -166,6 +166,61 @@ pub(crate) struct StagedFileShare {
     pub digest: String,
 }
 
+/// A one-shot authorization capability for a protocol-streamed file share.
+///
+/// The typed validation pipeline creates this only after room visibility,
+/// standing, declared-size policy, and live-session checks have succeeded.
+/// It deliberately retains the exact live session and membership snapshot
+/// that won those checks: finalization consumes the capability and does not
+/// re-run authorization after a potentially long upload.
+pub(crate) struct AuthorizedFileShare {
+    room_id: RoomId,
+    session: Arc<RoomSession>,
+    secret: SecretKeys,
+    snapshot: MembershipSnapshot,
+    display_name: String,
+    mime_type: String,
+    declared_bytes: u64,
+}
+
+/// One imported blob paired with the authorization capability that may author
+/// its single `file.shared` event.
+///
+/// Protocol uploads deliberately split import from publication so their
+/// private staging name can be removed successfully before any event is
+/// authored. The capability is neither cloneable nor externally constructible,
+/// so publication can consume it at most once.
+pub(crate) struct ImportedAuthorizedFileShare {
+    authorized: AuthorizedFileShare,
+    size_bytes: u64,
+    hash: [u8; 32],
+}
+
+impl ImportedAuthorizedFileShare {
+    pub(crate) const fn size_bytes(&self) -> u64 {
+        self.size_bytes
+    }
+
+    pub(crate) const fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
+}
+
+/// A finalization failure that carries the one typed fact the supervisor can
+/// discover only while importing. Infrastructure failures retain the ordinary
+/// core taxonomy; a count disagreement is kept separate so the typed boundary
+/// can produce `declared_size_mismatch` without parsing prose.
+pub(crate) enum FinalizeFileShareError {
+    CountDisagreement { observed_bytes: u64 },
+    Core(CoreError),
+}
+
+impl From<CoreError> for FinalizeFileShareError {
+    fn from(error: CoreError) -> Self {
+        Self::Core(error)
+    }
+}
+
 /// Semantic result of `member.remove`; infrastructure failures remain
 /// [`CoreError`]s, while the typed boundary maps these closed outcomes to the
 /// protocol's exact errors.
@@ -2246,6 +2301,141 @@ impl RoomSupervisor {
     // Files
     // ------------------------------------------------------------------
 
+    /// Capture the one live-session capability needed to finish a streamed
+    /// upload whose typed room gate has already succeeded.
+    ///
+    /// This method intentionally does not re-fold membership or re-check
+    /// standing. The supplied snapshot is the exact authorization decision
+    /// made by the typed pipeline; retaining it and the live session makes the
+    /// later consuming finalization a continuation of that decision rather
+    /// than a second operation with a new authorization instant.
+    pub(crate) fn authorize_file_share_once(
+        &self,
+        room_id: RoomId,
+        snapshot: MembershipSnapshot,
+        display_name: String,
+        mime_type: String,
+        declared_bytes: u64,
+    ) -> CoreResult<AuthorizedFileShare> {
+        let session = self.session(&room_id)?;
+        let secret = self.secrets()?;
+        Ok(AuthorizedFileShare {
+            room_id,
+            session,
+            secret,
+            snapshot,
+            display_name,
+            mime_type,
+            declared_bytes,
+        })
+    }
+
+    /// Consume one previously authorized share capability and import its
+    /// sealed source without authoring an event yet.
+    pub(crate) async fn import_authorized_file_share(
+        &self,
+        authorized: AuthorizedFileShare,
+        path: &Path,
+    ) -> Result<ImportedAuthorizedFileShare, FinalizeFileShareError> {
+        let meta = std::fs::metadata(path).map_err(|error| {
+            CoreError::internal(format!(
+                "could not inspect protocol upload staging: {error}"
+            ))
+        })?;
+        if !meta.is_file() {
+            return Err(
+                CoreError::internal("protocol upload staging is no longer a regular file").into(),
+            );
+        }
+        if meta.len() != authorized.declared_bytes {
+            return Err(FinalizeFileShareError::CountDisagreement {
+                observed_bytes: meta.len(),
+            });
+        }
+        let import_path = std::fs::canonicalize(path).map_err(|error| {
+            CoreError::internal(format!(
+                "could not resolve protocol upload staging: {error}"
+            ))
+        })?;
+        self.assert_shareable_path(&import_path)?;
+
+        let import = authorized
+            .session
+            .node
+            .blob_import(&import_path)
+            .await
+            .map_err(|error| internal("could not import the file into the blob store", error))?;
+        if import.size_bytes != authorized.declared_bytes {
+            return Err(FinalizeFileShareError::CountDisagreement {
+                observed_bytes: import.size_bytes,
+            });
+        }
+
+        Ok(ImportedAuthorizedFileShare {
+            authorized,
+            size_bytes: import.size_bytes,
+            hash: import.hash,
+        })
+    }
+
+    /// Consume one imported capability and author exactly one `file.shared`
+    /// event for it.
+    pub(crate) async fn publish_imported_file_share(
+        &self,
+        imported: ImportedAuthorizedFileShare,
+    ) -> Result<StagedFileShare, FinalizeFileShareError> {
+        let ImportedAuthorizedFileShare {
+            authorized,
+            size_bytes,
+            hash,
+        } = imported;
+
+        let mut file_id = [0u8; SHORT_ID_LEN];
+        getrandom::fill(&mut file_id).map_err(|error| internal("OS CSPRNG unavailable", error))?;
+        let room_device = self.authoring_device_key(
+            &authorized.snapshot,
+            &authorized.secret,
+            &authorized.room_id,
+        );
+        let heads = Self::node_heads(&authorized.session.node).await?;
+        let digest = iroh_rooms::files::HashRef::from_bytes(hash);
+        let wire = build_file_shared(
+            &authorized.secret.identity,
+            &room_device,
+            &authorized.room_id,
+            file_id,
+            &authorized.display_name,
+            &authorized.mime_type,
+            size_bytes,
+            digest,
+            Some("raw"),
+            &[room_device.device_key()],
+            &heads,
+            now_ms(),
+        );
+
+        let event_id =
+            Self::publish_authored(&authorized.session.node, &authorized.room_id, &wire).await?;
+        Ok(StagedFileShare {
+            file_id: file_handle(&file_id),
+            event_id: bare_event_hex(&event_id),
+            bytes: size_bytes,
+            digest: digest.to_string(),
+        })
+    }
+
+    /// Preserve the host-staged API's combined import-and-publish operation.
+    /// Protocol streams use the two capabilities separately so cleanup can be
+    /// made a pre-publication condition.
+    pub(crate) async fn finalize_authorized_file_share(
+        &self,
+        authorized: AuthorizedFileShare,
+        path: &Path,
+    ) -> Result<StagedFileShare, FinalizeFileShareError> {
+        let imported = self.import_authorized_file_share(authorized, path).await?;
+        self.publish_imported_file_share(imported).await
+    }
+
     /// `file.share`: import the file into the room's durable blob store and
     /// author + publish the signed `file.shared` reference.
     ///
@@ -2303,18 +2493,6 @@ impl RoomSupervisor {
             ));
         }
 
-        // Import into the room's durable blob store on the LIVE session (issue
-        // #84): the node reuses the store handle it already owns, so there is no
-        // second FsStore open (no lock contention), no session cycle, and no
-        // endpoint rebind — the dial address stays valid and peers see no churn.
-        let import = session
-            .node
-            .blob_import(&import_path)
-            .await
-            .map_err(|e| internal("could not import the file into the blob store", e))?;
-
-        let mut file_id = [0u8; SHORT_ID_LEN];
-        getrandom::fill(&mut file_id).map_err(|e| internal("OS CSPRNG unavailable", e))?;
         let display_name = match name {
             Some(n) if !n.is_empty() => n.to_owned(),
             _ => path
@@ -2326,31 +2504,26 @@ impl RoomSupervisor {
         let mime_type = mime
             .filter(|m| !m.is_empty())
             .map_or_else(|| guess_mime(path), str::to_owned);
-
-        let room_device = self.authoring_device_key(&snapshot, &secret, &room_id);
-        let heads = Self::node_heads(&session.node).await?;
-        let digest = iroh_rooms::files::HashRef::from_bytes(import.hash);
-        let wire = build_file_shared(
-            &secret.identity,
-            &room_device,
-            &room_id,
-            file_id,
-            &display_name,
-            &mime_type,
-            import.size_bytes,
-            digest,
-            Some("raw"),
-            &[room_device.device_key()],
-            &heads,
-            now_ms(),
-        );
-        let event_id = Self::publish_authored(&session.node, &room_id, &wire).await?;
-        Ok(StagedFileShare {
-            file_id: file_handle(&file_id),
-            event_id: bare_event_hex(&event_id),
-            bytes: import.size_bytes,
-            digest: digest.to_string(),
-        })
+        let authorized = AuthorizedFileShare {
+            room_id,
+            session,
+            secret,
+            snapshot,
+            display_name,
+            mime_type,
+            declared_bytes: meta.len(),
+        };
+        self.finalize_authorized_file_share(authorized, &import_path)
+            .await
+            .map_err(|error| match error {
+                FinalizeFileShareError::Core(error) => error,
+                FinalizeFileShareError::CountDisagreement { observed_bytes } => {
+                    CoreError::invalid(format!(
+                        "file changed while it was imported (expected {} bytes, observed {observed_bytes})",
+                        meta.len()
+                    ))
+                }
+            })
     }
 
     /// `file.list`: the room's `file.shared` references with honest

--- a/crates/jeliya-core/src/typed.rs
+++ b/crates/jeliya-core/src/typed.rs
@@ -80,7 +80,10 @@ use iroh_rooms::room::{MembershipSnapshot, RoomId as IrohRoomId};
 
 use crate::error::{CoreError, CoreResult, ErrorKind};
 use crate::projection::{self as proj, file_handle, Departures};
-use crate::supervisor::{LocalFile as ResolvedLocalFile, RemoveMemberOutcome, RoomSupervisor};
+use crate::supervisor::{
+    AuthorizedFileShare, LocalFile as ResolvedLocalFile, RemoveMemberOutcome, RoomSupervisor,
+    StagedFileShare,
+};
 
 /// The daemon's served limits, surfaced in `hello`/`VersionInfo` and enforced
 /// here. Values are the record's served-limits object; the shared-file maximum
@@ -1440,11 +1443,11 @@ impl<'a> TypedSupervisor<'a> {
 
     /// `file.share` — share bytes into a room.
     ///
-    /// **Not implemented on the typed WS surface in this build.** The record
-    /// streams the bytes alongside the declaration, and that framing is not
-    /// wired to the codec yet; the host-staged half below is what carries a
-    /// real share today. It is refused rather than fabricating an event for
-    /// bytes nobody sent.
+    /// Ordinary transport-free dispatch has no byte stream to consume, so it
+    /// remains `not_ready` rather than fabricating an event for bytes nobody
+    /// sent. `jeliyad` intercepts the typed WebSocket request and drives the
+    /// consumer-direction stream through the preparation API below; the
+    /// existing host-staged entry point remains separate as well.
     pub async fn file_share(
         &self,
         _ctx: &RoomContext,
@@ -2848,6 +2851,58 @@ async fn validated_context(
 // The typed dispatch table (the engine's v2 surface)
 // ---------------------------------------------------------------------------
 
+/// Run the post-ledger half of streamed `file.share` preparation.
+///
+/// The engine has already applied structural validation and the subject
+/// precondition before admitting an `op_id` owner. Repeating those checks here
+/// would obscure that ordering and could make a faithful join observe a new
+/// answer, so this function begins at the room/standing/role gate and then
+/// applies the operation's declared-size and live-session semantics.
+pub(crate) async fn authorize_file_share_after_gate(
+    sup: &RoomSupervisor,
+    req: &FileShare,
+) -> Result<AuthorizedFileShare, ApiError> {
+    let t = TypedSupervisor::new(sup);
+    let ctx = t.room_context(&req.room_id, false, false).await?;
+
+    let limit = limits().max_shared_file_bytes;
+    if req.declared_bytes > limit {
+        return Err(ApiError::FileTooLarge {
+            declared_bytes: req.declared_bytes,
+            limit_bytes: limit,
+            enforced_at: EnforcedAt::StageDeclared,
+        });
+    }
+
+    sup.authorize_file_share_once(
+        ctx.room_id,
+        ctx.snapshot,
+        req.name.clone(),
+        req.declared_content_type.clone(),
+        req.declared_bytes,
+    )
+    .map_err(|error| core_to_api_room(error, &req.room_id))
+}
+
+/// Project one already imported and authored streamed share onto its protocol
+/// result. The caller owns the post-END import/publication sequencing.
+pub(crate) fn project_streamed_file_share(
+    sup: &RoomSupervisor,
+    req: &FileShare,
+    shared: StagedFileShare,
+) -> Result<FileShareOut, ApiError> {
+    let room_id = TypedSupervisor::parse_room(&req.room_id)?;
+    let pos = TypedSupervisor::new(sup).pos_of_event(&room_id, &shared.event_id)?;
+    Ok(FileShareOut {
+        room_id: req.room_id.clone(),
+        file_id: FileId::new(shared.file_id),
+        event_id: EventId::new(shared.event_id),
+        pos,
+        bytes: shared.bytes,
+        digest: shared.digest,
+    })
+}
+
 /// Prepare one `file.read` through the same validation and authorization path
 /// as ordinary typed dispatch, returning metadata and one private local source.
 pub(crate) async fn prepare_file_read(
@@ -3063,14 +3118,13 @@ impl TypedCall {
         }
     }
 
-    /// A stable hash of the canonical request body, for telling a faithful
+    /// A stable digest of the canonical request body, for telling a faithful
     /// `op_id` retry from a conflicting reuse. The typed input serializes
     /// deterministically (serde field order is declaration order), so two
     /// calls with equal bodies hash alike and two with different bodies do
     /// not — which is exactly the fidelity the dedup ledger needs.
     #[must_use]
-    pub fn body_hash(&self) -> u64 {
-        use std::hash::{Hash, Hasher};
+    pub fn body_hash(&self) -> [u8; 32] {
         let body = match self {
             TypedCall::SubjectEnsure(r) => serde_json::to_vec(r),
             TypedCall::DaemonStop(r) => serde_json::to_vec(r),
@@ -3107,14 +3161,19 @@ impl TypedCall {
             TypedCall::StreamResync(r) => serde_json::to_vec(r),
         }
         .unwrap_or_default();
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher = blake3::Hasher::new();
         // The operation path is part of the fingerprint: two operations with
         // structurally identical inputs (pipe.connect and pipe.revoke both
         // serialize as {room_id, pipe_id}) must not read as a faithful replay
         // of one another. Hash the path alongside the body.
-        self.path().hash(&mut hasher);
-        body.hash(&mut hasher);
-        hasher.finish()
+        let path = self.path().as_bytes();
+        let path_len = u64::try_from(path.len()).unwrap_or(u64::MAX);
+        let body_len = u64::try_from(body.len()).unwrap_or(u64::MAX);
+        hasher.update(&path_len.to_be_bytes());
+        hasher.update(path);
+        hasher.update(&body_len.to_be_bytes());
+        hasher.update(&body);
+        *hasher.finalize().as_bytes()
     }
 }
 

--- a/crates/jeliyad/src/file_read.rs
+++ b/crates/jeliyad/src/file_read.rs
@@ -621,11 +621,28 @@ pub(crate) enum BinaryRoute {
 #[derive(Clone)]
 pub(crate) struct StreamRegistry {
     inner: Arc<Mutex<StreamRegistryState>>,
+    invalidated: Arc<Notify>,
 }
 
 struct StreamRegistryState {
     accepting: bool,
-    bindings: HashMap<StreamIdentity, Arc<StreamIngress>>,
+    bindings: HashMap<StreamIdentity, StreamEndpoint>,
+}
+
+#[derive(Clone)]
+enum StreamEndpoint {
+    Download(Arc<StreamIngress>),
+    Upload(Arc<crate::file_share::UploadIngress>),
+}
+
+#[cfg(test)]
+impl StreamEndpoint {
+    fn download(self) -> Arc<StreamIngress> {
+        match self {
+            Self::Download(ingress) => ingress,
+            Self::Upload(_) => panic!("test expected a download binding"),
+        }
+    }
 }
 
 /// Single owner for a connection-fatal WebSocket Close.
@@ -715,6 +732,21 @@ pub(crate) struct StreamBinding {
     ingress: Arc<StreamIngress>,
 }
 
+/// RAII ownership of one consumer-direction upload binding in the unified
+/// connection-local registry.
+pub(crate) struct UploadStreamBinding {
+    registry: StreamRegistry,
+    identity: StreamIdentity,
+    ingress: Arc<crate::file_share::UploadIngress>,
+}
+
+#[derive(Clone)]
+pub(crate) struct UploadStreamRetirement {
+    registry: StreamRegistry,
+    identity: StreamIdentity,
+    ingress: Arc<crate::file_share::UploadIngress>,
+}
+
 #[derive(Clone)]
 struct StreamRetirement {
     registry: StreamRegistry,
@@ -729,6 +761,7 @@ impl StreamRegistry {
                 accepting: true,
                 bindings: HashMap::new(),
             })),
+            invalidated: Arc::new(Notify::new()),
         }
     }
 
@@ -740,7 +773,7 @@ impl StreamRegistry {
         }
         match registry.bindings.entry(identity) {
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(ingress.clone());
+                entry.insert(StreamEndpoint::Download(ingress.clone()));
             }
             std::collections::hash_map::Entry::Occupied(_) => return None,
         }
@@ -760,6 +793,22 @@ impl StreamRegistry {
             .is_empty()
     }
 
+    pub(crate) fn is_accepting(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("stream registry poisoned")
+            .accepting
+    }
+
+    pub(crate) async fn wait_invalidated(&self) {
+        while self.is_accepting() {
+            tokio::select! {
+                () = self.invalidated.notified() => {}
+                () = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    }
+
     /// Atomically makes every current or future stream on this connection
     /// unstartable before a connection-fatal Close is queued. The registry
     /// lock is acquired before each stream sequencing lock, matching
@@ -769,18 +818,27 @@ impl StreamRegistry {
         let mut registry = self.inner.lock().expect("stream registry poisoned");
         registry.accepting = false;
         for ingress in registry.bindings.values() {
-            let _sequencing = ingress
-                .sequencing
-                .lock()
-                .expect("stream sequencing poisoned");
-            ingress.opening_fatal.store(true, Ordering::Release);
-            ingress.set_phase_locked(BindingPhase::Retired);
-            ingress.mailbox.close();
-            ingress.data_live.store(false, Ordering::Release);
+            match ingress {
+                StreamEndpoint::Download(ingress) => {
+                    let _sequencing = ingress
+                        .sequencing
+                        .lock()
+                        .expect("stream sequencing poisoned");
+                    ingress.opening_fatal.store(true, Ordering::Release);
+                    ingress.set_phase_locked(BindingPhase::Retired);
+                    ingress.mailbox.close();
+                    ingress.data_live.store(false, Ordering::Release);
+                }
+                StreamEndpoint::Upload(ingress) => ingress.invalidate_connection_locked(),
+            }
         }
         registry.bindings.clear();
+        drop(registry);
+        self.invalidated.notify_waiters();
+        self.invalidated.notify_one();
     }
 
+    #[cfg(test)]
     pub(crate) fn route_binary(&self, bytes: &[u8], bounds: &CodecBounds) -> BinaryRoute {
         if bytes.len() > bounds.max_frame_bytes {
             return BinaryRoute::CloseTooLarge;
@@ -790,7 +848,7 @@ impl StreamRegistry {
             Err(StreamCodecError::FrameTooLarge { .. }) => return BinaryRoute::CloseTooLarge,
             Err(_) => return BinaryRoute::CloseMalformed,
         };
-        let ingress = {
+        let endpoint = {
             self.inner
                 .lock()
                 .expect("stream registry poisoned")
@@ -798,11 +856,76 @@ impl StreamRegistry {
                 .get(&identity)
                 .cloned()
         };
-        let Some(ingress) = ingress else {
+        let Some(endpoint) = endpoint else {
             return BinaryRoute::CloseMalformed;
         };
 
-        Self::route_bound(&ingress, bytes, bounds)
+        match endpoint {
+            StreamEndpoint::Download(ingress) => Self::route_bound(&ingress, bytes, bounds),
+            // The production WebSocket path uses `route_binary_message`,
+            // which can await bounded upload ingress capacity. This legacy
+            // borrowed entry point remains for the existing download unit
+            // harness and must never turn legal scheduling pressure into a
+            // protocol error.
+            StreamEndpoint::Upload(_) => BinaryRoute::CloseMalformed,
+        }
+    }
+
+    /// Route one owned complete Binary message through the unified exact-pair
+    /// registry. Upload DATA retains the transport-owned `Bytes` while it
+    /// waits for bounded staging capacity, so no payload copy is needed.
+    pub(crate) async fn route_binary_message(
+        &self,
+        bytes: tokio_tungstenite::tungstenite::Bytes,
+        bounds: &CodecBounds,
+    ) -> BinaryRoute {
+        if bytes.len() > bounds.max_frame_bytes {
+            return BinaryRoute::CloseTooLarge;
+        }
+        let identity = match decode_stream_identity(&bytes, bounds) {
+            Ok(identity) => identity,
+            Err(StreamCodecError::FrameTooLarge { .. }) => return BinaryRoute::CloseTooLarge,
+            Err(_) => return BinaryRoute::CloseMalformed,
+        };
+        let endpoint = {
+            self.inner
+                .lock()
+                .expect("stream registry poisoned")
+                .bindings
+                .get(&identity)
+                .cloned()
+        };
+        let Some(endpoint) = endpoint else {
+            return BinaryRoute::CloseMalformed;
+        };
+        match endpoint {
+            StreamEndpoint::Download(ingress) => Self::route_bound(&ingress, &bytes, bounds),
+            StreamEndpoint::Upload(ingress) => ingress.route_bound(bytes, bounds).await,
+        }
+    }
+
+    /// Install an upload binding in the same map downloads use. A duplicate
+    /// full pair cannot replace or cross either direction.
+    pub(crate) fn bind_upload(
+        &self,
+        identity: StreamIdentity,
+        ingress: Arc<crate::file_share::UploadIngress>,
+    ) -> Option<UploadStreamBinding> {
+        let mut registry = self.inner.lock().expect("stream registry poisoned");
+        if !registry.accepting {
+            return None;
+        }
+        match registry.bindings.entry(identity) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(StreamEndpoint::Upload(ingress.clone()));
+            }
+            std::collections::hash_map::Entry::Occupied(_) => return None,
+        }
+        Some(UploadStreamBinding {
+            registry: self.clone(),
+            identity,
+            ingress,
+        })
     }
 
     fn route_bound(
@@ -986,7 +1109,9 @@ impl StreamRetirement {
         if registry
             .bindings
             .get(&self.identity)
-            .is_some_and(|current| Arc::ptr_eq(current, &self.ingress))
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Download(current) if Arc::ptr_eq(current, &self.ingress))
+            })
         {
             registry.bindings.remove(&self.identity);
         }
@@ -1011,7 +1136,9 @@ impl StreamRetirement {
         if registry
             .bindings
             .get(&self.identity)
-            .is_some_and(|current| Arc::ptr_eq(current, &self.ingress))
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Download(current) if Arc::ptr_eq(current, &self.ingress))
+            })
         {
             registry.bindings.remove(&self.identity);
         }
@@ -1019,6 +1146,106 @@ impl StreamRetirement {
 }
 
 impl Drop for StreamBinding {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
+impl UploadStreamBinding {
+    pub(crate) fn retire(&self) {
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        self.ingress.retire_locked();
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Upload(current) if Arc::ptr_eq(current, &self.ingress))
+            })
+        {
+            registry.bindings.remove(&self.identity);
+        }
+    }
+
+    pub(crate) fn retirement(&self) -> UploadStreamRetirement {
+        UploadStreamRetirement {
+            registry: self.registry.clone(),
+            identity: self.identity,
+            ingress: self.ingress.clone(),
+        }
+    }
+
+    /// Retire the first semantically valid daemon-ABORT ACK only if no later
+    /// exact-pair record was already queued behind it.
+    pub(crate) fn retire_daemon_ack(&self) -> bool {
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        if !self.ingress.daemon_ack_retire_locked() {
+            return false;
+        }
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Upload(current) if Arc::ptr_eq(current, &self.ingress))
+            })
+        {
+            registry.bindings.remove(&self.identity);
+        }
+        true
+    }
+}
+
+impl UploadStreamRetirement {
+    pub(crate) fn retire(&self) {
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        self.ingress.retire_locked();
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Upload(current) if Arc::ptr_eq(current, &self.ingress))
+            })
+        {
+            registry.bindings.remove(&self.identity);
+        }
+    }
+
+    /// Retire at the successful ACK writer boundary unless a later exact-pair
+    /// record won the sequencing lock first. In that case the actor retains
+    /// the binding long enough to promote the duplicate into protocol_error.
+    pub(crate) fn retire_client_abort_ack(&self) {
+        let mut registry = self
+            .registry
+            .inner
+            .lock()
+            .expect("stream registry poisoned");
+        if !self.ingress.client_abort_ack_sent_locked() {
+            return;
+        }
+        if registry
+            .bindings
+            .get(&self.identity)
+            .is_some_and(|current| {
+                matches!(current, StreamEndpoint::Upload(current) if Arc::ptr_eq(current, &self.ingress))
+            })
+        {
+            registry.bindings.remove(&self.identity);
+        }
+    }
+}
+
+impl Drop for UploadStreamBinding {
     fn drop(&mut self) {
         self.retire();
     }
@@ -3874,7 +4101,8 @@ mod tests {
                     .bindings
                     .get(&identity)
                     .cloned()
-                    .expect("client-aborted pair remains bound");
+                    .expect("client-aborted pair remains bound")
+                    .download();
                 if BindingPhase::load(&ingress.phase) == BindingPhase::ClientAbortPending {
                     break ingress;
                 }
@@ -3961,7 +4189,8 @@ mod tests {
                 .bindings
                 .get(&identity)
                 .cloned()
-                .expect("ACK-in-flight pair remains bound");
+                .expect("ACK-in-flight pair remains bound")
+                .download();
             assert_eq!(
                 BindingPhase::load(&ingress.phase),
                 BindingPhase::ClientAbortAckCommitted
@@ -4106,7 +4335,8 @@ mod tests {
                 .bindings
                 .get(&identity)
                 .cloned()
-                .expect("active exact pair");
+                .expect("active exact pair")
+                .download();
             if BindingPhase::load(&ingress.phase) == BindingPhase::DaemonAbortQueued {
                 break ingress;
             }
@@ -4272,7 +4502,8 @@ mod tests {
             .bindings
             .get(&identity)
             .cloned()
-            .expect("daemon-ABORT pair remains bound");
+            .expect("daemon-ABORT pair remains bound")
+            .download();
         assert_eq!(
             route_body(
                 &harness,

--- a/crates/jeliyad/src/file_share.rs
+++ b/crates/jeliyad/src/file_share.rs
@@ -1,0 +1,5335 @@
+//! Connection-local protocol-v2 `file.share` consumer runtime.
+//!
+//! The upload path owns no caller-visible filesystem object. One exclusive
+//! daemon staging file is created only after transfer admission, written
+//! sequentially through bounded DATA records, and consumed exactly once by
+//! finalization. The connection registry retains the complete
+//! `(request_id, stream_id)` identity and direction before any DATA payload is
+//! inspected or copied.
+
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
+    Arc, Mutex, Weak,
+};
+
+use jeliya_api::{
+    ApiError, ByteTotal, CancelOutcome, EnforcedAt, FileShare, FileShareOut, OpId,
+    StreamAbortReason, TransferCancel, TransferCancelOut,
+};
+use jeliya_codec::{
+    decode_stream_kind, decode_stream_record_view, encode_stream_record, BinaryAbortReason,
+    CodecBounds, StreamIdentity, StreamRecord, StreamRecordBody, StreamRecordBodyView,
+    StreamRecordKind,
+};
+use jeliya_core::engine::{
+    Engine, FileShareFinalizer, FileShareLedgerGate, FileShareLedgerOwner, FileShareSinkError,
+};
+use tokio::sync::{mpsc, oneshot, Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::time::{Duration, Instant};
+use tokio_tungstenite::tungstenite::Bytes;
+
+use crate::file_read::{
+    BinaryRoute, ConnectionCloser, RequestPermit, StreamRegistry, UploadStreamBinding,
+    UploadStreamRetirement,
+};
+use crate::outbound::{Outbound, WriteReceipt};
+use crate::transfer::{RuntimeLimits, StreamIdGenerator, TransferPool};
+
+#[cfg(test)]
+const UPLOAD_DATA_EVENT_SLOTS: usize = 4;
+const UPLOAD_TERMINAL_EVENT_SLOTS: usize = 4;
+const CONTROL_ATTEMPT_QUEUED: u8 = 0;
+const CONTROL_ATTEMPT_STARTED: u8 = 1;
+const CONTROL_ATTEMPT_CANCELLED: u8 = 2;
+const CONTROL_COMMIT_PENDING: u8 = 0;
+const PRODUCER_TERMINAL_NONE: u8 = 0;
+const PRODUCER_TERMINAL_END: u8 = 1;
+const PRODUCER_TERMINAL_ABORT: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum ControlCommit {
+    Committed = 1,
+    Deadline = 2,
+    Rejected = 3,
+}
+
+impl ControlCommit {
+    fn load(value: &AtomicU8) -> Self {
+        match value.load(Ordering::Acquire) {
+            1 => Self::Committed,
+            2 => Self::Deadline,
+            _ => Self::Rejected,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundedControlOutcome {
+    Sent,
+    Deadline,
+    DiscardedOrClosed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DaemonAbortSelection {
+    Selected,
+    TerminalPending,
+    Lost,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalYield {
+    None,
+    Any,
+    Preemptive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientAbortAckOutcome {
+    Sent,
+    ProtocolFaultBeforeSent,
+    ProtocolFaultAfterSent,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum UploadPhase {
+    Opening = 0,
+    Active = 1,
+    DaemonAbortQueued = 2,
+    DaemonAbortWaitAck = 3,
+    ClientAbortPending = 4,
+    ClientAbortAckCommitted = 5,
+    ClientAbortAckSent = 6,
+    Finalizing = 7,
+    AckPending = 8,
+    Retired = 9,
+}
+
+impl UploadPhase {
+    fn load(value: &AtomicU8) -> Self {
+        match value.load(Ordering::Acquire) {
+            0 => Self::Opening,
+            1 => Self::Active,
+            2 => Self::DaemonAbortQueued,
+            3 => Self::DaemonAbortWaitAck,
+            4 => Self::ClientAbortPending,
+            5 => Self::ClientAbortAckCommitted,
+            6 => Self::ClientAbortAckSent,
+            7 => Self::Finalizing,
+            8 => Self::AckPending,
+            _ => Self::Retired,
+        }
+    }
+}
+
+/// Connection-wide byte budget shared by every upload ingress on that
+/// connection. Record count is independently bounded by each mailbox.
+#[derive(Clone)]
+pub(crate) struct UploadIngressBudget {
+    bytes: Arc<Semaphore>,
+    data_messages: usize,
+}
+
+impl UploadIngressBudget {
+    pub(crate) fn new(limits: RuntimeLimits) -> Self {
+        Self {
+            // This is an inbound bound, distinct from the producer-direction
+            // writer queue. It covers every one-byte record in one complete
+            // legal CREDIT window across all connection-local uploads, so a
+            // compliant producer cannot strand later control traffic behind
+            // ordinary staging pressure.
+            bytes: Arc::new(Semaphore::new(limits.upload_ingress_capacity_bytes())),
+            data_messages: limits.upload_ingress_capacity_messages(),
+        }
+    }
+}
+
+enum UploadEventBody {
+    Record {
+        kind: StreamRecordKind,
+        bytes: Bytes,
+        _bytes: Option<OwnedSemaphorePermit>,
+    },
+    RejectedData(DataFailure),
+    Malformed,
+    Cancel {
+        response: oneshot::Sender<CancelAttempt>,
+    },
+}
+
+struct UploadEvent {
+    received_at: Instant,
+    body: UploadEventBody,
+    // Installed at the DATA sequencing boundary and retained until the actor
+    // has completely handled (or discarded) that record. A later END can be
+    // visible in the priority lane without overtaking this older work.
+    _pending_data: Option<PendingData>,
+}
+
+impl UploadEvent {
+    fn is_terminal(&self) -> bool {
+        !matches!(
+            &self.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Data,
+                ..
+            }
+        )
+    }
+
+    fn is_end(&self) -> bool {
+        matches!(
+            &self.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        )
+    }
+
+    fn is_cancel(&self) -> bool {
+        matches!(&self.body, UploadEventBody::Cancel { .. })
+    }
+
+    fn is_preemptive(&self) -> bool {
+        self.is_cancel()
+            || matches!(&self.body, UploadEventBody::RejectedData(_))
+            || matches!(
+                &self.body,
+                UploadEventBody::Record {
+                    kind: StreamRecordKind::Abort,
+                    ..
+                }
+            )
+    }
+}
+
+struct PendingData {
+    ingress: Arc<UploadIngress>,
+    credit_at_receipt: u64,
+}
+
+impl PendingData {
+    fn new(ingress: Arc<UploadIngress>, credit_at_receipt: u64) -> Self {
+        ingress.pending_data.fetch_add(1, Ordering::AcqRel);
+        Self {
+            ingress,
+            credit_at_receipt,
+        }
+    }
+}
+
+impl Drop for PendingData {
+    fn drop(&mut self) {
+        let previous = self.ingress.pending_data.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "upload pending DATA underflow");
+        self.ingress.terminal_notify.notify_waiters();
+        self.ingress.terminal_notify.notify_one();
+    }
+}
+
+#[derive(Default)]
+struct TerminalOrderState {
+    next: u64,
+    serving: u64,
+    cancelled: BTreeSet<u64>,
+}
+
+/// A visible, ordered terminal admission. The marker is installed while the
+/// sequencing lock is held, before bounded mailbox capacity is awaited, so a
+/// complete terminal received before a timer/disconnect cannot disappear in
+/// the wait for a full terminal lane.
+struct TerminalAdmission {
+    ingress: Arc<UploadIngress>,
+    sequence: u64,
+    cancel: bool,
+    preemptive: bool,
+    completed: bool,
+}
+
+impl TerminalAdmission {
+    async fn wait_for_turn(&self) {
+        loop {
+            let notified = self.ingress.terminal_order_notify.notified();
+            let is_turn = self
+                .ingress
+                .terminal_order
+                .lock()
+                .expect("upload terminal order poisoned")
+                .serving
+                == self.sequence;
+            if is_turn {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Complete while the upload sequencing lock is held.
+    fn complete_locked(&mut self) {
+        if self.completed {
+            return;
+        }
+        self.completed = true;
+        self.ingress.finish_terminal_admission_locked(
+            self.sequence,
+            self.cancel,
+            self.preemptive,
+            false,
+        );
+    }
+}
+
+impl Drop for TerminalAdmission {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        let ingress = self.ingress.clone();
+        let _sequencing = ingress
+            .sequencing
+            .lock()
+            .expect("upload sequencing poisoned");
+        ingress.finish_terminal_admission_locked(self.sequence, self.cancel, self.preemptive, true);
+        self.completed = true;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CancelAttempt {
+    Cancelled { accepted: u64 },
+    Unknown,
+}
+
+/// Direction-specific ingress installed in the unified stream registry.
+pub(crate) struct UploadIngress {
+    phase: AtomicU8,
+    sequencing: Mutex<()>,
+    opening_fatal: AtomicBool,
+    closed: AtomicBool,
+    accepted: AtomicU64,
+    // The largest writer-committed send_through CREDIT. DATA snapshots this at
+    // the complete-message receive boundary so a queued record cannot borrow
+    // credit that was granted only afterwards.
+    served_send_through: AtomicU64,
+    declared: u64,
+    file_limit: u64,
+    received_through: AtomicU64,
+    data_refusal_pending: AtomicBool,
+    queued_events: AtomicU64,
+    queued_terminals: AtomicU64,
+    queued_cancels: AtomicU64,
+    queued_preemptive: AtomicU64,
+    admitting_terminals: AtomicU64,
+    admitting_cancels: AtomicU64,
+    admitting_preemptive: AtomicU64,
+    processing_terminal: AtomicBool,
+    processing_preemptive: AtomicBool,
+    pending_data: AtomicU64,
+    producer_terminal: AtomicU8,
+    post_end_fatal: AtomicBool,
+    data_sender: mpsc::Sender<UploadEvent>,
+    terminal_sender: mpsc::Sender<UploadEvent>,
+    budget: UploadIngressBudget,
+    closed_notify: Notify,
+    terminal_notify: Notify,
+    terminal_order: Mutex<TerminalOrderState>,
+    terminal_order_notify: Notify,
+}
+
+struct UploadEvents {
+    data_receiver: mpsc::Receiver<UploadEvent>,
+    terminal_receiver: mpsc::Receiver<UploadEvent>,
+    deferred_end: Option<UploadEvent>,
+}
+
+impl UploadEvents {
+    fn account_dequeue(ingress: &UploadIngress, event: &UploadEvent) {
+        if event.is_terminal() {
+            let _sequencing = ingress
+                .sequencing
+                .lock()
+                .expect("upload sequencing poisoned");
+            ingress.processing_terminal.store(true, Ordering::Release);
+            ingress
+                .processing_preemptive
+                .store(event.is_preemptive(), Ordering::Release);
+            ingress.queued_terminals.fetch_sub(1, Ordering::AcqRel);
+            if event.is_preemptive() {
+                ingress.queued_preemptive.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+        if event.is_cancel() {
+            ingress.queued_cancels.fetch_sub(1, Ordering::AcqRel);
+        }
+        ingress.queued_events.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn has_deferred_end(&self) -> bool {
+        self.deferred_end.is_some()
+    }
+
+    fn defer_end_if_needed(
+        &mut self,
+        ingress: &UploadIngress,
+        event: UploadEvent,
+    ) -> Option<UploadEvent> {
+        if event.is_end() && ingress.pending_data.load(Ordering::Acquire) != 0 {
+            debug_assert!(self.deferred_end.is_none());
+            self.deferred_end = Some(event);
+            None
+        } else {
+            Some(event)
+        }
+    }
+
+    async fn recv(&mut self, ingress: &UploadIngress) -> Option<UploadEvent> {
+        loop {
+            if self.deferred_end.is_some() {
+                if ingress.pending_data.load(Ordering::Acquire) == 0 {
+                    return self.deferred_end.take();
+                }
+
+                let notified = ingress.terminal_notify.notified();
+                if let Ok(event) = self.data_receiver.try_recv() {
+                    Self::account_dequeue(ingress, &event);
+                    return Some(event);
+                }
+                if ingress.pending_data.load(Ordering::Acquire) == 0 {
+                    continue;
+                }
+                tokio::select! {
+                    event = self.data_receiver.recv() => {
+                        let event = event?;
+                        Self::account_dequeue(ingress, &event);
+                        return Some(event);
+                    }
+                    () = notified => continue,
+                }
+            }
+
+            let event = tokio::select! {
+                biased;
+                event = self.terminal_receiver.recv() => event,
+                event = self.data_receiver.recv() => event,
+            }?;
+            Self::account_dequeue(ingress, &event);
+            if let Some(event) = self.defer_end_if_needed(ingress, event) {
+                return Some(event);
+            }
+        }
+    }
+
+    fn try_recv(&mut self, ingress: &UploadIngress) -> Option<UploadEvent> {
+        loop {
+            if self.deferred_end.is_some() {
+                if ingress.pending_data.load(Ordering::Acquire) == 0 {
+                    return self.deferred_end.take();
+                }
+                let event = self.data_receiver.try_recv().ok()?;
+                Self::account_dequeue(ingress, &event);
+                return Some(event);
+            }
+
+            let event = self
+                .terminal_receiver
+                .try_recv()
+                .or_else(|_| self.data_receiver.try_recv())
+                .ok()?;
+            Self::account_dequeue(ingress, &event);
+            if let Some(event) = self.defer_end_if_needed(ingress, event) {
+                return Some(event);
+            }
+        }
+    }
+
+    /// Discard DATA that was already admitted before a producer terminal.
+    /// Terminal/control records use a distinct lane and remain available for
+    /// crossed-terminal and duplicate-terminal validation.
+    fn drain_data(&mut self, ingress: &UploadIngress) {
+        while let Ok(event) = self.data_receiver.try_recv() {
+            Self::account_dequeue(ingress, &event);
+        }
+    }
+}
+
+impl UploadIngress {
+    fn new(
+        budget: UploadIngressBudget,
+        declared: u64,
+        file_limit: u64,
+    ) -> (Arc<Self>, UploadEvents) {
+        let (data_sender, data_receiver) = mpsc::channel(budget.data_messages.max(1));
+        let (terminal_sender, terminal_receiver) = mpsc::channel(UPLOAD_TERMINAL_EVENT_SLOTS);
+        (
+            Arc::new(Self {
+                phase: AtomicU8::new(UploadPhase::Opening as u8),
+                sequencing: Mutex::new(()),
+                opening_fatal: AtomicBool::new(false),
+                closed: AtomicBool::new(false),
+                accepted: AtomicU64::new(0),
+                served_send_through: AtomicU64::new(0),
+                declared,
+                file_limit,
+                received_through: AtomicU64::new(0),
+                data_refusal_pending: AtomicBool::new(false),
+                queued_events: AtomicU64::new(0),
+                queued_terminals: AtomicU64::new(0),
+                queued_cancels: AtomicU64::new(0),
+                queued_preemptive: AtomicU64::new(0),
+                admitting_terminals: AtomicU64::new(0),
+                admitting_cancels: AtomicU64::new(0),
+                admitting_preemptive: AtomicU64::new(0),
+                processing_terminal: AtomicBool::new(false),
+                processing_preemptive: AtomicBool::new(false),
+                pending_data: AtomicU64::new(0),
+                producer_terminal: AtomicU8::new(PRODUCER_TERMINAL_NONE),
+                post_end_fatal: AtomicBool::new(false),
+                data_sender,
+                terminal_sender,
+                budget,
+                closed_notify: Notify::new(),
+                terminal_notify: Notify::new(),
+                terminal_order: Mutex::new(TerminalOrderState::default()),
+                terminal_order_notify: Notify::new(),
+            }),
+            UploadEvents {
+                data_receiver,
+                terminal_receiver,
+                deferred_end: None,
+            },
+        )
+    }
+
+    fn phase(&self) -> UploadPhase {
+        UploadPhase::load(&self.phase)
+    }
+
+    fn set_phase_locked(&self, phase: UploadPhase) {
+        self.phase.store(phase as u8, Ordering::Release);
+    }
+
+    /// Apply every DATA check that can be decided without touching staging.
+    /// The caller holds `sequencing`, making the receive frontier and CREDIT
+    /// snapshot one ordered admission decision.
+    fn admit_received_data_locked(
+        &self,
+        offset: u64,
+        payload_len: usize,
+        credit_at_receipt: u64,
+    ) -> Result<u64, DataFailure> {
+        let payload = u64::try_from(payload_len).map_err(|_| DataFailure::Protocol)?;
+        let candidate = offset.checked_add(payload).ok_or(DataFailure::Protocol)?;
+        if candidate > self.file_limit {
+            return Err(DataFailure::TooLarge {
+                observed: candidate,
+            });
+        }
+        if candidate > self.declared {
+            return Err(DataFailure::Declared {
+                observed: candidate,
+            });
+        }
+        if offset != self.received_through.load(Ordering::Acquire) {
+            return Err(DataFailure::Protocol);
+        }
+        if candidate > credit_at_receipt {
+            return Err(DataFailure::Protocol);
+        }
+        self.received_through.store(candidate, Ordering::Release);
+        Ok(candidate)
+    }
+
+    /// Admit one terminal at the complete-message sequencing boundary.
+    ///
+    /// The ticket is visible before bounded terminal-lane capacity is
+    /// awaited. This prevents deadline, disconnect, sink acceptance, or an
+    /// active CREDIT commit from overtaking a terminal that the connection
+    /// has already received and structurally classified. Tickets serialize
+    /// the eventual mailbox sends in the same order as this lock.
+    fn begin_terminal_locked(
+        self: &Arc<Self>,
+        cancel: bool,
+        preemptive: bool,
+    ) -> TerminalAdmission {
+        let sequence = {
+            let mut order = self
+                .terminal_order
+                .lock()
+                .expect("upload terminal order poisoned");
+            // Reuse the sequence space only at a quiescent boundary. In
+            // practice exhausting u64 is unreachable, but the transition is
+            // checked rather than allowed to wrap into a live ticket.
+            if order.next == u64::MAX
+                && self.admitting_terminals.load(Ordering::Acquire) == 0
+                && order.serving == order.next
+                && order.cancelled.is_empty()
+            {
+                order.next = 0;
+                order.serving = 0;
+            }
+            let sequence = order.next;
+            order.next = order
+                .next
+                .checked_add(1)
+                .expect("upload terminal admission sequence exhausted");
+            sequence
+        };
+        self.admitting_terminals.fetch_add(1, Ordering::AcqRel);
+        if cancel {
+            self.admitting_cancels.fetch_add(1, Ordering::AcqRel);
+        }
+        if preemptive {
+            self.admitting_preemptive.fetch_add(1, Ordering::AcqRel);
+        }
+        self.terminal_notify.notify_waiters();
+        self.terminal_notify.notify_one();
+        TerminalAdmission {
+            ingress: self.clone(),
+            sequence,
+            cancel,
+            preemptive,
+            completed: false,
+        }
+    }
+
+    /// Finish or roll back one ordered admission while `sequencing` is held.
+    fn finish_terminal_admission_locked(
+        &self,
+        sequence: u64,
+        cancel: bool,
+        preemptive: bool,
+        _rolled_back: bool,
+    ) {
+        self.admitting_terminals.fetch_sub(1, Ordering::AcqRel);
+        if cancel {
+            self.admitting_cancels.fetch_sub(1, Ordering::AcqRel);
+        }
+        if preemptive {
+            self.admitting_preemptive.fetch_sub(1, Ordering::AcqRel);
+        }
+
+        let mut order = self
+            .terminal_order
+            .lock()
+            .expect("upload terminal order poisoned");
+        if sequence == order.serving {
+            order.serving = order
+                .serving
+                .checked_add(1)
+                .expect("upload terminal serving sequence exhausted");
+            loop {
+                let serving = order.serving;
+                if !order.cancelled.remove(&serving) {
+                    break;
+                }
+                order.serving = order
+                    .serving
+                    .checked_add(1)
+                    .expect("upload terminal serving sequence exhausted");
+            }
+        } else if sequence > order.serving {
+            // Only a cancelled future can finish out of order: a live future
+            // waits for `serving == sequence` before reserving the mailbox.
+            order.cancelled.insert(sequence);
+        }
+        drop(order);
+        self.terminal_order_notify.notify_waiters();
+        self.terminal_order_notify.notify_one();
+        self.terminal_notify.notify_waiters();
+        self.terminal_notify.notify_one();
+    }
+
+    fn clear_processing_terminal(&self) {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        self.processing_terminal.store(false, Ordering::Release);
+        self.processing_preemptive.store(false, Ordering::Release);
+    }
+
+    fn commit_open_with<F>(&self, deadline: Instant, admit: F) -> ControlCommit
+    where
+        F: FnOnce() -> bool,
+    {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        // Preserve the already-sequenced cause. In particular, a connection
+        // invalidated before the deadline remains transport loss even if the
+        // writer task does not observe this callback until after the clock has
+        // advanced past the deadline.
+        if self.closed.load(Ordering::Acquire) || self.phase() != UploadPhase::Opening {
+            return ControlCommit::Rejected;
+        }
+        if Instant::now() >= deadline {
+            return ControlCommit::Deadline;
+        }
+        if !admit() {
+            return ControlCommit::Rejected;
+        }
+        self.set_phase_locked(UploadPhase::Active);
+        ControlCommit::Committed
+    }
+
+    fn try_start_active_credit(
+        &self,
+        attempt: &AtomicU8,
+        absolute_deadline: Instant,
+        stall_deadline: Instant,
+        send_through: u64,
+    ) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        let now = Instant::now();
+        if self.closed.load(Ordering::Acquire)
+            || self.phase() != UploadPhase::Active
+            || self.has_terminal_pending()
+            || now >= absolute_deadline
+            || now >= stall_deadline
+        {
+            return false;
+        }
+        let committed = attempt
+            .compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_STARTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok();
+        if committed {
+            // Writer start is the peer-visible CREDIT commit boundary used by
+            // every stream-control race. If the subsequent socket write
+            // fails, connection invalidation prevents any guessed DATA from
+            // producing a surviving result.
+            self.served_send_through
+                .store(send_through, Ordering::Release);
+        }
+        committed
+    }
+
+    fn commit_daemon_abort(&self, deadline: Instant) -> ControlCommit {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.closed.load(Ordering::Acquire) || self.phase() != UploadPhase::DaemonAbortQueued {
+            return ControlCommit::Rejected;
+        }
+        if Instant::now() >= deadline {
+            return ControlCommit::Deadline;
+        }
+        self.set_phase_locked(UploadPhase::DaemonAbortWaitAck);
+        ControlCommit::Committed
+    }
+
+    fn commit_finalizing(&self, accepted: u64) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.phase() != UploadPhase::Active {
+            return false;
+        }
+        self.accepted.store(accepted, Ordering::Release);
+        self.set_phase_locked(UploadPhase::Finalizing);
+        true
+    }
+
+    fn select_daemon_abort(&self, terminal_yield: TerminalYield) -> DaemonAbortSelection {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        match self.phase() {
+            UploadPhase::Active => {
+                let should_yield = match terminal_yield {
+                    TerminalYield::None => false,
+                    TerminalYield::Any => self.has_terminal_pending(),
+                    TerminalYield::Preemptive => self.has_preemptive_terminal_pending(),
+                };
+                if should_yield {
+                    return DaemonAbortSelection::TerminalPending;
+                }
+                self.set_phase_locked(UploadPhase::DaemonAbortQueued);
+                DaemonAbortSelection::Selected
+            }
+            UploadPhase::DaemonAbortQueued => DaemonAbortSelection::Selected,
+            UploadPhase::Opening
+            | UploadPhase::DaemonAbortWaitAck
+            | UploadPhase::ClientAbortPending
+            | UploadPhase::ClientAbortAckCommitted
+            | UploadPhase::ClientAbortAckSent
+            | UploadPhase::Finalizing
+            | UploadPhase::AckPending
+            | UploadPhase::Retired => DaemonAbortSelection::Lost,
+        }
+    }
+
+    fn try_select_daemon_abort(&self) -> bool {
+        self.select_daemon_abort(TerminalYield::None) == DaemonAbortSelection::Selected
+    }
+
+    fn try_select_client_abort(&self) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.phase() != UploadPhase::Active {
+            return false;
+        }
+        self.set_phase_locked(UploadPhase::ClientAbortPending);
+        true
+    }
+
+    fn promote_client_abort_protocol(&self) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if !matches!(
+            self.phase(),
+            UploadPhase::ClientAbortPending
+                | UploadPhase::ClientAbortAckCommitted
+                | UploadPhase::ClientAbortAckSent
+        ) {
+            return false;
+        }
+        self.set_phase_locked(UploadPhase::DaemonAbortQueued);
+        true
+    }
+
+    fn try_sequence_client_abort_ack(&self, attempt: &AtomicU8, deadline: Instant) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.closed.load(Ordering::Acquire)
+            || self.phase() != UploadPhase::ClientAbortPending
+            || self.has_non_cancel_terminal_pending()
+            || Instant::now() >= deadline
+            || attempt
+                .compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_STARTED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+        {
+            return false;
+        }
+        self.set_phase_locked(UploadPhase::ClientAbortAckCommitted);
+        true
+    }
+
+    fn cancel_client_abort_ack(&self, attempt: &AtomicU8) -> ClientAbortAckOutcome {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if attempt
+            .compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            return if self.phase() == UploadPhase::ClientAbortPending
+                && self.has_non_cancel_terminal_pending()
+            {
+                ClientAbortAckOutcome::ProtocolFaultBeforeSent
+            } else {
+                ClientAbortAckOutcome::Failed
+            };
+        }
+        if self.phase() == UploadPhase::ClientAbortAckCommitted {
+            ClientAbortAckOutcome::Sent
+        } else {
+            ClientAbortAckOutcome::Failed
+        }
+    }
+
+    pub(crate) fn client_abort_ack_sent_locked(&self) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.phase() == UploadPhase::ClientAbortAckCommitted
+            && self.has_non_cancel_terminal_pending()
+        {
+            self.set_phase_locked(UploadPhase::ClientAbortAckSent);
+            return false;
+        }
+        self.closed.store(true, Ordering::Release);
+        self.set_phase_locked(UploadPhase::Retired);
+        self.closed_notify.notify_waiters();
+        self.closed_notify.notify_one();
+        true
+    }
+
+    pub(crate) fn daemon_ack_retire_locked(&self) -> bool {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.phase() != UploadPhase::AckPending || self.has_non_cancel_terminal_pending() {
+            return false;
+        }
+        self.closed.store(true, Ordering::Release);
+        self.set_phase_locked(UploadPhase::Retired);
+        self.closed_notify.notify_waiters();
+        self.closed_notify.notify_one();
+        true
+    }
+
+    fn classify_client_abort_ack_sent(&self) -> ClientAbortAckOutcome {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.phase() == UploadPhase::ClientAbortAckSent {
+            ClientAbortAckOutcome::ProtocolFaultAfterSent
+        } else if self.phase() == UploadPhase::Retired {
+            ClientAbortAckOutcome::Sent
+        } else {
+            ClientAbortAckOutcome::Failed
+        }
+    }
+
+    fn has_terminal_pending(&self) -> bool {
+        self.admitting_terminals.load(Ordering::Acquire) != 0
+            || self.queued_terminals.load(Ordering::Acquire) != 0
+            || self.processing_terminal.load(Ordering::Acquire)
+    }
+
+    fn has_preemptive_terminal_pending(&self) -> bool {
+        self.admitting_preemptive.load(Ordering::Acquire) != 0
+            || self.queued_preemptive.load(Ordering::Acquire) != 0
+            || self.processing_preemptive.load(Ordering::Acquire)
+    }
+
+    fn has_non_cancel_terminal_pending(&self) -> bool {
+        self.admitting_terminals.load(Ordering::Acquire)
+            > self.admitting_cancels.load(Ordering::Acquire)
+            || self.queued_terminals.load(Ordering::Acquire)
+                > self.queued_cancels.load(Ordering::Acquire)
+    }
+
+    fn commit_accepted(
+        &self,
+        accepted: u64,
+        absolute_deadline: Instant,
+        stall_deadline: Instant,
+    ) -> Result<(), ActiveInterrupt> {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        if self.has_preemptive_terminal_pending() {
+            return Err(ActiveInterrupt::TerminalPending);
+        }
+        if self.closed.load(Ordering::Acquire) {
+            return if self.has_terminal_pending() {
+                Err(ActiveInterrupt::TerminalPending)
+            } else {
+                Err(ActiveInterrupt::TransportLost)
+            };
+        }
+        if self.phase() != UploadPhase::Active {
+            return Err(ActiveInterrupt::TransportLost);
+        }
+        let now = Instant::now();
+        if now >= absolute_deadline {
+            if !self.has_terminal_pending() {
+                self.set_phase_locked(UploadPhase::DaemonAbortQueued);
+            }
+            return Err(ActiveInterrupt::Deadline);
+        }
+        if now >= stall_deadline {
+            if !self.has_terminal_pending() {
+                self.set_phase_locked(UploadPhase::DaemonAbortQueued);
+            }
+            return Err(ActiveInterrupt::Stall);
+        }
+        self.accepted.store(accepted, Ordering::Release);
+        Ok(())
+    }
+
+    /// Called with the registry lock held, preserving the shared retirement
+    /// lock order. FINALIZING is deliberately not cancelled by disconnect.
+    pub(crate) fn invalidate_connection_locked(&self) {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        self.closed.store(true, Ordering::Release);
+        if self.phase() != UploadPhase::Finalizing
+            && !self.has_terminal_pending()
+            && !self.processing_terminal.load(Ordering::Acquire)
+        {
+            self.set_phase_locked(UploadPhase::Retired);
+        }
+        self.closed_notify.notify_waiters();
+        self.closed_notify.notify_one();
+    }
+
+    /// Called with the registry lock held by `UploadStreamBinding::retire`.
+    pub(crate) fn retire_locked(&self) {
+        let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+        self.closed.store(true, Ordering::Release);
+        self.set_phase_locked(UploadPhase::Retired);
+        self.closed_notify.notify_waiters();
+        self.closed_notify.notify_one();
+    }
+
+    async fn enqueue(
+        self: &Arc<Self>,
+        event: UploadEvent,
+        terminal: bool,
+        mut admission: Option<TerminalAdmission>,
+    ) -> BinaryRoute {
+        let cancel = event.is_cancel();
+        let preemptive = event.is_preemptive();
+        if let Some(admission) = admission.as_ref() {
+            admission.wait_for_turn().await;
+        }
+        let sender = if terminal {
+            &self.terminal_sender
+        } else {
+            &self.data_sender
+        };
+        let permit = match sender.reserve().await {
+            Ok(permit) => permit,
+            Err(_) => return BinaryRoute::CloseMalformed,
+        };
+        let accepted = {
+            let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+            if self.phase() == UploadPhase::Retired
+                || (self.closed.load(Ordering::Acquire) && admission.is_none())
+            {
+                false
+            } else {
+                self.queued_events.fetch_add(1, Ordering::AcqRel);
+                if terminal {
+                    self.queued_terminals.fetch_add(1, Ordering::AcqRel);
+                }
+                if cancel {
+                    self.queued_cancels.fetch_add(1, Ordering::AcqRel);
+                }
+                if preemptive {
+                    self.queued_preemptive.fetch_add(1, Ordering::AcqRel);
+                }
+                permit.send(event);
+                if terminal {
+                    admission
+                        .as_mut()
+                        .expect("terminal enqueue owns an admission marker")
+                        .complete_locked();
+                }
+                true
+            }
+        };
+        if !accepted {
+            return BinaryRoute::CloseMalformed;
+        }
+        if terminal {
+            self.terminal_notify.notify_waiters();
+            self.terminal_notify.notify_one();
+        }
+        BinaryRoute::Delivered
+    }
+
+    async fn malformed(self: &Arc<Self>, received_at: Instant) -> BinaryRoute {
+        let admission = {
+            let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+            if self.producer_terminal.load(Ordering::Acquire) == PRODUCER_TERMINAL_END {
+                // Record the fault before awaiting mailbox capacity. If the
+                // already-sequenced END wins while this follower is waiting,
+                // the actor will still request the same connection-fatal 4007.
+                self.post_end_fatal.store(true, Ordering::Release);
+            }
+            if self.phase() == UploadPhase::Finalizing
+                || self.phase() == UploadPhase::Retired
+                || self.closed.load(Ordering::Acquire)
+            {
+                None
+            } else {
+                Some(self.begin_terminal_locked(false, false))
+            }
+        };
+        let Some(admission) = admission else {
+            return BinaryRoute::CloseMalformed;
+        };
+        self.enqueue(
+            UploadEvent {
+                received_at,
+                body: UploadEventBody::Malformed,
+                _pending_data: None,
+            },
+            true,
+            Some(admission),
+        )
+        .await
+    }
+
+    /// Route one exact-bound record after the registry has validated its full
+    /// identity. Queue pressure awaits bounded capacity and applies ordinary
+    /// WebSocket/TCP backpressure; it is never reclassified as malformed.
+    pub(crate) async fn route_bound(
+        self: &Arc<Self>,
+        bytes: Bytes,
+        bounds: &CodecBounds,
+    ) -> BinaryRoute {
+        let received_at = Instant::now();
+        // Linearize credit observation before parsing or awaiting any ingress
+        // capacity. A later writer-committed CREDIT must not retroactively
+        // authorize this already received DATA message.
+        let credit_at_receipt = self.served_send_through.load(Ordering::Acquire);
+        let phase = {
+            let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+            let phase = self.phase();
+            if phase == UploadPhase::Opening {
+                self.opening_fatal.store(true, Ordering::Release);
+                self.closed.store(true, Ordering::Release);
+                return BinaryRoute::CloseMalformed;
+            }
+            if phase == UploadPhase::Retired {
+                return BinaryRoute::CloseMalformed;
+            }
+            phase
+        };
+
+        let kind = match decode_stream_kind(&bytes, bounds) {
+            Ok(kind) => kind,
+            Err(_) if phase == UploadPhase::Finalizing => return BinaryRoute::CloseMalformed,
+            Err(_) => return self.malformed(received_at).await,
+        };
+        let direction_ok = match phase {
+            UploadPhase::Opening | UploadPhase::Retired => false,
+            UploadPhase::Active => matches!(
+                kind,
+                StreamRecordKind::Data | StreamRecordKind::End | StreamRecordKind::Abort
+            ),
+            UploadPhase::DaemonAbortQueued => matches!(
+                kind,
+                StreamRecordKind::Data | StreamRecordKind::End | StreamRecordKind::Abort
+            ),
+            UploadPhase::DaemonAbortWaitAck => matches!(
+                kind,
+                StreamRecordKind::Data
+                    | StreamRecordKind::End
+                    | StreamRecordKind::Abort
+                    | StreamRecordKind::Ack
+            ),
+            UploadPhase::ClientAbortPending => matches!(
+                kind,
+                StreamRecordKind::Data | StreamRecordKind::End | StreamRecordKind::Abort
+            ),
+            UploadPhase::ClientAbortAckCommitted | UploadPhase::ClientAbortAckSent => matches!(
+                kind,
+                StreamRecordKind::Data | StreamRecordKind::End | StreamRecordKind::Abort
+            ),
+            UploadPhase::Finalizing => kind == StreamRecordKind::Abort,
+            UploadPhase::AckPending => false,
+        };
+        if !direction_ok {
+            return if phase == UploadPhase::Finalizing {
+                BinaryRoute::CloseMalformed
+            } else {
+                self.malformed(received_at).await
+            };
+        }
+
+        let view = match decode_stream_record_view(&bytes, bounds) {
+            Ok(view) => view,
+            Err(_) if phase == UploadPhase::Finalizing => return BinaryRoute::CloseMalformed,
+            Err(_) => return self.malformed(received_at).await,
+        };
+        if let StreamRecordBodyView::Abort { reason, .. } = view.body {
+            if !matches!(
+                reason,
+                BinaryAbortReason::Cancelled
+                    | BinaryAbortReason::SourceFailed
+                    | BinaryAbortReason::ProtocolError
+            ) {
+                return if phase == UploadPhase::Finalizing {
+                    BinaryRoute::CloseMalformed
+                } else {
+                    self.malformed(received_at).await
+                };
+            }
+        }
+        let (
+            current_phase,
+            terminal_conflict,
+            admission,
+            pending_data,
+            rejected_data,
+            discard_data,
+        ) = {
+            let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+            let current_phase = self.phase();
+            if self.closed.load(Ordering::Acquire) {
+                return BinaryRoute::CloseMalformed;
+            }
+            let prior = self.producer_terminal.load(Ordering::Acquire);
+            let valid_late_end_abort = prior == PRODUCER_TERMINAL_END
+                && matches!(
+                    view.body,
+                    StreamRecordBodyView::Abort {
+                        accepted_through,
+                        ..
+                    } if accepted_through == self.accepted.load(Ordering::Acquire)
+                );
+            let mut terminal_conflict = match prior {
+                PRODUCER_TERMINAL_NONE => {
+                    if kind == StreamRecordKind::End {
+                        self.producer_terminal
+                            .store(PRODUCER_TERMINAL_END, Ordering::Release);
+                    } else if kind == StreamRecordKind::Abort {
+                        self.producer_terminal
+                            .store(PRODUCER_TERMINAL_ABORT, Ordering::Release);
+                    }
+                    false
+                }
+                // ACK can still discharge a daemon ABORT whose timer won the
+                // actor race. No producer payload/control may follow END.
+                PRODUCER_TERMINAL_END => kind != StreamRecordKind::Ack && !valid_late_end_abort,
+                // ABORT ends producer traffic. A later producer record is a
+                // request-local protocol fault; only ACK for a crossed daemon
+                // ABORT remains legal.
+                PRODUCER_TERMINAL_ABORT => kind != StreamRecordKind::Ack,
+                _ => true,
+            };
+            if kind == StreamRecordKind::Ack && current_phase != UploadPhase::DaemonAbortWaitAck {
+                terminal_conflict = true;
+            }
+            if terminal_conflict && prior == PRODUCER_TERMINAL_END {
+                self.post_end_fatal.store(true, Ordering::Release);
+            }
+            if current_phase == UploadPhase::DaemonAbortWaitAck && kind == StreamRecordKind::Ack {
+                self.set_phase_locked(UploadPhase::AckPending);
+            }
+            let mut rejected_data = None;
+            let mut discard_data = false;
+            if kind == StreamRecordKind::Data && !terminal_conflict {
+                if current_phase != UploadPhase::Active
+                    || self.data_refusal_pending.load(Ordering::Acquire)
+                    || self.has_preemptive_terminal_pending()
+                {
+                    // A daemon/client terminal that already won needs only its
+                    // exact ACK obligations. Older producer DATA is discarded
+                    // without occupying the legal receive window so a later
+                    // ACK or unrelated control remains readable.
+                    discard_data = true;
+                } else if let StreamRecordBodyView::Data { offset, payload } = view.body {
+                    if let Err(failure) =
+                        self.admit_received_data_locked(offset, payload.len(), credit_at_receipt)
+                    {
+                        self.data_refusal_pending.store(true, Ordering::Release);
+                        rejected_data = Some(failure);
+                    }
+                }
+            }
+            // A DATA record is normally routed through the bounded data lane,
+            // but a DATA follower after a producer terminal is itself a
+            // terminal protocol fault. A preflight DATA refusal also bypasses
+            // DATA capacity as ordered, preemptive terminal work.
+            let admission =
+                (kind != StreamRecordKind::Data || terminal_conflict || rejected_data.is_some())
+                    .then(|| {
+                        self.begin_terminal_locked(
+                            false,
+                            rejected_data.is_some()
+                                || (kind == StreamRecordKind::Abort && !terminal_conflict),
+                        )
+                    });
+            let pending_data = (kind == StreamRecordKind::Data
+                && !terminal_conflict
+                && rejected_data.is_none()
+                && !discard_data)
+                .then(|| PendingData::new(self.clone(), credit_at_receipt));
+            (
+                current_phase,
+                terminal_conflict,
+                admission,
+                pending_data,
+                rejected_data,
+                discard_data,
+            )
+        };
+        if current_phase == UploadPhase::Finalizing {
+            // END already owns the result. A structurally valid late producer
+            // ABORT cannot change it and needs no second terminal exchange.
+            let valid_late_abort = matches!(
+                view.body,
+                StreamRecordBodyView::Abort {
+                    accepted_through,
+                    ..
+                } if accepted_through == self.accepted.load(Ordering::Acquire)
+            );
+            return if valid_late_abort {
+                BinaryRoute::Delivered
+            } else {
+                BinaryRoute::CloseMalformed
+            };
+        }
+        if terminal_conflict {
+            return self
+                .enqueue(
+                    UploadEvent {
+                        received_at,
+                        body: UploadEventBody::Malformed,
+                        _pending_data: None,
+                    },
+                    true,
+                    admission,
+                )
+                .await;
+        }
+        if discard_data {
+            return BinaryRoute::Delivered;
+        }
+        if let Some(failure) = rejected_data {
+            return self
+                .enqueue(
+                    UploadEvent {
+                        received_at,
+                        body: UploadEventBody::RejectedData(failure),
+                        _pending_data: None,
+                    },
+                    true,
+                    admission,
+                )
+                .await;
+        }
+
+        let byte_permit = if kind == StreamRecordKind::Data {
+            let permits = match u32::try_from(bytes.len()) {
+                Ok(permits) => permits,
+                Err(_) => return self.malformed(received_at).await,
+            };
+            match self.budget.bytes.clone().acquire_many_owned(permits).await {
+                Ok(permit) => Some(permit),
+                Err(_) => return BinaryRoute::CloseMalformed,
+            }
+        } else {
+            None
+        };
+        self.enqueue(
+            UploadEvent {
+                received_at,
+                body: UploadEventBody::Record {
+                    kind,
+                    bytes,
+                    _bytes: byte_permit,
+                },
+                _pending_data: pending_data,
+            },
+            kind != StreamRecordKind::Data,
+            admission,
+        )
+        .await
+    }
+
+    async fn request_cancel(self: &Arc<Self>) -> CancelAttempt {
+        let received_at = Instant::now();
+        let admission = {
+            let _sequencing = self.sequencing.lock().expect("upload sequencing poisoned");
+            if self.phase() != UploadPhase::Active || self.closed.load(Ordering::Acquire) {
+                return CancelAttempt::Unknown;
+            }
+            self.begin_terminal_locked(true, true)
+        };
+        let (response, result) = oneshot::channel();
+        if self
+            .enqueue(
+                UploadEvent {
+                    received_at,
+                    body: UploadEventBody::Cancel { response },
+                    _pending_data: None,
+                },
+                true,
+                Some(admission),
+            )
+            .await
+            != BinaryRoute::Delivered
+        {
+            return CancelAttempt::Unknown;
+        }
+        result.await.unwrap_or(CancelAttempt::Unknown)
+    }
+}
+
+#[derive(Clone)]
+struct UploadCancelTarget {
+    ingress: Arc<UploadIngress>,
+    total: u64,
+}
+
+/// Daemon-global principal-scoped cancellation table for streamed uploads.
+#[derive(Clone)]
+pub(crate) struct UploadCancellationRegistry {
+    inner: Arc<Mutex<HashMap<(String, OpId), UploadCancelTarget>>>,
+    engine: Option<Weak<Engine>>,
+}
+
+pub(crate) struct UploadCancellationGuard {
+    registry: UploadCancellationRegistry,
+    key: (String, OpId),
+    ingress: Arc<UploadIngress>,
+}
+
+impl UploadCancellationRegistry {
+    pub(crate) fn with_engine(engine: &Arc<Engine>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            engine: Some(Arc::downgrade(engine)),
+        }
+    }
+
+    fn register(
+        &self,
+        principal: String,
+        op_id: OpId,
+        ingress: Arc<UploadIngress>,
+        total: u64,
+    ) -> Option<UploadCancellationGuard> {
+        let key = (principal, op_id);
+        let mut entries = self
+            .inner
+            .lock()
+            .expect("upload cancellation registry poisoned");
+        if entries.contains_key(&key) {
+            return None;
+        }
+        entries.insert(
+            key.clone(),
+            UploadCancelTarget {
+                ingress: ingress.clone(),
+                total,
+            },
+        );
+        Some(UploadCancellationGuard {
+            registry: self.clone(),
+            key,
+            ingress,
+        })
+    }
+
+    pub(crate) async fn cancel(
+        &self,
+        principal: &str,
+        request: &TransferCancel,
+    ) -> Result<TransferCancelOut, ApiError> {
+        let key = (principal.to_owned(), request.transfer_op_id.clone());
+        let target = {
+            let entries = self
+                .inner
+                .lock()
+                .expect("upload cancellation registry poisoned");
+            match entries.get(&key) {
+                Some(target) => target.clone(),
+                None => {
+                    return self
+                        .recorded_cancellation(principal, request)
+                        .ok_or_else(|| ApiError::TransferUnknown {
+                            transfer_op_id: request.transfer_op_id.clone(),
+                        });
+                }
+            }
+        };
+
+        match target.ingress.request_cancel().await {
+            CancelAttempt::Cancelled { accepted } => {
+                // The actor annotates the canonical ledger before removing
+                // the active target and satisfying this oneshot. Therefore a
+                // concurrent or immediately repeated cancel cannot observe an
+                // Active/recorded gap and misreport `transfer_unknown`.
+                Ok(TransferCancelOut {
+                    transfer_op_id: request.transfer_op_id.clone(),
+                    outcome: CancelOutcome::Cancelled,
+                    transferred_bytes: accepted,
+                    total: ByteTotal::Known {
+                        bytes: target.total,
+                    },
+                })
+            }
+            CancelAttempt::Unknown => {
+                let mut entries = self
+                    .inner
+                    .lock()
+                    .expect("upload cancellation registry poisoned");
+                if matches!(
+                    entries.get(&key),
+                    Some(current) if Arc::ptr_eq(&current.ingress, &target.ingress)
+                ) {
+                    entries.remove(&key);
+                }
+                drop(entries);
+                self.recorded_cancellation(principal, request)
+                    .ok_or_else(|| ApiError::TransferUnknown {
+                        transfer_op_id: request.transfer_op_id.clone(),
+                    })
+            }
+        }
+    }
+
+    fn recorded_cancellation(
+        &self,
+        principal: &str,
+        request: &TransferCancel,
+    ) -> Option<TransferCancelOut> {
+        let engine = self.engine.as_ref()?.upgrade()?;
+        let (transferred_bytes, total) =
+            engine.recorded_file_share_cancellation(principal, &request.transfer_op_id)?;
+        Some(TransferCancelOut {
+            transfer_op_id: request.transfer_op_id.clone(),
+            outcome: CancelOutcome::AlreadyCancelled,
+            transferred_bytes,
+            total: ByteTotal::Known { bytes: total },
+        })
+    }
+}
+
+impl Default for UploadCancellationRegistry {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            engine: None,
+        }
+    }
+}
+
+impl UploadCancellationGuard {
+    fn select_cancelled(
+        &self,
+        owner: &mut FileShareLedgerOwner,
+        transferred: u64,
+        total: u64,
+    ) -> bool {
+        let mut entries = self
+            .registry
+            .inner
+            .lock()
+            .expect("upload cancellation registry poisoned");
+        if !matches!(
+            entries.get(&self.key),
+            Some(current) if Arc::ptr_eq(&current.ingress, &self.ingress)
+        ) {
+            return false;
+        }
+        if !self.ingress.try_select_daemon_abort() {
+            return false;
+        }
+        // Preserve the lock order registry -> ingress sequencing -> ledger.
+        // Removing the live target only after this annotation makes a miss
+        // provably replayable as `already_cancelled`, even before ABORT/ACK
+        // publishes the file.share terminal result.
+        owner.record_cancel_selected(transferred, total);
+        entries.remove(&self.key);
+        true
+    }
+
+    fn unregister(&self) {
+        let mut entries = self
+            .registry
+            .inner
+            .lock()
+            .expect("upload cancellation registry poisoned");
+        if matches!(
+            entries.get(&self.key),
+            Some(current) if Arc::ptr_eq(&current.ingress, &self.ingress)
+        ) {
+            entries.remove(&self.key);
+        }
+    }
+}
+
+impl Drop for UploadCancellationGuard {
+    fn drop(&mut self) {
+        self.unregister();
+    }
+}
+
+#[derive(Clone)]
+struct UploadRequestLease {
+    permit: Arc<Mutex<Option<RequestPermit>>>,
+}
+
+impl UploadRequestLease {
+    fn new(permit: RequestPermit) -> Self {
+        Self {
+            permit: Arc::new(Mutex::new(Some(permit))),
+        }
+    }
+
+    fn release(&self) {
+        drop(
+            self.permit
+                .lock()
+                .expect("upload request lease poisoned")
+                .take(),
+        );
+    }
+}
+
+#[derive(Debug)]
+struct ConsumerState {
+    declared: u64,
+    file_limit: u64,
+    accepted: u64,
+    credited_accepted: u64,
+    send_through: u64,
+    credit_history: VecDeque<(u64, u64)>,
+}
+
+impl ConsumerState {
+    fn new(declared: u64, file_limit: u64) -> Self {
+        Self {
+            declared,
+            file_limit,
+            accepted: 0,
+            credited_accepted: 0,
+            send_through: 0,
+            credit_history: VecDeque::new(),
+        }
+    }
+
+    fn probe_limit(&self) -> Option<u64> {
+        self.declared.min(self.file_limit).checked_add(1)
+    }
+
+    fn next_credit(&self, window: u64) -> Option<(u64, u64)> {
+        let probe = self.probe_limit()?;
+        // The observation sentinel is capacity only after every declared
+        // logical byte is durably accepted. Before that boundary CREDIT may
+        // reach the logical limit, but never cross it.
+        let send = if self.accepted == self.declared.min(self.file_limit) {
+            probe
+        } else {
+            self.accepted
+                .checked_add(window)?
+                .min(self.declared.min(self.file_limit))
+        };
+        Some((self.accepted, send))
+    }
+
+    fn record_credit(&mut self, accepted: u64, send: u64) -> Result<(), ()> {
+        if accepted != self.accepted
+            || accepted < self.credited_accepted
+            || send < self.send_through
+            || accepted > send
+            || send > self.probe_limit().ok_or(())?
+        {
+            return Err(());
+        }
+        self.credited_accepted = accepted;
+        self.send_through = send;
+        if self.credit_history.back().copied() != Some((accepted, send)) {
+            self.credit_history.push_back((accepted, send));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn validate_data(&mut self, offset: u64, payload_len: usize) -> Result<u64, DataFailure> {
+        self.validate_data_at_credit(offset, payload_len, self.send_through)
+    }
+
+    fn validate_data_at_credit(
+        &mut self,
+        offset: u64,
+        payload_len: usize,
+        credit_at_receipt: u64,
+    ) -> Result<u64, DataFailure> {
+        let payload = u64::try_from(payload_len).map_err(|_| DataFailure::Protocol)?;
+        let candidate = offset.checked_add(payload).ok_or(DataFailure::Protocol)?;
+        if candidate > self.file_limit {
+            return Err(DataFailure::TooLarge {
+                observed: candidate,
+            });
+        }
+        if candidate > self.declared {
+            return Err(DataFailure::Declared {
+                observed: candidate,
+            });
+        }
+        if offset != self.accepted {
+            return Err(DataFailure::Protocol);
+        }
+        if candidate > credit_at_receipt || credit_at_receipt > self.send_through {
+            return Err(DataFailure::Protocol);
+        }
+        // Crossing a prior send limit proves the producer observed a later
+        // CREDIT. Older accepted values can no longer be the high-water mark
+        // it legitimately echoes in ABORT, keeping this history bounded by
+        // the explicit in-flight window rather than by file size.
+        while self.credit_history.len() > 1
+            && self
+                .credit_history
+                .front()
+                .is_some_and(|(_, send)| *send < candidate)
+        {
+            self.credit_history.pop_front();
+        }
+        Ok(candidate)
+    }
+
+    fn data_accepted(&mut self, candidate: u64) {
+        self.accepted = candidate;
+    }
+
+    fn validate_end(&self, total: u64) -> Result<(), DataFailure> {
+        if total != self.accepted {
+            return Err(DataFailure::Protocol);
+        }
+        if total < self.declared {
+            return Err(DataFailure::Declared { observed: total });
+        }
+        if total != self.declared
+            || self.credited_accepted != self.accepted
+            || self.send_through != self.probe_limit().ok_or(DataFailure::Protocol)?
+        {
+            return Err(DataFailure::Protocol);
+        }
+        Ok(())
+    }
+
+    fn should_credit(&self) -> bool {
+        self.send_through == 0
+            || self.accepted == self.send_through
+            || self.accepted == self.declared
+    }
+
+    fn valid_producer_abort(&self, echoed_accepted: u64) -> bool {
+        self.credit_history
+            .iter()
+            .any(|(accepted, _)| *accepted == echoed_accepted)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DataFailure {
+    Protocol,
+    TooLarge { observed: u64 },
+    Declared { observed: u64 },
+}
+
+#[derive(Debug, Clone)]
+enum UploadFailure {
+    Protocol,
+    Sink,
+    Cancelled,
+    Deadline { budget_ms: u64 },
+    Stall,
+    TooLarge,
+    Declared { observed: u64 },
+}
+
+fn known_total(total: u64) -> ByteTotal {
+    ByteTotal::Known { bytes: total }
+}
+
+fn stream_bytes(
+    identity: StreamIdentity,
+    body: StreamRecordBody,
+    bounds: &CodecBounds,
+) -> Option<Vec<u8>> {
+    encode_stream_record(&StreamRecord { identity, body }, bounds).ok()
+}
+
+fn reply_bytes<E>(id: u64, result: Result<&FileShareOut, E>) -> Vec<u8>
+where
+    E: std::borrow::Borrow<ApiError>,
+{
+    let reply = match result {
+        Ok(out) => jeliya_codec::Reply {
+            id,
+            ok: true,
+            out: serde_json::to_value(out).ok(),
+            err: None,
+        },
+        Err(error) => jeliya_codec::Reply {
+            id,
+            ok: false,
+            out: None,
+            err: Some(error.borrow().clone()),
+        },
+    };
+    reply.to_bytes()
+}
+
+async fn send_reply<E>(
+    outbound: &Outbound,
+    id: u64,
+    result: Result<&FileShareOut, E>,
+    request: &UploadRequestLease,
+) -> bool
+where
+    E: std::borrow::Borrow<ApiError>,
+{
+    let release = request.clone();
+    outbound
+        .text_with_on_sent(reply_bytes(id, result), move || release.release())
+        .await
+        == WriteReceipt::Sent
+}
+
+async fn send_reply_and_retire<E>(
+    outbound: &Outbound,
+    id: u64,
+    result: Result<&FileShareOut, E>,
+    request: &UploadRequestLease,
+    binding: &UploadStreamBinding,
+) -> bool
+where
+    E: std::borrow::Borrow<ApiError>,
+{
+    let release = request.clone();
+    let retirement = binding.retirement();
+    outbound
+        .text_with_on_sent(reply_bytes(id, result), move || {
+            retirement.retire();
+            release.release();
+        })
+        .await
+        == WriteReceipt::Sent
+}
+
+fn failure_error(failure: &UploadFailure, state: &ConsumerState) -> ApiError {
+    match failure {
+        UploadFailure::Protocol => ApiError::MalformedFrame,
+        UploadFailure::Sink => ApiError::StreamAborted {
+            transferred_bytes: state.accepted,
+            total: known_total(state.declared),
+            reason: StreamAbortReason::SinkFailed,
+        },
+        UploadFailure::Cancelled => ApiError::StreamAborted {
+            transferred_bytes: state.accepted,
+            total: known_total(state.declared),
+            reason: StreamAbortReason::Cancelled,
+        },
+        UploadFailure::Deadline { budget_ms } => ApiError::TransferDeadlineExceeded {
+            transferred_bytes: state.accepted,
+            total: known_total(state.declared),
+            budget_ms: *budget_ms,
+        },
+        UploadFailure::Stall => ApiError::TransferStalled {
+            transferred_bytes: state.accepted,
+            total: known_total(state.declared),
+        },
+        UploadFailure::TooLarge => ApiError::FileTooLarge {
+            declared_bytes: state.declared,
+            limit_bytes: state.file_limit,
+            enforced_at: EnforcedAt::StageStream,
+        },
+        UploadFailure::Declared { observed } => ApiError::DeclaredSizeMismatch {
+            declared_bytes: state.declared,
+            observed_bytes: *observed,
+        },
+    }
+}
+
+fn failure_abort_reason(failure: &UploadFailure) -> BinaryAbortReason {
+    match failure {
+        UploadFailure::Protocol => BinaryAbortReason::ProtocolError,
+        UploadFailure::Sink => BinaryAbortReason::SinkFailed,
+        UploadFailure::Cancelled => BinaryAbortReason::Cancelled,
+        UploadFailure::Deadline { .. }
+        | UploadFailure::Stall
+        | UploadFailure::TooLarge
+        | UploadFailure::Declared { .. } => BinaryAbortReason::OperationError,
+    }
+}
+
+fn final_sink_error(error: FileShareSinkError, state: &ConsumerState) -> ApiError {
+    match error {
+        FileShareSinkError::FileTooLarge {
+            candidate: _,
+            limit,
+        } => ApiError::FileTooLarge {
+            declared_bytes: state.declared,
+            limit_bytes: limit,
+            enforced_at: EnforcedAt::StageStream,
+        },
+        FileShareSinkError::DeclaredSizeMismatch { declared, observed } => {
+            ApiError::DeclaredSizeMismatch {
+                declared_bytes: declared,
+                observed_bytes: observed,
+            }
+        }
+        FileShareSinkError::OffsetMismatch { .. }
+        | FileShareSinkError::Arithmetic
+        | FileShareSinkError::EmptyRecord => ApiError::MalformedFrame,
+        FileShareSinkError::CountDisagreement { observed, .. } => ApiError::DeclaredSizeMismatch {
+            declared_bytes: state.declared,
+            observed_bytes: observed,
+        },
+        FileShareSinkError::Create(_)
+        | FileShareSinkError::Write { .. }
+        | FileShareSinkError::PartialWrite { .. }
+        | FileShareSinkError::Flush(_)
+        | FileShareSinkError::Sync(_)
+        | FileShareSinkError::StagingDisappeared
+        | FileShareSinkError::StagingReplaced
+        | FileShareSinkError::Cleanup(_)
+        | FileShareSinkError::SinkClosed => ApiError::StreamAborted {
+            transferred_bytes: state.accepted,
+            total: known_total(state.declared),
+            reason: StreamAbortReason::SinkFailed,
+        },
+    }
+}
+
+async fn send_control_until<F>(
+    outbound: &Outbound,
+    bytes: Vec<u8>,
+    deadline: Instant,
+    commit: F,
+) -> BoundedControlOutcome
+where
+    F: FnOnce() -> ControlCommit + Send + 'static,
+{
+    let attempt = Arc::new(AtomicU8::new(CONTROL_ATTEMPT_QUEUED));
+    let commit_result = Arc::new(AtomicU8::new(CONTROL_COMMIT_PENDING));
+    let stream_live = Arc::new(AtomicBool::new(true));
+    let commit_attempt = attempt.clone();
+    let writer_commit_result = commit_result.clone();
+    let write = outbound.binary_control_with_start(bytes, stream_live.clone(), move || {
+        if commit_attempt
+            .compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_STARTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        let decision = commit();
+        writer_commit_result.store(decision as u8, Ordering::Release);
+        decision == ControlCommit::Committed
+    });
+    tokio::pin!(write);
+    let classify = |receipt| match receipt {
+        WriteReceipt::Sent => BoundedControlOutcome::Sent,
+        WriteReceipt::Discarded
+            if ControlCommit::load(&commit_result) == ControlCommit::Deadline =>
+        {
+            BoundedControlOutcome::Deadline
+        }
+        WriteReceipt::Discarded | WriteReceipt::Closed => BoundedControlOutcome::DiscardedOrClosed,
+    };
+    tokio::select! {
+        biased;
+        receipt = &mut write => classify(receipt),
+        () = tokio::time::sleep_until(deadline) => {
+            if attempt.compare_exchange(
+                CONTROL_ATTEMPT_QUEUED,
+                CONTROL_ATTEMPT_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ).is_ok() {
+                stream_live.store(false, Ordering::Release);
+                BoundedControlOutcome::Deadline
+            } else {
+                // Writer start won before the bound. Reconcile the finite
+                // writer watchdog because the control may be peer-visible.
+                classify(write.await)
+            }
+        }
+    }
+}
+
+async fn send_open<F>(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    identity: StreamIdentity,
+    total: u64,
+    bounds: &CodecBounds,
+    deadline: Instant,
+    admit: F,
+) -> BoundedControlOutcome
+where
+    F: FnOnce() -> bool + Send + 'static,
+{
+    let Some(open) = stream_bytes(identity, StreamRecordBody::Open { total }, bounds) else {
+        return BoundedControlOutcome::DiscardedOrClosed;
+    };
+    let commit_ingress = ingress.clone();
+    send_control_until(outbound, open, deadline, move || {
+        commit_ingress.commit_open_with(deadline, admit)
+    })
+    .await
+}
+
+#[derive(Clone, Copy)]
+enum ControlInterrupt {
+    TerminalPending,
+    Deadline,
+    Stall,
+    TransportLost,
+}
+
+struct ActiveControlResult {
+    receipt: WriteReceipt,
+    interrupt: Option<ControlInterrupt>,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_active_control(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    identity: StreamIdentity,
+    body: StreamRecordBody,
+    bounds: &CodecBounds,
+    absolute_deadline: Instant,
+    stall_deadline: Instant,
+    committed_send_through: u64,
+) -> ActiveControlResult {
+    let Some(bytes) = stream_bytes(identity, body, bounds) else {
+        return ActiveControlResult {
+            receipt: WriteReceipt::Closed,
+            interrupt: None,
+        };
+    };
+    let attempt = Arc::new(AtomicU8::new(CONTROL_ATTEMPT_QUEUED));
+    let live = Arc::new(AtomicBool::new(true));
+    let commit_attempt = attempt.clone();
+    let commit_ingress = ingress.clone();
+    let write = outbound.binary_control_with_start(bytes, live.clone(), move || {
+        commit_ingress.try_start_active_credit(
+            &commit_attempt,
+            absolute_deadline,
+            stall_deadline,
+            committed_send_through,
+        )
+    });
+    tokio::pin!(write);
+    loop {
+        let interrupt_now = if ingress.has_terminal_pending() {
+            Some(ControlInterrupt::TerminalPending)
+        } else if ingress.closed.load(Ordering::Acquire) {
+            Some(ControlInterrupt::TransportLost)
+        } else if Instant::now() > absolute_deadline {
+            Some(ControlInterrupt::Deadline)
+        } else if Instant::now() > stall_deadline {
+            Some(ControlInterrupt::Stall)
+        } else {
+            None
+        };
+        if let Some(interrupt) = interrupt_now {
+            if attempt
+                .compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_CANCELLED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                live.store(false, Ordering::Release);
+                return ActiveControlResult {
+                    receipt: WriteReceipt::Discarded,
+                    interrupt: Some(interrupt),
+                };
+            }
+            return ActiveControlResult {
+                receipt: write.await,
+                interrupt: Some(interrupt),
+            };
+        }
+        tokio::select! {
+            biased;
+            () = ingress.terminal_notify.notified() => {
+                if !ingress.has_terminal_pending() {
+                    continue;
+                }
+                let interrupt = ControlInterrupt::TerminalPending;
+                if attempt.compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_CANCELLED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ).is_ok() {
+                    live.store(false, Ordering::Release);
+                    return ActiveControlResult {
+                        receipt: WriteReceipt::Discarded,
+                        interrupt: Some(interrupt),
+                    };
+                }
+                return ActiveControlResult {
+                    receipt: write.await,
+                    interrupt: Some(interrupt),
+                };
+            }
+            () = ingress.closed_notify.notified() => {
+                let interrupt = ControlInterrupt::TransportLost;
+                if attempt.compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_CANCELLED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ).is_ok() {
+                    live.store(false, Ordering::Release);
+                    return ActiveControlResult {
+                        receipt: WriteReceipt::Discarded,
+                        interrupt: Some(interrupt),
+                    };
+                }
+                return ActiveControlResult {
+                    receipt: write.await,
+                    interrupt: Some(interrupt),
+                };
+            }
+            () = tokio::time::sleep_until(absolute_deadline) => {
+                let interrupt = ControlInterrupt::Deadline;
+                if attempt.compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_CANCELLED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ).is_ok() {
+                    live.store(false, Ordering::Release);
+                    return ActiveControlResult {
+                        receipt: WriteReceipt::Discarded,
+                        interrupt: Some(interrupt),
+                    };
+                }
+                return ActiveControlResult {
+                    receipt: write.await,
+                    interrupt: Some(interrupt),
+                };
+            }
+            () = tokio::time::sleep_until(stall_deadline) => {
+                let interrupt = ControlInterrupt::Stall;
+                if attempt.compare_exchange(
+                    CONTROL_ATTEMPT_QUEUED,
+                    CONTROL_ATTEMPT_CANCELLED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ).is_ok() {
+                    live.store(false, Ordering::Release);
+                    return ActiveControlResult {
+                        receipt: WriteReceipt::Discarded,
+                        interrupt: Some(interrupt),
+                    };
+                }
+                return ActiveControlResult {
+                    receipt: write.await,
+                    interrupt: Some(interrupt),
+                };
+            }
+            receipt = &mut write => {
+                return ActiveControlResult {
+                    receipt,
+                    interrupt: None,
+                };
+            }
+        }
+    }
+}
+
+async fn send_abort(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    identity: StreamIdentity,
+    accepted: u64,
+    reason: BinaryAbortReason,
+    bounds: &CodecBounds,
+    deadline: Instant,
+) -> BoundedControlOutcome {
+    let Some(bytes) = stream_bytes(
+        identity,
+        StreamRecordBody::Abort {
+            accepted_through: accepted,
+            reason,
+        },
+        bounds,
+    ) else {
+        return BoundedControlOutcome::DiscardedOrClosed;
+    };
+    let commit_ingress = ingress.clone();
+    send_control_until(outbound, bytes, deadline, move || {
+        commit_ingress.commit_daemon_abort(deadline)
+    })
+    .await
+}
+
+async fn send_ack_until(
+    outbound: &Outbound,
+    identity: StreamIdentity,
+    accepted: u64,
+    bounds: &CodecBounds,
+    deadline: Instant,
+) -> BoundedControlOutcome {
+    let Some(bytes) = stream_bytes(
+        identity,
+        StreamRecordBody::Ack {
+            accepted_through: accepted,
+        },
+        bounds,
+    ) else {
+        return BoundedControlOutcome::DiscardedOrClosed;
+    };
+    send_control_until(outbound, bytes, deadline, move || {
+        if Instant::now() < deadline {
+            ControlCommit::Committed
+        } else {
+            ControlCommit::Deadline
+        }
+    })
+    .await
+}
+
+async fn send_client_abort_ack_until(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    retirement: UploadStreamRetirement,
+    identity: StreamIdentity,
+    accepted: u64,
+    bounds: &CodecBounds,
+    deadline: Instant,
+) -> ClientAbortAckOutcome {
+    let Some(bytes) = stream_bytes(
+        identity,
+        StreamRecordBody::Ack {
+            accepted_through: accepted,
+        },
+        bounds,
+    ) else {
+        return ClientAbortAckOutcome::Failed;
+    };
+    let attempt = Arc::new(AtomicU8::new(CONTROL_ATTEMPT_QUEUED));
+    let stream_live = Arc::new(AtomicBool::new(true));
+    let commit_attempt = attempt.clone();
+    let commit_ingress = ingress.clone();
+    let write = outbound.binary_control_with_hooks(
+        bytes,
+        stream_live.clone(),
+        move || commit_ingress.try_sequence_client_abort_ack(&commit_attempt, deadline),
+        move || retirement.retire_client_abort_ack(),
+    );
+    tokio::pin!(write);
+    tokio::select! {
+        biased;
+        receipt = &mut write => match receipt {
+            WriteReceipt::Sent => ingress.classify_client_abort_ack_sent(),
+            WriteReceipt::Discarded => ingress.cancel_client_abort_ack(&attempt),
+            WriteReceipt::Closed => ClientAbortAckOutcome::Failed,
+        },
+        () = tokio::time::sleep_until(deadline) => {
+            let outcome = ingress.cancel_client_abort_ack(&attempt);
+            match outcome {
+                ClientAbortAckOutcome::Sent => {
+                    if write.await == WriteReceipt::Sent {
+                        ingress.classify_client_abort_ack_sent()
+                    } else {
+                        ClientAbortAckOutcome::Failed
+                    }
+                }
+                other => {
+                    stream_live.store(false, Ordering::Release);
+                    other
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn issue_credit(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    identity: StreamIdentity,
+    state: &mut ConsumerState,
+    window: u64,
+    bounds: &CodecBounds,
+    absolute_deadline: Instant,
+    stall_deadline: Instant,
+    budget_ms: u64,
+) -> Result<CreditOutcome, UploadFailure> {
+    let (accepted, send_through) = state.next_credit(window).ok_or(UploadFailure::Protocol)?;
+    let receipt = send_active_control(
+        outbound,
+        ingress,
+        identity,
+        StreamRecordBody::Credit {
+            accepted_through: accepted,
+            send_through,
+        },
+        bounds,
+        absolute_deadline,
+        stall_deadline,
+        send_through,
+    )
+    .await;
+    if receipt.receipt == WriteReceipt::Sent {
+        state
+            .record_credit(accepted, send_through)
+            .map_err(|()| UploadFailure::Protocol)?;
+    }
+    match receipt.interrupt {
+        Some(ControlInterrupt::TerminalPending) => Ok(CreditOutcome::TerminalPending),
+        Some(ControlInterrupt::TransportLost) => Ok(CreditOutcome::TransportLost),
+        Some(ControlInterrupt::Deadline) => Err(UploadFailure::Deadline { budget_ms }),
+        Some(ControlInterrupt::Stall) => Err(UploadFailure::Stall),
+        None if receipt.receipt == WriteReceipt::Sent => Ok(CreditOutcome::Sent),
+        None if receipt.receipt == WriteReceipt::Closed => Ok(CreditOutcome::TransportLost),
+        None => Err(UploadFailure::Protocol),
+    }
+}
+
+enum CreditOutcome {
+    Sent,
+    TerminalPending,
+    TransportLost,
+}
+
+enum ActiveInput {
+    Event(UploadEvent),
+    Deadline,
+    Stall,
+    TransportLost,
+}
+
+enum ActiveInterrupt {
+    TerminalPending,
+    Deadline,
+    Stall,
+    TransportLost,
+}
+
+fn explicit_terminal_wins_timer_tie(
+    event: &UploadEvent,
+    state: &ConsumerState,
+    bounds: &CodecBounds,
+) -> bool {
+    match &event.body {
+        UploadEventBody::Cancel { .. } => true,
+        UploadEventBody::Record {
+            kind: StreamRecordKind::Abort,
+            bytes,
+            ..
+        } => decode_stream_record_view(bytes, bounds).is_ok_and(|view| {
+            matches!(
+                view.body,
+                StreamRecordBodyView::Abort {
+                    accepted_through,
+                    reason:
+                        BinaryAbortReason::Cancelled
+                        | BinaryAbortReason::SourceFailed
+                        | BinaryAbortReason::ProtocolError,
+                } if state.valid_producer_abort(accepted_through)
+            )
+        }),
+        UploadEventBody::Record { .. }
+        | UploadEventBody::RejectedData(_)
+        | UploadEventBody::Malformed => false,
+    }
+}
+
+fn active_event_timer_failure(
+    event: &UploadEvent,
+    state: &ConsumerState,
+    bounds: &CodecBounds,
+    absolute_deadline: Instant,
+    stall_deadline: Instant,
+    budget_ms: u64,
+) -> Option<UploadFailure> {
+    let explicit_terminal = explicit_terminal_wins_timer_tie(event, state, bounds);
+    if event.received_at > absolute_deadline
+        || (event.received_at == absolute_deadline && !explicit_terminal)
+    {
+        Some(UploadFailure::Deadline { budget_ms })
+    } else if event.received_at > stall_deadline
+        || (event.received_at == stall_deadline && !explicit_terminal)
+    {
+        Some(UploadFailure::Stall)
+    } else {
+        None
+    }
+}
+
+async fn await_active_operation<F, T>(
+    operation: F,
+    ingress: &Arc<UploadIngress>,
+    absolute_deadline: Instant,
+    stall_deadline: Instant,
+) -> Result<T, ActiveInterrupt>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::pin!(operation);
+    loop {
+        if ingress.has_preemptive_terminal_pending() {
+            return Err(ActiveInterrupt::TerminalPending);
+        }
+        if ingress.closed.load(Ordering::Acquire) {
+            return if ingress.has_terminal_pending() {
+                Err(ActiveInterrupt::TerminalPending)
+            } else {
+                Err(ActiveInterrupt::TransportLost)
+            };
+        }
+        let now = Instant::now();
+        if now > absolute_deadline {
+            return Err(ActiveInterrupt::Deadline);
+        }
+        if now > stall_deadline {
+            return Err(ActiveInterrupt::Stall);
+        }
+        tokio::select! {
+            biased;
+            () = ingress.terminal_notify.notified() => {
+                if ingress.has_preemptive_terminal_pending() {
+                    return Err(ActiveInterrupt::TerminalPending);
+                }
+            }
+            () = ingress.closed_notify.notified() => {
+                if ingress.has_terminal_pending() {
+                    return Err(ActiveInterrupt::TerminalPending);
+                }
+                return Err(ActiveInterrupt::TransportLost);
+            }
+            () = tokio::time::sleep_until(absolute_deadline) => {
+                return Err(ActiveInterrupt::Deadline);
+            }
+            () = tokio::time::sleep_until(stall_deadline) => {
+                return Err(ActiveInterrupt::Stall);
+            }
+            output = &mut operation => return Ok(output),
+        }
+    }
+}
+
+async fn next_active(
+    events: &mut UploadEvents,
+    ingress: &Arc<UploadIngress>,
+    absolute_deadline: Instant,
+    stall_deadline: Instant,
+) -> ActiveInput {
+    loop {
+        // The prior terminal has now been fully handled. Clear its processing
+        // marker under the same sequencing lock used by dequeue and writer
+        // commit hooks, preserving an atomic queued -> processing -> handled
+        // handoff with no CREDIT-commit gap.
+        if !events.has_deferred_end() {
+            ingress.clear_processing_terminal();
+        }
+        // A record already admitted through the shared sequencing lock
+        // precedes later socket teardown and timers. If it is still waiting
+        // for its separately bounded terminal-lane slot, wait for that
+        // admission to enqueue or roll back before considering either.
+        if let Some(event) = events.try_recv(ingress) {
+            return ActiveInput::Event(event);
+        }
+        if ingress.has_terminal_pending() {
+            tokio::select! {
+                biased;
+                event = events.recv(ingress) => match event {
+                    Some(event) => return ActiveInput::Event(event),
+                    None => return ActiveInput::TransportLost,
+                },
+                () = ingress.terminal_notify.notified() => continue,
+            }
+        }
+        if ingress.closed.load(Ordering::Acquire) {
+            return ActiveInput::TransportLost;
+        }
+        tokio::select! {
+            biased;
+            event = events.recv(ingress) => match event {
+                Some(event) => return ActiveInput::Event(event),
+                None => return ActiveInput::TransportLost,
+            },
+            () = ingress.terminal_notify.notified() => continue,
+            () = ingress.closed_notify.notified() => continue,
+            () = tokio::time::sleep_until(absolute_deadline) => return ActiveInput::Deadline,
+            () = tokio::time::sleep_until(stall_deadline) => return ActiveInput::Stall,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finish_client_abort(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    events: &mut UploadEvents,
+    binding: &UploadStreamBinding,
+    identity: StreamIdentity,
+    state: &ConsumerState,
+    bounds: &CodecBounds,
+    id: u64,
+    request: &UploadRequestLease,
+    reason: StreamAbortReason,
+    stall: Duration,
+    closer: &ConnectionCloser,
+    owner: FileShareLedgerOwner,
+) -> bool {
+    let terminal_error = ApiError::StreamAborted {
+        transferred_bytes: state.accepted,
+        total: known_total(state.declared),
+        reason,
+    };
+    // ABORT owns the terminal lane and may overtake older DATA waiting in the
+    // bounded data lane. Those records are explicitly discarded before ACK;
+    // later producer traffic is classified into the terminal lane as a fault.
+    events.drain_data(ingress);
+    let ack_deadline = Instant::now()
+        .checked_add(stall)
+        .expect("served stall duration was validated");
+    let ack_outcome = send_client_abort_ack_until(
+        outbound,
+        ingress,
+        binding.retirement(),
+        identity,
+        state.accepted,
+        bounds,
+        ack_deadline,
+    )
+    .await;
+    let protocol_followup = match ack_outcome {
+        ClientAbortAckOutcome::Sent => false,
+        ClientAbortAckOutcome::ProtocolFaultBeforeSent => {
+            // The first producer ABORT is still owed its ACK. Discharge it,
+            // then promote the queued follower into a crossed daemon
+            // protocol terminal.
+            if send_ack_until(outbound, identity, state.accepted, bounds, ack_deadline).await
+                != BoundedControlOutcome::Sent
+            {
+                binding.retire();
+                let _ = owner.complete(Err(ApiError::MalformedFrame));
+                closer.malformed();
+                return false;
+            }
+            true
+        }
+        ClientAbortAckOutcome::ProtocolFaultAfterSent => true,
+        ClientAbortAckOutcome::Failed => {
+            binding.retire();
+            let _ = owner.complete(Err(terminal_error));
+            closer.malformed();
+            return false;
+        }
+    };
+    if protocol_followup {
+        while let Some(event) = events.try_recv(ingress) {
+            if let UploadEventBody::Cancel { response } = event.body {
+                let _ = response.send(CancelAttempt::Unknown);
+            }
+        }
+        if !ingress.promote_client_abort_protocol() {
+            binding.retire();
+            let _ = owner.complete(Err(ApiError::MalformedFrame));
+            return false;
+        }
+        return finish_daemon_abort(
+            outbound,
+            ingress,
+            events,
+            binding,
+            identity,
+            state,
+            bounds,
+            id,
+            request,
+            UploadFailure::Protocol,
+            stall,
+            closer,
+            owner,
+        )
+        .await;
+    }
+    // Publish only after the explicit ACK boundary so a joined replay cannot
+    // emit terminal Text ahead of the owner handshake. Every failed ACK path
+    // above publishes the same selected result before returning.
+    let terminal = owner.complete(Err(terminal_error));
+    let replied = send_reply(outbound, id, terminal.as_ref(), request).await;
+    if !replied {
+        closer.malformed();
+    }
+    replied
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finish_daemon_abort(
+    outbound: &Outbound,
+    ingress: &Arc<UploadIngress>,
+    events: &mut UploadEvents,
+    binding: &UploadStreamBinding,
+    identity: StreamIdentity,
+    state: &ConsumerState,
+    bounds: &CodecBounds,
+    id: u64,
+    request: &UploadRequestLease,
+    failure: UploadFailure,
+    stall: Duration,
+    closer: &ConnectionCloser,
+    owner: FileShareLedgerOwner,
+) -> bool {
+    let terminal_error = failure_error(&failure, state);
+    if ingress.phase() != UploadPhase::DaemonAbortQueued {
+        let _ = owner.complete(Err(terminal_error));
+        return false;
+    }
+    let abort_deadline = Instant::now()
+        .checked_add(stall)
+        .expect("served stall duration was validated");
+    if send_abort(
+        outbound,
+        ingress,
+        identity,
+        state.accepted,
+        failure_abort_reason(&failure),
+        bounds,
+        abort_deadline,
+    )
+    .await
+        != BoundedControlOutcome::Sent
+    {
+        let _ = owner.complete(Err(terminal_error));
+        closer.malformed();
+        return false;
+    }
+
+    let ack_deadline = Instant::now()
+        .checked_add(stall)
+        .expect("served stall duration was validated");
+    let mut acknowledged = false;
+    let mut crossed_abort_acked = false;
+    loop {
+        let next = tokio::select! {
+            biased;
+            event = events.recv(ingress) => event,
+            () = ingress.closed_notify.notified() => None,
+            () = tokio::time::sleep_until(ack_deadline) => None,
+        };
+        let Some(event) = next else {
+            break;
+        };
+        if event.received_at > ack_deadline {
+            break;
+        }
+        match event.body {
+            UploadEventBody::Record { bytes, .. } => {
+                match decode_stream_record_view(&bytes, bounds).map(|view| view.body) {
+                    Ok(StreamRecordBodyView::Ack { accepted_through })
+                        if accepted_through == state.accepted =>
+                    {
+                        // Routing latched this first ACK as AckPending. Retire
+                        // under the registry+sequencing locks only when no
+                        // duplicate exact-pair record is already queued.
+                        acknowledged = binding.retire_daemon_ack();
+                        break;
+                    }
+                    Ok(StreamRecordBodyView::Abort {
+                        accepted_through,
+                        reason,
+                    }) if matches!(
+                        reason,
+                        BinaryAbortReason::Cancelled
+                            | BinaryAbortReason::SourceFailed
+                            | BinaryAbortReason::ProtocolError
+                    ) && state.valid_producer_abort(accepted_through) =>
+                    {
+                        // Crossed ABORT: discharge the producer's explicit ACK
+                        // obligation, then continue waiting for ours. The
+                        // daemon-selected terminal remains authoritative.
+                        if crossed_abort_acked
+                            || send_ack_until(
+                                outbound,
+                                identity,
+                                state.accepted,
+                                bounds,
+                                ack_deadline,
+                            )
+                            .await
+                                != BoundedControlOutcome::Sent
+                        {
+                            break;
+                        }
+                        crossed_abort_acked = true;
+                    }
+                    Ok(StreamRecordBodyView::Data { .. } | StreamRecordBodyView::End { .. }) => {
+                        // Older in-flight producer records are drained and
+                        // discarded until ACK proves the boundary.
+                    }
+                    _ => break,
+                }
+            }
+            UploadEventBody::Cancel { response } => {
+                let _ = response.send(CancelAttempt::Unknown);
+            }
+            UploadEventBody::RejectedData(_) | UploadEventBody::Malformed => break,
+        }
+    }
+    if !acknowledged {
+        binding.retire();
+    }
+    // ACK or its bounded timeout is the publication boundary. A joined
+    // faithful replay now receives the exact selected result, but never
+    // outruns the owner's ABORT/ACK obligations.
+    let terminal = owner.complete(Err(terminal_error));
+    let replied = send_reply(outbound, id, terminal.as_ref(), request).await;
+    if !acknowledged || !replied {
+        closer.malformed();
+    }
+    replied
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_detached(
+    finalizer: FileShareFinalizer,
+    owner: FileShareLedgerOwner,
+    outbound: Outbound,
+    id: u64,
+    request: UploadRequestLease,
+    binding: UploadStreamBinding,
+) {
+    // The exact END produced one opaque, single-use import/event capability.
+    // Its private staging object is removed on either result.
+    let result = finalizer.finalize().await;
+    let result = owner.complete(result);
+    let sent = send_reply_and_retire(&outbound, id, result.as_ref(), &request, &binding).await;
+    if !sent {
+        // Connection teardown may legitimately discard a lost final reply;
+        // the ledger already owns the exact replayable result.
+        binding.retire();
+        request.release();
+    }
+}
+
+/// Execute one complete consumer-direction `file.share` request.
+///
+/// The caller should spawn this owner independently of the connection's
+/// abort-on-teardown request set. Registry invalidation supplies the pre-END
+/// transport-loss signal, while exact-END finalization is moved into its own
+/// detached task before this future returns.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_file_share(
+    engine: Arc<Engine>,
+    request_body: FileShare,
+    op_id: Option<OpId>,
+    principal_key: String,
+    id: u64,
+    request_permit: RequestPermit,
+    outbound: Outbound,
+    registry: StreamRegistry,
+    stream_ids: Arc<Mutex<StreamIdGenerator>>,
+    transfer_pool: TransferPool,
+    limits: RuntimeLimits,
+    closer: ConnectionCloser,
+    cancellations: UploadCancellationRegistry,
+    ingress_budget: UploadIngressBudget,
+) -> bool {
+    let request = UploadRequestLease::new(request_permit);
+    // This detached task must finish the structural/subject/ledger boundary
+    // even if its socket disappears concurrently. Otherwise an op_id could
+    // vanish before acquiring ownership and a reconnect would incorrectly
+    // open a fresh stream instead of replaying transport_lost.
+    let gate = engine
+        .gate_file_share(&request_body, op_id.clone(), &principal_key)
+        .await;
+    let owner = match gate {
+        FileShareLedgerGate::Replay(result) => {
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+        FileShareLedgerGate::Owner(owner) => owner,
+    };
+    if !registry.is_accepting() {
+        let _ = owner.transport_lost(0);
+        request.release();
+        return false;
+    }
+    let progress = owner.progress();
+    let prepared = match tokio::select! {
+        biased;
+        () = registry.wait_invalidated() => {
+            drop(owner);
+            request.release();
+            return false;
+        }
+        prepared = engine.prepare_file_share_after_gate(&request_body) => prepared,
+    } {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            let result = owner.complete(Err(error));
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+    };
+    let file_limit = engine.limits().max_shared_file_bytes;
+
+    // A successful pool reservation is the absolute-deadline start and
+    // precedes both staging creation and OPEN.
+    let admitted_at = Instant::now();
+    let reservation = match transfer_pool.reserve(request_body.declared_bytes) {
+        Ok(reservation) => reservation,
+        Err(error) => {
+            let result = owner.complete(Err(error));
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+    };
+    let (absolute_deadline, budget_ms) =
+        match limits.deadline(admitted_at, request_body.declared_bytes) {
+            Ok(deadline) => deadline,
+            Err(_) => {
+                drop(reservation);
+                let result = owner.complete(Err(ApiError::NotReady));
+                return send_reply(&outbound, id, result.as_ref(), &request).await;
+            }
+        };
+
+    let stage = tokio::select! {
+        biased;
+        () = registry.wait_invalidated() => {
+            drop(reservation);
+            drop(owner);
+            request.release();
+            return false;
+        }
+        () = tokio::time::sleep_until(absolute_deadline) => {
+            drop(reservation);
+            let result = owner.complete(Err(ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 0,
+                total: known_total(request_body.declared_bytes),
+                budget_ms,
+            }));
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+        stage = prepared.open_sink() => match stage {
+            Ok(stage) => stage,
+            Err(_) => {
+                drop(reservation);
+                let result = owner.complete(Err(ApiError::StreamAborted {
+                    transferred_bytes: 0,
+                    total: known_total(request_body.declared_bytes),
+                    reason: StreamAbortReason::SinkFailed,
+                }));
+                return send_reply(&outbound, id, result.as_ref(), &request).await;
+            }
+        }
+    };
+
+    let identity = {
+        let mut generator = stream_ids.lock().expect("stream id generator poisoned");
+        generator.next(id)
+    };
+    let identity = match identity {
+        Ok(identity) => identity,
+        Err(_) => {
+            drop(stage);
+            drop(reservation);
+            let result = owner.complete(Err(ApiError::NotReady));
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+    };
+    let (ingress, mut events) =
+        UploadIngress::new(ingress_budget, request_body.declared_bytes, file_limit);
+    let Some(binding) = registry.bind_upload(identity, ingress.clone()) else {
+        drop(stage);
+        drop(reservation);
+        let result = owner.complete(Err(ApiError::NotReady));
+        return send_reply(&outbound, id, result.as_ref(), &request).await;
+    };
+    let bounds = CodecBounds {
+        max_frame_bytes: limits.max_frame_bytes(),
+        ..CodecBounds::default()
+    };
+    let cancellation_slot = Arc::new(Mutex::new(None));
+    let install_slot = cancellation_slot.clone();
+    let install_cancellations = cancellations.clone();
+    let install_ingress = ingress.clone();
+    let install_principal = principal_key;
+    let install_op_id = op_id;
+    let declared_total = request_body.declared_bytes;
+    match send_open(
+        &outbound,
+        &ingress,
+        identity,
+        request_body.declared_bytes,
+        &bounds,
+        absolute_deadline,
+        move || {
+            let Some(op_id) = install_op_id else {
+                return true;
+            };
+            let Some(guard) = install_cancellations.register(
+                install_principal,
+                op_id,
+                install_ingress,
+                declared_total,
+            ) else {
+                return false;
+            };
+            *install_slot
+                .lock()
+                .expect("upload cancellation slot poisoned") = Some(guard);
+            true
+        },
+    )
+    .await
+    {
+        BoundedControlOutcome::Sent => {}
+        _ if ingress.opening_fatal.load(Ordering::Acquire) => {
+            drop(stage);
+            drop(reservation);
+            drop(binding);
+            drop(owner);
+            closer.malformed();
+            return false;
+        }
+        BoundedControlOutcome::Deadline => {
+            drop(stage);
+            drop(reservation);
+            binding.retire();
+            let result = owner.complete(Err(ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 0,
+                total: known_total(request_body.declared_bytes),
+                budget_ms,
+            }));
+            return send_reply(&outbound, id, result.as_ref(), &request).await;
+        }
+        BoundedControlOutcome::DiscardedOrClosed => {
+            drop(stage);
+            drop(reservation);
+            drop(binding);
+            drop(owner);
+            closer.malformed();
+            return false;
+        }
+    }
+
+    let mut cancellation_guard = cancellation_slot
+        .lock()
+        .expect("upload cancellation slot poisoned")
+        .take();
+    let mut reservation = Some(reservation);
+    let mut stage = Some(stage);
+    let mut owner = Some(owner);
+    let mut pending_cancel_response = None;
+    let mut state = ConsumerState::new(request_body.declared_bytes, file_limit);
+    let window = u64::try_from(limits.max_data_payload_bytes()).unwrap_or(u64::MAX);
+    let mut stall_deadline = limits
+        .stall_deadline(Instant::now())
+        .expect("served stall duration was validated");
+
+    let initial_credit = issue_credit(
+        &outbound,
+        &ingress,
+        identity,
+        &mut state,
+        window,
+        &bounds,
+        absolute_deadline,
+        stall_deadline,
+        budget_ms,
+    )
+    .await;
+    if matches!(initial_credit, Ok(CreditOutcome::TransportLost)) {
+        drop(stage.take());
+        drop(reservation.take());
+        drop(cancellation_guard.take());
+        binding.retire();
+        let _ = owner
+            .take()
+            .expect("upload owns ledger completion")
+            .transport_lost(state.accepted);
+        request.release();
+        return false;
+    }
+    if let Err(failure) = initial_credit {
+        match ingress.select_daemon_abort(TerminalYield::Any) {
+            DaemonAbortSelection::TerminalPending => {}
+            DaemonAbortSelection::Lost => {
+                drop(stage.take());
+                drop(reservation.take());
+                drop(cancellation_guard.take());
+                let _ = owner
+                    .take()
+                    .expect("upload owns ledger completion")
+                    .transport_lost(state.accepted);
+                request.release();
+                return false;
+            }
+            DaemonAbortSelection::Selected => {
+                drop(stage.take());
+                drop(reservation.take());
+                drop(cancellation_guard.take());
+                return finish_daemon_abort(
+                    &outbound,
+                    &ingress,
+                    &mut events,
+                    &binding,
+                    identity,
+                    &state,
+                    &bounds,
+                    id,
+                    &request,
+                    failure,
+                    limits.transfer_stall(),
+                    &closer,
+                    owner.take().expect("upload owns ledger completion"),
+                )
+                .await;
+            }
+        }
+    }
+
+    loop {
+        let input = next_active(&mut events, &ingress, absolute_deadline, stall_deadline).await;
+        let mut terminal_yield = if matches!(&input, ActiveInput::Deadline | ActiveInput::Stall) {
+            TerminalYield::Any
+        } else {
+            TerminalYield::None
+        };
+        let failure = match input {
+            ActiveInput::Deadline => Some(UploadFailure::Deadline { budget_ms }),
+            ActiveInput::Stall => Some(UploadFailure::Stall),
+            ActiveInput::TransportLost => {
+                drop(stage.take());
+                drop(reservation.take());
+                drop(cancellation_guard.take());
+                binding.retire();
+                let _ = owner
+                    .take()
+                    .expect("upload owns ledger completion")
+                    .transport_lost(state.accepted);
+                request.release();
+                return false;
+            }
+            ActiveInput::Event(event) => {
+                // Timestamped input never gets to jump an already-expired
+                // absolute deadline or stall boundary merely because the
+                // actor was descheduled. An explicitly sequenced
+                // transfer.cancel and a semantically valid producer ABORT win
+                // exact equality. Invalid ABORT, END, and ordinary wire input
+                // lose ties to deadline, then stall.
+                if let Some(failure) = active_event_timer_failure(
+                    &event,
+                    &state,
+                    &bounds,
+                    absolute_deadline,
+                    stall_deadline,
+                    budget_ms,
+                ) {
+                    Some(failure)
+                } else {
+                    let credit_at_receipt = event
+                        ._pending_data
+                        .as_ref()
+                        .map(|pending| pending.credit_at_receipt);
+                    match event.body {
+                        UploadEventBody::Malformed => Some(UploadFailure::Protocol),
+                        UploadEventBody::RejectedData(DataFailure::Protocol) => {
+                            Some(UploadFailure::Protocol)
+                        }
+                        UploadEventBody::RejectedData(DataFailure::TooLarge { observed }) => {
+                            let _ = observed;
+                            Some(UploadFailure::TooLarge)
+                        }
+                        UploadEventBody::RejectedData(DataFailure::Declared { observed }) => {
+                            Some(UploadFailure::Declared { observed })
+                        }
+                        UploadEventBody::Cancel { response } => {
+                            let selected = cancellation_guard.as_ref().is_some_and(|guard| {
+                                guard.select_cancelled(
+                                    owner
+                                        .as_mut()
+                                        .expect("active upload owns ledger completion"),
+                                    state.accepted,
+                                    state.declared,
+                                )
+                            });
+                            if selected {
+                                pending_cancel_response = Some(response);
+                                Some(UploadFailure::Cancelled)
+                            } else {
+                                let _ = response.send(CancelAttempt::Unknown);
+                                None
+                            }
+                        }
+                        UploadEventBody::Record { kind, bytes, .. } => {
+                            let view = match decode_stream_record_view(&bytes, &bounds) {
+                                Ok(view) => view,
+                                Err(_) => {
+                                    drop(bytes);
+                                    if kind == StreamRecordKind::Data {
+                                        // Permit is retained by the event until
+                                        // this whole match arm leaves.
+                                    }
+                                    return finish_daemon_abort(
+                                        &outbound,
+                                        &ingress,
+                                        &mut events,
+                                        &binding,
+                                        identity,
+                                        &state,
+                                        &bounds,
+                                        id,
+                                        &request,
+                                        UploadFailure::Protocol,
+                                        limits.transfer_stall(),
+                                        &closer,
+                                        owner.take().expect("upload owns ledger completion"),
+                                    )
+                                    .await;
+                                }
+                            };
+                            match view.body {
+                                StreamRecordBodyView::Data { offset, payload } => {
+                                    let Some(credit_at_receipt) = credit_at_receipt else {
+                                        return finish_daemon_abort(
+                                            &outbound,
+                                            &ingress,
+                                            &mut events,
+                                            &binding,
+                                            identity,
+                                            &state,
+                                            &bounds,
+                                            id,
+                                            &request,
+                                            UploadFailure::Protocol,
+                                            limits.transfer_stall(),
+                                            &closer,
+                                            owner.take().expect("upload owns ledger completion"),
+                                        )
+                                        .await;
+                                    };
+                                    match state.validate_data_at_credit(
+                                        offset,
+                                        payload.len(),
+                                        credit_at_receipt,
+                                    ) {
+                                        Err(DataFailure::Protocol) => {
+                                            terminal_yield = TerminalYield::Preemptive;
+                                            Some(UploadFailure::Protocol)
+                                        }
+                                        Err(DataFailure::TooLarge { observed }) => {
+                                            let _ = observed;
+                                            terminal_yield = TerminalYield::Preemptive;
+                                            Some(UploadFailure::TooLarge)
+                                        }
+                                        Err(DataFailure::Declared { observed }) => {
+                                            terminal_yield = TerminalYield::Preemptive;
+                                            Some(UploadFailure::Declared { observed })
+                                        }
+                                        Ok(candidate) => {
+                                            let accepted = await_active_operation(
+                                                stage
+                                                    .as_mut()
+                                                    .expect("active upload owns staging")
+                                                    .accept(offset, payload),
+                                                &ingress,
+                                                absolute_deadline,
+                                                stall_deadline,
+                                            )
+                                            .await;
+                                            match accepted {
+                                                Err(ActiveInterrupt::TerminalPending) => None,
+                                                Err(ActiveInterrupt::Deadline) => {
+                                                    terminal_yield = TerminalYield::Any;
+                                                    Some(UploadFailure::Deadline { budget_ms })
+                                                }
+                                                Err(ActiveInterrupt::Stall) => {
+                                                    terminal_yield = TerminalYield::Any;
+                                                    Some(UploadFailure::Stall)
+                                                }
+                                                Err(ActiveInterrupt::TransportLost) => {
+                                                    drop(stage.take());
+                                                    drop(reservation.take());
+                                                    drop(cancellation_guard.take());
+                                                    binding.retire();
+                                                    let _ = owner
+                                                        .take()
+                                                        .expect("upload owns ledger completion")
+                                                        .transport_lost(state.accepted);
+                                                    request.release();
+                                                    return false;
+                                                }
+                                                Ok(accepted) => match accepted {
+                                                    Ok(accepted) if accepted == candidate => {
+                                                        match ingress.commit_accepted(
+                                                            candidate,
+                                                            absolute_deadline,
+                                                            stall_deadline,
+                                                        ) {
+                                                            Ok(()) => {
+                                                                state.data_accepted(candidate);
+                                                                progress.record_accepted(candidate);
+                                                                stall_deadline = limits
+                                                                    .stall_deadline(Instant::now())
+                                                                    .expect(
+                                                                        "served stall duration was validated",
+                                                                    );
+                                                                None
+                                                            }
+                                                            Err(
+                                                                ActiveInterrupt::TerminalPending,
+                                                            ) => None,
+                                                            Err(ActiveInterrupt::Deadline) => {
+                                                                terminal_yield = TerminalYield::Any;
+                                                                Some(UploadFailure::Deadline {
+                                                                    budget_ms,
+                                                                })
+                                                            }
+                                                            Err(ActiveInterrupt::Stall) => {
+                                                                terminal_yield = TerminalYield::Any;
+                                                                Some(UploadFailure::Stall)
+                                                            }
+                                                            Err(ActiveInterrupt::TransportLost) => {
+                                                                drop(stage.take());
+                                                                drop(reservation.take());
+                                                                drop(cancellation_guard.take());
+                                                                binding.retire();
+                                                                let _ = owner
+                                                                    .take()
+                                                                    .expect(
+                                                                        "upload owns ledger completion",
+                                                                    )
+                                                                    .transport_lost(state.accepted);
+                                                                request.release();
+                                                                return false;
+                                                            }
+                                                        }
+                                                    }
+                                                    Ok(_) | Err(_) => {
+                                                        terminal_yield = TerminalYield::Preemptive;
+                                                        Some(UploadFailure::Sink)
+                                                    }
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                                StreamRecordBodyView::End { total } => {
+                                    let end_failure = match state.validate_end(total) {
+                                        Ok(()) => None,
+                                        Err(DataFailure::Protocol) => Some(UploadFailure::Protocol),
+                                        Err(DataFailure::Declared { observed }) => {
+                                            Some(UploadFailure::Declared { observed })
+                                        }
+                                        Err(DataFailure::TooLarge { .. }) => unreachable!(
+                                            "END validation does not apply aggregate DATA policy"
+                                        ),
+                                    };
+                                    if let Some(failure) = end_failure {
+                                        Some(failure)
+                                    } else if !ingress.commit_finalizing(state.accepted) {
+                                        Some(UploadFailure::Protocol)
+                                    } else {
+                                        // A follower classified after this END
+                                        // but before the actor consumed it may
+                                        // already be waiting in the bounded
+                                        // ingress lane. END still owns the
+                                        // finalization result, while that
+                                        // duplicate/late record deterministically
+                                        // closes the connection with 4007.
+                                        if ingress.post_end_fatal.load(Ordering::Acquire) {
+                                            closer.malformed();
+                                        }
+                                        drop(reservation.take());
+                                        drop(cancellation_guard.take());
+                                        let stage = match stage.take() {
+                                            Some(stage) => stage,
+                                            None => return false,
+                                        };
+                                        let finalization = match stage.finish(total).await {
+                                            Ok(stage) => stage,
+                                            Err(error) => {
+                                                let result = owner
+                                                    .take()
+                                                    .expect("upload owns ledger completion")
+                                                    .complete(Err(final_sink_error(error, &state)));
+                                                let sent = send_reply_and_retire(
+                                                    &outbound,
+                                                    id,
+                                                    result.as_ref(),
+                                                    &request,
+                                                    &binding,
+                                                )
+                                                .await;
+                                                if !sent {
+                                                    binding.retire();
+                                                    request.release();
+                                                }
+                                                return sent;
+                                            }
+                                        };
+                                        let outbound = outbound.clone();
+                                        let request = request.clone();
+                                        let owner =
+                                            owner.take().expect("upload owns ledger completion");
+                                        tokio::spawn(async move {
+                                            finalize_detached(
+                                                finalization,
+                                                owner,
+                                                outbound,
+                                                id,
+                                                request,
+                                                binding,
+                                            )
+                                            .await;
+                                        });
+                                        return true;
+                                    }
+                                }
+                                StreamRecordBodyView::Abort {
+                                    accepted_through,
+                                    reason,
+                                } => {
+                                    if !state.valid_producer_abort(accepted_through) {
+                                        Some(UploadFailure::Protocol)
+                                    } else {
+                                        if !ingress.try_select_client_abort() {
+                                            return false;
+                                        }
+                                        drop(stage.take());
+                                        drop(reservation.take());
+                                        drop(cancellation_guard.take());
+                                        let reason = match reason {
+                                            BinaryAbortReason::Cancelled => {
+                                                StreamAbortReason::Cancelled
+                                            }
+                                            BinaryAbortReason::SourceFailed => {
+                                                StreamAbortReason::SourceFailed
+                                            }
+                                            BinaryAbortReason::ProtocolError => {
+                                                StreamAbortReason::ProtocolError
+                                            }
+                                            BinaryAbortReason::SinkFailed
+                                            | BinaryAbortReason::OperationError => {
+                                                return finish_daemon_abort(
+                                                    &outbound,
+                                                    &ingress,
+                                                    &mut events,
+                                                    &binding,
+                                                    identity,
+                                                    &state,
+                                                    &bounds,
+                                                    id,
+                                                    &request,
+                                                    UploadFailure::Protocol,
+                                                    limits.transfer_stall(),
+                                                    &closer,
+                                                    owner
+                                                        .take()
+                                                        .expect("upload owns ledger completion"),
+                                                )
+                                                .await;
+                                            }
+                                        };
+                                        return finish_client_abort(
+                                            &outbound,
+                                            &ingress,
+                                            &mut events,
+                                            &binding,
+                                            identity,
+                                            &state,
+                                            &bounds,
+                                            id,
+                                            &request,
+                                            reason,
+                                            limits.transfer_stall(),
+                                            &closer,
+                                            owner.take().expect("upload owns ledger completion"),
+                                        )
+                                        .await;
+                                    }
+                                }
+                                StreamRecordBodyView::Open { .. }
+                                | StreamRecordBodyView::Credit { .. }
+                                | StreamRecordBodyView::Ack { .. } => Some(UploadFailure::Protocol),
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        if let Some(failure) = failure {
+            match ingress.select_daemon_abort(terminal_yield) {
+                DaemonAbortSelection::TerminalPending => continue,
+                DaemonAbortSelection::Lost => {
+                    drop(stage.take());
+                    drop(reservation.take());
+                    drop(cancellation_guard.take());
+                    let _ = owner
+                        .take()
+                        .expect("upload owns ledger completion")
+                        .transport_lost(state.accepted);
+                    request.release();
+                    return false;
+                }
+                DaemonAbortSelection::Selected => {}
+            }
+            drop(stage.take());
+            drop(reservation.take());
+            // Selection already moved cancellation provenance into the
+            // canonical ledger; every terminal drops only this exact live
+            // registry guard.
+            drop(cancellation_guard.take());
+            if let Some(response) = pending_cancel_response.take() {
+                let _ = response.send(CancelAttempt::Cancelled {
+                    accepted: state.accepted,
+                });
+            }
+            return finish_daemon_abort(
+                &outbound,
+                &ingress,
+                &mut events,
+                &binding,
+                identity,
+                &state,
+                &bounds,
+                id,
+                &request,
+                failure,
+                limits.transfer_stall(),
+                &closer,
+                owner.take().expect("upload owns ledger completion"),
+            )
+            .await;
+        }
+
+        // DATA success is handled separately because the borrowed payload
+        // cannot outlive its owned message. This fallback indicates a
+        // cancel request that lost without selecting a terminal.
+        if state.should_credit() && state.credited_accepted != state.accepted {
+            let credit = issue_credit(
+                &outbound,
+                &ingress,
+                identity,
+                &mut state,
+                window,
+                &bounds,
+                absolute_deadline,
+                stall_deadline,
+                budget_ms,
+            )
+            .await;
+            if matches!(credit, Ok(CreditOutcome::TransportLost)) {
+                drop(stage.take());
+                drop(reservation.take());
+                drop(cancellation_guard.take());
+                binding.retire();
+                let _ = owner
+                    .take()
+                    .expect("upload owns ledger completion")
+                    .transport_lost(state.accepted);
+                request.release();
+                return false;
+            }
+            if let Err(failure) = credit {
+                match ingress.select_daemon_abort(TerminalYield::Any) {
+                    DaemonAbortSelection::TerminalPending => continue,
+                    DaemonAbortSelection::Lost => {
+                        drop(stage.take());
+                        drop(reservation.take());
+                        drop(cancellation_guard.take());
+                        let _ = owner
+                            .take()
+                            .expect("upload owns ledger completion")
+                            .transport_lost(state.accepted);
+                        request.release();
+                        return false;
+                    }
+                    DaemonAbortSelection::Selected => {}
+                }
+                drop(stage.take());
+                drop(reservation.take());
+                drop(cancellation_guard.take());
+                return finish_daemon_abort(
+                    &outbound,
+                    &ingress,
+                    &mut events,
+                    &binding,
+                    identity,
+                    &state,
+                    &bounds,
+                    id,
+                    &request,
+                    failure,
+                    limits.transfer_stall(),
+                    &closer,
+                    owner.take().expect("upload owns ledger completion"),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use jeliya_codec::STREAM_HEADER_BYTES;
+    use tempfile::TempDir;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    const REQUEST_ID: u64 = 41;
+    const STREAM_ID: u128 = 0x0102_0304_0506_0708_1112_1314_1516_1718;
+
+    /// Spec-authored `JBS2` record constructor. These tests deliberately do
+    /// not obtain expected wire bytes from the implementation encoder.
+    fn wire(
+        kind: u8,
+        request_id: u64,
+        stream_id: u128,
+        offset: u64,
+        value: u64,
+        payload: &[u8],
+    ) -> Bytes {
+        let mut bytes = Vec::with_capacity(STREAM_HEADER_BYTES + payload.len());
+        bytes.extend_from_slice(b"JBS2");
+        bytes.push(kind);
+        bytes.extend_from_slice(&[0, 0, 0]);
+        bytes.extend_from_slice(&request_id.to_be_bytes());
+        bytes.extend_from_slice(&stream_id.to_be_bytes());
+        bytes.extend_from_slice(&offset.to_be_bytes());
+        bytes.extend_from_slice(&value.to_be_bytes());
+        bytes.extend_from_slice(payload);
+        Bytes::from(bytes)
+    }
+
+    fn bounds(max_frame_bytes: usize) -> CodecBounds {
+        CodecBounds {
+            max_frame_bytes,
+            ..CodecBounds::default()
+        }
+    }
+
+    fn budget(bytes: usize) -> UploadIngressBudget {
+        UploadIngressBudget {
+            bytes: Arc::new(Semaphore::new(bytes)),
+            data_messages: UPLOAD_DATA_EVENT_SLOTS,
+        }
+    }
+
+    fn active_ingress(bytes: usize) -> (Arc<UploadIngress>, UploadEvents) {
+        let (ingress, events) = UploadIngress::new(budget(bytes), u64::MAX, u64::MAX);
+        let deadline = Instant::now()
+            .checked_add(Duration::from_secs(1))
+            .expect("test deadline is finite");
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        ingress
+            .served_send_through
+            .store(u64::MAX, Ordering::Release);
+        (ingress, events)
+    }
+
+    async fn next_event(events: &mut UploadEvents, ingress: &UploadIngress) -> UploadEvent {
+        timeout(Duration::from_secs(1), events.recv(ingress))
+            .await
+            .expect("upload event timed out")
+            .expect("upload ingress remained open")
+    }
+
+    fn cancel_request(value: &str) -> TransferCancel {
+        TransferCancel {
+            transfer_op_id: OpId::new(value),
+        }
+    }
+
+    async fn cancellation_ledger(
+        op_id: &OpId,
+        principal: &str,
+        declared_bytes: u64,
+    ) -> (
+        TempDir,
+        Arc<Engine>,
+        FileShareLedgerOwner,
+        UploadCancellationRegistry,
+    ) {
+        let dir = TempDir::new().expect("cancellation ledger tempdir");
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::mpsc::channel(1);
+        let engine = Engine::new(
+            dir.path().to_path_buf(),
+            true,
+            jeliya_core::engine::EngineConfig {
+                port: 0,
+                version: "test".into(),
+                shutdown_tx,
+            },
+        )
+        .expect("cancellation ledger engine");
+        engine
+            .execute(jeliya_core::typed::TypedCall::SubjectEnsure(
+                jeliya_api::SubjectEnsure {},
+            ))
+            .await
+            .reply
+            .expect("subject.ensure");
+        let request = FileShare {
+            room_id: jeliya_api::RoomId::new("room-for-cancellation-ledger"),
+            name: "cancelled.bin".into(),
+            declared_bytes,
+            declared_content_type: "application/octet-stream".into(),
+        };
+        let FileShareLedgerGate::Owner(owner) = engine
+            .gate_file_share(&request, Some(op_id.clone()), principal)
+            .await
+        else {
+            panic!("fresh cancellation ledger key must be owned");
+        };
+        let registry = UploadCancellationRegistry::with_engine(&engine);
+        (dir, engine, owner, registry)
+    }
+
+    fn assert_transfer_unknown(result: Result<TransferCancelOut, ApiError>, op_id: &OpId) {
+        assert!(matches!(
+            result,
+            Err(ApiError::TransferUnknown { transfer_op_id })
+                if transfer_op_id == *op_id
+        ));
+    }
+
+    #[test]
+    fn cumulative_credit_holds_the_sentinel_until_declared_bytes_are_accepted() {
+        let mut zero = ConsumerState::new(0, 8);
+        assert_eq!(zero.next_credit(4), Some((0, 1)));
+        zero.record_credit(0, 1).unwrap();
+        assert_eq!(zero.credit_history.len(), 1);
+
+        let mut one = ConsumerState::new(1, 8);
+        assert_eq!(one.next_credit(64), Some((0, 1)));
+        one.record_credit(0, 1).unwrap();
+        let candidate = one.validate_data(0, 1).unwrap();
+        one.data_accepted(candidate);
+        assert_eq!(one.next_credit(64), Some((1, 2)));
+
+        let mut ordinary = ConsumerState::new(5, 8);
+        assert_eq!(ordinary.next_credit(3), Some((0, 3)));
+        ordinary.record_credit(0, 3).unwrap();
+        ordinary.record_credit(0, 3).unwrap();
+        assert_eq!(ordinary.credit_history.len(), 1, "repeat CREDIT is bounded");
+        let candidate = ordinary.validate_data(0, 3).unwrap();
+        ordinary.data_accepted(candidate);
+        assert!(ordinary.should_credit());
+        assert_eq!(ordinary.next_credit(3), Some((3, 5)));
+        ordinary.record_credit(3, 5).unwrap();
+        let candidate = ordinary.validate_data(3, 2).unwrap();
+        ordinary.data_accepted(candidate);
+        assert_eq!(ordinary.next_credit(3), Some((5, 6)));
+
+        let mut maximum = ConsumerState::new(8, 8);
+        assert_eq!(maximum.next_credit(8), Some((0, 8)));
+        maximum.record_credit(0, 8).unwrap();
+        let candidate = maximum.validate_data(0, 8).unwrap();
+        maximum.data_accepted(candidate);
+        assert_eq!(maximum.next_credit(8), Some((8, 9)));
+    }
+
+    #[test]
+    fn data_refusal_order_is_policy_then_declaration_then_continuity_and_credit() {
+        let mut aggregate_first = ConsumerState::new(3, 2);
+        assert_eq!(
+            aggregate_first.validate_data(0, 4),
+            Err(DataFailure::TooLarge { observed: 4 }),
+            "aggregate policy precedes declaration and absent credit"
+        );
+        assert_eq!(aggregate_first.accepted, 0);
+
+        let mut declaration_second = ConsumerState::new(3, 10);
+        assert_eq!(
+            declaration_second.validate_data(4, 1),
+            Err(DataFailure::Declared { observed: 5 }),
+            "declaration precedes both wrong continuity and absent credit"
+        );
+        assert_eq!(declaration_second.accepted, 0);
+
+        let mut exact = ConsumerState::new(4, 4);
+        exact.record_credit(0, 4).unwrap();
+        let candidate = exact.validate_data(0, 4).unwrap();
+        exact.data_accepted(candidate);
+        exact.record_credit(4, 5).unwrap();
+        assert_eq!(
+            exact.validate_data(4, 1),
+            Err(DataFailure::TooLarge { observed: 5 })
+        );
+        assert_eq!(exact.accepted, 4, "one-past rejection is atomic");
+
+        let mut no_credit = ConsumerState::new(10, 10);
+        assert_eq!(no_credit.validate_data(1, 1), Err(DataFailure::Protocol));
+        no_credit.record_credit(0, 2).unwrap();
+        assert_eq!(no_credit.validate_data(0, 3), Err(DataFailure::Protocol));
+        assert_eq!(no_credit.accepted, 0);
+
+        let mut overflow = ConsumerState::new(u64::MAX, u64::MAX);
+        assert_eq!(
+            overflow.validate_data(u64::MAX, 1),
+            Err(DataFailure::Protocol)
+        );
+        assert_eq!(overflow.probe_limit(), None);
+    }
+
+    #[test]
+    fn stage_stream_too_large_reports_the_original_declaration() {
+        let state = ConsumerState::new(2, 1);
+        assert_eq!(
+            failure_error(&UploadFailure::TooLarge, &state),
+            ApiError::FileTooLarge {
+                declared_bytes: 2,
+                limit_bytes: 1,
+                enforced_at: EnforcedAt::StageStream,
+            }
+        );
+    }
+
+    #[test]
+    fn finish_time_count_disagreement_is_an_exact_declaration_error() {
+        let state = ConsumerState::new(7, 8);
+        assert_eq!(
+            final_sink_error(
+                FileShareSinkError::CountDisagreement {
+                    expected: 7,
+                    observed: 6,
+                },
+                &state,
+            ),
+            ApiError::DeclaredSizeMismatch {
+                declared_bytes: 7,
+                observed_bytes: 6,
+            }
+        );
+    }
+
+    #[test]
+    fn end_distinguishes_exact_below_and_noncontiguous_totals() {
+        let mut exact = ConsumerState::new(4, 8);
+        exact.data_accepted(4);
+        assert_eq!(
+            exact.validate_end(4),
+            Err(DataFailure::Protocol),
+            "END cannot precede writer-committed final accepted/sentinel CREDIT"
+        );
+        exact.record_credit(4, 5).unwrap();
+        assert_eq!(exact.validate_end(4), Ok(()));
+
+        let mut zero = ConsumerState::new(0, 8);
+        assert_eq!(zero.validate_end(0), Err(DataFailure::Protocol));
+        zero.record_credit(0, 1).unwrap();
+        assert_eq!(zero.validate_end(0), Ok(()));
+
+        let mut below = ConsumerState::new(4, 8);
+        below.data_accepted(2);
+        assert_eq!(
+            below.validate_end(2),
+            Err(DataFailure::Declared { observed: 2 })
+        );
+        assert_eq!(
+            below.validate_end(4),
+            Err(DataFailure::Protocol),
+            "END at the declaration is noncontiguous while only two bytes are accepted"
+        );
+        assert_eq!(below.validate_end(3), Err(DataFailure::Protocol));
+    }
+
+    #[tokio::test]
+    async fn exact_pair_routing_is_size_first_directional_and_request_local() {
+        let limits = bounds(64);
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let other_identity = StreamIdentity::new(REQUEST_ID + 1, STREAM_ID + 1).unwrap();
+        let shared_budget = budget(512);
+        let (one, mut one_events) = UploadIngress::new(shared_budget.clone(), u64::MAX, u64::MAX);
+        let (two, mut two_events) = UploadIngress::new(shared_budget, u64::MAX, u64::MAX);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            one.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        assert_eq!(
+            two.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        one.served_send_through.store(u64::MAX, Ordering::Release);
+        two.served_send_through.store(u64::MAX, Ordering::Release);
+        let _one_binding = registry.bind_upload(identity, one.clone()).unwrap();
+        let _two_binding = registry.bind_upload(other_identity, two.clone()).unwrap();
+
+        let valid = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[0xaa]);
+        assert_eq!(
+            registry.route_binary_message(valid, &limits).await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut one_events, &one).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Data,
+                ..
+            }
+        ));
+
+        assert_eq!(
+            registry
+                .route_binary_message(wire(0x02, REQUEST_ID + 1, STREAM_ID, 0, 0, &[1]), &limits,)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+        assert_eq!(
+            registry
+                .route_binary_message(wire(0x02, REQUEST_ID, STREAM_ID + 1, 0, 0, &[1]), &limits,)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+
+        let mut bound_bad_reserved = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]).to_vec();
+        bound_bad_reserved[5] = 1;
+        assert_eq!(
+            registry
+                .route_binary_message(Bytes::from(bound_bad_reserved), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut one_events, &one).await.body,
+            UploadEventBody::Malformed
+        ));
+
+        assert_eq!(
+            registry
+                .route_binary_message(
+                    wire(0x02, REQUEST_ID + 1, STREAM_ID + 1, 0, 0, &[2]),
+                    &limits,
+                )
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut two_events, &two).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Data,
+                ..
+            }
+        ));
+
+        assert_eq!(
+            registry
+                .route_binary_message(
+                    wire(0x03, REQUEST_ID + 1, STREAM_ID + 1, 0, 1, &[]),
+                    &limits,
+                )
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut two_events, &two).await.body,
+            UploadEventBody::Malformed
+        ));
+
+        let mut unbound_bad_reserved = wire(0x02, 99, 99, 0, 0, &[1]).to_vec();
+        unbound_bad_reserved[5] = 1;
+        assert_eq!(
+            registry
+                .route_binary_message(Bytes::from(unbound_bad_reserved), &limits)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+        assert_eq!(
+            registry
+                .route_binary_message(Bytes::from(vec![0; 65]), &limits)
+                .await,
+            BinaryRoute::CloseTooLarge,
+            "complete-message size precedes header and content"
+        );
+        assert_eq!(
+            registry
+                .route_binary_message(Bytes::from_static(b"JBS2"), &limits)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+        let mut bad_magic = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]).to_vec();
+        bad_magic[0] = b'X';
+        assert_eq!(
+            registry
+                .route_binary_message(Bytes::from(bad_magic), &limits)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_producer_abort_reasons_are_endpoint_scoped() {
+        let limits = bounds(64);
+        for reason in [
+            BinaryAbortReason::Cancelled,
+            BinaryAbortReason::SourceFailed,
+            BinaryAbortReason::ProtocolError,
+        ] {
+            let (ingress, mut events) = active_ingress(128);
+            assert_eq!(
+                ingress
+                    .route_bound(
+                        wire(0x05, REQUEST_ID, STREAM_ID, 0, reason as u64, &[]),
+                        &limits,
+                    )
+                    .await,
+                BinaryRoute::Delivered
+            );
+            let UploadEventBody::Record { bytes, .. } =
+                next_event(&mut events, &ingress).await.body
+            else {
+                panic!("valid producer ABORT was not routed as a record");
+            };
+            assert!(matches!(
+                decode_stream_record_view(&bytes, &limits).unwrap().body,
+                StreamRecordBodyView::Abort { reason: observed, .. } if observed == reason
+            ));
+        }
+
+        for daemon_only in [
+            BinaryAbortReason::SinkFailed,
+            BinaryAbortReason::OperationError,
+        ] {
+            let (ingress, mut events) = active_ingress(128);
+            assert_eq!(
+                ingress
+                    .route_bound(
+                        wire(0x05, REQUEST_ID, STREAM_ID, 0, daemon_only as u64, &[]),
+                        &limits,
+                    )
+                    .await,
+                BinaryRoute::Delivered
+            );
+            assert!(matches!(
+                next_event(&mut events, &ingress).await.body,
+                UploadEventBody::Malformed
+            ));
+        }
+
+        let (ingress, mut events) = active_ingress(128);
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x06, REQUEST_ID, STREAM_ID, 0, 5, &[]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Malformed
+        ));
+    }
+
+    #[tokio::test]
+    async fn first_valid_end_wins_finalizing_and_late_records_cannot_rewrite_it() {
+        let limits = bounds(64);
+        let (ingress, mut events) = active_ingress(128);
+        let end = wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]);
+        assert_eq!(
+            ingress.route_bound(end.clone(), &limits).await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            ingress.route_bound(end, &limits).await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(ingress.commit_finalizing(0));
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Malformed
+        ));
+        assert_eq!(ingress.phase(), UploadPhase::Finalizing);
+        assert!(!ingress.try_select_daemon_abort());
+
+        let (ingress, mut events) = active_ingress(128);
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        drop(next_event(&mut events, &ingress).await);
+        assert!(ingress.commit_finalizing(0));
+        assert!(!ingress.try_select_daemon_abort());
+        assert!(!ingress.try_select_client_abort());
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &limits,)
+                .await,
+            BinaryRoute::Delivered,
+            "valid late producer ABORT cannot change accepted END"
+        );
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 1, 1, &[]), &limits,)
+                .await,
+            BinaryRoute::CloseMalformed,
+            "late FINALIZING ABORT must echo the final accepted count"
+        );
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]), &limits)
+                .await,
+            BinaryRoute::CloseMalformed
+        );
+        assert_eq!(ingress.request_cancel().await, CancelAttempt::Unknown);
+
+        let (invalid_end, mut invalid_events) = active_ingress(128);
+        assert_eq!(
+            invalid_end
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            invalid_end
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut invalid_events, &invalid_end).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        let invalid_state = ConsumerState::new(1, 8);
+        assert_eq!(
+            invalid_state.validate_end(0),
+            Err(DataFailure::Declared { observed: 0 })
+        );
+        assert!(invalid_end.try_select_daemon_abort());
+        assert!(matches!(
+            next_event(&mut invalid_events, &invalid_end).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn declared_sentinel_data_is_refused_before_a_queued_exact_end() {
+        let limits = bounds(64);
+        let (ingress, mut events) = UploadIngress::new(budget(128), 3, 8);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        ingress.served_send_through.store(4, Ordering::Release);
+        ingress.received_through.store(3, Ordering::Release);
+        ingress.accepted.store(3, Ordering::Release);
+
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 3, 0, &[0xaa]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 3, 0, &[]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::RejectedData(DataFailure::Declared { observed: 4 })
+        ));
+        assert_eq!(
+            ingress.select_daemon_abort(TerminalYield::None),
+            DaemonAbortSelection::Selected,
+            "a later END cannot erase the earlier DATA refusal"
+        );
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(!ingress.commit_finalizing(3));
+    }
+
+    #[tokio::test]
+    async fn maximum_sentinel_data_hits_stream_policy_before_a_queued_exact_end() {
+        let limits = bounds(64);
+        let (ingress, mut events) = UploadIngress::new(budget(128), 3, 3);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        ingress.served_send_through.store(4, Ordering::Release);
+        ingress.received_through.store(3, Ordering::Release);
+        ingress.accepted.store(3, Ordering::Release);
+
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 3, 0, &[0xbb]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 3, 0, &[]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::RejectedData(DataFailure::TooLarge { observed: 4 })
+        ));
+        assert_eq!(
+            ingress.select_daemon_abort(TerminalYield::None),
+            DaemonAbortSelection::Selected,
+            "the max+1 stage-stream refusal must win over a later exact END"
+        );
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(!ingress.commit_finalizing(3));
+    }
+
+    #[tokio::test]
+    async fn a_complete_end_queued_before_disconnect_can_still_commit_finalizing() {
+        let limits = bounds(64);
+        let registry = StreamRegistry::new();
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+        let (ingress, mut events) = UploadIngress::new(budget(128), u64::MAX, u64::MAX);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        let _binding = registry.bind_upload(identity, ingress.clone()).unwrap();
+        assert_eq!(
+            registry
+                .route_binary_message(wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+
+        registry.invalidate_connection();
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(ingress.commit_finalizing(0));
+        assert_eq!(ingress.phase(), UploadPhase::Finalizing);
+    }
+
+    #[tokio::test]
+    async fn admitted_end_survives_full_terminal_lane_disconnect_and_preserves_order() {
+        let (ingress, mut events) = active_ingress(128);
+        let mut cancel_receivers = Vec::new();
+        for _ in 0..UPLOAD_TERMINAL_EVENT_SLOTS {
+            let (response, result) = oneshot::channel();
+            let admission = {
+                let _sequencing = ingress
+                    .sequencing
+                    .lock()
+                    .expect("upload sequencing poisoned");
+                ingress.begin_terminal_locked(true, true)
+            };
+            assert_eq!(
+                ingress
+                    .enqueue(
+                        UploadEvent {
+                            received_at: Instant::now(),
+                            body: UploadEventBody::Cancel { response },
+                            _pending_data: None,
+                        },
+                        true,
+                        Some(admission),
+                    )
+                    .await,
+                BinaryRoute::Delivered
+            );
+            cancel_receivers.push(result);
+        }
+
+        let end_admission = {
+            let _sequencing = ingress
+                .sequencing
+                .lock()
+                .expect("upload sequencing poisoned");
+            ingress
+                .producer_terminal
+                .store(PRODUCER_TERMINAL_END, Ordering::Release);
+            ingress.begin_terminal_locked(false, false)
+        };
+        let end_ingress = ingress.clone();
+        let end = tokio::spawn(async move {
+            end_ingress
+                .enqueue(
+                    UploadEvent {
+                        received_at: Instant::now(),
+                        body: UploadEventBody::Record {
+                            kind: StreamRecordKind::End,
+                            bytes: wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+                            _bytes: None,
+                        },
+                        _pending_data: None,
+                    },
+                    true,
+                    Some(end_admission),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !end.is_finished(),
+            "full terminal lane applies backpressure"
+        );
+
+        ingress.invalidate_connection_locked();
+        assert_eq!(ingress.phase(), UploadPhase::Active);
+        let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+        else {
+            panic!("terminal FIFO must preserve the first cancellation");
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(1), end).await.unwrap().unwrap(),
+            BinaryRoute::Delivered
+        );
+        for _ in 1..UPLOAD_TERMINAL_EVENT_SLOTS {
+            let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+            else {
+                panic!("queued cancellation order changed");
+            };
+            response.send(CancelAttempt::Unknown).unwrap();
+        }
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(ingress.commit_finalizing(0));
+        for result in cancel_receivers {
+            assert_eq!(result.await.unwrap(), CancelAttempt::Unknown);
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_admission_order_is_preserved_across_end_cancel_task_reordering() {
+        let (ingress, mut events) = active_ingress(128);
+        let (end_admission, cancel_admission) = {
+            let _sequencing = ingress
+                .sequencing
+                .lock()
+                .expect("upload sequencing poisoned");
+            (
+                ingress.begin_terminal_locked(false, false),
+                ingress.begin_terminal_locked(true, true),
+            )
+        };
+        let (cancel_response, cancel_result) = oneshot::channel();
+        let cancel_ingress = ingress.clone();
+        let cancel = tokio::spawn(async move {
+            cancel_ingress
+                .enqueue(
+                    UploadEvent {
+                        received_at: Instant::now(),
+                        body: UploadEventBody::Cancel {
+                            response: cancel_response,
+                        },
+                        _pending_data: None,
+                    },
+                    true,
+                    Some(cancel_admission),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(!cancel.is_finished(), "later cancel waits for admitted END");
+
+        let end_ingress = ingress.clone();
+        let end = tokio::spawn(async move {
+            end_ingress
+                .enqueue(
+                    UploadEvent {
+                        received_at: Instant::now(),
+                        body: UploadEventBody::Record {
+                            kind: StreamRecordKind::End,
+                            bytes: wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]),
+                            _bytes: None,
+                        },
+                        _pending_data: None,
+                    },
+                    true,
+                    Some(end_admission),
+                )
+                .await
+        });
+        assert_eq!(end.await.unwrap(), BinaryRoute::Delivered);
+        assert_eq!(cancel.await.unwrap(), BinaryRoute::Delivered);
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+        else {
+            panic!("cancel must follow END admission order");
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+        assert_eq!(cancel_result.await.unwrap(), CancelAttempt::Unknown);
+    }
+
+    #[tokio::test]
+    async fn client_abort_overtakes_older_uncommitted_data_and_followers_become_protocol_faults() {
+        let limits = bounds(64);
+        let (ingress, mut events) = active_ingress(256);
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]), &limits)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert!(matches!(
+            await_active_operation(pending::<()>(), &ingress, deadline, deadline).await,
+            Err(ActiveInterrupt::TerminalPending)
+        ));
+        assert_eq!(ingress.accepted.load(Ordering::Acquire), 0);
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                ..
+            }
+        ));
+        events.drain_data(&ingress);
+        assert_eq!(ingress.queued_events.load(Ordering::Acquire), 0);
+
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &limits,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(ingress.try_select_client_abort());
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Malformed
+        ));
+        assert!(ingress.promote_client_abort_protocol());
+        assert_eq!(ingress.phase(), UploadPhase::DaemonAbortQueued);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_open_expires_without_committing_and_abort_ack_waits_are_bounded() {
+        let (outbound, _queues) = Outbound::new(8, 1, 4096, 4096, 4096);
+        let codec_bounds = bounds(64);
+        let identity = StreamIdentity::new(REQUEST_ID, STREAM_ID).unwrap();
+
+        let (opening, _events) = UploadIngress::new(budget(128), u64::MAX, u64::MAX);
+        let open_deadline = Instant::now() + Duration::from_millis(10);
+        let open_outbound = outbound.clone();
+        let open_ingress = opening.clone();
+        let open = tokio::spawn(async move {
+            send_open(
+                &open_outbound,
+                &open_ingress,
+                identity,
+                0,
+                &codec_bounds,
+                open_deadline,
+                || true,
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert_eq!(open.await.unwrap(), BoundedControlOutcome::Deadline);
+        assert_eq!(opening.phase(), UploadPhase::Opening);
+
+        let (aborting, _events) = active_ingress(128);
+        assert!(aborting.try_select_daemon_abort());
+        let abort_deadline = Instant::now() + Duration::from_millis(10);
+        let abort_outbound = outbound.clone();
+        let abort_ingress = aborting.clone();
+        let abort = tokio::spawn(async move {
+            send_abort(
+                &abort_outbound,
+                &abort_ingress,
+                identity,
+                0,
+                BinaryAbortReason::ProtocolError,
+                &codec_bounds,
+                abort_deadline,
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert_eq!(abort.await.unwrap(), BoundedControlOutcome::Deadline);
+        assert_eq!(aborting.phase(), UploadPhase::DaemonAbortQueued);
+
+        let ack_deadline = Instant::now() + Duration::from_millis(10);
+        let ack_outbound = outbound.clone();
+        let ack = tokio::spawn(async move {
+            send_ack_until(&ack_outbound, identity, 0, &codec_bounds, ack_deadline).await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert_eq!(ack.await.unwrap(), BoundedControlOutcome::Deadline);
+    }
+
+    #[tokio::test]
+    async fn inbound_queue_is_bounded_by_both_complete_record_bytes_and_count() {
+        let limits = bounds(64);
+        let record = wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]);
+        let record_bytes = record.len();
+
+        let shared = budget(record_bytes);
+        let (one, mut one_events) = UploadIngress::new(shared.clone(), u64::MAX, u64::MAX);
+        let (two, mut two_events) = UploadIngress::new(shared, u64::MAX, u64::MAX);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            one.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        assert_eq!(
+            two.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        one.served_send_through.store(u64::MAX, Ordering::Release);
+        two.served_send_through.store(u64::MAX, Ordering::Release);
+        assert_eq!(
+            one.route_bound(record.clone(), &limits).await,
+            BinaryRoute::Delivered
+        );
+        let blocked_ingress = two.clone();
+        let blocked_record = record.clone();
+        let byte_waiter =
+            tokio::spawn(async move { blocked_ingress.route_bound(blocked_record, &limits).await });
+        tokio::task::yield_now().await;
+        assert!(!byte_waiter.is_finished());
+        drop(next_event(&mut one_events, &one).await);
+        assert_eq!(
+            timeout(Duration::from_secs(1), byte_waiter)
+                .await
+                .unwrap()
+                .unwrap(),
+            BinaryRoute::Delivered
+        );
+        drop(next_event(&mut two_events, &two).await);
+
+        let (ingress, mut events) = active_ingress(record_bytes * (UPLOAD_DATA_EVENT_SLOTS + 1));
+        for offset in 0..UPLOAD_DATA_EVENT_SLOTS {
+            assert_eq!(
+                ingress
+                    .route_bound(
+                        wire(
+                            0x02,
+                            REQUEST_ID,
+                            STREAM_ID,
+                            u64::try_from(offset).unwrap(),
+                            0,
+                            &[1],
+                        ),
+                        &limits,
+                    )
+                    .await,
+                BinaryRoute::Delivered
+            );
+        }
+        let blocked_ingress = ingress.clone();
+        let count_waiter = tokio::spawn(async move {
+            blocked_ingress
+                .route_bound(
+                    wire(
+                        0x02,
+                        REQUEST_ID,
+                        STREAM_ID,
+                        u64::try_from(UPLOAD_DATA_EVENT_SLOTS).unwrap(),
+                        0,
+                        &[1],
+                    ),
+                    &limits,
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert!(!count_waiter.is_finished());
+        drop(next_event(&mut events, &ingress).await);
+        assert_eq!(
+            timeout(Duration::from_secs(1), count_waiter)
+                .await
+                .unwrap()
+                .unwrap(),
+            BinaryRoute::Delivered
+        );
+        for _ in 0..UPLOAD_DATA_EVENT_SLOTS {
+            drop(next_event(&mut events, &ingress).await);
+        }
+        assert_eq!(ingress.queued_events.load(Ordering::Acquire), 0);
+
+        let (terminal_ingress, mut terminal_events) = active_ingress(128);
+        for _ in 0..UPLOAD_TERMINAL_EVENT_SLOTS {
+            assert_eq!(
+                terminal_ingress.malformed(Instant::now()).await,
+                BinaryRoute::Delivered
+            );
+        }
+        let blocked_terminal = terminal_ingress.clone();
+        let terminal_waiter =
+            tokio::spawn(async move { blocked_terminal.malformed(Instant::now()).await });
+        tokio::task::yield_now().await;
+        assert!(!terminal_waiter.is_finished());
+        drop(next_event(&mut terminal_events, &terminal_ingress).await);
+        assert_eq!(
+            timeout(Duration::from_secs(1), terminal_waiter)
+                .await
+                .unwrap()
+                .unwrap(),
+            BinaryRoute::Delivered
+        );
+        for _ in 0..UPLOAD_TERMINAL_EVENT_SLOTS {
+            drop(next_event(&mut terminal_events, &terminal_ingress).await);
+        }
+        assert_eq!(terminal_ingress.queued_events.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn complete_legal_tiny_record_credit_window_cannot_hide_following_end() {
+        let mut served = jeliya_core::typed::limits();
+        served.max_frame_bytes = 128;
+        served.max_concurrent_transfers = 1;
+        let runtime = RuntimeLimits::from_served(&served).unwrap();
+        let window = runtime.max_data_payload_bytes();
+        assert!(window > UPLOAD_DATA_EVENT_SLOTS);
+
+        let (ingress, mut events) = UploadIngress::new(
+            UploadIngressBudget::new(runtime),
+            u64::try_from(window).unwrap(),
+            u64::try_from(window).unwrap(),
+        );
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        let credit_attempt = AtomicU8::new(CONTROL_ATTEMPT_QUEUED);
+        assert!(ingress.try_start_active_credit(
+            &credit_attempt,
+            deadline,
+            deadline,
+            u64::try_from(window).unwrap(),
+        ));
+
+        let codec_bounds = bounds(runtime.max_frame_bytes());
+        for offset in 0..window {
+            assert_eq!(
+                timeout(
+                    Duration::from_secs(1),
+                    ingress.route_bound(
+                        wire(
+                            0x02,
+                            REQUEST_ID,
+                            STREAM_ID,
+                            u64::try_from(offset).unwrap(),
+                            0,
+                            &[0x5a],
+                        ),
+                        &codec_bounds,
+                    ),
+                )
+                .await
+                .expect("every record inside one CREDIT window is immediately admissible"),
+                BinaryRoute::Delivered
+            );
+        }
+        assert_eq!(
+            timeout(
+                Duration::from_secs(1),
+                ingress.route_bound(
+                    wire(
+                        0x04,
+                        REQUEST_ID,
+                        STREAM_ID,
+                        u64::try_from(window).unwrap(),
+                        0,
+                        &[],
+                    ),
+                    &codec_bounds,
+                ),
+            )
+            .await
+            .expect("the terminal lane remains reachable after a full legal DATA window"),
+            BinaryRoute::Delivered
+        );
+
+        for expected in 0..window {
+            let event = next_event(&mut events, &ingress).await;
+            let UploadEventBody::Record {
+                kind: StreamRecordKind::Data,
+                bytes,
+                ..
+            } = event.body
+            else {
+                panic!("END overtook DATA admitted earlier on the wire");
+            };
+            let view = decode_stream_record_view(&bytes, &codec_bounds).unwrap();
+            assert!(matches!(
+                view.body,
+                StreamRecordBodyView::Data { offset, payload }
+                    if offset == u64::try_from(expected).unwrap() && payload == [0x5a]
+            ));
+        }
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_data_bypasses_a_full_data_lane_without_borrowing_later_credit() {
+        let codec_bounds = bounds(64);
+        let record_bytes = STREAM_HEADER_BYTES + 1;
+        let budget = UploadIngressBudget {
+            bytes: Arc::new(Semaphore::new(record_bytes)),
+            data_messages: 1,
+        };
+        let (ingress, mut events) = UploadIngress::new(budget, 2, 2);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        let first_credit = AtomicU8::new(CONTROL_ATTEMPT_QUEUED);
+        assert!(ingress.try_start_active_credit(&first_credit, deadline, deadline, 1));
+
+        assert_eq!(
+            ingress
+                .route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[1]), &codec_bounds)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert_eq!(ingress.budget.bytes.available_permits(), 0);
+
+        // This duplicate is both discontinuous with the receive frontier and
+        // beyond no new CREDIT. It must reach the terminal lane without
+        // waiting for the full DATA byte/message lane.
+        assert_eq!(
+            timeout(
+                Duration::from_secs(1),
+                ingress.route_bound(wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[2]), &codec_bounds,),
+            )
+            .await
+            .expect("invalid DATA bypasses DATA capacity"),
+            BinaryRoute::Delivered
+        );
+
+        // A later writer commit cannot retroactively turn that already
+        // received refusal into accepted DATA.
+        let later_credit = AtomicU8::new(CONTROL_ATTEMPT_QUEUED);
+        assert!(!ingress.try_start_active_credit(&later_credit, deadline, deadline, 2));
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::RejectedData(DataFailure::Protocol)
+        ));
+        assert_eq!(ingress.received_through.load(Ordering::Acquire), 1);
+        assert_eq!(ingress.budget.bytes.available_permits(), 0);
+        drop(next_event(&mut events, &ingress).await);
+        assert_eq!(ingress.budget.bytes.available_permits(), record_bytes);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn full_data_lane_cannot_starve_end_abort_cancel_or_ack_behind_timers() {
+        async fn fill_data(ingress: &Arc<UploadIngress>, bounds: &CodecBounds) {
+            for offset in 0..UPLOAD_DATA_EVENT_SLOTS {
+                assert_eq!(
+                    ingress
+                        .route_bound(
+                            wire(
+                                0x02,
+                                REQUEST_ID,
+                                STREAM_ID,
+                                u64::try_from(offset).unwrap(),
+                                0,
+                                &[1],
+                            ),
+                            bounds,
+                        )
+                        .await,
+                    BinaryRoute::Delivered
+                );
+            }
+        }
+
+        let codec_bounds = bounds(64);
+        let data_bytes = STREAM_HEADER_BYTES + 1;
+
+        let (ending, mut end_events) = active_ingress(data_bytes * UPLOAD_DATA_EVENT_SLOTS);
+        fill_data(&ending, &codec_bounds).await;
+        let end_boundary = Instant::now() + Duration::from_millis(10);
+        assert_eq!(
+            ending
+                .route_bound(
+                    wire(
+                        0x04,
+                        REQUEST_ID,
+                        STREAM_ID,
+                        u64::try_from(UPLOAD_DATA_EVENT_SLOTS).unwrap(),
+                        0,
+                        &[],
+                    ),
+                    &codec_bounds,
+                )
+                .await,
+            BinaryRoute::Delivered
+        );
+        tokio::time::advance(Duration::from_millis(10)).await;
+        for _ in 0..UPLOAD_DATA_EVENT_SLOTS {
+            assert!(matches!(
+                next_active(&mut end_events, &ending, end_boundary, end_boundary).await,
+                ActiveInput::Event(UploadEvent {
+                    body: UploadEventBody::Record {
+                        kind: StreamRecordKind::Data,
+                        ..
+                    },
+                    ..
+                })
+            ));
+        }
+        assert!(
+            matches!(
+                next_active(&mut end_events, &ending, end_boundary, end_boundary).await,
+                ActiveInput::Event(UploadEvent {
+                    body: UploadEventBody::Record {
+                        kind: StreamRecordKind::End,
+                        ..
+                    },
+                    ..
+                })
+            ),
+            "END remains visible ahead of the timer but cannot overtake DATA admitted before it"
+        );
+
+        let (aborting, mut abort_events) = active_ingress(data_bytes * UPLOAD_DATA_EVENT_SLOTS);
+        fill_data(&aborting, &codec_bounds).await;
+        let stall_boundary = Instant::now() + Duration::from_millis(10);
+        assert_eq!(
+            aborting
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]), &codec_bounds)
+                .await,
+            BinaryRoute::Delivered
+        );
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert!(matches!(
+            next_active(
+                &mut abort_events,
+                &aborting,
+                stall_boundary + Duration::from_secs(1),
+                stall_boundary,
+            )
+            .await,
+            ActiveInput::Event(UploadEvent {
+                body: UploadEventBody::Record {
+                    kind: StreamRecordKind::Abort,
+                    ..
+                },
+                ..
+            })
+        ));
+
+        let (cancelling, mut cancel_events) = active_ingress(data_bytes * UPLOAD_DATA_EVENT_SLOTS);
+        fill_data(&cancelling, &codec_bounds).await;
+        let cancel_boundary = Instant::now() + Duration::from_millis(10);
+        let cancelling_ingress = cancelling.clone();
+        let cancel = tokio::spawn(async move { cancelling_ingress.request_cancel().await });
+        while cancelling.queued_cancels.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(Duration::from_millis(10)).await;
+        let ActiveInput::Event(UploadEvent {
+            body: UploadEventBody::Cancel { response },
+            ..
+        }) = next_active(
+            &mut cancel_events,
+            &cancelling,
+            cancel_boundary,
+            cancel_boundary,
+        )
+        .await
+        else {
+            panic!("cancel must own the terminal lane ahead of full DATA and timers");
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+        assert_eq!(cancel.await.unwrap(), CancelAttempt::Unknown);
+
+        let (acking, mut ack_events) = active_ingress(data_bytes * UPLOAD_DATA_EVENT_SLOTS);
+        fill_data(&acking, &codec_bounds).await;
+        assert!(acking.try_select_daemon_abort());
+        let ack_deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            acking.commit_daemon_abort(ack_deadline),
+            ControlCommit::Committed
+        );
+        assert_eq!(
+            acking
+                .route_bound(wire(0x06, REQUEST_ID, STREAM_ID, 0, 5, &[]), &codec_bounds)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut ack_events, &acking).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Ack,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn zero_logical_byte_pool_still_routes_one_sentinel_probe_for_typed_refusal() {
+        let mut served = jeliya_core::typed::limits();
+        served.max_concurrent_transfers = 1;
+        served.max_transfer_bytes_inflight = 0;
+        let runtime = RuntimeLimits::from_served(&served).unwrap();
+        assert_eq!(runtime.data_queue_capacity_bytes(), 0);
+        assert!(runtime.upload_ingress_capacity_bytes() > STREAM_HEADER_BYTES);
+
+        let (ingress, mut events) =
+            UploadIngress::new(UploadIngressBudget::new(runtime), 0, u64::MAX);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        assert_eq!(
+            ingress.commit_open_with(deadline, || true),
+            ControlCommit::Committed
+        );
+        ingress.served_send_through.store(1, Ordering::Release);
+        assert_eq!(
+            timeout(
+                Duration::from_secs(1),
+                ingress.route_bound(
+                    wire(0x02, REQUEST_ID, STREAM_ID, 0, 0, &[0xff]),
+                    &bounds(runtime.max_frame_bytes()),
+                ),
+            )
+            .await
+            .expect("sentinel probe must not deadlock behind a zero-byte semaphore"),
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut events, &ingress).await.body,
+            UploadEventBody::RejectedData(DataFailure::Declared { observed: 1 })
+        ));
+        assert_eq!(ingress.received_through.load(Ordering::Acquire), 0);
+        assert_eq!(
+            ingress.budget.bytes.available_permits(),
+            runtime.upload_ingress_capacity_bytes(),
+            "a policy-refused sentinel must consume no DATA storage"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_is_principal_scoped_and_concurrent_repeats_use_the_ledger() {
+        let request = cancel_request("transfer-op");
+        let (_dir, engine, mut owner, registry) =
+            cancellation_ledger(&request.transfer_op_id, "principal-a", 9).await;
+        let (ingress, mut events) = active_ingress(256);
+        let guard = registry
+            .register(
+                "principal-a".into(),
+                request.transfer_op_id.clone(),
+                ingress.clone(),
+                9,
+            )
+            .unwrap();
+
+        assert_transfer_unknown(
+            registry.cancel("principal-b", &request).await,
+            &request.transfer_op_id,
+        );
+
+        let first_registry = registry.clone();
+        let first_request = request.clone();
+        let first =
+            tokio::spawn(async move { first_registry.cancel("principal-a", &first_request).await });
+        let second_registry = registry.clone();
+        let second_request = request.clone();
+        let second =
+            tokio::spawn(
+                async move { second_registry.cancel("principal-a", &second_request).await },
+            );
+        timeout(Duration::from_secs(1), async {
+            while ingress.queued_events.load(Ordering::Acquire) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both concurrent cancellation requests reached the actor");
+
+        let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+        else {
+            panic!("expected first cancellation event");
+        };
+        assert!(guard.select_cancelled(&mut owner, 3, 9));
+        response
+            .send(CancelAttempt::Cancelled { accepted: 3 })
+            .unwrap();
+
+        let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+        else {
+            panic!("expected concurrent cancellation event");
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+
+        let first = first.await.unwrap().unwrap();
+        let second = second.await.unwrap().unwrap();
+        assert_eq!(
+            usize::from(matches!(&first.outcome, CancelOutcome::Cancelled))
+                + usize::from(matches!(&second.outcome, CancelOutcome::Cancelled)),
+            1
+        );
+        assert_eq!(
+            usize::from(matches!(&first.outcome, CancelOutcome::AlreadyCancelled))
+                + usize::from(matches!(&second.outcome, CancelOutcome::AlreadyCancelled)),
+            1
+        );
+        for result in [&first, &second] {
+            assert_eq!(result.transferred_bytes, 3);
+            assert_eq!(result.total, ByteTotal::Known { bytes: 9 });
+        }
+
+        let repeated = registry.cancel("principal-a", &request).await.unwrap();
+        assert_eq!(repeated.outcome, CancelOutcome::AlreadyCancelled);
+        assert_eq!(repeated.transferred_bytes, 3);
+        drop(guard);
+        let published = owner.complete(Err(ApiError::NotReady));
+        assert!(matches!(
+            published,
+            Err(ApiError::StreamAborted {
+                transferred_bytes: 3,
+                total: ByteTotal::Known { bytes: 9 },
+                reason: StreamAbortReason::Cancelled,
+            })
+        ));
+        assert_eq!(
+            engine.recorded_file_share_cancellation("principal-a", &request.transfer_op_id),
+            Some((3, 9))
+        );
+        assert_eq!(
+            registry
+                .cancel("principal-a", &request)
+                .await
+                .unwrap()
+                .outcome,
+            CancelOutcome::AlreadyCancelled,
+            "ledger publication preserves cancellation replay without a tombstone"
+        );
+
+        let (other_ingress, _other_events) = active_ingress(128);
+        let other_guard = registry
+            .register(
+                "principal-b".into(),
+                request.transfer_op_id.clone(),
+                other_ingress,
+                9,
+            )
+            .expect("same op_id is isolated by principal");
+        drop(other_guard);
+        assert_transfer_unknown(
+            registry.cancel("principal-b", &request).await,
+            &request.transfer_op_id,
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_refuses_finalizing_and_unknown_uploads() {
+        let registry = UploadCancellationRegistry::default();
+        let request = cancel_request("finalizing-op");
+        assert_transfer_unknown(
+            registry.cancel("principal", &request).await,
+            &request.transfer_op_id,
+        );
+
+        let (ingress, _events) = active_ingress(128);
+        let guard = registry
+            .register(
+                "principal".into(),
+                request.transfer_op_id.clone(),
+                ingress.clone(),
+                0,
+            )
+            .unwrap();
+        assert!(ingress.commit_finalizing(0));
+        assert_transfer_unknown(
+            registry.cancel("principal", &request).await,
+            &request.transfer_op_id,
+        );
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_end_races_preserve_the_first_active_terminal() {
+        let codec_bounds = bounds(64);
+
+        // END is the first terminal admitted. Once the actor validates it and
+        // enters FINALIZING, a principal-scoped cancel cannot replace that
+        // result or record daemon-selected cancellation provenance.
+        let end_registry = UploadCancellationRegistry::default();
+        let end_request = cancel_request("end-first-op");
+        let (ending, mut end_events) = active_ingress(128);
+        let end_guard = end_registry
+            .register(
+                "principal".into(),
+                end_request.transfer_op_id.clone(),
+                ending.clone(),
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            ending
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]), &codec_bounds,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        let UploadEventBody::Record { bytes, .. } = next_event(&mut end_events, &ending).await.body
+        else {
+            panic!("END must own the first terminal admission");
+        };
+        assert!(matches!(
+            decode_stream_record_view(&bytes, &codec_bounds)
+                .unwrap()
+                .body,
+            StreamRecordBodyView::End { total: 0 }
+        ));
+        let mut state = ConsumerState::new(0, 8);
+        state.record_credit(0, 1).unwrap();
+        assert_eq!(state.validate_end(0), Ok(()));
+        assert!(ending.commit_finalizing(0));
+        assert_transfer_unknown(
+            end_registry.cancel("principal", &end_request).await,
+            &end_request.transfer_op_id,
+        );
+        drop(end_guard);
+
+        // The reverse order selects cancellation while ACTIVE. A later END is
+        // drained under the daemon-selected ABORT and cannot enter FINALIZING.
+        let cancel_request = cancel_request("cancel-first-end-op");
+        let (_cancel_dir, _cancel_engine, mut cancel_owner, cancel_registry) =
+            cancellation_ledger(&cancel_request.transfer_op_id, "principal", 0).await;
+        let (cancelling, mut cancel_events) = active_ingress(128);
+        let cancel_guard = cancel_registry
+            .register(
+                "principal".into(),
+                cancel_request.transfer_op_id.clone(),
+                cancelling.clone(),
+                0,
+            )
+            .unwrap();
+        let cancel_registry_task = cancel_registry.clone();
+        let cancel_request_task = cancel_request.clone();
+        let cancel = tokio::spawn(async move {
+            cancel_registry_task
+                .cancel("principal", &cancel_request_task)
+                .await
+        });
+        while cancelling.queued_cancels.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        let UploadEventBody::Cancel { response } =
+            next_event(&mut cancel_events, &cancelling).await.body
+        else {
+            panic!("cancel must own the first terminal admission");
+        };
+        assert!(cancel_guard.select_cancelled(&mut cancel_owner, 0, 0));
+        response
+            .send(CancelAttempt::Cancelled { accepted: 0 })
+            .unwrap();
+        let outcome = cancel.await.unwrap().unwrap();
+        assert_eq!(outcome.outcome, CancelOutcome::Cancelled);
+        assert_eq!(outcome.transferred_bytes, 0);
+
+        assert_eq!(
+            cancelling
+                .route_bound(wire(0x04, REQUEST_ID, STREAM_ID, 0, 0, &[]), &codec_bounds,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            next_event(&mut cancel_events, &cancelling).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::End,
+                ..
+            }
+        ));
+        assert!(!cancelling.commit_finalizing(0));
+        assert_eq!(
+            cancel_registry
+                .cancel("principal", &cancel_request)
+                .await
+                .unwrap()
+                .outcome,
+            CancelOutcome::AlreadyCancelled
+        );
+        drop(cancel_guard);
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_client_abort_races_preserve_the_first_terminal_owner() {
+        let codec_bounds = bounds(64);
+
+        // A producer ABORT admitted first owns the client-abort handshake;
+        // the later cancellation request is indistinguishable from unknown.
+        let abort_registry = UploadCancellationRegistry::default();
+        let abort_request = cancel_request("abort-first-op");
+        let (aborting, mut abort_events) = active_ingress(128);
+        let abort_guard = abort_registry
+            .register(
+                "principal".into(),
+                abort_request.transfer_op_id.clone(),
+                aborting.clone(),
+                0,
+            )
+            .unwrap();
+        assert_eq!(
+            aborting
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 2, &[]), &codec_bounds,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        let abort_registry_task = abort_registry.clone();
+        let abort_request_task = abort_request.clone();
+        let cancel = tokio::spawn(async move {
+            abort_registry_task
+                .cancel("principal", &abort_request_task)
+                .await
+        });
+        while aborting.queued_cancels.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        assert!(matches!(
+            next_event(&mut abort_events, &aborting).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                ..
+            }
+        ));
+        assert!(aborting.try_select_client_abort());
+        let UploadEventBody::Cancel { response } =
+            next_event(&mut abort_events, &aborting).await.body
+        else {
+            panic!("later cancel must remain queued behind producer ABORT");
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+        assert_transfer_unknown(cancel.await.unwrap(), &abort_request.transfer_op_id);
+        assert_eq!(aborting.phase(), UploadPhase::ClientAbortPending);
+        drop(abort_guard);
+
+        // A cancel admitted first selects the daemon's authoritative ABORT.
+        // The crossed producer ABORT remains an ACK obligation but cannot
+        // replace the cancellation result.
+        let cancel_request = cancel_request("cancel-first-abort-op");
+        let (_cancel_dir, _cancel_engine, mut cancel_owner, cancel_registry) =
+            cancellation_ledger(&cancel_request.transfer_op_id, "principal", 0).await;
+        let (cancelling, mut cancel_events) = active_ingress(128);
+        let cancel_guard = cancel_registry
+            .register(
+                "principal".into(),
+                cancel_request.transfer_op_id.clone(),
+                cancelling.clone(),
+                0,
+            )
+            .unwrap();
+        let cancel_registry_task = cancel_registry.clone();
+        let cancel_request_task = cancel_request.clone();
+        let cancel = tokio::spawn(async move {
+            cancel_registry_task
+                .cancel("principal", &cancel_request_task)
+                .await
+        });
+        while cancelling.queued_cancels.load(Ordering::Acquire) == 0 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            cancelling
+                .route_bound(wire(0x05, REQUEST_ID, STREAM_ID, 0, 2, &[]), &codec_bounds,)
+                .await,
+            BinaryRoute::Delivered
+        );
+        let UploadEventBody::Cancel { response } =
+            next_event(&mut cancel_events, &cancelling).await.body
+        else {
+            panic!("cancel must own the first terminal admission");
+        };
+        assert!(cancel_guard.select_cancelled(&mut cancel_owner, 0, 0));
+        response
+            .send(CancelAttempt::Cancelled { accepted: 0 })
+            .unwrap();
+        assert_eq!(
+            cancel.await.unwrap().unwrap().outcome,
+            CancelOutcome::Cancelled
+        );
+        assert!(matches!(
+            next_event(&mut cancel_events, &cancelling).await.body,
+            UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                ..
+            }
+        ));
+        assert!(!cancelling.try_select_client_abort());
+        assert_eq!(cancelling.phase(), UploadPhase::DaemonAbortQueued);
+        assert_eq!(
+            cancel_registry
+                .cancel("principal", &cancel_request)
+                .await
+                .unwrap()
+                .outcome,
+            CancelOutcome::AlreadyCancelled
+        );
+        drop(cancel_guard);
+    }
+
+    #[tokio::test]
+    async fn an_already_selected_deadline_makes_cancellation_unknown() {
+        let registry = UploadCancellationRegistry::default();
+        let request = cancel_request("deadline-first-op");
+        let (ingress, _events) = active_ingress(128);
+        let guard = registry
+            .register(
+                "principal".into(),
+                request.transfer_op_id.clone(),
+                ingress.clone(),
+                1,
+            )
+            .unwrap();
+        let now = Instant::now();
+        assert!(matches!(
+            ingress.commit_accepted(0, now, now + Duration::from_secs(1)),
+            Err(ActiveInterrupt::Deadline)
+        ));
+        assert_eq!(ingress.phase(), UploadPhase::DaemonAbortQueued);
+        assert_transfer_unknown(
+            registry.cancel("principal", &request).await,
+            &request.transfer_op_id,
+        );
+        drop(guard);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn explicit_terminals_win_timer_equality_but_local_acceptance_does_not() {
+        let (ingress, mut events) = active_ingress(128);
+        let boundary = Instant::now() + Duration::from_millis(10);
+        tokio::time::advance(Duration::from_millis(10)).await;
+
+        let (response, _result) = oneshot::channel();
+        let admission = {
+            let _sequencing = ingress
+                .sequencing
+                .lock()
+                .expect("upload sequencing poisoned");
+            ingress.begin_terminal_locked(true, true)
+        };
+        assert_eq!(
+            ingress
+                .enqueue(
+                    UploadEvent {
+                        received_at: boundary,
+                        body: UploadEventBody::Cancel { response },
+                        _pending_data: None,
+                    },
+                    true,
+                    Some(admission),
+                )
+                .await,
+            BinaryRoute::Delivered
+        );
+        assert!(matches!(
+            await_active_operation(pending::<()>(), &ingress, boundary, boundary).await,
+            Err(ActiveInterrupt::TerminalPending)
+        ));
+        let UploadEventBody::Cancel { response } = next_event(&mut events, &ingress).await.body
+        else {
+            panic!("expected cancellation event");
+        };
+        let cancel_event = UploadEvent {
+            received_at: boundary,
+            body: UploadEventBody::Cancel { response },
+            _pending_data: None,
+        };
+        let mut state = ConsumerState::new(0, 8);
+        state.record_credit(0, 1).unwrap();
+        assert!(active_event_timer_failure(
+            &cancel_event,
+            &state,
+            &bounds(64),
+            boundary,
+            boundary,
+            10,
+        )
+        .is_none());
+        let UploadEventBody::Cancel { response } = cancel_event.body else {
+            unreachable!()
+        };
+        response.send(CancelAttempt::Unknown).unwrap();
+
+        let valid_abort = UploadEvent {
+            received_at: boundary,
+            body: UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                bytes: wire(0x05, REQUEST_ID, STREAM_ID, 0, 1, &[]),
+                _bytes: None,
+            },
+            _pending_data: None,
+        };
+        assert!(active_event_timer_failure(
+            &valid_abort,
+            &state,
+            &bounds(64),
+            boundary,
+            boundary,
+            10,
+        )
+        .is_none());
+        assert!(active_event_timer_failure(
+            &valid_abort,
+            &state,
+            &bounds(64),
+            boundary + Duration::from_millis(1),
+            boundary,
+            10,
+        )
+        .is_none());
+
+        let invalid_abort = UploadEvent {
+            received_at: boundary,
+            body: UploadEventBody::Record {
+                kind: StreamRecordKind::Abort,
+                bytes: wire(0x05, REQUEST_ID, STREAM_ID, 1, 1, &[]),
+                _bytes: None,
+            },
+            _pending_data: None,
+        };
+        assert!(matches!(
+            active_event_timer_failure(&invalid_abort, &state, &bounds(64), boundary, boundary, 10,),
+            Some(UploadFailure::Deadline { .. })
+        ));
+        assert!(matches!(
+            active_event_timer_failure(
+                &invalid_abort,
+                &state,
+                &bounds(64),
+                boundary + Duration::from_millis(1),
+                boundary,
+                10,
+            ),
+            Some(UploadFailure::Stall)
+        ));
+
+        assert!(matches!(
+            ingress.commit_accepted(1, boundary, boundary),
+            Err(ActiveInterrupt::TerminalPending)
+        ));
+        ingress.clear_processing_terminal();
+        assert!(matches!(
+            ingress.commit_accepted(1, boundary, boundary),
+            Err(ActiveInterrupt::Deadline)
+        ));
+        assert_eq!(ingress.phase(), UploadPhase::DaemonAbortQueued);
+        assert_eq!(ingress.accepted.load(Ordering::Acquire), 0);
+    }
+}

--- a/crates/jeliyad/src/main.rs
+++ b/crates/jeliyad/src/main.rs
@@ -14,6 +14,7 @@
 //! `--supervised` mode that exits when the parent closes stdin.
 
 mod file_read;
+mod file_share;
 mod lifecycle;
 mod outbound;
 mod serve;
@@ -103,6 +104,8 @@ pub(crate) struct AppState {
     pub(crate) runtime_limits: transfer::RuntimeLimits,
     /// Daemon-global transfer count and logical-byte admission pool.
     pub(crate) transfer_pool: transfer::TransferPool,
+    /// Principal-scoped cancellation state for protocol-v2 streamed uploads.
+    pub(crate) upload_cancellations: file_share::UploadCancellationRegistry,
 }
 
 #[tokio::main]
@@ -198,6 +201,7 @@ async fn main() {
             std::process::exit(1);
         }
     };
+    let upload_cancellations = file_share::UploadCancellationRegistry::with_engine(&engine);
     let engine_limits = engine.limits();
     let runtime_limits = match transfer::RuntimeLimits::from_served(&engine_limits) {
         Ok(limits) => limits,
@@ -216,6 +220,7 @@ async fn main() {
         connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         runtime_limits,
         transfer_pool,
+        upload_cancellations,
     };
 
     let portfile = lifecycle::Portfile {

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -983,6 +983,7 @@ pub async fn serve_ws<S>(
     });
 
     let streams = crate::file_read::StreamRegistry::new();
+    let upload_budget = crate::file_share::UploadIngressBudget::new(state.runtime_limits);
     let requests = crate::file_read::RequestTracker::new(served.max_inflight_requests);
     let stream_ids = std::sync::Arc::new(std::sync::Mutex::new(
         crate::transfer::StreamIdGenerator::new(),
@@ -1104,11 +1105,12 @@ pub async fn serve_ws<S>(
                                 &closer,
                                 &mut inflight,
                                 &principal_key,
+                                &upload_budget,
                             ).await {
                                 break;
                             }
                         }
-                        Message::Binary(bytes) => match streams.route_binary(&bytes, &bounds) {
+                        Message::Binary(bytes) => match streams.route_binary_message(bytes, &bounds).await {
                             crate::file_read::BinaryRoute::Delivered => {}
                             crate::file_read::BinaryRoute::CloseTooLarge => {
                                 closer.request(tokio_tungstenite::tungstenite::protocol::CloseFrame {
@@ -1657,6 +1659,7 @@ async fn dispatch_text(
     closer: &crate::file_read::ConnectionCloser,
     inflight: &mut tokio::task::JoinSet<bool>,
     principal_key: &str,
+    upload_budget: &crate::file_share::UploadIngressBudget,
 ) -> bool {
     // This is the final request-admission linearization point. If it wins
     // before a concurrent Close claim, the request was already in flight and
@@ -1728,10 +1731,54 @@ async fn dispatch_text(
         _ => {}
     }
 
-    // `file.read` is the one producer-direction stream in this slice. Its
-    // request remains outstanding inside the actor through END/ABORT and the
-    // terminal Text writer acknowledgement. `file.share` deliberately stays
-    // on the ordinary engine path and continues returning `not_ready`.
+    // Stream requests remain outstanding inside their actors through the
+    // terminal Text writer acknowledgement. Upload owners are detached from
+    // the connection task set so accepted-END finalization and ledger
+    // publication survive socket teardown; registry invalidation remains the
+    // pre-END transport-loss signal.
+    if request.call.op == "file.share" {
+        let Some(file_share) = request
+            .call
+            .input_any()
+            .downcast_ref::<jeliya_api::FileShare>()
+            .cloned()
+        else {
+            return send_api_err(out_tx, request.id, jeliya_api::ApiError::MalformedFrame).await;
+        };
+        let engine = state.engine.clone();
+        let outbound = out_tx.clone();
+        let registry = streams.clone();
+        let stream_ids = stream_ids.clone();
+        let transfer_pool = state.transfer_pool.clone();
+        let limits = state.runtime_limits;
+        let closer = closer.clone();
+        let cancellations = state.upload_cancellations.clone();
+        let upload_budget = upload_budget.clone();
+        let principal_key = principal_key.to_owned();
+        let op_id = request.op_id.clone();
+        let id = request.id;
+        tokio::spawn(async move {
+            let _ = crate::file_share::run_file_share(
+                engine,
+                file_share,
+                op_id,
+                principal_key,
+                id,
+                request_permit,
+                outbound,
+                registry,
+                stream_ids,
+                transfer_pool,
+                limits,
+                closer,
+                cancellations,
+                upload_budget,
+            )
+            .await;
+        });
+        return true;
+    }
+
     if request.call.op == "file.read" {
         let Some(file_read) = request
             .call
@@ -1763,6 +1810,38 @@ async fn dispatch_text(
                 closer,
             )
             .await
+        });
+        return true;
+    }
+
+    // Upload cancellation is transport-owned and principal-scoped. Its own
+    // envelope op_id is intentionally ignored; only transfer_op_id selects a
+    // cancellable upload. Structural decoding has already succeeded, and the
+    // subject precondition remains ahead of the live-transfer lookup.
+    if request.call.op == "transfer.cancel" {
+        let Some(cancel) = request
+            .call
+            .input_any()
+            .downcast_ref::<jeliya_api::TransferCancel>()
+            .cloned()
+        else {
+            return send_api_err(out_tx, request.id, jeliya_api::ApiError::MalformedFrame).await;
+        };
+        let id = request.id;
+        let engine = state.engine.clone();
+        let cancellations = state.upload_cancellations.clone();
+        let principal_key = principal_key.to_owned();
+        let out_tx = out_tx.clone();
+        inflight.spawn(async move {
+            let _request_permit = request_permit;
+            let result = match engine.validate_transfer_cancel() {
+                Ok(()) => cancellations.cancel(&principal_key, &cancel).await,
+                Err(error) => Err(error),
+            };
+            match result {
+                Ok(out) => send_typed(&out_tx, id, &out).await,
+                Err(error) => send_api_err(&out_tx, id, error).await,
+            }
         });
         return true;
     }
@@ -1866,7 +1945,7 @@ fn text(status: StatusCode, body: &'static str) -> Response<Full<Bytes>> {
 mod tests {
     use std::sync::Arc;
 
-    use futures_util::{SinkExt, StreamExt};
+    use futures_util::{FutureExt, SinkExt, StreamExt};
     use hyper::{header::CONTENT_TYPE, StatusCode};
     use tempfile::TempDir;
     use tokio_tungstenite::tungstenite::{protocol::Role, Message};
@@ -1897,6 +1976,8 @@ mod tests {
         let runtime_limits =
             crate::transfer::RuntimeLimits::from_served(&limits).expect("test runtime limits");
         let transfer_pool = crate::transfer::TransferPool::from_runtime(&runtime_limits);
+        let upload_cancellations =
+            crate::file_share::UploadCancellationRegistry::with_engine(&engine);
         let state = crate::AppState {
             data_dir: dir.path().to_path_buf(),
             engine,
@@ -1906,8 +1987,39 @@ mod tests {
             connections: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             runtime_limits,
             transfer_pool,
+            upload_cancellations,
         };
         (dir, state)
+    }
+
+    fn configure_transfer_pool(
+        state: &mut crate::AppState,
+        max_concurrent_transfers: u64,
+        max_transfer_bytes_inflight: u64,
+    ) {
+        let mut limits = state.engine.limits();
+        limits.max_frame_bytes = SOCKET_FRAME_BYTES as u64;
+        limits.max_concurrent_transfers = max_concurrent_transfers;
+        limits.max_transfer_bytes_inflight = max_transfer_bytes_inflight;
+        state.runtime_limits =
+            crate::transfer::RuntimeLimits::from_served(&limits).expect("test runtime limits");
+        state.transfer_pool = crate::transfer::TransferPool::from_runtime(&state.runtime_limits);
+    }
+
+    fn configure_transfer_timers(
+        state: &mut crate::AppState,
+        transfer_stall_ms: u64,
+        transfer_connect_allowance_ms: u64,
+        transfer_floor_bits_per_second: u64,
+    ) {
+        let mut limits = state.engine.limits();
+        limits.max_frame_bytes = SOCKET_FRAME_BYTES as u64;
+        limits.transfer_stall_ms = transfer_stall_ms;
+        limits.transfer_connect_allowance_ms = transfer_connect_allowance_ms;
+        limits.transfer_floor_bits_per_second = transfer_floor_bits_per_second;
+        state.runtime_limits =
+            crate::transfer::RuntimeLimits::from_served(&limits).expect("test runtime limits");
+        state.transfer_pool = crate::transfer::TransferPool::from_runtime(&state.runtime_limits);
     }
 
     async fn socket_pair(
@@ -1916,15 +2028,26 @@ mod tests {
         WebSocketStream<tokio::io::DuplexStream>,
         tokio::task::JoinHandle<()>,
     ) {
+        socket_pair_as(state, "serve-test").await
+    }
+
+    async fn socket_pair_as(
+        state: crate::AppState,
+        client_id: &str,
+    ) -> (
+        WebSocketStream<tokio::io::DuplexStream>,
+        tokio::task::JoinHandle<()>,
+    ) {
         let (server_io, client_io) = tokio::io::duplex(1 << 20);
         let server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
         let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let client_id = client_id.to_owned();
         let task = tokio::spawn(serve_ws(
             server,
             state,
             jeliya_codec::SessionPrincipal {
                 credential: "test-token".into(),
-                client_id: Some("serve-test".into()),
+                client_id: Some(client_id),
             },
         ));
         (client, task)
@@ -2014,6 +2137,12 @@ mod tests {
         bytes
     }
 
+    fn stream_data_wire(request_id: u64, stream_id: u128, offset: u64, payload: &[u8]) -> Vec<u8> {
+        let mut bytes = stream_wire(0x02, request_id, stream_id, offset, 0);
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
     async fn send_file_read(
         client: &mut WebSocketStream<tokio::io::DuplexStream>,
         id: u64,
@@ -2031,6 +2160,166 @@ mod tests {
             ))
             .await
             .expect("send file.read");
+    }
+
+    async fn complete_open_file_read(
+        client: &mut WebSocketStream<tokio::io::DuplexStream>,
+        request_id: u64,
+        stream_id: u128,
+        expected: &[u8],
+        bounds: &jeliya_codec::CodecBounds,
+    ) -> jeliya_codec::Reply {
+        let total = u64::try_from(expected.len()).unwrap();
+        client
+            .send(Message::Binary(
+                stream_wire(0x03, request_id, stream_id, 0, total).into(),
+            ))
+            .await
+            .expect("grant file.read credit");
+
+        let mut accepted = 0_u64;
+        loop {
+            let Message::Binary(record) = client.next().await.unwrap().unwrap() else {
+                panic!("file.read success reply preceded END");
+            };
+            let record = jeliya_codec::decode_stream_record(&record, bounds).unwrap();
+            match record.body {
+                jeliya_codec::StreamRecordBody::Data { offset, payload } => {
+                    assert_eq!(offset, accepted);
+                    let start = usize::try_from(accepted).unwrap();
+                    assert_eq!(payload, expected[start..start + payload.len()]);
+                    accepted += u64::try_from(payload.len()).unwrap();
+                    client
+                        .send(Message::Binary(
+                            stream_wire(0x03, request_id, stream_id, accepted, total).into(),
+                        ))
+                        .await
+                        .expect("acknowledge file.read DATA");
+                }
+                jeliya_codec::StreamRecordBody::End { total: observed } => {
+                    assert_eq!(observed, total);
+                    assert_eq!(accepted, total);
+                    break;
+                }
+                other => panic!("unexpected file.read record: {other:?}"),
+            }
+        }
+
+        let Message::Text(reply) = client.next().await.unwrap().unwrap() else {
+            panic!("file.read terminal success must be Text");
+        };
+        let reply: jeliya_codec::Reply = serde_json::from_str(&reply).unwrap();
+        assert!(reply.ok);
+        assert_eq!(reply.id, request_id);
+        reply
+    }
+
+    async fn next_socket_message(client: &mut WebSocketStream<tokio::io::DuplexStream>) -> Message {
+        tokio::time::timeout(std::time::Duration::from_secs(10), client.next())
+            .await
+            .expect("WebSocket stream made progress")
+            .expect("WebSocket connection remained open")
+            .expect("WebSocket message was readable")
+    }
+
+    async fn upload_through_declared_boundary(
+        client: &mut WebSocketStream<tokio::io::DuplexStream>,
+        request_id: u64,
+        identity: jeliya_codec::StreamIdentity,
+        declared: u64,
+        chunk_bytes: usize,
+        bounds: &jeliya_codec::CodecBounds,
+    ) {
+        assert!(chunk_bytes > 0);
+        let chunk_bytes_u64 = u64::try_from(chunk_bytes).unwrap();
+        let payload = vec![0x5a; chunk_bytes];
+        let mut offset = 0_u64;
+        while offset < declared {
+            let remaining = declared - offset;
+            let payload_len = usize::try_from(remaining.min(chunk_bytes_u64)).unwrap();
+            client
+                .send(Message::Binary(
+                    stream_data_wire(
+                        request_id,
+                        identity.stream_id().get(),
+                        offset,
+                        &payload[..payload_len],
+                    )
+                    .into(),
+                ))
+                .await
+                .expect("send one bounded upload DATA record");
+            offset += u64::try_from(payload_len).unwrap();
+
+            let credit = tokio::time::timeout(std::time::Duration::from_secs(30), client.next())
+                .await
+                .expect("bounded upload must continue making sink progress")
+                .expect("bounded upload connection remains open")
+                .expect("bounded upload CREDIT is readable");
+            let Message::Binary(credit) = credit else {
+                panic!("accepted upload DATA must advance Binary CREDIT");
+            };
+            let credit = jeliya_codec::decode_stream_record(&credit, bounds).unwrap();
+            assert_eq!(credit.identity, identity);
+            let send_through = if offset == declared {
+                declared.checked_add(1).unwrap()
+            } else {
+                offset.checked_add(chunk_bytes_u64).unwrap().min(declared)
+            };
+            assert_eq!(
+                credit.body,
+                jeliya_codec::StreamRecordBody::Credit {
+                    accepted_through: offset,
+                    send_through,
+                }
+            );
+        }
+    }
+
+    async fn open_one_byte_file_share(
+        client: &mut WebSocketStream<tokio::io::DuplexStream>,
+        request_id: u64,
+        room_id: &str,
+        name: &str,
+        bounds: &jeliya_codec::CodecBounds,
+    ) -> jeliya_codec::StreamIdentity {
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": request_id,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": room_id,
+                        "name": name,
+                        "declared_bytes": 1,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("send one-byte file.share");
+        let Message::Binary(open) = next_socket_message(client).await else {
+            panic!("admitted file.share must begin with Binary OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, bounds).expect("decode upload OPEN");
+        assert_eq!(open.body, jeliya_codec::StreamRecordBody::Open { total: 1 });
+
+        let Message::Binary(credit) = next_socket_message(client).await else {
+            panic!("upload OPEN must be followed by Binary CREDIT");
+        };
+        let credit =
+            jeliya_codec::decode_stream_record(&credit, bounds).expect("decode initial CREDIT");
+        assert_eq!(credit.identity, open.identity);
+        assert_eq!(
+            credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            }
+        );
+        open.identity
     }
 
     #[test]
@@ -2309,7 +2598,7 @@ mod tests {
                     "op": "file.share",
                     "in": {
                         "room_id": request.room_id,
-                        "name": "still-not-streamed.bin",
+                        "name": "empty.bin",
                         "declared_bytes": 0,
                         "declared_content_type": "application/octet-stream",
                     }
@@ -2319,15 +2608,2577 @@ mod tests {
             ))
             .await
             .unwrap();
+        let Message::Binary(share_open) = second.next().await.unwrap().unwrap() else {
+            panic!("file.share must begin with Binary OPEN");
+        };
+        let share_open = jeliya_codec::decode_stream_record(&share_open, &bounds).unwrap();
+        assert_eq!(
+            share_open.body,
+            jeliya_codec::StreamRecordBody::Open { total: 0 }
+        );
+        let Message::Binary(share_credit) = second.next().await.unwrap().unwrap() else {
+            panic!("OPEN must be followed by Binary CREDIT");
+        };
+        let share_credit = jeliya_codec::decode_stream_record(&share_credit, &bounds).unwrap();
+        assert_eq!(share_credit.identity, share_open.identity);
+        assert_eq!(
+            share_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            }
+        );
+        second
+            .send(Message::Binary(
+                stream_wire(0x04, 9, share_open.identity.stream_id().get(), 0, 0).into(),
+            ))
+            .await
+            .unwrap();
         let Message::Text(share_reply) = second.next().await.unwrap().unwrap() else {
-            panic!("file.share refusal must remain an ordinary Text reply");
+            panic!("file.share success must follow END as Text");
         };
         let share_reply: jeliya_codec::Reply = serde_json::from_str(&share_reply).unwrap();
-        assert_eq!(share_reply.err, Some(jeliya_api::ApiError::NotReady));
+        assert!(share_reply.ok);
+        assert_eq!(share_reply.id, 9);
         second.close(None).await.unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(1), second_server)
             .await
             .expect("completed connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_joins_replays_and_authors_once() {
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let room_id = existing.room_id;
+        let request = serde_json::json!({
+            "op_id": "op-socket-upload-join-1",
+            "op": "file.share",
+            "in": {
+                "room_id": room_id,
+                "name": "joined.bin",
+                "declared_bytes": 3,
+                "declared_content_type": "application/octet-stream",
+            }
+        });
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+
+        let (mut owner, owner_server) = socket_pair(state.clone()).await;
+        let (mut joiner, joiner_server) = socket_pair(state.clone()).await;
+        assert!(matches!(owner.next().await, Some(Ok(Message::Text(_)))));
+        assert!(matches!(joiner.next().await, Some(Ok(Message::Text(_)))));
+
+        let mut owner_request = request.clone();
+        owner_request["id"] = 31.into();
+        owner
+            .send(Message::Text(owner_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Binary(open) = owner.next().await.unwrap().unwrap() else {
+            panic!("fresh upload owner must receive OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        assert_eq!(open.body, jeliya_codec::StreamRecordBody::Open { total: 3 });
+        let identity = open.identity;
+        let Message::Binary(initial_credit) = owner.next().await.unwrap().unwrap() else {
+            panic!("OPEN must be followed by CREDIT");
+        };
+        let initial_credit = jeliya_codec::decode_stream_record(&initial_credit, &bounds).unwrap();
+        assert_eq!(initial_credit.identity, identity);
+        assert_eq!(
+            initial_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 3,
+            }
+        );
+
+        let mut joined_request = request.clone();
+        joined_request["id"] = 32.into();
+        joiner
+            .send(Message::Text(joined_request.to_string().into()))
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), joiner.next())
+                .await
+                .is_err(),
+            "faithful concurrent replay must neither open nor reply before its owner"
+        );
+
+        owner
+            .send(Message::Binary(
+                stream_data_wire(31, identity.stream_id().get(), 0, &[1, 2]).into(),
+            ))
+            .await
+            .unwrap();
+        owner
+            .send(Message::Binary(
+                stream_data_wire(31, identity.stream_id().get(), 2, &[3]).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(sentinel_credit) = owner.next().await.unwrap().unwrap() else {
+            panic!("accepted declaration must expose the sentinel CREDIT");
+        };
+        let sentinel_credit =
+            jeliya_codec::decode_stream_record(&sentinel_credit, &bounds).unwrap();
+        assert_eq!(sentinel_credit.identity, identity);
+        assert_eq!(
+            sentinel_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 3,
+                send_through: 4,
+            }
+        );
+        owner
+            .send(Message::Binary(
+                stream_wire(0x04, 31, identity.stream_id().get(), 3, 0).into(),
+            ))
+            .await
+            .unwrap();
+
+        let Message::Text(owner_reply) = owner.next().await.unwrap().unwrap() else {
+            panic!("owner terminal must be Text");
+        };
+        let owner_reply: jeliya_codec::Reply = serde_json::from_str(&owner_reply).unwrap();
+        assert!(owner_reply.ok);
+        let Message::Text(joined_reply) = joiner.next().await.unwrap().unwrap() else {
+            panic!("faithful join terminal must be Text only");
+        };
+        let joined_reply: jeliya_codec::Reply = serde_json::from_str(&joined_reply).unwrap();
+        assert!(joined_reply.ok);
+        assert_eq!(joined_reply.out, owner_reply.out);
+
+        let mut replay_request = request.clone();
+        replay_request["id"] = 33.into();
+        joiner
+            .send(Message::Text(replay_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Text(replayed) = joiner.next().await.unwrap().unwrap() else {
+            panic!("completed replay must not open a second stream");
+        };
+        let replayed: jeliya_codec::Reply = serde_json::from_str(&replayed).unwrap();
+        assert_eq!(replayed.out, owner_reply.out);
+
+        let mut divergent = request;
+        divergent["id"] = 34.into();
+        divergent["in"]["name"] = "different.bin".into();
+        joiner
+            .send(Message::Text(divergent.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Text(conflict) = joiner.next().await.unwrap().unwrap() else {
+            panic!("divergent replay refusal must be Text");
+        };
+        let conflict: jeliya_codec::Reply = serde_json::from_str(&conflict).unwrap();
+        assert!(matches!(
+            conflict.err,
+            Some(jeliya_api::ApiError::OpIdConflict { .. })
+        ));
+
+        let listed = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::FileList(
+                jeliya_api::FileList {
+                    room_id: room_id.clone(),
+                    page: jeliya_api::Page {
+                        cursor: jeliya_api::Cursor::Start,
+                        direction: jeliya_api::Direction::Forward,
+                        limit: 100,
+                    },
+                },
+            ))
+            .await
+            .reply
+            .expect("file.list after streamed share");
+        let jeliya_core::typed::TypedReply::FileList(listed) = listed else {
+            panic!("wrong file.list reply");
+        };
+        assert_eq!(
+            listed
+                .files
+                .iter()
+                .filter(|file| file.name == "joined.bin")
+                .count(),
+            1,
+            "join and replay must not import or author again"
+        );
+
+        joiner
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 35,
+                    "op": "transfer.cancel",
+                    "in": { "transfer_op_id": "op-socket-upload-join-1" }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(completed_cancel) = joiner.next().await.unwrap().unwrap() else {
+            panic!("completed transfer cancel refusal must be Text");
+        };
+        let completed_cancel: jeliya_codec::Reply =
+            serde_json::from_str(&completed_cancel).unwrap();
+        assert!(matches!(
+            completed_cancel.err,
+            Some(jeliya_api::ApiError::TransferUnknown { .. })
+        ));
+
+        owner.close(None).await.unwrap();
+        joiner.close(None).await.unwrap();
+        for server in [owner_server, joiner_server] {
+            tokio::time::timeout(std::time::Duration::from_secs(1), server)
+                .await
+                .expect("connection teardown")
+                .expect("serve task");
+        }
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_succeeds_at_served_maximum_with_sentinel_credit() {
+        const EXPECTED_MAX_SHARED_BYTES: u64 = 100 * 1024 * 1024;
+        const DATA_PAYLOAD_BYTES: usize = 65_536;
+        const DATA_PAYLOAD_BYTES_U64: u64 = 65_536;
+        const REQUEST_ID: u64 = 36;
+
+        // A complete DATA record is bounded to 64 KiB by RuntimeLimits. Keep
+        // exactly one such payload resident and wait for advancing CREDIT
+        // after each record, so the test never allocates or queues the whole
+        // 100 MiB upload.
+        let max_frame_bytes = jeliya_codec::STREAM_HEADER_BYTES + DATA_PAYLOAD_BYTES;
+        let (dir, state) = test_state(u64::try_from(max_frame_bytes).unwrap());
+        let declared = state.engine.limits().max_shared_file_bytes;
+        assert_eq!(declared, EXPECTED_MAX_SHARED_BYTES);
+        assert_eq!(
+            state.runtime_limits.max_data_payload_bytes(),
+            DATA_PAYLOAD_BYTES
+        );
+
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::SubjectEnsure(
+                jeliya_api::SubjectEnsure {},
+            ))
+            .await
+            .reply
+            .expect("subject.ensure");
+        let created = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomCreate(
+                jeliya_api::RoomCreate {
+                    name: "maximum socket upload".into(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.create");
+        let jeliya_core::typed::TypedReply::RoomCreate(created) = created else {
+            panic!("wrong room.create reply");
+        };
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomActivate(
+                jeliya_api::RoomActivate {
+                    room_id: created.room_id.clone(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.activate");
+
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": REQUEST_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": created.room_id,
+                        "name": "served-maximum.bin",
+                        "declared_bytes": declared,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("send maximum file.share");
+
+        let Message::Binary(open) = client.next().await.unwrap().unwrap() else {
+            panic!("maximum upload must begin with Binary OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        assert_eq!(
+            open.body,
+            jeliya_codec::StreamRecordBody::Open { total: declared }
+        );
+        let identity = open.identity;
+
+        let Message::Binary(initial_credit) = client.next().await.unwrap().unwrap() else {
+            panic!("OPEN must be followed by Binary CREDIT");
+        };
+        let initial_credit = jeliya_codec::decode_stream_record(&initial_credit, &bounds).unwrap();
+        assert_eq!(initial_credit.identity, identity);
+        assert_eq!(
+            initial_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: DATA_PAYLOAD_BYTES_U64,
+            }
+        );
+
+        upload_through_declared_boundary(
+            &mut client,
+            REQUEST_ID,
+            identity,
+            declared,
+            DATA_PAYLOAD_BYTES,
+            &bounds,
+        )
+        .await;
+
+        client
+            .send(Message::Binary(
+                stream_wire(0x04, REQUEST_ID, identity.stream_id().get(), declared, 0).into(),
+            ))
+            .await
+            .expect("send END at the served maximum");
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(120), client.next())
+            .await
+            .expect("maximum upload finalization completes")
+            .expect("maximum upload connection remains open")
+            .expect("maximum upload terminal is readable");
+        let Message::Text(terminal) = terminal else {
+            panic!("maximum upload terminal must be Text");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert!(terminal.ok, "maximum upload failed: {:?}", terminal.err);
+        let output: jeliya_api::FileShareOut =
+            serde_json::from_value(terminal.out.expect("maximum upload output")).unwrap();
+        assert_eq!(output.bytes, declared);
+        assert!(!output.digest.is_empty());
+
+        let listed = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::FileList(
+                jeliya_api::FileList {
+                    room_id: created.room_id.clone(),
+                    page: jeliya_api::Page {
+                        cursor: jeliya_api::Cursor::Start,
+                        direction: jeliya_api::Direction::Forward,
+                        limit: 100,
+                    },
+                },
+            ))
+            .await
+            .reply
+            .expect("file.list after maximum upload");
+        let jeliya_core::typed::TypedReply::FileList(listed) = listed else {
+            panic!("wrong file.list reply");
+        };
+        assert_eq!(listed.files.len(), 1, "exactly one file_shared event");
+        assert_eq!(listed.files[0].file_id, output.file_id);
+        assert_eq!(listed.files[0].name, "served-maximum.bin");
+
+        let protocol_staging = dir.path().join("protocol-v2-stream-staging");
+        assert!(protocol_staging.is_dir());
+        assert_eq!(
+            std::fs::read_dir(protocol_staging).unwrap().count(),
+            0,
+            "successful maximum upload leaves no protocol staging residue"
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_declared_max_plus_one_refuses_before_open() {
+        const REQUEST_ID: u64 = 131;
+        const SURVIVAL_ID: u64 = 132;
+
+        let (dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let limit = state.engine.limits().max_shared_file_bytes;
+        let declared = limit.checked_add(1).unwrap();
+        let protocol_staging = dir.path().join("protocol-v2-stream-staging");
+        assert!(!protocol_staging.exists());
+
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": REQUEST_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "declared-too-large.bin",
+                        "declared_bytes": declared,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let Message::Text(refused) = next_socket_message(&mut client).await else {
+            panic!("stage_declared refusal must be Text without OPEN");
+        };
+        let refused: jeliya_codec::Reply = serde_json::from_str(&refused).unwrap();
+        assert_eq!(refused.id, REQUEST_ID);
+        assert_eq!(
+            refused.err,
+            Some(jeliya_api::ApiError::FileTooLarge {
+                declared_bytes: declared,
+                limit_bytes: limit,
+                enforced_at: jeliya_api::EnforcedAt::StageDeclared,
+            })
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert!(
+            !protocol_staging.exists(),
+            "declared policy runs before reservation and staging"
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SURVIVAL_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(survival) = next_socket_message(&mut client).await else {
+            panic!("stage_declared refusal must leave the connection usable");
+        };
+        let survival: jeliya_codec::Reply = serde_json::from_str(&survival).unwrap();
+        assert_eq!(survival.id, SURVIVAL_ID);
+        assert!(survival.ok);
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_declared_sentinel_data_aborts_then_replies_mismatch() {
+        const REQUEST_ID: u64 = 133;
+        const SURVIVAL_ID: u64 = 134;
+        const DECLARED: u64 = 3;
+
+        let (dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": REQUEST_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "declared-sentinel-probe.bin",
+                        "declared_bytes": DECLARED,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(open) = next_socket_message(&mut client).await else {
+            panic!("ordinary upload must OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        assert_eq!(
+            open.body,
+            jeliya_codec::StreamRecordBody::Open { total: DECLARED }
+        );
+        let identity = open.identity;
+        let Message::Binary(initial_credit) = next_socket_message(&mut client).await else {
+            panic!("ordinary upload OPEN must be followed by CREDIT");
+        };
+        let initial_credit = jeliya_codec::decode_stream_record(&initial_credit, &bounds).unwrap();
+        assert_eq!(initial_credit.identity, identity);
+        assert_eq!(
+            initial_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: DECLARED,
+            }
+        );
+
+        client
+            .send(Message::Binary(
+                stream_data_wire(REQUEST_ID, identity.stream_id().get(), 0, b"abc").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(sentinel_credit) = next_socket_message(&mut client).await else {
+            panic!("accepted declaration must expose sentinel CREDIT");
+        };
+        let sentinel_credit =
+            jeliya_codec::decode_stream_record(&sentinel_credit, &bounds).unwrap();
+        assert_eq!(sentinel_credit.identity, identity);
+        assert_eq!(
+            sentinel_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: DECLARED,
+                send_through: DECLARED + 1,
+            }
+        );
+
+        client
+            .send(Message::Binary(
+                stream_data_wire(REQUEST_ID, identity.stream_id().get(), DECLARED, b"x").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(abort) = next_socket_message(&mut client).await else {
+            panic!("one-past declaration DATA must receive daemon ABORT");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: DECLARED,
+                reason: jeliya_codec::BinaryAbortReason::OperationError,
+            }
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        client
+            .send(Message::Binary(
+                stream_wire(0x06, REQUEST_ID, identity.stream_id().get(), DECLARED, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(terminal) = next_socket_message(&mut client).await else {
+            panic!("declared mismatch terminal must follow client ACK as Text");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.id, REQUEST_ID);
+        assert_eq!(
+            terminal.err,
+            Some(jeliya_api::ApiError::DeclaredSizeMismatch {
+                declared_bytes: DECLARED,
+                observed_bytes: DECLARED + 1,
+            })
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.path().join("protocol-v2-stream-staging"))
+                .unwrap()
+                .count(),
+            0
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SURVIVAL_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(survival) = next_socket_message(&mut client).await else {
+            panic!("declared mismatch must leave the connection usable");
+        };
+        let survival: jeliya_codec::Reply = serde_json::from_str(&survival).unwrap();
+        assert_eq!(survival.id, SURVIVAL_ID);
+        assert!(survival.ok);
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_maximum_sentinel_data_aborts_then_replies_stage_stream() {
+        const EXPECTED_MAX_SHARED_BYTES: u64 = 100 * 1024 * 1024;
+        const DATA_PAYLOAD_BYTES: usize = 65_536;
+        const DATA_PAYLOAD_BYTES_U64: u64 = 65_536;
+        const REQUEST_ID: u64 = 135;
+        const SURVIVAL_ID: u64 = 136;
+
+        let max_frame_bytes = jeliya_codec::STREAM_HEADER_BYTES + DATA_PAYLOAD_BYTES;
+        let (dir, state, existing) =
+            file_state(b"seed", u64::try_from(max_frame_bytes).unwrap()).await;
+        let declared = state.engine.limits().max_shared_file_bytes;
+        assert_eq!(declared, EXPECTED_MAX_SHARED_BYTES);
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": REQUEST_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "maximum-sentinel-probe.bin",
+                        "declared_bytes": declared,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(open) = next_socket_message(&mut client).await else {
+            panic!("maximum sentinel probe must OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        assert_eq!(
+            open.body,
+            jeliya_codec::StreamRecordBody::Open { total: declared }
+        );
+        let identity = open.identity;
+        let Message::Binary(initial_credit) = next_socket_message(&mut client).await else {
+            panic!("maximum OPEN must be followed by CREDIT");
+        };
+        let initial_credit = jeliya_codec::decode_stream_record(&initial_credit, &bounds).unwrap();
+        assert_eq!(initial_credit.identity, identity);
+        assert_eq!(
+            initial_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: DATA_PAYLOAD_BYTES_U64,
+            }
+        );
+        upload_through_declared_boundary(
+            &mut client,
+            REQUEST_ID,
+            identity,
+            declared,
+            DATA_PAYLOAD_BYTES,
+            &bounds,
+        )
+        .await;
+
+        client
+            .send(Message::Binary(
+                stream_data_wire(REQUEST_ID, identity.stream_id().get(), declared, b"x").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(abort) = next_socket_message(&mut client).await else {
+            panic!("maximum+1 DATA must receive daemon ABORT");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: declared,
+                reason: jeliya_codec::BinaryAbortReason::OperationError,
+            }
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        client
+            .send(Message::Binary(
+                stream_wire(0x06, REQUEST_ID, identity.stream_id().get(), declared, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(terminal) = next_socket_message(&mut client).await else {
+            panic!("stage_stream terminal must follow client ACK as Text");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.id, REQUEST_ID);
+        assert_eq!(
+            terminal.err,
+            Some(jeliya_api::ApiError::FileTooLarge {
+                declared_bytes: declared,
+                limit_bytes: declared,
+                enforced_at: jeliya_api::EnforcedAt::StageStream,
+            })
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.path().join("protocol-v2-stream-staging"))
+                .unwrap()
+                .count(),
+            0,
+            "maximum sentinel is observed but never staged"
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SURVIVAL_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(survival) = next_socket_message(&mut client).await else {
+            panic!("stage_stream refusal must leave the connection usable");
+        };
+        let survival: jeliya_codec::Reply = serde_json::from_str(&survival).unwrap();
+        assert_eq!(survival.id, SURVIVAL_ID);
+        assert!(survival.ok);
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_duplicate_end_closes_4007_but_preserves_one_replayable_finalization() {
+        const OWNER_ID: u64 = 37;
+        const REPLAY_ID: u64 = 38;
+
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let room_id = existing.room_id;
+        let request = serde_json::json!({
+            "op_id": "op-duplicate-end-finalization",
+            "op": "file.share",
+            "in": {
+                "room_id": room_id,
+                "name": "duplicate-end.bin",
+                "declared_bytes": 0,
+                "declared_content_type": "application/octet-stream",
+            }
+        });
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+
+        let (mut owner, owner_server) = socket_pair(state.clone()).await;
+        assert!(matches!(owner.next().await, Some(Ok(Message::Text(_)))));
+        let mut owner_request = request.clone();
+        owner_request["id"] = OWNER_ID.into();
+        owner
+            .send(Message::Text(owner_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Binary(open) = owner.next().await.unwrap().unwrap() else {
+            panic!("duplicate-END upload must open");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        let identity = open.identity;
+        assert_eq!(open.body, jeliya_codec::StreamRecordBody::Open { total: 0 });
+        let Message::Binary(credit) = owner.next().await.unwrap().unwrap() else {
+            panic!("duplicate-END upload must receive sentinel CREDIT");
+        };
+        assert_eq!(
+            jeliya_codec::decode_stream_record(&credit, &bounds)
+                .unwrap()
+                .body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            }
+        );
+
+        let end =
+            Message::Binary(stream_wire(0x04, OWNER_ID, identity.stream_id().get(), 0, 0).into());
+        owner.feed(end.clone()).await.unwrap();
+        owner.feed(end).await.unwrap();
+        owner.flush().await.unwrap();
+
+        let close = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match owner.next().await {
+                    Some(Ok(Message::Close(frame))) => break frame,
+                    Some(Ok(Message::Text(reply))) => {
+                        let reply: jeliya_codec::Reply = serde_json::from_str(&reply).unwrap();
+                        assert!(reply.ok, "accepted END result must not be rewritten");
+                    }
+                    Some(Ok(other)) => panic!("unexpected post-END message: {other:?}"),
+                    Some(Err(error)) => panic!("connection failed before Close: {error}"),
+                    None => panic!("connection ended without 4007 Close"),
+                }
+            }
+        })
+        .await
+        .expect("duplicate END must close promptly");
+        let close = close.expect("malformed close carries a frame");
+        assert_eq!(close.code, 4007.into());
+        tokio::time::timeout(std::time::Duration::from_secs(2), owner_server)
+            .await
+            .expect("duplicate-END connection teardown")
+            .expect("serve task");
+
+        let (mut replay, replay_server) = socket_pair(state.clone()).await;
+        assert!(matches!(replay.next().await, Some(Ok(Message::Text(_)))));
+        let mut replay_request = request;
+        replay_request["id"] = REPLAY_ID.into();
+        replay
+            .send(Message::Text(replay_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Text(replayed) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), replay.next())
+                .await
+                .expect("detached finalization publishes replay")
+                .unwrap()
+                .unwrap()
+        else {
+            panic!("faithful replay must return Text without a second OPEN");
+        };
+        let replayed: jeliya_codec::Reply = serde_json::from_str(&replayed).unwrap();
+        assert!(replayed.ok);
+
+        let listed = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::FileList(
+                jeliya_api::FileList {
+                    room_id,
+                    page: jeliya_api::Page {
+                        cursor: jeliya_api::Cursor::Start,
+                        direction: jeliya_api::Direction::Forward,
+                        limit: 100,
+                    },
+                },
+            ))
+            .await
+            .reply
+            .expect("file.list after duplicate END");
+        let jeliya_core::typed::TypedReply::FileList(listed) = listed else {
+            panic!("wrong file.list reply");
+        };
+        assert_eq!(
+            listed
+                .files
+                .iter()
+                .filter(|file| file.name == "duplicate-end.bin")
+                .count(),
+            1,
+            "duplicate END must not author a second event"
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        replay.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), replay_server)
+            .await
+            .expect("replay connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_shared_transfer_count_exhaustion_crosses_upload_to_download() {
+        const UPLOAD_ID: u64 = 91;
+        const REFUSED_READ_ID: u64 = 92;
+        const ADMITTED_READ_ID: u64 = 93;
+
+        let download = b"read";
+        let (_dir, mut state, read_request) = file_state(download, SOCKET_FRAME_BYTES as u64).await;
+        configure_transfer_pool(&mut state, 1, 8);
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": UPLOAD_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": read_request.room_id,
+                        "name": "count-holder.bin",
+                        "declared_bytes": 1,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(upload_open) = client.next().await.unwrap().unwrap() else {
+            panic!("first upload must receive OPEN");
+        };
+        let upload_open = jeliya_codec::decode_stream_record(&upload_open, &bounds).unwrap();
+        assert_eq!(
+            upload_open.body,
+            jeliya_codec::StreamRecordBody::Open { total: 1 }
+        );
+        let upload_identity = upload_open.identity;
+        let Message::Binary(upload_credit) = client.next().await.unwrap().unwrap() else {
+            panic!("upload OPEN must be followed by CREDIT");
+        };
+        let upload_credit = jeliya_codec::decode_stream_record(&upload_credit, &bounds).unwrap();
+        assert_eq!(
+            upload_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            }
+        );
+        assert_eq!(state.transfer_pool.usage(), (1, 1));
+
+        send_file_read(&mut client, REFUSED_READ_ID, &read_request).await;
+        let Message::Text(refused) = client.next().await.unwrap().unwrap() else {
+            panic!("count exhaustion must reply as Text without a second OPEN");
+        };
+        let refused: jeliya_codec::Reply = serde_json::from_str(&refused).unwrap();
+        assert_eq!(
+            refused.err,
+            Some(jeliya_api::ApiError::ResourceExhausted {
+                resource: "max_concurrent_transfers".into(),
+                limit: 1,
+            })
+        );
+        assert_eq!(state.transfer_pool.usage(), (1, 1));
+
+        // The refused download cannot disturb the upload that owns the slot.
+        client
+            .send(Message::Binary(
+                stream_data_wire(UPLOAD_ID, upload_identity.stream_id().get(), 0, b"x").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(sentinel) = client.next().await.unwrap().unwrap() else {
+            panic!("the active upload must remain usable");
+        };
+        let sentinel = jeliya_codec::decode_stream_record(&sentinel, &bounds).unwrap();
+        assert_eq!(
+            sentinel.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            }
+        );
+        client
+            .send(Message::Binary(
+                stream_wire(0x04, UPLOAD_ID, upload_identity.stream_id().get(), 1, 0).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(upload_reply) = client.next().await.unwrap().unwrap() else {
+            panic!("active upload terminal must be Text");
+        };
+        let upload_reply: jeliya_codec::Reply = serde_json::from_str(&upload_reply).unwrap();
+        assert!(upload_reply.ok);
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        // Releasing the upload slot makes the same-direction-independent
+        // download admission succeed on this connection.
+        send_file_read(&mut client, ADMITTED_READ_ID, &read_request).await;
+        let Message::Binary(read_open) = client.next().await.unwrap().unwrap() else {
+            panic!("released count capacity must admit file.read OPEN");
+        };
+        let read_open = jeliya_codec::decode_stream_record(&read_open, &bounds).unwrap();
+        assert_eq!(
+            read_open.body,
+            jeliya_codec::StreamRecordBody::Open {
+                total: download.len() as u64,
+            }
+        );
+        complete_open_file_read(
+            &mut client,
+            ADMITTED_READ_ID,
+            read_open.identity.stream_id().get(),
+            download,
+            &bounds,
+        )
+        .await;
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_shared_transfer_byte_exhaustion_crosses_download_to_upload() {
+        const READ_ID: u64 = 94;
+        const REFUSED_UPLOAD_ID: u64 = 95;
+        const ADMITTED_UPLOAD_ID: u64 = 96;
+
+        let download = b"read";
+        let (dir, mut state, read_request) = file_state(download, SOCKET_FRAME_BYTES as u64).await;
+        configure_transfer_pool(&mut state, 2, u64::try_from(download.len()).unwrap());
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        send_file_read(&mut client, READ_ID, &read_request).await;
+        let Message::Binary(read_open) = client.next().await.unwrap().unwrap() else {
+            panic!("first download must receive OPEN");
+        };
+        let read_open = jeliya_codec::decode_stream_record(&read_open, &bounds).unwrap();
+        assert_eq!(
+            read_open.body,
+            jeliya_codec::StreamRecordBody::Open {
+                total: download.len() as u64,
+            }
+        );
+        let read_identity = read_open.identity;
+        assert_eq!(
+            state.transfer_pool.usage(),
+            (1, u64::try_from(download.len()).unwrap())
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": REFUSED_UPLOAD_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": read_request.room_id,
+                        "name": "byte-refused.bin",
+                        "declared_bytes": 1,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(refused) = client.next().await.unwrap().unwrap() else {
+            panic!("byte exhaustion must reply as Text without an upload OPEN");
+        };
+        let refused: jeliya_codec::Reply = serde_json::from_str(&refused).unwrap();
+        assert_eq!(
+            refused.err,
+            Some(jeliya_api::ApiError::ResourceExhausted {
+                resource: "max_transfer_bytes_inflight".into(),
+                limit: u64::try_from(download.len()).unwrap(),
+            })
+        );
+        assert!(
+            !dir.path().join("protocol-v2-stream-staging").exists(),
+            "byte refusal precedes upload staging creation"
+        );
+
+        // The refused upload cannot disturb the download holding the bytes.
+        complete_open_file_read(
+            &mut client,
+            READ_ID,
+            read_identity.stream_id().get(),
+            download,
+            &bounds,
+        )
+        .await;
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": ADMITTED_UPLOAD_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": read_request.room_id,
+                        "name": "byte-admitted.bin",
+                        "declared_bytes": 1,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(upload_open) = client.next().await.unwrap().unwrap() else {
+            panic!("released byte capacity must admit file.share OPEN");
+        };
+        let upload_open = jeliya_codec::decode_stream_record(&upload_open, &bounds).unwrap();
+        assert_eq!(
+            upload_open.body,
+            jeliya_codec::StreamRecordBody::Open { total: 1 }
+        );
+        let upload_identity = upload_open.identity;
+        let Message::Binary(upload_credit) = client.next().await.unwrap().unwrap() else {
+            panic!("admitted upload OPEN must be followed by CREDIT");
+        };
+        let upload_credit = jeliya_codec::decode_stream_record(&upload_credit, &bounds).unwrap();
+        assert_eq!(
+            upload_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: 1,
+            }
+        );
+        client
+            .send(Message::Binary(
+                stream_data_wire(
+                    ADMITTED_UPLOAD_ID,
+                    upload_identity.stream_id().get(),
+                    0,
+                    b"y",
+                )
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(sentinel) = client.next().await.unwrap().unwrap() else {
+            panic!("admitted upload must reach sentinel CREDIT");
+        };
+        let sentinel = jeliya_codec::decode_stream_record(&sentinel, &bounds).unwrap();
+        assert_eq!(
+            sentinel.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            }
+        );
+        client
+            .send(Message::Binary(
+                stream_wire(
+                    0x04,
+                    ADMITTED_UPLOAD_ID,
+                    upload_identity.stream_id().get(),
+                    1,
+                    0,
+                )
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(upload_reply) = client.next().await.unwrap().unwrap() else {
+            panic!("admitted upload terminal must be Text");
+        };
+        let upload_reply: jeliya_codec::Reply = serde_json::from_str(&upload_reply).unwrap();
+        assert!(upload_reply.ok);
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert_eq!(
+            std::fs::read_dir(dir.path().join("protocol-v2-stream-staging"))
+                .unwrap()
+                .count(),
+            0
+        );
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_full_tiny_record_credit_window_cannot_starve_controls_or_abort() {
+        const UPLOAD_ID: u64 = 118;
+        const ORDINARY_ID: u64 = 119;
+
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let window = state.runtime_limits.max_data_payload_bytes();
+        assert!(window > 4, "regression must exceed the former fixed lane");
+        let declared = u64::try_from(window).unwrap();
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": UPLOAD_ID,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "tiny-window.bin",
+                        "declared_bytes": declared,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(open) = next_socket_message(&mut client).await else {
+            panic!("upload must begin with OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        assert_eq!(
+            open.body,
+            jeliya_codec::StreamRecordBody::Open { total: declared }
+        );
+        let identity = open.identity;
+        let Message::Binary(credit) = next_socket_message(&mut client).await else {
+            panic!("OPEN must be followed by CREDIT");
+        };
+        let credit = jeliya_codec::decode_stream_record(&credit, &bounds).unwrap();
+        assert_eq!(credit.identity, identity);
+        assert_eq!(
+            credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 0,
+                send_through: declared,
+            }
+        );
+
+        // Fill the complete legal window with the maximum possible record
+        // count without reading staging progress. The next Ping, ordinary
+        // Text request, and producer ABORT must still reach their independent
+        // control paths through the real WebSocket reader.
+        for offset in 0..window {
+            client
+                .send(Message::Binary(
+                    stream_data_wire(
+                        UPLOAD_ID,
+                        identity.stream_id().get(),
+                        u64::try_from(offset).unwrap(),
+                        &[0x5a],
+                    )
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        }
+        let ping_payload = b"after-full-upload-window".to_vec();
+        client
+            .send(Message::Ping(ping_payload.clone().into()))
+            .await
+            .unwrap();
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": ORDINARY_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        client
+            .send(Message::Binary(
+                stream_wire(0x05, UPLOAD_ID, identity.stream_id().get(), 0, 0x01).into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut saw_pong = false;
+        let mut ordinary_reply = false;
+        let mut acknowledged = None;
+        let mut upload_reply = None;
+        while !saw_pong || !ordinary_reply || acknowledged.is_none() || upload_reply.is_none() {
+            match next_socket_message(&mut client).await {
+                Message::Pong(payload) => {
+                    assert_eq!(payload.as_ref(), ping_payload.as_slice());
+                    saw_pong = true;
+                }
+                Message::Binary(bytes) => {
+                    let record = jeliya_codec::decode_stream_record(&bytes, &bounds).unwrap();
+                    assert_eq!(record.identity, identity);
+                    match record.body {
+                        jeliya_codec::StreamRecordBody::Credit { .. } => {}
+                        jeliya_codec::StreamRecordBody::Ack { accepted_through } => {
+                            assert!(acknowledged.replace(accepted_through).is_none());
+                        }
+                        other => panic!("unexpected upload control after client ABORT: {other:?}"),
+                    }
+                }
+                Message::Text(text) => {
+                    let reply: jeliya_codec::Reply = serde_json::from_str(&text).unwrap();
+                    if reply.id == ORDINARY_ID {
+                        assert!(reply.ok);
+                        ordinary_reply = true;
+                    } else if reply.id == UPLOAD_ID {
+                        assert!(!reply.ok);
+                        assert!(upload_reply.replace(reply).is_none());
+                    } else {
+                        panic!("unexpected reply id {}", reply.id);
+                    }
+                }
+                other => panic!("unexpected message while draining upload controls: {other:?}"),
+            }
+        }
+
+        let acknowledged = acknowledged.unwrap();
+        let upload_reply = upload_reply.unwrap();
+        assert!(matches!(
+            upload_reply.err,
+            Some(jeliya_api::ApiError::StreamAborted {
+                transferred_bytes,
+                total: jeliya_api::ByteTotal::Known { bytes },
+                reason: jeliya_api::StreamAbortReason::Cancelled,
+            }) if transferred_bytes == acknowledged && bytes == declared
+        ));
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn websocket_interleaves_multiple_uploads_download_requests_controls_and_pushes() {
+        const SUBSCRIBE_ID: u64 = 121;
+        const UPLOAD_ONE_ID: u64 = 122;
+        const UPLOAD_TWO_ID: u64 = 123;
+        const READ_ID: u64 = 124;
+        const ORDINARY_ID: u64 = 125;
+        const UPLOAD_ONE_NAME: &str = "interleaved-one.bin";
+        const UPLOAD_TWO_NAME: &str = "interleaved-two.bin";
+
+        let download = b"download";
+        let (dir, mut state, read_request) = file_state(download, SOCKET_FRAME_BYTES as u64).await;
+        let mut interleaved_limits = state.engine.limits();
+        interleaved_limits.max_frame_bytes = SOCKET_FRAME_BYTES as u64;
+        interleaved_limits.transfer_connect_allowance_ms = 60_000;
+        interleaved_limits.transfer_stall_ms = 60_000;
+        state.runtime_limits =
+            crate::transfer::RuntimeLimits::from_served(&interleaved_limits).unwrap();
+        state.transfer_pool = crate::transfer::TransferPool::from_runtime(&state.runtime_limits);
+        let push_loop = state.engine.start_push_loop();
+        let room_id = read_request.room_id.clone();
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SUBSCRIBE_ID,
+                    "op": "stream.subscribe",
+                    "in": jeliya_api::StreamSubscribe {
+                        room_id: room_id.clone(),
+                        from: jeliya_api::Cursor::Start,
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        loop {
+            let Message::Text(text) = next_socket_message(&mut client).await else {
+                panic!("stream.subscribe must receive a Text reply");
+            };
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            if value.get("id").and_then(serde_json::Value::as_u64) == Some(SUBSCRIBE_ID) {
+                let reply: jeliya_codec::Reply = serde_json::from_value(value).unwrap();
+                assert!(reply.ok);
+                break;
+            }
+            let _: jeliya_api::Push = serde_json::from_value(value).unwrap();
+        }
+
+        for (id, name) in [
+            (UPLOAD_ONE_ID, UPLOAD_ONE_NAME),
+            (UPLOAD_TWO_ID, UPLOAD_TWO_NAME),
+        ] {
+            client
+                .send(Message::Text(
+                    serde_json::json!({
+                        "id": id,
+                        "op": "file.share",
+                        "in": {
+                            "room_id": room_id,
+                            "name": name,
+                            "declared_bytes": 1,
+                            "declared_content_type": "application/octet-stream",
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        }
+        send_file_read(&mut client, READ_ID, &read_request).await;
+
+        let mut upload_one = None;
+        let mut upload_two = None;
+        let mut read = None;
+        let mut upload_one_credit = false;
+        let mut upload_two_credit = false;
+        while upload_one.is_none()
+            || upload_two.is_none()
+            || read.is_none()
+            || !upload_one_credit
+            || !upload_two_credit
+        {
+            match next_socket_message(&mut client).await {
+                Message::Binary(bytes) => {
+                    let record = jeliya_codec::decode_stream_record(&bytes, &bounds).unwrap();
+                    match (record.identity.request_id().get(), record.body) {
+                        (UPLOAD_ONE_ID, jeliya_codec::StreamRecordBody::Open { total: 1 }) => {
+                            assert!(upload_one.replace(record.identity).is_none());
+                        }
+                        (
+                            UPLOAD_ONE_ID,
+                            jeliya_codec::StreamRecordBody::Credit {
+                                accepted_through: 0,
+                                send_through: 1,
+                            },
+                        ) => {
+                            assert_eq!(upload_one, Some(record.identity));
+                            upload_one_credit = true;
+                        }
+                        (UPLOAD_TWO_ID, jeliya_codec::StreamRecordBody::Open { total: 1 }) => {
+                            assert!(upload_two.replace(record.identity).is_none());
+                        }
+                        (
+                            UPLOAD_TWO_ID,
+                            jeliya_codec::StreamRecordBody::Credit {
+                                accepted_through: 0,
+                                send_through: 1,
+                            },
+                        ) => {
+                            assert_eq!(upload_two, Some(record.identity));
+                            upload_two_credit = true;
+                        }
+                        (READ_ID, jeliya_codec::StreamRecordBody::Open { total }) => {
+                            assert_eq!(total, u64::try_from(download.len()).unwrap());
+                            assert!(read.replace(record.identity).is_none());
+                        }
+                        (request_id, body) => {
+                            panic!("unexpected opening record for request {request_id}: {body:?}")
+                        }
+                    }
+                }
+                Message::Text(text) => {
+                    // A delayed push for the host-staged download source is
+                    // harmless; replies from these fresh stream requests are
+                    // forbidden before their terminal records.
+                    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    assert!(value.get("id").is_none(), "stream replied before OPEN");
+                    let _: jeliya_api::Push = serde_json::from_value(value).unwrap();
+                }
+                other => panic!("unexpected opening message: {other:?}"),
+            }
+        }
+        let upload_one = upload_one.unwrap();
+        let upload_two = upload_two.unwrap();
+        let read = read.unwrap();
+        assert_ne!(upload_one, upload_two);
+        assert_ne!(upload_one, read);
+        assert_ne!(upload_two, read);
+        assert_eq!(
+            state.transfer_pool.usage(),
+            (3, u64::try_from(download.len()).unwrap() + 2)
+        );
+
+        // Control and ordinary Text work must remain schedulable while all
+        // three byte streams are paused and active.
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": ORDINARY_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let ping_payload = b"interleaved-control".to_vec();
+        client
+            .send(Message::Ping(ping_payload.clone().into()))
+            .await
+            .unwrap();
+        let mut ordinary_reply = false;
+        let mut pong = false;
+        while !ordinary_reply || !pong {
+            match next_socket_message(&mut client).await {
+                Message::Text(text) => {
+                    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    if value.get("id").and_then(serde_json::Value::as_u64) == Some(ORDINARY_ID) {
+                        let reply: jeliya_codec::Reply = serde_json::from_value(value).unwrap();
+                        assert!(reply.ok);
+                        ordinary_reply = true;
+                    } else {
+                        let _: jeliya_api::Push = serde_json::from_value(value).unwrap();
+                    }
+                }
+                Message::Pong(payload) => {
+                    assert_eq!(payload.as_ref(), ping_payload.as_slice());
+                    pong = true;
+                }
+                other => panic!("paused streams emitted unexpected work: {other:?}"),
+            }
+        }
+
+        // Complete the first upload while the second upload and download stay
+        // active. Its subscribed file_shared push and terminal reply may
+        // arrive in either order.
+        client
+            .send(Message::Binary(
+                stream_data_wire(UPLOAD_ONE_ID, upload_one.stream_id().get(), 0, b"a").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(first_sentinel) = next_socket_message(&mut client).await else {
+            panic!("first upload must advance CREDIT");
+        };
+        let first_sentinel = jeliya_codec::decode_stream_record(&first_sentinel, &bounds).unwrap();
+        assert_eq!(first_sentinel.identity, upload_one);
+        assert_eq!(
+            first_sentinel.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            }
+        );
+        client
+            .send(Message::Binary(
+                stream_wire(0x04, UPLOAD_ONE_ID, upload_one.stream_id().get(), 1, 0).into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut first_reply = false;
+        let mut first_push = false;
+        while !first_reply || !first_push {
+            let message = next_socket_message(&mut client).await;
+            let Message::Text(text) = message else {
+                panic!("first upload completion must use Text reply/push frames, got {message:?}");
+            };
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            if value.get("id").and_then(serde_json::Value::as_u64) == Some(UPLOAD_ONE_ID) {
+                let reply: jeliya_codec::Reply = serde_json::from_value(value).unwrap();
+                assert!(reply.ok);
+                first_reply = true;
+                continue;
+            }
+            let push: jeliya_api::Push = serde_json::from_value(value).unwrap();
+            if let jeliya_api::Push::Event {
+                room_id: pushed,
+                event,
+            } = push
+            {
+                assert_eq!(pushed, room_id);
+                if let jeliya_api::EventKindContent::FileShared { name, .. } = event.kind {
+                    if name == UPLOAD_ONE_NAME {
+                        first_push = true;
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            state.transfer_pool.usage(),
+            (2, u64::try_from(download.len()).unwrap() + 1),
+            "the other upload and download remain admitted across the push"
+        );
+
+        // Now progress the remaining upload and download together. Route every
+        // Binary message by the complete identity; their relative order is
+        // intentionally unconstrained.
+        client
+            .send(Message::Binary(
+                stream_data_wire(UPLOAD_TWO_ID, upload_two.stream_id().get(), 0, b"b").into(),
+            ))
+            .await
+            .unwrap();
+        client
+            .send(Message::Binary(
+                stream_wire(
+                    0x03,
+                    READ_ID,
+                    read.stream_id().get(),
+                    0,
+                    u64::try_from(download.len()).unwrap(),
+                )
+                .into(),
+            ))
+            .await
+            .unwrap();
+
+        let mut second_end_sent = false;
+        let mut second_reply = false;
+        let mut second_push = false;
+        let mut read_accepted = 0_u64;
+        let mut read_end = false;
+        let mut read_reply = false;
+        while !second_reply || !second_push || !read_end || !read_reply {
+            match next_socket_message(&mut client).await {
+                Message::Binary(bytes) => {
+                    let record = jeliya_codec::decode_stream_record(&bytes, &bounds).unwrap();
+                    let request_id = record.identity.request_id().get();
+                    if request_id == UPLOAD_TWO_ID {
+                        assert_eq!(record.identity, upload_two);
+                        assert_eq!(
+                            record.body,
+                            jeliya_codec::StreamRecordBody::Credit {
+                                accepted_through: 1,
+                                send_through: 2,
+                            }
+                        );
+                        assert!(!second_end_sent);
+                        client
+                            .send(Message::Binary(
+                                stream_wire(
+                                    0x04,
+                                    UPLOAD_TWO_ID,
+                                    upload_two.stream_id().get(),
+                                    1,
+                                    0,
+                                )
+                                .into(),
+                            ))
+                            .await
+                            .unwrap();
+                        second_end_sent = true;
+                    } else if request_id == READ_ID {
+                        assert_eq!(record.identity, read);
+                        match record.body {
+                            jeliya_codec::StreamRecordBody::Data { offset, payload } => {
+                                assert_eq!(offset, read_accepted);
+                                let start = usize::try_from(read_accepted).unwrap();
+                                assert_eq!(payload, download[start..start + payload.len()]);
+                                read_accepted += u64::try_from(payload.len()).unwrap();
+                                client
+                                    .send(Message::Binary(
+                                        stream_wire(
+                                            0x03,
+                                            READ_ID,
+                                            read.stream_id().get(),
+                                            read_accepted,
+                                            u64::try_from(download.len()).unwrap(),
+                                        )
+                                        .into(),
+                                    ))
+                                    .await
+                                    .unwrap();
+                            }
+                            jeliya_codec::StreamRecordBody::End { total } => {
+                                assert_eq!(total, u64::try_from(download.len()).unwrap());
+                                assert_eq!(read_accepted, total);
+                                read_end = true;
+                            }
+                            other => panic!("unexpected download record: {other:?}"),
+                        }
+                    } else {
+                        panic!("Binary record crossed to request {request_id}");
+                    }
+                }
+                Message::Text(text) => {
+                    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+                    if let Some(id) = value.get("id").and_then(serde_json::Value::as_u64) {
+                        let reply: jeliya_codec::Reply = serde_json::from_value(value).unwrap();
+                        assert!(reply.ok);
+                        match id {
+                            UPLOAD_TWO_ID => second_reply = true,
+                            READ_ID => read_reply = true,
+                            _ => panic!("unexpected terminal reply id {id}"),
+                        }
+                    } else {
+                        let push: jeliya_api::Push = serde_json::from_value(value).unwrap();
+                        if let jeliya_api::Push::Event {
+                            room_id: pushed,
+                            event,
+                        } = push
+                        {
+                            assert_eq!(pushed, room_id);
+                            if let jeliya_api::EventKindContent::FileShared { name, .. } =
+                                event.kind
+                            {
+                                if name == UPLOAD_TWO_NAME {
+                                    second_push = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                other => panic!("unexpected interleaved message: {other:?}"),
+            }
+        }
+        assert!(second_end_sent);
+        assert_eq!(read_accepted, u64::try_from(download.len()).unwrap());
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert_eq!(
+            std::fs::read_dir(dir.path().join("protocol-v2-stream-staging"))
+                .unwrap()
+                .count(),
+            0
+        );
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+        push_loop.stop();
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_cancel_is_principal_scoped_and_idempotent() {
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let room_id = existing.room_id;
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let transfer_op_id = "op-socket-upload-cancel-1";
+
+        let (mut owner, owner_server) = socket_pair(state.clone()).await;
+        let (mut joiner, joiner_server) = socket_pair(state.clone()).await;
+        let (mut canceller, canceller_server) = socket_pair(state.clone()).await;
+        let (mut stranger, stranger_server) = socket_pair_as(state.clone(), "other-client").await;
+        for client in [&mut owner, &mut joiner, &mut canceller, &mut stranger] {
+            assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        }
+
+        owner
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 41,
+                    "op_id": transfer_op_id,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": room_id,
+                        "name": "cancelled.bin",
+                        "declared_bytes": 3,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(open) = owner.next().await.unwrap().unwrap() else {
+            panic!("upload owner must receive OPEN");
+        };
+        let open = jeliya_codec::decode_stream_record(&open, &bounds).unwrap();
+        let identity = open.identity;
+        assert!(matches!(
+            owner.next().await.unwrap().unwrap(),
+            Message::Binary(_)
+        ));
+
+        joiner
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 44,
+                    "op_id": transfer_op_id,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": room_id,
+                        "name": "cancelled.bin",
+                        "declared_bytes": 3,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), joiner.next())
+                .await
+                .is_err(),
+            "faithful join must receive neither OPEN nor an early reply"
+        );
+
+        stranger
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 51,
+                    "op": "transfer.cancel",
+                    "in": { "transfer_op_id": transfer_op_id }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(unknown) = stranger.next().await.unwrap().unwrap() else {
+            panic!("wrong-principal cancel refusal must be Text");
+        };
+        let unknown: jeliya_codec::Reply = serde_json::from_str(&unknown).unwrap();
+        assert!(matches!(
+            unknown.err,
+            Some(jeliya_api::ApiError::TransferUnknown { .. })
+        ));
+
+        canceller
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 42,
+                    "op_id": "ignored-cancel-envelope-id",
+                    "op": "transfer.cancel",
+                    "in": { "transfer_op_id": transfer_op_id }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(cancelled) = canceller.next().await.unwrap().unwrap() else {
+            panic!("cancel outcome must be Text");
+        };
+        let cancelled: jeliya_codec::Reply = serde_json::from_str(&cancelled).unwrap();
+        let cancelled: jeliya_api::TransferCancelOut =
+            serde_json::from_value(cancelled.out.expect("cancelled outcome")).unwrap();
+        assert_eq!(cancelled.outcome, jeliya_api::CancelOutcome::Cancelled);
+        assert_eq!(cancelled.transferred_bytes, 0);
+        assert_eq!(cancelled.total, jeliya_api::ByteTotal::Known { bytes: 3 });
+        assert_eq!(
+            state.transfer_pool.usage(),
+            (0, 0),
+            "cancel reply cannot outrun local reservation release"
+        );
+
+        let Message::Binary(abort) = owner.next().await.unwrap().unwrap() else {
+            panic!("winning cancellation must send daemon ABORT");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: jeliya_codec::BinaryAbortReason::Cancelled,
+            }
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), joiner.next())
+                .await
+                .is_err(),
+            "ledger publication must wait for the owner's explicit ACK obligation"
+        );
+        owner
+            .send(Message::Binary(
+                stream_wire(0x06, 41, identity.stream_id().get(), 0, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(original) = owner.next().await.unwrap().unwrap() else {
+            panic!("original upload terminal must follow ACK as Text");
+        };
+        let original: jeliya_codec::Reply = serde_json::from_str(&original).unwrap();
+        assert_eq!(
+            original.err,
+            Some(jeliya_api::ApiError::StreamAborted {
+                transferred_bytes: 0,
+                total: jeliya_api::ByteTotal::Known { bytes: 3 },
+                reason: jeliya_api::StreamAbortReason::Cancelled,
+            })
+        );
+        let Message::Text(joined) = joiner.next().await.unwrap().unwrap() else {
+            panic!("faithful join must receive the selected terminal Text result");
+        };
+        let joined: jeliya_codec::Reply = serde_json::from_str(&joined).unwrap();
+        assert_eq!(joined.err, original.err);
+
+        canceller
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 43,
+                    "op": "transfer.cancel",
+                    "in": { "transfer_op_id": transfer_op_id }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(already) = canceller.next().await.unwrap().unwrap() else {
+            panic!("repeat cancel outcome must be Text");
+        };
+        let already: jeliya_codec::Reply = serde_json::from_str(&already).unwrap();
+        let already: jeliya_api::TransferCancelOut =
+            serde_json::from_value(already.out.expect("already-cancelled outcome")).unwrap();
+        assert_eq!(already.outcome, jeliya_api::CancelOutcome::AlreadyCancelled);
+        assert_eq!(already.transferred_bytes, cancelled.transferred_bytes);
+        assert_eq!(already.total, cancelled.total);
+
+        owner.close(None).await.unwrap();
+        joiner.close(None).await.unwrap();
+        canceller.close(None).await.unwrap();
+        stranger.close(None).await.unwrap();
+        for server in [
+            owner_server,
+            joiner_server,
+            canceller_server,
+            stranger_server,
+        ] {
+            tokio::time::timeout(std::time::Duration::from_secs(1), server)
+                .await
+                .expect("connection teardown")
+                .expect("serve task");
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_crossed_abort_is_correlated_and_connection_survives() {
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 55,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "crossed-abort.bin",
+                        "declared_bytes": 0,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(open) = client.next().await.unwrap().unwrap() else {
+            panic!("upload must open");
+        };
+        let identity = jeliya_codec::decode_stream_record(&open, &bounds)
+            .unwrap()
+            .identity;
+        assert!(matches!(
+            client.next().await.unwrap().unwrap(),
+            Message::Binary(_)
+        ));
+
+        // Empty DATA is an exact-bound request-local fault. Queue a valid
+        // producer ABORT immediately behind it so the daemon must preserve its
+        // selected protocol_error while discharging both ACK obligations.
+        client
+            .send(Message::Binary(
+                stream_wire(0x02, 55, identity.stream_id().get(), 0, 0).into(),
+            ))
+            .await
+            .unwrap();
+        client
+            .send(Message::Binary(
+                stream_wire(0x05, 55, identity.stream_id().get(), 0, 0x02).into(),
+            ))
+            .await
+            .unwrap();
+
+        let Message::Binary(daemon_abort) = client.next().await.unwrap().unwrap() else {
+            panic!("bound fault must send daemon ABORT");
+        };
+        let daemon_abort = jeliya_codec::decode_stream_record(&daemon_abort, &bounds).unwrap();
+        assert_eq!(daemon_abort.identity, identity);
+        assert_eq!(
+            daemon_abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: jeliya_codec::BinaryAbortReason::ProtocolError,
+            }
+        );
+        let Message::Binary(client_abort_ack) = client.next().await.unwrap().unwrap() else {
+            panic!("daemon must ACK the crossed producer ABORT");
+        };
+        let client_abort_ack =
+            jeliya_codec::decode_stream_record(&client_abort_ack, &bounds).unwrap();
+        assert_eq!(client_abort_ack.identity, identity);
+        assert_eq!(
+            client_abort_ack.body,
+            jeliya_codec::StreamRecordBody::Ack {
+                accepted_through: 0,
+            }
+        );
+        client
+            .send(Message::Binary(
+                stream_wire(0x06, 55, identity.stream_id().get(), 0, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(terminal) = client.next().await.unwrap().unwrap() else {
+            panic!("daemon terminal must follow the crossed ACK exchange");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.err, Some(jeliya_api::ApiError::MalformedFrame));
+
+        client
+            .send(Message::Text(
+                r#"{"id":56,"op":"subject.ensure","in":{}}"#.into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(unrelated) = client.next().await.unwrap().unwrap() else {
+            panic!("request-local upload fault must leave the connection usable");
+        };
+        let unrelated: jeliya_codec::Reply = serde_json::from_str(&unrelated).unwrap();
+        assert!(unrelated.ok);
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 57,
+                    "op": "file.share",
+                    "in": {
+                        "room_id": existing.room_id,
+                        "name": "client-abort.bin",
+                        "declared_bytes": 0,
+                        "declared_content_type": "application/octet-stream",
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(second_open) = client.next().await.unwrap().unwrap() else {
+            panic!("unrelated upload must still open");
+        };
+        let second_identity = jeliya_codec::decode_stream_record(&second_open, &bounds)
+            .unwrap()
+            .identity;
+        assert!(matches!(
+            client.next().await.unwrap().unwrap(),
+            Message::Binary(_)
+        ));
+        client
+            .send(Message::Binary(
+                stream_wire(0x05, 57, second_identity.stream_id().get(), 0, 0x02).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(ack) = client.next().await.unwrap().unwrap() else {
+            panic!("producer ABORT must be ACKed");
+        };
+        let ack = jeliya_codec::decode_stream_record(&ack, &bounds).unwrap();
+        assert_eq!(ack.identity, second_identity);
+        assert_eq!(
+            ack.body,
+            jeliya_codec::StreamRecordBody::Ack {
+                accepted_through: 0,
+            }
+        );
+        let Message::Text(aborted) = client.next().await.unwrap().unwrap() else {
+            panic!("client ABORT must finish with Text stream_aborted");
+        };
+        let aborted: jeliya_codec::Reply = serde_json::from_str(&aborted).unwrap();
+        assert_eq!(
+            aborted.err,
+            Some(jeliya_api::ApiError::StreamAborted {
+                transferred_bytes: 0,
+                total: jeliya_api::ByteTotal::Known { bytes: 0 },
+                reason: jeliya_api::StreamAbortReason::SourceFailed,
+            })
+        );
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_daemon_abort_ack_timeout_replies_then_closes_4007() {
+        const REQUEST_ID: u64 = 71;
+        const STALL_MS: u64 = 200;
+
+        let (dir, mut state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        configure_transfer_timers(&mut state, STALL_MS, 5_000, 8_000);
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        let identity = open_one_byte_file_share(
+            &mut client,
+            REQUEST_ID,
+            existing.room_id.as_str(),
+            "ack-timeout.bin",
+            &bounds,
+        )
+        .await;
+
+        // Freeze only after staging and OPEN/CREDIT have completed. The
+        // malformed record then selects protocol_error without allowing a
+        // paused clock to race asynchronous staging setup.
+        tokio::time::pause();
+        client
+            .send(Message::Binary(
+                stream_wire(0x02, REQUEST_ID, identity.stream_id().get(), 0, 0).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(abort) = next_socket_message(&mut client).await else {
+            panic!("bound malformed DATA must receive daemon ABORT");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: jeliya_codec::BinaryAbortReason::ProtocolError,
+            }
+        );
+
+        // The local terminal decision releases admission and discards the
+        // private stage before waiting for the producer's exact ACK.
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        let staging = dir.path().join("protocol-v2-stream-staging");
+        assert_eq!(std::fs::read_dir(&staging).unwrap().count(), 0);
+
+        assert!(
+            client.next().now_or_never().is_none(),
+            "terminal Text must wait for the ACK boundary"
+        );
+        tokio::time::advance(std::time::Duration::from_millis(STALL_MS - 1)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            client.next().now_or_never().is_none(),
+            "ACK wait must remain open through transfer_stall_ms - 1"
+        );
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+
+        let Message::Text(terminal) = next_socket_message(&mut client).await else {
+            panic!("ACK timeout must publish the selected terminal Text result");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.id, REQUEST_ID);
+        assert_eq!(terminal.err, Some(jeliya_api::ApiError::MalformedFrame));
+
+        let Message::Close(Some(close)) = next_socket_message(&mut client).await else {
+            panic!("ACK timeout terminal must be followed by a Close frame");
+        };
+        assert_eq!(u16::from(close.code), 4007);
+        assert_eq!(close.reason, "malformed_frame");
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("ACK-timeout connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert_eq!(std::fs::read_dir(staging).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_no_progress_stalls_and_survives_exact_ack() {
+        const REQUEST_ID: u64 = 72;
+        const SURVIVAL_ID: u64 = 73;
+        const STALL_MS: u64 = 100;
+
+        let (dir, mut state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        configure_transfer_timers(&mut state, STALL_MS, 5_000, 8_000);
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        let identity = open_one_byte_file_share(
+            &mut client,
+            REQUEST_ID,
+            existing.room_id.as_str(),
+            "stalled-upload.bin",
+            &bounds,
+        )
+        .await;
+
+        tokio::time::pause();
+        tokio::time::advance(std::time::Duration::from_millis(STALL_MS)).await;
+        tokio::task::yield_now().await;
+        let Message::Binary(abort) = next_socket_message(&mut client).await else {
+            panic!("zero accepted progress must receive daemon ABORT");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: 0,
+                reason: jeliya_codec::BinaryAbortReason::OperationError,
+            }
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        let staging = dir.path().join("protocol-v2-stream-staging");
+        assert_eq!(std::fs::read_dir(&staging).unwrap().count(), 0);
+
+        client
+            .send(Message::Binary(
+                stream_wire(0x06, REQUEST_ID, identity.stream_id().get(), 0, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(terminal) = next_socket_message(&mut client).await else {
+            panic!("exact ACK must release the stalled terminal Text reply");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.id, REQUEST_ID);
+        assert_eq!(
+            terminal.err,
+            Some(jeliya_api::ApiError::TransferStalled {
+                transferred_bytes: 0,
+                total: jeliya_api::ByteTotal::Known { bytes: 1 },
+            })
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SURVIVAL_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(survival) = next_socket_message(&mut client).await else {
+            panic!("an exact daemon-ABORT ACK must preserve the connection");
+        };
+        let survival: jeliya_codec::Reply = serde_json::from_str(&survival).unwrap();
+        assert_eq!(survival.id, SURVIVAL_ID);
+        assert!(survival.ok);
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("stalled upload connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert_eq!(std::fs::read_dir(staging).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_progress_resets_stall_but_not_absolute_deadline() {
+        const REQUEST_ID: u64 = 74;
+        const SURVIVAL_ID: u64 = 75;
+        const STALL_MS: u64 = 1_000;
+        const DEADLINE_BUDGET_MS: u64 = 1_600;
+
+        let (dir, mut state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        // One byte costs exactly 1 ms at 8,000 bits/s, so the admitted
+        // absolute budget is 1,599 + 1 = 1,600 ms. Accepting at about 800 ms
+        // moves the stall boundary to about 1,800 ms without moving the
+        // absolute deadline.
+        configure_transfer_timers(&mut state, STALL_MS, 1_599, 8_000);
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let (mut client, server) = socket_pair(state.clone()).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+        let identity = open_one_byte_file_share(
+            &mut client,
+            REQUEST_ID,
+            existing.room_id.as_str(),
+            "deadline-upload.bin",
+            &bounds,
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        client
+            .send(Message::Binary(
+                stream_data_wire(REQUEST_ID, identity.stream_id().get(), 0, b"x").into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(sentinel_credit) = next_socket_message(&mut client).await else {
+            panic!("durably accepted progress must advance CREDIT");
+        };
+        let sentinel_credit =
+            jeliya_codec::decode_stream_record(&sentinel_credit, &bounds).unwrap();
+        assert_eq!(sentinel_credit.identity, identity);
+        assert_eq!(
+            sentinel_credit.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            }
+        );
+
+        let Message::Binary(abort) = next_socket_message(&mut client).await else {
+            panic!("absolute deadline must receive daemon ABORT after progress");
+        };
+        let abort = jeliya_codec::decode_stream_record(&abort, &bounds).unwrap();
+        assert_eq!(abort.identity, identity);
+        assert_eq!(
+            abort.body,
+            jeliya_codec::StreamRecordBody::Abort {
+                accepted_through: 1,
+                reason: jeliya_codec::BinaryAbortReason::OperationError,
+            }
+        );
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        let staging = dir.path().join("protocol-v2-stream-staging");
+        assert_eq!(std::fs::read_dir(&staging).unwrap().count(), 0);
+
+        client
+            .send(Message::Binary(
+                stream_wire(0x06, REQUEST_ID, identity.stream_id().get(), 1, 0x05).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(terminal) = next_socket_message(&mut client).await else {
+            panic!("exact ACK must release the deadline terminal Text reply");
+        };
+        let terminal: jeliya_codec::Reply = serde_json::from_str(&terminal).unwrap();
+        assert_eq!(terminal.id, REQUEST_ID);
+        assert_eq!(
+            terminal.err,
+            Some(jeliya_api::ApiError::TransferDeadlineExceeded {
+                transferred_bytes: 1,
+                total: jeliya_api::ByteTotal::Known { bytes: 1 },
+                budget_ms: DEADLINE_BUDGET_MS,
+            })
+        );
+
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": SURVIVAL_ID,
+                    "op": "room.list",
+                    "in": {},
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(survival) = next_socket_message(&mut client).await else {
+            panic!("deadline terminal with exact ACK must preserve the connection");
+        };
+        let survival: jeliya_codec::Reply = serde_json::from_str(&survival).unwrap();
+        assert_eq!(survival.id, SURVIVAL_ID);
+        assert!(survival.ok);
+
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), server)
+            .await
+            .expect("deadline upload connection teardown")
+            .expect("serve task");
+        assert_eq!(state.transfer_pool.usage(), (0, 0));
+        assert_eq!(std::fs::read_dir(staging).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn websocket_file_share_disconnect_replays_pre_and_post_end_results() {
+        let (_dir, state, existing) = file_state(b"seed", SOCKET_FRAME_BYTES as u64).await;
+        let room_id = existing.room_id;
+        let bounds = jeliya_codec::CodecBounds {
+            max_frame_bytes: SOCKET_FRAME_BYTES,
+            ..jeliya_codec::CodecBounds::default()
+        };
+        let pre_body = serde_json::json!({
+            "op_id": "op-socket-upload-pre-end-loss-1",
+            "op": "file.share",
+            "in": {
+                "room_id": room_id,
+                "name": "pre-end-lost.bin",
+                "declared_bytes": 1,
+                "declared_content_type": "application/octet-stream",
+            }
+        });
+
+        let (mut first, first_server) = socket_pair(state.clone()).await;
+        assert!(matches!(first.next().await, Some(Ok(Message::Text(_)))));
+        let mut first_request = pre_body.clone();
+        first_request["id"] = 61.into();
+        first
+            .send(Message::Text(first_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Binary(open) = first.next().await.unwrap().unwrap() else {
+            panic!("pre-END upload must open");
+        };
+        let identity = jeliya_codec::decode_stream_record(&open, &bounds)
+            .unwrap()
+            .identity;
+        assert!(matches!(
+            first.next().await.unwrap().unwrap(),
+            Message::Binary(_)
+        ));
+        first
+            .send(Message::Binary(
+                stream_data_wire(61, identity.stream_id().get(), 0, &[7]).into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Binary(accepted) = first.next().await.unwrap().unwrap() else {
+            panic!("accepted DATA must advance sentinel CREDIT");
+        };
+        let accepted = jeliya_codec::decode_stream_record(&accepted, &bounds).unwrap();
+        assert_eq!(
+            accepted.body,
+            jeliya_codec::StreamRecordBody::Credit {
+                accepted_through: 1,
+                send_through: 2,
+            }
+        );
+        drop(first);
+        tokio::time::timeout(std::time::Duration::from_secs(1), first_server)
+            .await
+            .expect("pre-END disconnect teardown")
+            .expect("serve task");
+
+        let (mut replay, replay_server) = socket_pair(state.clone()).await;
+        assert!(matches!(replay.next().await, Some(Ok(Message::Text(_)))));
+        let mut replay_request = pre_body;
+        replay_request["id"] = 62.into();
+        replay
+            .send(Message::Text(replay_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Text(pre_lost) = replay.next().await.unwrap().unwrap() else {
+            panic!("pre-END replay must return Text without OPEN");
+        };
+        let pre_lost: jeliya_codec::Reply = serde_json::from_str(&pre_lost).unwrap();
+        assert_eq!(
+            pre_lost.err,
+            Some(jeliya_api::ApiError::StreamAborted {
+                transferred_bytes: 1,
+                total: jeliya_api::ByteTotal::Known { bytes: 1 },
+                reason: jeliya_api::StreamAbortReason::TransportLost,
+            })
+        );
+
+        let post_body = serde_json::json!({
+            "op_id": "op-socket-upload-post-end-loss-1",
+            "op": "file.share",
+            "in": {
+                "room_id": room_id,
+                "name": "post-end-committed.bin",
+                "declared_bytes": 0,
+                "declared_content_type": "application/octet-stream",
+            }
+        });
+        let mut post_request = post_body.clone();
+        post_request["id"] = 63.into();
+        replay
+            .send(Message::Text(post_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Binary(post_open) = replay.next().await.unwrap().unwrap() else {
+            panic!("post-END owner must open");
+        };
+        let post_identity = jeliya_codec::decode_stream_record(&post_open, &bounds)
+            .unwrap()
+            .identity;
+        assert!(matches!(
+            replay.next().await.unwrap().unwrap(),
+            Message::Binary(_)
+        ));
+        replay
+            .send(Message::Binary(
+                stream_wire(0x04, 63, post_identity.stream_id().get(), 0, 0).into(),
+            ))
+            .await
+            .unwrap();
+        // Drop immediately after the END write: the actor must honor the
+        // already-routed terminal before connection invalidation can synthesize
+        // transport_lost.
+        drop(replay);
+        tokio::time::timeout(std::time::Duration::from_secs(1), replay_server)
+            .await
+            .expect("post-END disconnect teardown")
+            .expect("serve task");
+
+        let (mut final_replay, final_server) = socket_pair(state.clone()).await;
+        assert!(matches!(
+            final_replay.next().await,
+            Some(Ok(Message::Text(_)))
+        ));
+        let mut final_request = post_body;
+        final_request["id"] = 64.into();
+        final_replay
+            .send(Message::Text(final_request.to_string().into()))
+            .await
+            .unwrap();
+        let Message::Text(committed) = final_replay.next().await.unwrap().unwrap() else {
+            panic!("post-END replay must return the committed Text result");
+        };
+        let committed: jeliya_codec::Reply = serde_json::from_str(&committed).unwrap();
+        assert!(committed.ok);
+
+        let listed = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::FileList(
+                jeliya_api::FileList {
+                    room_id: room_id.clone(),
+                    page: jeliya_api::Page {
+                        cursor: jeliya_api::Cursor::Start,
+                        direction: jeliya_api::Direction::Forward,
+                        limit: 100,
+                    },
+                },
+            ))
+            .await
+            .reply
+            .expect("file.list after disconnect races");
+        let jeliya_core::typed::TypedReply::FileList(listed) = listed else {
+            panic!("wrong file.list reply");
+        };
+        assert_eq!(
+            listed
+                .files
+                .iter()
+                .filter(|file| file.name == "pre-end-lost.bin")
+                .count(),
+            0
+        );
+        assert_eq!(
+            listed
+                .files
+                .iter()
+                .filter(|file| file.name == "post-end-committed.bin")
+                .count(),
+            1
+        );
+        final_replay.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), final_server)
+            .await
+            .expect("final replay teardown")
             .expect("serve task");
         assert_eq!(state.transfer_pool.usage(), (0, 0));
     }

--- a/crates/jeliyad/src/transfer.rs
+++ b/crates/jeliyad/src/transfer.rs
@@ -35,6 +35,8 @@ pub(crate) struct RuntimeLimits {
     max_frame_bytes: usize,
     max_data_payload_bytes: usize,
     data_queue_capacity_bytes: usize,
+    upload_ingress_capacity_bytes: usize,
+    upload_ingress_capacity_messages: usize,
     control_queue_capacity_messages: usize,
     data_queue_capacity_messages: usize,
     max_concurrent_transfers: u64,
@@ -79,6 +81,8 @@ impl RuntimeLimits {
             limits.max_transfer_bytes_inflight,
             max_data_payload_bytes,
         )?;
+        let (upload_ingress_capacity_bytes, upload_ingress_capacity_messages) =
+            upload_ingress_capacity(limits.max_concurrent_transfers, max_data_payload_bytes)?;
         let control_queue_capacity_messages = writer_queue_capacity(
             "control",
             limits.max_inflight_requests,
@@ -96,6 +100,8 @@ impl RuntimeLimits {
             max_frame_bytes,
             max_data_payload_bytes,
             data_queue_capacity_bytes,
+            upload_ingress_capacity_bytes,
+            upload_ingress_capacity_messages,
             control_queue_capacity_messages,
             data_queue_capacity_messages,
             max_concurrent_transfers: limits.max_concurrent_transfers,
@@ -128,6 +134,19 @@ impl RuntimeLimits {
     /// Byte permits reserved for at most one queued DATA record per transfer.
     pub(crate) const fn data_queue_capacity_bytes(self) -> usize {
         self.data_queue_capacity_bytes
+    }
+
+    /// Complete inbound DATA bytes retained across every upload on one
+    /// connection. This covers the largest legal credit window even when it
+    /// is split into one-byte records, so a producer that obeys CREDIT cannot
+    /// block the socket reader before a following control message is read.
+    pub(crate) const fn upload_ingress_capacity_bytes(self) -> usize {
+        self.upload_ingress_capacity_bytes
+    }
+
+    /// Per-upload DATA record slots for the largest legal credit window.
+    pub(crate) const fn upload_ingress_capacity_messages(self) -> usize {
+        self.upload_ingress_capacity_messages
     }
 
     /// Aggregate queued Text/control bytes. One maximum-size message always
@@ -415,6 +434,13 @@ pub(crate) enum RuntimeConfigError {
         capacity_bytes: usize,
         maximum: usize,
     },
+    /// The legal upload credit window cannot be represented on this host.
+    UploadIngressCapacityNotRepresentable,
+    /// Tokio's byte semaphore cannot represent the legal upload window.
+    UploadIngressCapacityTooLarge {
+        capacity_bytes: usize,
+        maximum: usize,
+    },
     /// The advertised complete-message bound cannot back a byte semaphore.
     ControlQueueCapacityTooLarge {
         capacity_bytes: usize,
@@ -471,6 +497,16 @@ impl fmt::Display for RuntimeConfigError {
             } => write!(
                 f,
                 "DATA queue capacity {capacity_bytes} exceeds semaphore maximum {maximum}"
+            ),
+            Self::UploadIngressCapacityNotRepresentable => {
+                f.write_str("the bounded upload ingress capacity is not representable")
+            }
+            Self::UploadIngressCapacityTooLarge {
+                capacity_bytes,
+                maximum,
+            } => write!(
+                f,
+                "upload ingress capacity {capacity_bytes} exceeds semaphore maximum {maximum}"
             ),
             Self::ControlQueueCapacityTooLarge {
                 capacity_bytes,
@@ -647,6 +683,38 @@ fn data_queue_capacity(
     Ok(capacity_bytes)
 }
 
+fn upload_ingress_capacity(
+    max_concurrent_transfers: u64,
+    max_data_payload_bytes: usize,
+) -> Result<(usize, usize), RuntimeConfigError> {
+    // CREDIT grants at most one DATA-payload window per upload at a time.
+    // Because DATA is nonempty, splitting that window into one-byte records
+    // also maximizes its record count and complete-record header overhead.
+    // Reserving that full legal window keeps the sole WebSocket reader free to
+    // reach a following END, ABORT, ACK, JSON request, Ping, or Close. Records
+    // that fail receive-side policy, continuity, or CREDIT validation bypass
+    // this DATA lane as ordered terminal work.
+    let messages_per_upload = max_data_payload_bytes.max(1);
+    let complete_one_byte_record = STREAM_HEADER_BYTES
+        .checked_add(1)
+        .ok_or(RuntimeConfigError::UploadIngressCapacityNotRepresentable)?;
+    let per_upload_bytes = messages_per_upload
+        .checked_mul(complete_one_byte_record)
+        .ok_or(RuntimeConfigError::UploadIngressCapacityNotRepresentable)?;
+    let concurrent = usize::try_from(max_concurrent_transfers)
+        .map_err(|_| RuntimeConfigError::UploadIngressCapacityNotRepresentable)?;
+    let capacity_bytes = concurrent
+        .checked_mul(per_upload_bytes)
+        .ok_or(RuntimeConfigError::UploadIngressCapacityNotRepresentable)?;
+    if capacity_bytes > Semaphore::MAX_PERMITS {
+        return Err(RuntimeConfigError::UploadIngressCapacityTooLarge {
+            capacity_bytes,
+            maximum: Semaphore::MAX_PERMITS,
+        });
+    }
+    Ok((capacity_bytes, messages_per_upload))
+}
+
 fn deadline_budget_ms(
     connect_allowance_ms: u64,
     floor_bits_per_second: u64,
@@ -814,6 +882,11 @@ mod tests {
             2 * (STREAM_HEADER_BYTES + 65_536)
         );
         assert_eq!(
+            runtime.upload_ingress_capacity_bytes(),
+            2 * 65_536 * (STREAM_HEADER_BYTES + 1)
+        );
+        assert_eq!(runtime.upload_ingress_capacity_messages(), 65_536);
+        assert_eq!(
             runtime.control_queue_capacity_messages(),
             usize::try_from(limits.max_inflight_requests).unwrap() + CONTROL_QUEUE_ALLOWANCE
         );
@@ -894,12 +967,8 @@ mod tests {
             })
         ));
 
-        limits = served_limits();
-        limits.max_concurrent_transfers = maximum;
-        limits.max_transfer_bytes_inflight = 0;
-        let exact_data = RuntimeLimits::from_served(&limits).expect("exact channel maximum");
         assert_eq!(
-            exact_data.data_queue_capacity_messages(),
+            writer_queue_capacity("DATA", maximum, 0, 1).expect("exact channel maximum"),
             Semaphore::MAX_PERMITS
         );
 
@@ -909,16 +978,47 @@ mod tests {
         let one_past_maximum_usize = Semaphore::MAX_PERMITS
             .checked_add(1)
             .expect("Tokio reserves headroom below usize::MAX");
-        limits.max_concurrent_transfers = one_past_maximum;
-        limits.max_transfer_bytes_inflight = 0;
         assert_eq!(
-            RuntimeLimits::from_served(&limits),
+            writer_queue_capacity("DATA", one_past_maximum, 0, 1),
             Err(RuntimeConfigError::WriterQueueCapacityTooLarge {
                 queue: "DATA",
                 capacity_messages: one_past_maximum_usize,
                 maximum: Semaphore::MAX_PERMITS,
             })
         );
+
+        limits = served_limits();
+        limits.max_transfer_bytes_inflight = 0;
+        let ingress_bytes_per_upload = limits
+            .max_frame_bytes
+            .checked_sub(STREAM_HEADER_BYTES as u64)
+            .unwrap()
+            .min(65_536)
+            .checked_mul((STREAM_HEADER_BYTES + 1) as u64)
+            .unwrap();
+        let ingress_transfers_at_maximum =
+            u64::try_from(Semaphore::MAX_PERMITS).unwrap() / ingress_bytes_per_upload;
+        limits.max_concurrent_transfers = ingress_transfers_at_maximum;
+        let exact_ingress = RuntimeLimits::from_served(&limits)
+            .expect("largest complete upload ingress bound below semaphore maximum");
+        assert_eq!(
+            exact_ingress.upload_ingress_capacity_bytes(),
+            usize::try_from(ingress_transfers_at_maximum * ingress_bytes_per_upload).unwrap()
+        );
+
+        limits.max_concurrent_transfers = ingress_transfers_at_maximum + 1;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::UploadIngressCapacityTooLarge { .. })
+        ));
+
+        limits.max_concurrent_transfers = maximum;
+        limits.max_transfer_bytes_inflight = 0;
+        assert!(matches!(
+            RuntimeLimits::from_served(&limits),
+            Err(RuntimeConfigError::UploadIngressCapacityNotRepresentable
+                | RuntimeConfigError::UploadIngressCapacityTooLarge { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Refs #233

## Summary

- implement the complete consumer-direction protocol-v2 `file.share` stream runtime over Binary `JBS2` records while preserving Text JSON and the existing `file.read` path
- add bounded forward-only protocol staging, sentinel CREDIT, atomic DATA acceptance, END finalization, ABORT/ACK races, deadlines, stalls, disconnect cleanup, and shared transfer admission
- generalize the operation ledger for principal-scoped streamed owner/join/replay and implement cross-connection `transfer.cancel` for uploads with `op_id`
- add startup cleanup scoped only to abandoned protocol-upload staging and preserve the host-staged API and HTTP file routes
- add raw-wire codec, state-machine, fault-injection, resource-bound, replay, cancellation, and WebSocket integration coverage

## Scope

This is the third implementation slice for #233. Replay-harness execution, clients, Dioxus, adapters/FFI, `file.fetch`, progress pushes, and HTTP route changes remain out of scope.

## Validation

- `cargo +1.96.0 fmt --all --check`
- `cargo +1.96.0 build --locked --workspace`
- `cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings`
- `cargo +1.96.0 test --locked --workspace`
- `cargo +1.91.0 check --locked --workspace --all-targets`
- `node scripts/check-docs.mjs`
- `node scripts/check-v2-corpus.mjs`
- `git diff --check`