### PR TITLE
test(conformance): retire the inexecutable aggregate no-path case and validate fixture variable bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,10 @@ jobs:
       # (conformance/v2) is validated shape-wise by scripts/check-v2-corpus.mjs,
       # and the live replay harness runs against the real daemon.
       - name: Protocol-v2 conformance corpus shape validation
-        run: node scripts/check-v2-corpus.mjs
+        run: |
+          set -euo pipefail
+          node --test scripts/check-v2-corpus.test.mjs
+          node scripts/check-v2-corpus.mjs
 
       - name: Protocol-v2 conformance replay (handshake + subject lifecycle)
         run: |

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -608,7 +608,15 @@ bodies and `upgrade` query values resolve whole, so only whole-string
 references count there. A `save` on a `send` or `control` step is invalid —
 the runner applies captures only where a step produces a result. One
 reply-position builtin exists: `await {reply: "$id"}` names the connection's
-most recent request id and is not a variable. An unknown reference is invalid rather than an
+most recent request id and is not a variable. `$request` is likewise
+positional — legal only as a deferred call's save source, and an ordinary,
+never-bound name anywhere else. A dotted tail on a documented binding other
+than `$limits`/`$daemon` is invalid: those bindings are scalar identifiers,
+so the tail resolves against nothing. Binding validation proves the capture
+statement exists and gates which names a step may read; whether a save's
+*source path* resolves at replay is executor behavior — the corpus-wide
+bracket-index notation (`out.files[0].file_id`) predates this contract and
+is settled with the executor work, not here. An unknown reference is invalid rather than an
 interestingly-named literal: the harness resolves an unbound `$name` to its
 literal string form, which satisfies subset matching and quietly turns the
 step into no evidence at all. Two pre-existing U2-blocked fixtures

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -585,9 +585,11 @@ resource preconditions (`resource:shared_file`, `resource:fetched_file`,
 `resource:large_file`) bind `$fid`, with the large-file companions
 `$fid_unsized` and `$fid_one_byte` bound by `resource:large_file`. Like the
 deferred-call contract, this states the DSL contract; the current live
-harness pre-seeds the unconditional set and implements the room, member,
-subject, and tcp-service bindings, while the file-resource and foreign-room
-bindings await their executor.
+harness pre-seeds the unconditional set and implements the
+`room:plain`/`live`/`quiescent`/`with_history`/`left`, single-letter member
+(`member:b`/`member:c`), second-subject/outsider, and tcp-service bindings,
+while `room:removed`, the agent-member variants, and the file-resource and
+foreign-room bindings await their executor.
 
 In `files.json` the validator enforces the contract: every `$name` a step
 reads must be captured by a `save` on an **earlier** step of the same case,
@@ -596,11 +598,15 @@ documented name alone is never evidence, because the historical failure was
 exactly a `requires` rewrite that dropped a binding while the reference
 survived. A whole-string `$`-prefixed value that is not a well-formed
 reference (`$fid-2`, `$fid[0]` — shapes the harness cannot resolve) is
-invalid outright, and a `$`-rooted assertion or save path must open with the
-bare variable name followed by `.` or nothing (`$rid[0].secret` looks up the
-nonexistent variable `rid[0]`, so an `absent` on it would silently pass).
-`http` and `upgrade` strings are scanned for embedded references too, since
-the harness substitutes `$name` mid-string there (`Bearer $token`). One
+invalid outright, and a `$`-rooted assertion or save path must be the bare
+variable name followed by well-formed dot segments, each optionally carrying
+`[*]` (`$rid[0].secret`, `$rid..secret`, and `$rid.` all resolve against
+nothing, so an `absent` on them would silently pass). `http`/`upgrade`
+header values and the `http` path are scanned for embedded references, since
+the harness substitutes `$name` mid-string there (`Bearer $token`); `http`
+bodies and `upgrade` query values resolve whole, so only whole-string
+references count there. A `save` on a `send` or `control` step is invalid —
+the runner applies captures only where a step produces a result. One
 reply-position builtin exists: `await {reply: "$id"}` names the connection's
 most recent request id and is not a variable. An unknown reference is invalid rather than an
 interestingly-named literal: the harness resolves an unbound `$name` to its

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -596,7 +596,13 @@ documented name alone is never evidence, because the historical failure was
 exactly a `requires` rewrite that dropped a binding while the reference
 survived. A whole-string `$`-prefixed value that is not a well-formed
 reference (`$fid-2`, `$fid[0]` — shapes the harness cannot resolve) is
-invalid outright. An unknown reference is invalid rather than an
+invalid outright, and a `$`-rooted assertion or save path must open with the
+bare variable name followed by `.` or nothing (`$rid[0].secret` looks up the
+nonexistent variable `rid[0]`, so an `absent` on it would silently pass).
+`http` and `upgrade` strings are scanned for embedded references too, since
+the harness substitutes `$name` mid-string there (`Bearer $token`). One
+reply-position builtin exists: `await {reply: "$id"}` names the connection's
+most recent request id and is not a variable. An unknown reference is invalid rather than an
 interestingly-named literal: the harness resolves an unbound `$name` to its
 literal string form, which satisfies subset matching and quietly turns the
 step into no evidence at all. Two pre-existing U2-blocked fixtures

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -30,23 +30,23 @@ claims:
 
 | Slice | Status | What the claim means |
 |---|---|---|
-| Structural validation | Implemented for all 342 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics, and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
+| Structural validation | Implemented for all 341 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
 | Selected JSON-envelope/subject slice | Partial (14 CI-selected cases) | The Node harness runs this selected JSON-envelope and subject-lifecycle slice against `jeliyad`; this is neither corpus coverage nor file-stream evidence. It is not a smoke, E2E, or Dart execution claim. |
 | Binary byte-stream executor | Unimplemented | No harness codec/runtime executes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records, so file-stream cases are declarative, not live evidence. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
 |---|---:|
-| Cases | 342 |
+| Cases | 341 |
 | Attributed to an operation | 237 |
-| `operation: null` | 105 |
-| Untargeted / in-process-core / client-adapter targeted | 336 / 1 / 5 |
+| `operation: null` | 104 |
+| Untargeted / in-process-core / client-adapter targeted | 335 / 1 / 5 |
 | Distinct step verbs in use | 7 |
 | Taxonomy codes / without a direct canonical operation case or verified transport representation | 64 / 9 (`forbidden_origin`, `pairing_code_invalid`, `protocol_unsupported`, `role_not_grantable`, `session_expired`, `storage_generation_mismatch`, `stream_aborted`, `unauthenticated`, `unknown_operation`) |
 | Blocked on upstream | 14 (U1: 5, U2: 8, U3: 1) |
 | Blocked on a settled record contradiction | 1 |
 
-Per-file case totals are: `files.json` 44, `handshake.json` 69,
+Per-file case totals are: `files.json` 43, `handshake.json` 69,
 `invites.json` 37, `pipes.json` 43, `rooms.json` 65,
 `subject-daemon.json` 24, and `timeline-streams.json` 60.
 
@@ -64,6 +64,24 @@ exactly once; it is status metadata, not corpus coverage.
 The files pass-3 re-transcription retired cases about an unknown declared size:
 `declared_bytes` is a required `<uint>` and there are no optional request fields,
 so that state is not expressible in v2 and collapsed onto existing cases.
+
+The aggregate no-path case
+(`no_file_operation_carries_a_filesystem_path_in_any_direction`) was retired
+as inexecutable evidence. Its original transcription required
+`remote_provider` — the precondition that would have established the second,
+remotely provided file its `$fid2` named — and asserted over `all_frames`, a
+scope the normative DSL does not carry. Normalization replaced
+`remote_provider` with `link:up` and folded the assertions onto the final
+frame, so the fetch step named a file no surviving precondition or save
+established, the read step read the freshly shared `$fid` rather than a
+fetched file, and the path assertions ran only against the `transfer.cancel`
+reply. Its obligations live in the operation-specific share, list, fetch,
+read, and cancel cases, which assert the forbidden path-bearing keys `absent`
+on their actual reply roots. The validator now rejects an unbound `$name` in
+`files.json` — including a documented precondition variable whose binding
+precondition the case does not declare — closing this regression class apart
+from the two U2-blocked fixtures named in the validator's exemption ledger
+(see "Runner-provided variables").
 
 Top-level `authoring_notes`, where retained in unchanged domains, are historical,
 non-normative transcription notes. Validators never use them as taxonomy-code
@@ -550,6 +568,45 @@ capture. Retired `$result` and `$error` paths are invalid: use `out` and `err`.
 
 This replaces `save`, `save_out`, and `save_error`, which differed only in which
 root they read from — now expressed as the path's root.
+
+### Runner-provided variables
+
+`save` is the only in-case binder. Beyond it, the replay runner pre-seeds a
+small documented set before step 1 — `$op_id_new`, `$op_id_fixed`, `$limits`,
+`$daemon`, `$daemon_sg` — and the preconditions a case **declares** in
+`requires` bind the fixture identifiers the case operates on: room, member,
+or file-resource setup binds the case's `$rid` and `$self_sid` (a file exists
+only in a room, so a file resource establishes the room too; `room:left`
+additionally binds `$rid_left`); `room:foreign` binds `$foreign_rid` and
+`$foreign_fid`; `member:b`/`member:c` bind `$member_b_sid`/`$member_c_sid`;
+`subject:second` binds `$sb` and `subject:outsider` `$sc`;
+`resource:tcp_service` binds `$svc_port` and `$svc_port_v6`; and the file
+resource preconditions (`resource:shared_file`, `resource:fetched_file`,
+`resource:large_file`) bind `$fid`, with the large-file companions
+`$fid_unsized` and `$fid_one_byte` bound by `resource:large_file`. Like the
+deferred-call contract, this states the DSL contract; the current live
+harness pre-seeds the unconditional set and implements the room, member,
+subject, and tcp-service bindings, while the file-resource and foreign-room
+bindings await their executor.
+
+In `files.json` the validator enforces the contract: every `$name` a step
+reads must be captured by a `save` on an **earlier** step of the same case,
+or be documented above **with its binding precondition declared** — a
+documented name alone is never evidence, because the historical failure was
+exactly a `requires` rewrite that dropped a binding while the reference
+survived. A whole-string `$`-prefixed value that is not a well-formed
+reference (`$fid-2`, `$fid[0]` — shapes the harness cannot resolve) is
+invalid outright. An unknown reference is invalid rather than an
+interestingly-named literal: the harness resolves an unbound `$name` to its
+literal string form, which satisfies subset matching and quietly turns the
+step into no evidence at all. Two pre-existing U2-blocked fixtures
+(`a_transfer_with_no_forward_progress_fails_with_transfer_stalled` and
+`fetch_completed_result_replays_without_a_second_transfer`) read the `$fid`
+family without declaring a file resource precondition; they are exempted by
+name in the validator's ledger until their `requires` are repaired under
+#233. The legacy domains still carry pre-normalization placeholder
+conventions (`$op1`-style tokens), so enforcement extends to them only with
+their own re-transcription pass.
 
 ### Computed values
 

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -414,6 +414,26 @@
             {
               "path": "out.data_dir",
               "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
             }
           ]
         },
@@ -1465,6 +1485,78 @@
             {
               "path": "out.files[*].path",
               "op": "absent"
+            },
+            {
+              "path": "out.files[*].save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].file_url",
+              "op": "absent"
+            },
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
             }
           ]
         },
@@ -1759,6 +1851,30 @@
             },
             {
               "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
               "op": "absent"
             },
             {
@@ -2414,6 +2530,38 @@
               "op": "absent"
             },
             {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            },
+            {
               "path": "out.mime",
               "op": "absent"
             },
@@ -2807,6 +2955,50 @@
               "transfer_op_id": "op-does-not-exist"
             }
           }
+        },
+        {
+          "assert": [
+            {
+              "path": "err.path",
+              "op": "absent"
+            },
+            {
+              "path": "err.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "err.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.directory",
+              "op": "absent"
+            },
+            {
+              "path": "err.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "err.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.uri",
+              "op": "absent"
+            },
+            {
+              "path": "err.file_url",
+              "op": "absent"
+            }
+          ]
         }
       ]
     },
@@ -3453,6 +3645,46 @@
               "path": "out.transferred_bytes",
               "op": "lte",
               "value": "$cancel_total"
+            },
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
             }
           ],
           "on": "subject:self"
@@ -3749,122 +3981,6 @@
                 "op": "eq",
                 "value": 0
               }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "no_file_operation_carries_a_filesystem_path_in_any_direction",
-      "kind": "success",
-      "operation": null,
-      "intent": "Proves filesystem paths have left the protocol on the file surface: across a full share, list, fetch and read cycle no request or response contains a path-typed key or any value that normalizes to a path, which is what lets the same corpus serve a browser and an Android content:// consumer.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "doc.bin",
-            "declared_bytes": 4096,
-            "declared_content_type": "application/octet-stream"
-          },
-          "save": {
-            "fid": "out.file_id"
-          },
-          "op_id": "op-nopath-1",
-          "stream": {
-            "send_bytes": 4096
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid2"
-          },
-          "op_id": "op-nopath-2"
-        },
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "stream": {
-            "receive_bytes": 4096
-          }
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-nopath-2"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.path",
-              "op": "absent"
-            },
-            {
-              "path": "frame.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "frame.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "frame.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "frame.dir",
-              "op": "absent"
-            },
-            {
-              "path": "frame.directory",
-              "op": "absent"
-            },
-            {
-              "path": "frame.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "frame.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "frame.uri",
-              "op": "absent"
-            },
-            {
-              "path": "frame.file_url",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.data_dir",
-              "op": "absent"
             }
           ]
         }

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -101,16 +101,16 @@
     }
   ],
   "target_counts": {
-    "untargeted": 336,
+    "untargeted": 335,
     "daemon": 0,
     "in_process_core": 1,
     "client_adapter": 5
   },
   "totals": {
-    "cases": 342,
+    "cases": 341,
     "attributed_to_an_operation": 237,
-    "not_operation_scoped": 105,
-    "conforming_to_the_dsl": 342,
+    "not_operation_scoped": 104,
+    "conforming_to_the_dsl": 341,
     "distinct_step_verbs_in_use": 7,
     "quarantined": 0,
     "blocked_on_upstream": 14,
@@ -118,9 +118,9 @@
   },
   "per_file_totals": {
     "files.json": {
-      "cases": 44,
+      "cases": 43,
       "attributed_to_an_operation": 41,
-      "not_operation_scoped": 3,
+      "not_operation_scoped": 2,
       "blocked_on_upstream": {
         "U1": 0,
         "U2": 8,
@@ -468,8 +468,7 @@
     "by_file": {
       "files.json": [
         "file_operations_are_not_a_membership_oracle",
-        "handshake_serves_the_file_and_transfer_limits_as_integers",
-        "no_file_operation_carries_a_filesystem_path_in_any_direction"
+        "handshake_serves_the_file_and_transfer_limits_as_integers"
       ],
       "handshake.json": [
         "a_duplicate_in_flight_id_is_refused_and_executes_only_once",
@@ -586,7 +585,7 @@
         "the_push_stream_is_not_a_membership_oracle"
       ]
     },
-    "count": 105
+    "count": 104
   },
   "normalization": "Normalized in #213; `files.json` re-transcribed in pass 3, which added the `stream` DSL key (the files domain is not expressible without it), restored the record's file request and reply shapes, repaired the split assertion fragments, and retired two cases whose subject - an unknown declared size - v2 does not represent."
 }

--- a/docs/protocol-v2.md
+++ b/docs/protocol-v2.md
@@ -45,7 +45,7 @@ The record states
 [the corpus's own README](../conformance/v2/README.md) — one normative fixture
 DSL. An independent adapter can implement from this document alone.
 
-The 342 hand-authored fixtures in
+The 341 hand-authored fixtures in
 [`conformance/v2/`](../conformance/v2/README.md) are normalized to that DSL
 (#213): every case conforms structurally and the corpus is replayable by an
 independent harness. Shape validation is not live byte-stream evidence. Where a

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -130,6 +130,63 @@ const BARE_REQUIRES = new Set(["subject", "daemon"]);
 // The retired tags the README names explicitly.
 const RETIRED_TAGS = new Set(["hex64", "u64", "number", "int", "variant", "array"]);
 
+// The variable-binding contract for files.json (README "Runner-provided
+// variables"). The harness resolves a whole-string "$name" anywhere a literal
+// is legal, and conformance/v2/harness/values.mjs deliberately lets an
+// unresolved reference degrade to its literal string form — which satisfies
+// subset matching and turns the step into no evidence at all. Structural
+// validation therefore proves every reference is either captured by an
+// earlier save on the same case or documented below; otherwise a case can
+// reference a never-established "$fid2" and still read as coverage.
+const RUNNER_PROVIDED_VARIABLES = new Set([
+  // Pre-seeded for every case before step 1 (conformance/v2/harness/runner.mjs).
+  "op_id_new", "op_id_fixed", "limits", "daemon", "daemon_sg",
+]);
+// Which DECLARED precondition binds each documented variable (README
+// "Runner-provided variables"). The historical $fid2 regression was a
+// requires rewrite that lost a binding while the reference survived, so a
+// documented name alone is never evidence — the case must declare the
+// precondition that binds it, or capture the value itself with a save.
+const FILE_RESOURCE_REQUIRES = new Set([
+  "resource:shared_file", "resource:fetched_file", "resource:large_file",
+]);
+// A file exists only in a room, so a file resource precondition establishes
+// the room (and its authority subject) along with the file.
+const bindsOwnRoom = (requires) => requires.some((token) =>
+  /^room:(plain|live|quiescent|left|removed|with_history)$/.test(token)
+  || /^member:/.test(token) || FILE_RESOURCE_REQUIRES.has(token));
+const PRECONDITION_BINDINGS = new Map([
+  ["rid", bindsOwnRoom],
+  ["self_sid", bindsOwnRoom],
+  ["rid_left", (requires) => requires.includes("room:left")],
+  ["foreign_rid", (requires) => requires.includes("room:foreign")],
+  ["foreign_fid", (requires) => requires.includes("room:foreign")],
+  ["member_b_sid", (requires) => requires.includes("member:b")],
+  ["member_c_sid", (requires) => requires.includes("member:c")],
+  ["sb", (requires) => requires.includes("subject:second")],
+  ["sc", (requires) => requires.includes("subject:outsider")],
+  ["svc_port", (requires) => requires.includes("resource:tcp_service")],
+  ["svc_port_v6", (requires) => requires.includes("resource:tcp_service")],
+  ["fid", (requires) => requires.some((token) => FILE_RESOURCE_REQUIRES.has(token))],
+  ["fid_unsized", (requires) => requires.includes("resource:large_file")],
+  ["fid_one_byte", (requires) => requires.includes("resource:large_file")],
+]);
+// Two pre-existing U2-blocked fixtures read the fid family without declaring
+// a file resource precondition; their requires predate that vocabulary.
+// Exempting them BY NAME lets the conditional check land without editing
+// fixtures this change does not own — #233 tracks the requires repair, and
+// deleting an entry here is how its exemption closes.
+const PRECONDITION_GAP_CASES = new Map([
+  ["a_transfer_with_no_forward_progress_fails_with_transfer_stalled", new Set(["fid", "fid_unsized"])],
+  ["fetch_completed_result_replays_without_a_second_transfer", new Set(["fid"])],
+]);
+// A whole-string value reference the harness can resolve: "$name" plus
+// optional dot segments (values.mjs resolves the tail with resolvePath,
+// which splits on "." only — "$fid-2" or "$fid[0]" resolve to nothing and
+// degrade to literal strings, so they are malformed rather than clever).
+const VALUE_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)(?:\.[A-Za-z0-9_]+)*$/;
+const VARIABLE_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)/;
+
 const OPERATIONS = new Set([
   "subject.ensure", "daemon.stop",
   "room.create", "room.list", "room.activate", "room.deactivate", "room.leave",
@@ -293,6 +350,105 @@ function fileErrorIsCanonical(err) {
   return Array.isArray(err.providers) && err.providers.length > 0
     && err.providers.every((provider) =>
       checkExactKeySet(provider, ["subject_id", "device_id", "link"]));
+}
+
+/** The variable a "$name"-rooted path reads, or null for the non-variable
+ * roots: out/err/frame, "$" (the whole step value), and the deferred-call
+ * capture "$request". */
+function pathRootReference(path) {
+  if (typeof path !== "string" || path === "$request") return null;
+  if (path === "$" || path.startsWith("$.")) return null;
+  const m = path.match(VARIABLE_REFERENCE);
+  return m ? m[1] : null;
+}
+
+/** Collect every $variable read from a value node, recursing through arrays,
+ * objects, and computed-node operands ($unknown takes a type tag, never a
+ * reference). A whole-string "$…" value that is not a well-formed reference
+ * is collected as malformed ({name: null, raw}). */
+function collectValueReferences(node, at, refs) {
+  if (typeof node === "string") {
+    if (!node.startsWith("$")) return;
+    const m = node.match(VALUE_REFERENCE);
+    if (m) refs.push({ name: m[1], at });
+    else refs.push({ name: null, raw: node, at });
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((el, i) => collectValueReferences(el, `${at}[${i}]`, refs));
+    return;
+  }
+  if (isObject(node)) {
+    const keys = Object.keys(node);
+    if (keys.length === 1 && keys[0].startsWith("$")) {
+      if (keys[0] !== "$unknown") collectValueReferences(node[keys[0]], `${at}.${keys[0]}`, refs);
+      return;
+    }
+    for (const [k, v] of Object.entries(node)) collectValueReferences(v, `${at}.${k}`, refs);
+  }
+}
+
+/** Every $variable a step reads: nested inputs, the envelope op_id, stream
+ * counts, expectations, await matchers and reply handles, control value
+ * fields, assertion paths / comparison values / observation arguments, raw
+ * frames, http/upgrade requests, and save source paths. Label and vocabulary
+ * positions (`on`, control `do`/`between`/`limit`/`fault`/`daemon`/
+ * `op_id_prefix`, observation `scope`/`on`/`between`/`call`, `exact_keys`
+ * key names, `type` tag names) never carry references. */
+function collectStepVariableReferences(step) {
+  const refs = [];
+  if (!isObject(step)) return refs;
+  for (const key of ["in", "op_id", "expect", "stream", "send", "http", "upgrade"]) {
+    if (key in step) collectValueReferences(step[key], key, refs);
+  }
+  if (isObject(step.await)) {
+    if (typeof step.await.reply === "string") {
+      const name = pathRootReference(step.await.reply);
+      if (name) refs.push({ name, at: "await.reply" });
+    }
+    for (const key of ["push", "frame"]) {
+      if (key in step.await) collectValueReferences(step.await[key], `await.${key}`, refs);
+    }
+  }
+  if (isObject(step.control)) {
+    for (const [key, value] of Object.entries(step.control)) {
+      if (["do", "on", "between", "limit", "fault", "daemon", "op_id_prefix"].includes(key)) continue;
+      collectValueReferences(value, `control.${key}`, refs);
+    }
+  }
+  if (Array.isArray(step.assert)) {
+    step.assert.forEach((a, i) => {
+      if (!isObject(a)) return;
+      const at = `assert[${i}]`;
+      if ("observe" in a) {
+        if ("room_id" in a) collectValueReferences(a.room_id, `${at}.room_id`, refs);
+        if (isObject(a.value) && "value" in a.value) {
+          collectValueReferences(a.value.value, `${at}.value.value`, refs);
+        } else if (typeof a.value === "string") {
+          collectValueReferences(a.value, `${at}.value`, refs);
+        }
+        if (isObject(a.match)) collectValueReferences(a.match, `${at}.match`, refs);
+        return;
+      }
+      const root = pathRootReference(a.path);
+      if (root) refs.push({ name: root, at: `${at}.path` });
+      if (a.op === "eq_except" && isObject(a.value)) {
+        const targetRoot = pathRootReference(a.value.path);
+        if (targetRoot) refs.push({ name: targetRoot, at: `${at}.value.path` });
+      } else if (["len", "byte_len"].includes(a.op) && isObject(a.value)) {
+        collectValueReferences(a.value.value, `${at}.value.value`, refs);
+      } else if (!["exact_keys", "type"].includes(a.op) && "value" in a) {
+        collectValueReferences(a.value, `${at}.value`, refs);
+      }
+    });
+  }
+  if (isObject(step.save)) {
+    for (const [name, path] of Object.entries(step.save)) {
+      const root = pathRootReference(path);
+      if (root) refs.push({ name: root, at: `save.${name}` });
+    }
+  }
+  return refs;
 }
 
 function checkAssertion(a, file, caseName, where) {
@@ -878,6 +1034,47 @@ function checkCase(c, file) {
       fail(file, name, `step ${deferred.step + 1}`,
         `deferred handle ${handle} has ${deferred.terminals} terminal paths; exactly one later await or same-session disconnect is required`);
     }
+  }
+  // Variable-binding contract (files.json): every $name a step reads must be
+  // captured by a save on an EARLIER step of this case, or be a documented
+  // variable whose binding precondition the case DECLARES in requires.
+  // Bindings are case-scoped, so nothing carries over from other cases.
+  if (file === "files.json" && Array.isArray(c.steps)) {
+    const requires = Array.isArray(c.requires)
+      ? c.requires.filter((token) => typeof token === "string") : [];
+    const exempt = PRECONDITION_GAP_CASES.get(c.name) ?? new Set();
+    const savedAt = new Map();
+    c.steps.forEach((step, i) => {
+      if (!isObject(step?.save)) return;
+      for (const variable of Object.keys(step.save)) {
+        if (!savedAt.has(variable)) savedAt.set(variable, i);
+      }
+    });
+    c.steps.forEach((step, i) => {
+      for (const reference of collectStepVariableReferences(step)) {
+        const { name: variable, at } = reference;
+        if (variable === null) {
+          fail(file, name, `step ${i + 1}`,
+            `${JSON.stringify(reference.raw)} (${at}) is not a well-formed $variable reference — the harness cannot resolve it, so it degrades to a literal string`);
+          continue;
+        }
+        if (RUNNER_PROVIDED_VARIABLES.has(variable)) continue;
+        const saved = savedAt.get(variable);
+        if (saved !== undefined && saved < i) continue;
+        const binder = PRECONDITION_BINDINGS.get(variable);
+        if (binder) {
+          if (binder(requires) || exempt.has(variable)) continue;
+          fail(file, name, `step ${i + 1}`,
+            `"$${variable}" (${at}) names a precondition variable, but this case declares no precondition that binds it and no earlier save captures it`);
+        } else if (saved === undefined) {
+          fail(file, name, `step ${i + 1}`,
+            `"$${variable}" (${at}) is never bound: no save captures it and it is not a documented runner/precondition variable — the harness degrades an unbound reference to a literal string, so the step asserts nothing`);
+        } else {
+          fail(file, name, `step ${i + 1}`,
+            `"$${variable}" (${at}) is used before its save on step ${saved + 1} — a capture binds later steps only`);
+        }
+      }
+    });
   }
   if (PRINCIPAL_ISOLATION_CASES.has(name)) {
     if (c.requires.includes("subject:second")) {

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -352,14 +352,39 @@ function fileErrorIsCanonical(err) {
       checkExactKeySet(provider, ["subject_id", "device_id", "link"]));
 }
 
-/** The variable a "$name"-rooted path reads, or null for the non-variable
- * roots: out/err/frame, "$" (the whole step value), and the deferred-call
- * capture "$request". */
+/** The variable a "$name"-rooted path reads. Returns null for the
+ * non-variable roots (out/err/frame, "$" the whole step value, the
+ * deferred-call capture "$request"), {name} for a well-formed variable root,
+ * or {malformed: true} when the root segment is not a bare "$name" — the
+ * assert engine splits paths on "." only, so "$rid[0].secret" looks up the
+ * nonexistent variable "rid[0]" and an absent assertion on it silently
+ * passes. */
 function pathRootReference(path) {
-  if (typeof path !== "string" || path === "$request") return null;
+  if (typeof path !== "string" || !path.startsWith("$") || path === "$request") return null;
   if (path === "$" || path.startsWith("$.")) return null;
-  const m = path.match(VARIABLE_REFERENCE);
-  return m ? m[1] : null;
+  const m = path.match(/^\$([A-Za-z_][A-Za-z0-9_]*)(?:$|\.)/);
+  return m ? { name: m[1] } : { malformed: true };
+}
+
+/** Collect $name references embedded ANYWHERE in http/upgrade strings — the
+ * harness's header/path resolution substitutes them mid-string ("Bearer
+ * $token", "/files/$fid"), so whole-string scanning is not enough there. */
+function collectInterpolatedReferences(node, at, refs) {
+  if (typeof node === "string") {
+    for (const m of node.matchAll(/\$([A-Za-z_][A-Za-z0-9_]*)/g)) {
+      refs.push({ name: m[1], at });
+    }
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((el, i) => collectInterpolatedReferences(el, `${at}[${i}]`, refs));
+    return;
+  }
+  if (isObject(node)) {
+    for (const [k, v] of Object.entries(node)) {
+      collectInterpolatedReferences(v, `${at}.${k}`, refs);
+    }
+  }
 }
 
 /** Collect every $variable read from a value node, recursing through arrays,
@@ -398,13 +423,20 @@ function collectValueReferences(node, at, refs) {
 function collectStepVariableReferences(step) {
   const refs = [];
   if (!isObject(step)) return refs;
-  for (const key of ["in", "op_id", "expect", "stream", "send", "http", "upgrade"]) {
+  for (const key of ["in", "op_id", "expect", "stream", "send"]) {
     if (key in step) collectValueReferences(step[key], key, refs);
   }
+  for (const key of ["http", "upgrade"]) {
+    if (key in step) collectInterpolatedReferences(step[key], key, refs);
+  }
   if (isObject(step.await)) {
-    if (typeof step.await.reply === "string") {
-      const name = pathRootReference(step.await.reply);
-      if (name) refs.push({ name, at: "await.reply" });
+    // `$id` is the reply-position builtin naming the connection's most
+    // recent request id (runner.mjs) — not a variable.
+    if (typeof step.await.reply === "string" && step.await.reply.startsWith("$")
+        && step.await.reply !== "$id") {
+      const m = step.await.reply.match(VALUE_REFERENCE);
+      if (m) refs.push({ name: m[1], at: "await.reply" });
+      else refs.push({ name: null, raw: step.await.reply, at: "await.reply" });
     }
     for (const key of ["push", "frame"]) {
       if (key in step.await) collectValueReferences(step.await[key], `await.${key}`, refs);
@@ -431,10 +463,10 @@ function collectStepVariableReferences(step) {
         return;
       }
       const root = pathRootReference(a.path);
-      if (root) refs.push({ name: root, at: `${at}.path` });
+      if (root) refs.push({ name: root.name ?? null, raw: a.path, at: `${at}.path` });
       if (a.op === "eq_except" && isObject(a.value)) {
         const targetRoot = pathRootReference(a.value.path);
-        if (targetRoot) refs.push({ name: targetRoot, at: `${at}.value.path` });
+        if (targetRoot) refs.push({ name: targetRoot.name ?? null, raw: a.value.path, at: `${at}.value.path` });
       } else if (["len", "byte_len"].includes(a.op) && isObject(a.value)) {
         collectValueReferences(a.value.value, `${at}.value.value`, refs);
       } else if (!["exact_keys", "type"].includes(a.op) && "value" in a) {
@@ -445,7 +477,7 @@ function collectStepVariableReferences(step) {
   if (isObject(step.save)) {
     for (const [name, path] of Object.entries(step.save)) {
       const root = pathRootReference(path);
-      if (root) refs.push({ name: root, at: `save.${name}` });
+      if (root) refs.push({ name: root.name ?? null, raw: path, at: `save.${name}` });
     }
   }
   return refs;
@@ -1055,7 +1087,7 @@ function checkCase(c, file) {
         const { name: variable, at } = reference;
         if (variable === null) {
           fail(file, name, `step ${i + 1}`,
-            `${JSON.stringify(reference.raw)} (${at}) is not a well-formed $variable reference — the harness cannot resolve it, so it degrades to a literal string`);
+            `${JSON.stringify(reference.raw)} (${at}) is not a well-formed $variable reference — it resolves against nothing (a value degrades to a literal string; a path names a variable that cannot exist), so it asserts nothing`);
           continue;
         }
         if (RUNNER_PROVIDED_VARIABLES.has(variable)) continue;

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -180,6 +180,13 @@ const PRECONDITION_GAP_CASES = new Map([
   ["a_transfer_with_no_forward_progress_fails_with_transfer_stalled", new Set(["fid", "fid_unsized"])],
   ["fetch_completed_result_replays_without_a_second_transfer", new Set(["fid"])],
 ]);
+// Every documented binding except $limits and $daemon is a scalar id or
+// port, so a dotted tail on one is statically unresolvable — an absent
+// assertion on "$rid.secret" would silently pass.
+const SCALAR_PROVIDED_VARIABLES = new Set([
+  "op_id_new", "op_id_fixed", "daemon_sg",
+  ...PRECONDITION_BINDINGS.keys(),
+]);
 // A whole-string value reference the harness can resolve: "$name" plus
 // optional dot segments (values.mjs resolves the tail with resolvePath,
 // which splits on "." only — "$fid-2" or "$fid[0]" resolve to nothing and
@@ -358,17 +365,18 @@ function fileErrorIsCanonical(err) {
 }
 
 /** The variable a "$name"-rooted path reads. Returns null for the
- * non-variable roots (out/err/frame, "$" the whole step value, the
- * deferred-call capture "$request"), {name} for a well-formed variable root,
- * or {malformed: true} when the root segment is not a bare "$name" — the
- * assert engine splits paths on "." only, so "$rid[0].secret" looks up the
- * nonexistent variable "rid[0]" and an absent assertion on it silently
- * passes. */
+ * non-variable roots (out/err/frame, "$" the whole step value), {name,
+ * hasTail} for a well-formed variable path, or {malformed: true} when the
+ * shape cannot resolve — the assert engine splits paths on "." only, so
+ * "$rid[0].secret" looks up the nonexistent variable "rid[0]" and an absent
+ * assertion on it silently passes. "$request" is NOT special here: the DSL
+ * reserves it solely as a deferred call's save source, which its scan site
+ * skips; anywhere else it is an ordinary, never-bound name. */
 function pathRootReference(path) {
-  if (typeof path !== "string" || !path.startsWith("$") || path === "$request") return null;
+  if (typeof path !== "string" || !path.startsWith("$")) return null;
   if (path === "$" || path.startsWith("$.")) return null;
   const m = path.match(VARIABLE_PATH);
-  return m ? { name: m[1] } : { malformed: true };
+  return m ? { name: m[1], hasTail: path.length > m[1].length + 1 } : { malformed: true };
 }
 
 /** Collect $name references embedded ANYWHERE in http/upgrade strings — the
@@ -383,7 +391,8 @@ function collectInterpolatedReferences(node, at, refs) {
     for (const m of node.matchAll(/\$([A-Za-z_][A-Za-z0-9_.]*)/g)) {
       const name = m[1];
       if (/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$/.test(name)) {
-        refs.push({ name: name.split(".")[0], at });
+        const root = name.split(".")[0];
+        refs.push({ name: root, at, hasTail: root !== name });
       } else {
         refs.push({ name: null, raw: `$${name}`, at });
       }
@@ -409,7 +418,7 @@ function collectValueReferences(node, at, refs) {
   if (typeof node === "string") {
     if (!node.startsWith("$")) return;
     const m = node.match(VALUE_REFERENCE);
-    if (m) refs.push({ name: m[1], at });
+    if (m) refs.push({ name: m[1], at, hasTail: node.length > m[1].length + 1 });
     else refs.push({ name: null, raw: node, at });
     return;
   }
@@ -460,7 +469,7 @@ function collectStepVariableReferences(step) {
     if (typeof step.await.reply === "string" && step.await.reply.startsWith("$")
         && step.await.reply !== "$id") {
       const m = step.await.reply.match(VALUE_REFERENCE);
-      if (m) refs.push({ name: m[1], at: "await.reply" });
+      if (m) refs.push({ name: m[1], at: "await.reply", hasTail: step.await.reply.length > m[1].length + 1 });
       else refs.push({ name: null, raw: step.await.reply, at: "await.reply" });
     }
     for (const key of ["push", "frame"]) {
@@ -488,10 +497,10 @@ function collectStepVariableReferences(step) {
         return;
       }
       const root = pathRootReference(a.path);
-      if (root) refs.push({ name: root.name ?? null, raw: a.path, at: `${at}.path` });
+      if (root) refs.push({ name: root.name ?? null, raw: a.path, at: `${at}.path`, hasTail: root.hasTail });
       if (a.op === "eq_except" && isObject(a.value)) {
         const targetRoot = pathRootReference(a.value.path);
-        if (targetRoot) refs.push({ name: targetRoot.name ?? null, raw: a.value.path, at: `${at}.value.path` });
+        if (targetRoot) refs.push({ name: targetRoot.name ?? null, raw: a.value.path, at: `${at}.value.path`, hasTail: targetRoot.hasTail });
       } else if (["len", "byte_len"].includes(a.op) && isObject(a.value)) {
         collectValueReferences(a.value.value, `${at}.value.value`, refs);
       } else if (!["exact_keys", "type"].includes(a.op) && "value" in a) {
@@ -501,8 +510,11 @@ function collectStepVariableReferences(step) {
   }
   if (isObject(step.save)) {
     for (const [name, path] of Object.entries(step.save)) {
+      // "$request" is legal only here, as a deferred call's save source;
+      // checkStep validates that pairing separately.
+      if (path === "$request") continue;
       const root = pathRootReference(path);
-      if (root) refs.push({ name: root.name ?? null, raw: path, at: `save.${name}` });
+      if (root) refs.push({ name: root.name ?? null, raw: path, at: `save.${name}`, hasTail: root.hasTail });
     }
   }
   return refs;
@@ -1123,9 +1135,18 @@ function checkCase(c, file) {
             `${JSON.stringify(reference.raw)} (${at}) is not a well-formed $variable reference — it resolves against nothing (a value degrades to a literal string; a path names a variable that cannot exist), so it asserts nothing`);
           continue;
         }
-        if (RUNNER_PROVIDED_VARIABLES.has(variable)) continue;
         const saved = savedAt.get(variable);
-        if (saved !== undefined && saved < i) continue;
+        const savedEarlier = saved !== undefined && saved < i;
+        // A save shadows the documented binding with a value of unknown
+        // shape; without one, a dotted tail into a documented scalar id
+        // resolves against nothing.
+        if (!savedEarlier && reference.hasTail && SCALAR_PROVIDED_VARIABLES.has(variable)) {
+          fail(file, name, `step ${i + 1}`,
+            `"$${variable}" (${at}) carries a dotted tail, but the documented ${variable} binding is a scalar — the tail resolves against nothing`);
+          continue;
+        }
+        if (savedEarlier) continue;
+        if (RUNNER_PROVIDED_VARIABLES.has(variable)) continue;
         const binder = PRECONDITION_BINDINGS.get(variable);
         if (binder) {
           if (binder(requires) || exempt.has(variable)) continue;

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -185,6 +185,11 @@ const PRECONDITION_GAP_CASES = new Map([
 // which splits on "." only — "$fid-2" or "$fid[0]" resolve to nothing and
 // degrade to literal strings, so they are malformed rather than clever).
 const VALUE_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)(?:\.[A-Za-z0-9_]+)*$/;
+// A $variable-rooted assertion/save path the assert engine can resolve: the
+// bare root, then dot segments, each optionally carrying the [*] wildcard.
+// The engine splits on "." and rewrites only [*], so "$rid..secret",
+// "$rid.", and "$rid.foo[0]" all resolve against nothing.
+const VARIABLE_PATH = /^\$([A-Za-z_][A-Za-z0-9_]*)(?:\.[A-Za-z0-9_]+(?:\[\*\])?)*$/;
 const VARIABLE_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)/;
 
 const OPERATIONS = new Set([
@@ -362,7 +367,7 @@ function fileErrorIsCanonical(err) {
 function pathRootReference(path) {
   if (typeof path !== "string" || !path.startsWith("$") || path === "$request") return null;
   if (path === "$" || path.startsWith("$.")) return null;
-  const m = path.match(/^\$([A-Za-z_][A-Za-z0-9_]*)(?:$|\.)/);
+  const m = path.match(VARIABLE_PATH);
   return m ? { name: m[1] } : { malformed: true };
 }
 
@@ -426,8 +431,19 @@ function collectStepVariableReferences(step) {
   for (const key of ["in", "op_id", "expect", "stream", "send"]) {
     if (key in step) collectValueReferences(step[key], key, refs);
   }
-  for (const key of ["http", "upgrade"]) {
-    if (key in step) collectInterpolatedReferences(step[key], key, refs);
+  // The runner interpolates $name mid-string in http/upgrade HEADERS and the
+  // http PATH (#resolveHeaderValue), but resolves http BODY and upgrade QUERY
+  // values whole (resolveValue) — so "$rid[0]" in a body is not a read of
+  // $rid, it is an unresolvable literal.
+  if (isObject(step.http)) {
+    for (const key of ["path", "headers"]) {
+      if (key in step.http) collectInterpolatedReferences(step.http[key], `http.${key}`, refs);
+    }
+    if ("body" in step.http) collectValueReferences(step.http.body, "http.body", refs);
+  }
+  if (isObject(step.upgrade)) {
+    if ("headers" in step.upgrade) collectInterpolatedReferences(step.upgrade.headers, "upgrade.headers", refs);
+    if ("query" in step.upgrade) collectValueReferences(step.upgrade.query, "upgrade.query", refs);
   }
   if (isObject(step.await)) {
     // `$id` is the reply-position builtin naming the connection's most
@@ -1078,6 +1094,14 @@ function checkCase(c, file) {
     const savedAt = new Map();
     c.steps.forEach((step, i) => {
       if (!isObject(step?.save)) return;
+      // The runner never applies a save on a send or control step (it
+      // returns before the capture logic), so such a save binds nothing at
+      // replay time and must not count as a binding here.
+      if ("send" in step || "control" in step) {
+        fail(file, name, `step ${i + 1}`,
+          `save on a ${"send" in step ? "send" : "control"} step captures nothing — the runner applies captures only where a step produces a result (call, http, upgrade, await, assert, or a verbless capture step)`);
+        return;
+      }
       for (const variable of Object.keys(step.save)) {
         if (!savedAt.has(variable)) savedAt.set(variable, i);
       }

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -376,8 +376,17 @@ function pathRootReference(path) {
  * $token", "/files/$fid"), so whole-string scanning is not enough there. */
 function collectInterpolatedReferences(node, at, refs) {
   if (typeof node === "string") {
-    for (const m of node.matchAll(/\$([A-Za-z_][A-Za-z0-9_]*)/g)) {
-      refs.push({ name: m[1], at });
+    // Mirror #resolveHeaderValue's capture exactly: its name grammar
+    // consumes dots ([A-Za-z0-9_.]*), so "$rid..secret" is one unresolvable
+    // reference — not a read of $rid followed by text — and the literal
+    // stays in the request when resolution fails.
+    for (const m of node.matchAll(/\$([A-Za-z_][A-Za-z0-9_.]*)/g)) {
+      const name = m[1];
+      if (/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$/.test(name)) {
+        refs.push({ name: name.split(".")[0], at });
+      } else {
+        refs.push({ name: null, raw: `$${name}`, at });
+      }
     }
     return;
   }

--- a/scripts/check-v2-corpus.test.mjs
+++ b/scripts/check-v2-corpus.test.mjs
@@ -242,12 +242,19 @@ test('a malformed $-prefixed value the harness cannot resolve is invalid', () =>
   );
 });
 
-test('a $-rooted path whose root is not a bare variable name is invalid', () => {
+test('a $-rooted path must be a bare root plus well-formed dot segments', () => {
   const output = runValidator([
     fileCase({
       steps: [
-        { call: 'file.list', in: { room_id: '$rid', ...LIST_IN } },
+        {
+          call: 'file.list',
+          in: { room_id: '$rid', ...LIST_IN },
+          save: { first: 'out' },
+        },
         { assert: [{ path: '$rid[0].secret', op: 'absent' }] },
+        { assert: [{ path: '$rid..secret', op: 'absent' }] },
+        { assert: [{ path: '$rid.foo[0]', op: 'absent' }] },
+        { assert: [{ path: '$first.files[*].file_id', op: 'present' }] },
       ],
     }),
   ]);
@@ -255,6 +262,53 @@ test('a $-rooted path whose root is not a bare variable name is invalid', () => 
     output.includes('"$rid[0].secret" (assert[0].path) is not a well-formed $variable reference'),
     output,
   );
+  assert.ok(
+    output.includes('"$rid..secret" (assert[0].path) is not a well-formed $variable reference'),
+    output,
+  );
+  assert.ok(
+    output.includes('"$rid.foo[0]" (assert[0].path) is not a well-formed $variable reference'),
+    output,
+  );
+  assert.ok(!output.includes('"$first.files[*].file_id"'), output);
+});
+
+test('http bodies and upgrade queries resolve whole, unlike headers and paths', () => {
+  const output = runValidator([
+    fileCase({
+      kind: 'handshake',
+      steps: [
+        {
+          http: {
+            method: 'POST',
+            path: '/api/session',
+            headers: {},
+            body: { room_id: '$rid[0]' },
+          },
+        },
+      ],
+    }),
+  ]);
+  assert.ok(
+    output.includes('"$rid[0]" (http.body.room_id) is not a well-formed $variable reference'),
+    output,
+  );
+});
+
+test('a save on a send or control step captures nothing and is invalid', () => {
+  const output = runValidator([
+    fileCase({
+      steps: [
+        {
+          control: { do: 'idle', ms: 0 },
+          save: { ghost_capture: 'out.value' },
+        },
+        { call: 'file.list', in: { room_id: '$rid', ...LIST_IN, limit: '$ghost_capture' } },
+      ],
+    }),
+  ]);
+  assert.ok(output.includes('save on a control step captures nothing'), output);
+  assert.ok(output.includes('"$ghost_capture"'), output);
 });
 
 test('the await reply builtin $id is not treated as a variable', () => {

--- a/scripts/check-v2-corpus.test.mjs
+++ b/scripts/check-v2-corpus.test.mjs
@@ -337,12 +337,24 @@ test('references embedded inside http and upgrade strings are checked', () => {
             body: null,
           },
         },
+        {
+          http: {
+            method: 'GET',
+            path: '/files/$rid..secret',
+            headers: {},
+            body: null,
+          },
+        },
         { upgrade: { query: { sg: '$daemon_sg' }, headers: {} } },
       ],
     }),
   ]);
   assert.ok(output.includes('"$ghost_http" (http.path) is never bound'), output);
   assert.ok(output.includes('"$ghost_header" (http.headers.authorization) is never bound'), output);
+  assert.ok(
+    output.includes('"$rid..secret" (http.path) is not a well-formed $variable reference'),
+    output,
+  );
   assert.ok(!output.includes('"$daemon_sg"'), output);
 });
 

--- a/scripts/check-v2-corpus.test.mjs
+++ b/scripts/check-v2-corpus.test.mjs
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, test } from 'node:test';
+
+// The variable-binding contract for files.json: a "$name" reference must be
+// captured by a save on an earlier step of the same case, or be one of the
+// documented runner/precondition variables — the harness degrades an unbound
+// reference to a literal string, which satisfies subset matching and turns
+// the step into no evidence (the $fid2 failure mode that retired the
+// aggregate no-path case).
+//
+// The validator resolves its corpus directory relative to its own location,
+// and the ESM loader realpaths the entry module (a symlink would validate the
+// real repository), so each scenario copies the script into a temp tree with
+// a synthetic conformance/v2/files.json. The temp tree carries no manifest or
+// workflow file; those produce unrelated problem lines, so assertions match
+// only the binding-contract messages.
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'check-v2-corpus.mjs');
+const NEVER_BOUND = 'is never bound';
+const BEFORE_SAVE = 'is used before its save';
+
+const tempRoots = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function runValidator(cases) {
+  const root = mkdtempSync(join(tmpdir(), 'jeliya-v2-corpus-check-'));
+  tempRoots.push(root);
+  mkdirSync(join(root, 'scripts'), { recursive: true });
+  mkdirSync(join(root, 'conformance', 'v2'), { recursive: true });
+  copyFileSync(SCRIPT, join(root, 'scripts', 'check-v2-corpus.mjs'));
+  writeFileSync(
+    join(root, 'conformance', 'v2', 'files.json'),
+    JSON.stringify({ domain: 'files', note: 'binding-contract test fixture', cases }, null, 2),
+  );
+  const result = spawnSync(process.execPath, [join(root, 'scripts', 'check-v2-corpus.mjs')], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.error, undefined);
+  return `${result.stdout}${result.stderr}`;
+}
+
+function fileCase(overrides) {
+  return {
+    name: 'binding_probe_case',
+    kind: 'success',
+    operation: 'file.list',
+    intent: 'Proves the validator enforces the files.json variable-binding contract.',
+    requires: ['subject', 'room:live'],
+    steps: [],
+    ...overrides,
+  };
+}
+
+const LIST_IN = { cursor: { state: 'start' }, direction: 'forward', limit: 50 };
+
+test('a prior save permits later use of the captured variable', () => {
+  const output = runValidator([
+    fileCase({
+      steps: [
+        { call: 'room.create', in: { name: 'Bind' }, save: { r: 'out.room_id' }, op_id: 'op-b-1' },
+        { call: 'file.list', in: { room_id: '$r', ...LIST_IN } },
+      ],
+    }),
+  ]);
+  assert.ok(!output.includes(NEVER_BOUND), output);
+  assert.ok(!output.includes(BEFORE_SAVE), output);
+});
+
+test('use before save fails with the one-indexed binding step named', () => {
+  const output = runValidator([
+    fileCase({
+      steps: [
+        { call: 'file.list', in: { room_id: '$r', ...LIST_IN } },
+        { call: 'room.create', in: { name: 'Bind' }, save: { r: 'out.room_id' }, op_id: 'op-b-1' },
+      ],
+    }),
+  ]);
+  assert.ok(
+    output.includes('binding_probe_case [step 1]: "$r" (in.room_id) is used before its save on step 2'),
+    output,
+  );
+});
+
+test('a never-bound variable such as $fid2 fails while documented $rid passes', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      steps: [{ call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid2' }, op_id: 'op-b-2' }],
+    }),
+  ]);
+  assert.ok(output.includes('"$fid2" (in.file_id) is never bound'), output);
+  assert.ok(!output.includes('"$rid"'), output);
+});
+
+test('documented precondition and runner-provided variables remain valid', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      requires: ['subject', 'room:foreign', 'resource:fetched_file'],
+      steps: [
+        {
+          call: 'file.fetch',
+          in: { room_id: '$foreign_rid', file_id: '$foreign_fid' },
+          op_id: '$op_id_new',
+        },
+        {
+          call: 'file.read',
+          in: { room_id: '$rid', file_id: '$fid' },
+          stream: { receive_bytes: 4096 },
+        },
+      ],
+    }),
+  ]);
+  assert.ok(!output.includes(NEVER_BOUND), output);
+  assert.ok(!output.includes(BEFORE_SAVE), output);
+});
+
+test('computed-node operands and stream counts are checked', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.share',
+      steps: [
+        {
+          call: 'file.share',
+          in: {
+            room_id: '$rid',
+            name: 'a.bin',
+            declared_bytes: { $add: ['$lim', 1] },
+            declared_content_type: 'application/octet-stream',
+          },
+          op_id: 'op-b-3',
+          stream: { send_bytes: '$lim' },
+        },
+      ],
+    }),
+  ]);
+  assert.ok(output.includes('"$lim" (in.declared_bytes.$add[0]) is never bound'), output);
+  assert.ok(output.includes('"$lim" (stream.send_bytes) is never bound'), output);
+});
+
+test('a hello-captured limit satisfies computed-node and stream references', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.share',
+      steps: [
+        { upgrade: { query: {}, headers: {} } },
+        { await: { frame: { t: 'hello' } }, save: { lim: 'frame.limits.max_shared_file_bytes' } },
+        {
+          call: 'file.share',
+          in: {
+            room_id: '$rid',
+            name: 'a.bin',
+            declared_bytes: { $add: ['$lim', 1] },
+            declared_content_type: 'application/octet-stream',
+          },
+          op_id: 'op-b-3',
+          stream: { send_bytes: '$lim' },
+        },
+      ],
+    }),
+  ]);
+  assert.ok(!output.includes(NEVER_BOUND), output);
+  assert.ok(!output.includes(BEFORE_SAVE), output);
+});
+
+test('a documented precondition variable without its binding precondition fails', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      requires: ['subject', 'room:live'],
+      steps: [{ call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid' }, op_id: 'op-b-6' }],
+    }),
+  ]);
+  assert.ok(
+    output.includes(
+      '"$fid" (in.file_id) names a precondition variable, but this case declares no precondition that binds it',
+    ),
+    output,
+  );
+  assert.ok(!output.includes('"$rid"'), output);
+});
+
+test('an explicit save binds a documented name whose precondition is absent', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      requires: ['subject', 'room:live', 'link:up'],
+      steps: [
+        {
+          call: 'file.list',
+          in: { room_id: '$rid', ...LIST_IN },
+          save: { fid: 'out.files[0].file_id' },
+        },
+        { call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid' }, op_id: 'op-b-7' },
+      ],
+    }),
+  ]);
+  assert.ok(!output.includes(NEVER_BOUND), output);
+  assert.ok(!output.includes('names a precondition variable'), output);
+});
+
+test('the named ledger exempts the pre-existing U2 fixtures, and only them', () => {
+  const steps = [
+    { call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid' }, op_id: 'op-b-8' },
+    { call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid_unsized' }, op_id: 'op-b-9' },
+  ];
+  const requires = ['subject', 'room:live', 'link:up'];
+  const exempted = runValidator([
+    fileCase({
+      name: 'a_transfer_with_no_forward_progress_fails_with_transfer_stalled',
+      operation: 'file.fetch',
+      requires,
+      steps,
+    }),
+  ]);
+  assert.ok(!exempted.includes('names a precondition variable'), exempted);
+  const unexempted = runValidator([
+    fileCase({ name: 'some_other_case_with_the_same_shape', operation: 'file.fetch', requires, steps }),
+  ]);
+  assert.ok(unexempted.includes('"$fid" (in.file_id) names a precondition variable'), unexempted);
+  assert.ok(unexempted.includes('"$fid_unsized" (in.file_id) names a precondition variable'), unexempted);
+});
+
+test('a malformed $-prefixed value the harness cannot resolve is invalid', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      steps: [{ call: 'file.fetch', in: { room_id: '$rid', file_id: '$fid-2' }, op_id: 'op-b-10' }],
+    }),
+  ]);
+  assert.ok(
+    output.includes('"$fid-2" (in.file_id) is not a well-formed $variable reference'),
+    output,
+  );
+});
+
+test('nested expectation, assertion-path, and observation references are checked', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'transfer.cancel',
+      steps: [
+        {
+          call: 'transfer.cancel',
+          in: { transfer_op_id: 'op-b-4' },
+          expect: {
+            ok: false,
+            err: { code: 'transfer_unknown', transfer_op_id: '$ghost' },
+          },
+        },
+        { assert: [{ path: '$missing.field', op: 'present' }] },
+        { assert: [{ observe: 'no_push', room_id: '$ghost_room', scope: 'case' }] },
+        { assert: [{ observe: 'close_code', value: '$ghost_code', on: 'subject:self' }] },
+      ],
+    }),
+  ]);
+  assert.ok(output.includes('"$ghost" (expect.err.transfer_op_id) is never bound'), output);
+  assert.ok(output.includes('"$missing" (assert[0].path) is never bound'), output);
+  assert.ok(output.includes('"$ghost_room" (assert[0].room_id) is never bound'), output);
+  assert.ok(output.includes('"$ghost_code" (assert[0].value) is never bound'), output);
+});
+
+test('captures do not leak between cases', () => {
+  const output = runValidator([
+    fileCase({
+      name: 'binding_scope_case_a',
+      operation: 'room.create',
+      steps: [
+        { call: 'room.create', in: { name: 'A' }, save: { shared_var: 'out.room_id' }, op_id: 'op-b-5' },
+      ],
+    }),
+    fileCase({
+      name: 'binding_scope_case_b',
+      steps: [{ call: 'file.list', in: { room_id: '$shared_var', ...LIST_IN } }],
+    }),
+  ]);
+  assert.ok(
+    output.includes('binding_scope_case_b [step 1]: "$shared_var" (in.room_id) is never bound'),
+    output,
+  );
+  assert.ok(!output.includes('binding_scope_case_a [step 1]: "$shared_var"'), output);
+});

--- a/scripts/check-v2-corpus.test.mjs
+++ b/scripts/check-v2-corpus.test.mjs
@@ -229,6 +229,58 @@ test('the named ledger exempts the pre-existing U2 fixtures, and only them', () 
   assert.ok(unexempted.includes('"$fid_unsized" (in.file_id) names a precondition variable'), unexempted);
 });
 
+test('a dotted tail on a documented scalar binding is invalid', () => {
+  const output = runValidator([
+    fileCase({
+      steps: [
+        { call: 'file.list', in: { room_id: '$rid', ...LIST_IN } },
+        { assert: [{ path: '$rid.secret', op: 'absent' }] },
+        { upgrade: { query: { sg: '$daemon.storage_generation' }, headers: {} } },
+      ],
+    }),
+  ]);
+  assert.ok(
+    output.includes(
+      '"$rid" (assert[0].path) carries a dotted tail, but the documented rid binding is a scalar',
+    ),
+    output,
+  );
+  assert.ok(!output.includes('"$daemon"'), output);
+});
+
+test('$request is a save-source token only, never an assertable path', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'file.fetch',
+      requires: ['subject', 'room:live', 'link:up', 'resource:large_file'],
+      steps: [
+        {
+          call: 'file.fetch',
+          in: { room_id: '$rid', file_id: '$fid' },
+          op_id: 'op-b-12',
+          defer: true,
+          save: { fetch_request: '$request' },
+        },
+        {
+          await: { reply: '$fetch_request' },
+          expect: {
+            ok: false,
+            err: {
+              code: 'stream_aborted',
+              transferred_bytes: 0,
+              total: { state: 'unknown' },
+              reason: 'cancelled',
+            },
+          },
+        },
+        { assert: [{ path: '$request', op: 'absent' }] },
+      ],
+    }),
+  ]);
+  assert.ok(output.includes('"$request" (assert[0].path) is never bound'), output);
+  assert.ok(!output.includes('"$fetch_request"'), output);
+});
+
 test('a malformed $-prefixed value the harness cannot resolve is invalid', () => {
   const output = runValidator([
     fileCase({

--- a/scripts/check-v2-corpus.test.mjs
+++ b/scripts/check-v2-corpus.test.mjs
@@ -242,6 +242,56 @@ test('a malformed $-prefixed value the harness cannot resolve is invalid', () =>
   );
 });
 
+test('a $-rooted path whose root is not a bare variable name is invalid', () => {
+  const output = runValidator([
+    fileCase({
+      steps: [
+        { call: 'file.list', in: { room_id: '$rid', ...LIST_IN } },
+        { assert: [{ path: '$rid[0].secret', op: 'absent' }] },
+      ],
+    }),
+  ]);
+  assert.ok(
+    output.includes('"$rid[0].secret" (assert[0].path) is not a well-formed $variable reference'),
+    output,
+  );
+});
+
+test('the await reply builtin $id is not treated as a variable', () => {
+  const output = runValidator([
+    fileCase({
+      operation: 'room.create',
+      steps: [
+        { call: 'room.create', in: { name: 'Reply' }, op_id: 'op-b-11' },
+        { await: { reply: '$id' }, expect: { ok: true, out: { room_id: '<room_id>' } } },
+      ],
+    }),
+  ]);
+  assert.ok(!output.includes('"$id"'), output);
+});
+
+test('references embedded inside http and upgrade strings are checked', () => {
+  const output = runValidator([
+    fileCase({
+      kind: 'handshake',
+      steps: [
+        {
+          http: {
+            method: 'GET',
+            path: '/files/$ghost_http',
+            headers: { authorization: 'Bearer $ghost_header' },
+            body: null,
+          },
+        },
+        { upgrade: { query: { sg: '$daemon_sg' }, headers: {} } },
+      ],
+    }),
+  ]);
+  assert.ok(output.includes('"$ghost_http" (http.path) is never bound'), output);
+  assert.ok(output.includes('"$ghost_header" (http.headers.authorization) is never bound'), output);
+  assert.ok(!output.includes('"$daemon_sg"'), output);
+});
+
 test('nested expectation, assertion-path, and observation references are checked', () => {
   const output = runValidator([
     fileCase({


### PR DESCRIPTION
Refs #233 — prerequisite corpus-quality repair; the replay-harness implementation resumes separately after this merges.

## Why the aggregate case had to go

`no_file_operation_carries_a_filesystem_path_in_any_direction` was not executable evidence:

- **Its `$fid2` is bound by nothing.** The original transcription (98a80f8) required `remote_provider` — the precondition that would have established the second, remotely provided file `$fid2` named — and asserted with `scope: "all_frames"`. Corpus normalization (#213) replaced `remote_provider` with `link:up` and folded the assertions onto per-step form, keeping `$fid2` with no surviving precondition or save that establishes it. The harness deliberately degrades an unbound `$name` to its literal string (`conformance/v2/harness/values.mjs`), so the `file.fetch` step named a "file" that is actually the string `"$fid2"`.
- **Its `file.read` read `$fid`** (the freshly shared upload), not a fetched file, so the fetch leg proved nothing even about sequencing.
- **Its path assertions ran only against the final `frame`**, after `transfer.cancel` — the `all_frames` scope did not survive normalization, so every earlier share/list/fetch/read reply could leak a filesystem path and the case would still pass.

Neither one-line substitution repairs it: `$fid2 → $fid` silently redefines the case to fetch a self-hosted upload (a different, already-covered scenario, not what the `remote_provider` original asserted), and `$fid → $fid2` invents a resource alias no precondition provides. Both would be fixture text derived from convenience rather than from the record, which the corpus's independence rule forbids. Retirement plus explicit per-operation coverage is the spec-faithful repair; no daemon behavior change is implied.

## Where the no-path contract now lives

The obligations move to explicit `absent` assertions on the actual reply roots, immediately after the corresponding operations, covering the full field set the retired case named (`path`, `local_path`, `save_dir`, `data_dir`, `dir`, `directory`, `staged_path`, `download_dir`, `uri`, `file_url`):

| Surface | Case | Root |
|---|---|---|
| `file.share` success | `share_below_the_served_limit_succeeds` | `out` |
| `file.list` rows + top level | `list_names_provider_devices_with_fetchable_and_self_hosted_as_stated_facts` | `out.files[*]` and `out` |
| `file.fetch` success | `fetch_from_a_reachable_provider_holds_the_bytes_locally` | `out` |
| `file.read` success | `read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field` | `out` |
| `transfer.cancel` refusal | `transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown` | `err` |
| `transfer.cancel` result | `cancel_result_reports_bytes_transferred` (declarative until U2) | `out` |

Matching stays subset-based; only `absent` assertions were added — no expected value changed, no `exact_keys` introduced (the canonical file error matchers close the *matcher* shape, not the reply key set, so explicit absence is the right instrument).

## Preventing recurrence: variable-binding validation

`scripts/check-v2-corpus.mjs` now enforces, for `files.json`, that every `$name` a step reads is one of:

- a capture from a `save` on an **earlier** step of the same case (case-scoped; first save wins; same-step self-reference is invalid);
- a runner pre-seeded builtin (`$op_id_new`, `$op_id_fixed`, `$limits`, `$daemon`, `$daemon_sg`);
- a documented precondition variable **whose binding precondition the case actually declares in `requires`** — `$rid`/`$self_sid` from room/member/file-resource setup, `$rid_left` from `room:left`, `$foreign_rid`/`$foreign_fid` from `room:foreign`, `$member_b_sid`/`$member_c_sid` from `member:b`/`c`, `$sb`/`$sc` from `subject:second`/`outsider`, `$svc_port`(`_v6`) from `resource:tcp_service`, and the `$fid` family from the file resource preconditions.

The conditioning matters: the historical regression was precisely a `requires` rewrite (`remote_provider` → `link:up`) that orphaned a reference, so a documented *name* alone is never accepted as evidence. A whole-string `$`-prefixed value that is not a well-formed reference (`$fid-2`, `$fid[0]` — shapes `values.mjs` cannot resolve) is invalid outright. References are collected from every value position the DSL admits: nested `in`, `op_id`, `expect`, `stream` counts, `send`, `http`/`upgrade`, `await` matchers and reply handles, `control` value fields, assertion paths, `eq_except` paths, `len`/`byte_len` nested comparisons, assertion values, observation `room_id`/`value`/`match` (object and scalar forms), and `save` source paths. Vocabulary positions (`on`, `control.do`/`between`/`limit`/`fault`/`daemon`/`op_id_prefix`, `exact_keys` key names, `type` tags, `$unknown` operands, the `$` whole-step root, `$request`) are excluded by construction. The new README section "Runner-provided variables" is the normative home for the documented set, with the caveat that the file-resource and foreign-room bindings state the DSL contract ahead of their executor.

Run against the pre-change corpus, the strengthened validator flags **exactly one problem: the retired case's `$fid2`** — and nothing else.

### Defects the conditional check exposed — reported, not broad-edited

Two pre-existing U2-blocked fixtures read the `$fid` family without declaring a file resource precondition (their `requires` predate that vocabulary): `a_transfer_with_no_forward_progress_fails_with_transfer_stalled` (`$fid`, `$fid_unsized`) and `fetch_completed_result_replays_without_a_second_transfer` (`$fid`). Per the repo's precedent for named legacy carve-outs (`LEGACY_REQUEST_CONCURRENCY_CASES`, `TRANSPORT_CODE_FIXTURES`), they are exempted **by name** in a `PRECONDITION_GAP_CASES` ledger rather than silently repaired here — the spec-derived `requires` repair belongs to a follow-up under #233, and deleting a ledger entry is how each exemption closes. (`client_must_not_render_peer_declared_bytes_inline`'s `$rid` under `resource:fetched_file` is not a gap: a file exists only in a room, so a file resource precondition establishes the room, which the README now states.)

### Tests

`scripts/check-v2-corpus.test.mjs` (12 cases, wired into CI beside the shape-validation step) proves: prior save permits later use; use before save fails naming the one-indexed binding step; never-bound `$fid2` fails while documented `$rid` passes; documented precondition/built-in variables remain valid; a documented name **without** its binding precondition fails; an explicit save rescues a documented name whose precondition is absent; the ledger exempts exactly the named legacy fixtures; malformed `$`-values fail; computed-node operands and `stream` counts are checked; nested expectation/assertion/observation references (including scalar observe values) are checked; captures do not leak between cases.

Enforcement is `files.json`-only, following the validator's existing "strengthened file-domain" precedent: the legacy domains still carry pre-normalization placeholder conventions (`$op1`/`$o1`-style tokens that intentionally resolve as distinguishable literals), so extending enforcement there requires their own re-transcription pass first, not a blanket blessing of unknown `$name`s.

## Recomputed metadata

All counts recomputed by the validator, not assumed: totals 342 → **341**, `operation: null` 105 → **104**, untargeted 336 → **335**, `files.json` 44 → **43** cases / 3 → 2 op-null; `manifest.json`, `conformance/v2/README.md` (status matrix, computed-fact table, per-file totals, retirement note, new DSL section), and `docs/protocol-v2.md`'s fixture-count citation updated. `docs/protocol-v2.md` remains authoritative; nothing in it changed except that count.

## Review round

An adversarial multi-lens review of the draft diff (4 lenses, per-finding refutation) confirmed 12 findings, all addressed before publication — chiefly that the first draft's allowlist was *unconditional* on `requires` (it could not catch the historical regression class and its README prose overclaimed), plus an under-anchored reference grammar, uncollected scalar observe values, missing harness-implementation caveats, and an overstated provenance claim about `$fid2`'s original binding.

## Checks

- `node --test scripts/check-v2-corpus.test.mjs` — 12/12 pass
- `node scripts/check-v2-corpus.mjs` — green (341 cases, 2105 steps)
- same validator vs. pre-change corpus — exactly the one `$fid2` problem
- `node scripts/check-docs.mjs` — green
- `git diff --check` — clean

No harness, Rust runtime, codec, HTTP-route, fixture-stream-behavior, client, or `file.fetch` implementation changes; CI carries the unchanged Rust/workspace coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
