### PR TITLE
feat(conformance): implement the protocol-v2 byte-stream executor in the replay harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,17 +331,21 @@ jobs:
           node --test scripts/check-v2-corpus.test.mjs
           node scripts/check-v2-corpus.mjs
 
-      - name: Protocol-v2 conformance replay (handshake + subject lifecycle)
+      - name: Protocol-v2 conformance replay (handshake + subject lifecycle + file streams)
         run: |
           set -euo pipefail
           cd conformance/v2/harness
           npm ci --ignore-scripts
-          # Run the handshake and subject-daemon files. The replay harness
-          # exits non-zero on any unexpected failure or error; the corpus's
-          # current coverage is tracked in the PR and grows as the
-          # implementation fills the remaining v2 features. For now this gate
-          # pins the reliably-green slice so a regression in the implemented
-          # surface goes red.
+          # Run the handshake, subject-daemon, and executable file cases. The
+          # replay harness exits non-zero on any unexpected failure or error;
+          # the corpus's current coverage is tracked in the PR and grows as
+          # the implementation fills the remaining v2 features. For now this
+          # gate pins the reliably-green slice so a regression in the
+          # implemented surface goes red. The file cases exercise the binary
+          # byte-stream executor (upload streaming, pre-OPEN refusals with
+          # bytes_streamed 0, and a declared-size-mismatch stream); the
+          # at-limit and over-limit cases stream the served 100 MiB bound and
+          # stay local-only.
           node main.mjs ../../../target/debug/jeliyad \
             --case subject_ensure_creates_the_subject_on_a_fresh_daemon \
             --case subject_ensure_never_returns_secret_material \
@@ -356,7 +360,15 @@ jobs:
             --case daemon_stop_does_not_require_a_subject \
             --case room_list_without_a_subject_returns_subject_absent_not_an_empty_list \
             --case subject_absent_is_returned_before_any_effect_is_performed \
-            --case subject_absent_outranks_room_not_available_and_is_not_a_membership_oracle
+            --case subject_absent_outranks_room_not_available_and_is_not_a_membership_oracle \
+            --case handshake_serves_the_file_and_transfer_limits_as_integers \
+            --case share_one_byte_past_the_served_limit_is_refused_at_stage_declared \
+            --case share_size_refusal_is_never_reported_as_digest_mismatch \
+            --case share_completed_result_replays_without_a_second_stream_and_authors_once \
+            --case a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch \
+            --case list_of_a_room_that_is_not_available_answers_room_not_available \
+            --case fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown \
+            --case transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown
 
       # The network evidence harness (scripts/realnet-*.mjs) drove the retired
       # v1 WS protocol (`room.create`, `invite.create`, `message.send` over v1

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -31,8 +31,8 @@ claims:
 | Slice | Status | What the claim means |
 |---|---|---|
 | Structural validation | Implemented for all 341 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
-| Selected JSON-envelope/subject slice | Partial (14 CI-selected cases) | The Node harness runs this selected JSON-envelope and subject-lifecycle slice against `jeliyad`; this is neither corpus coverage nor file-stream evidence. It is not a smoke, E2E, or Dart execution claim. |
-| Binary byte-stream executor | Unimplemented | No harness codec/runtime executes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records, so file-stream cases are declarative, not live evidence. |
+| Selected JSON-envelope/subject slice | Partial (22 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
+| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. The download path has no executable fixture yet (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the raw-record, credit-pause, client-ABORT, and transport-drop fault controls remain unimplemented, so malformed/backpressure stream cases are still declarative. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
@@ -588,8 +588,13 @@ deferred-call contract, this states the DSL contract; the current live
 harness pre-seeds the unconditional set and implements the
 `room:plain`/`live`/`quiescent`/`with_history`/`left`, single-letter member
 (`member:b`/`member:c`), second-subject/outsider, and tcp-service bindings,
-while `room:removed`, the agent-member variants, and the file-resource and
-foreign-room bindings await their executor.
+while `room:removed`, the agent-member variants, the remaining file-resource
+bindings, and the foreign-room bindings await their executor.
+`resource:shared_file` is implemented: the harness genuinely streams a
+4096-byte seed file into the required room through the byte-stream executor
+and binds `$fid` from the daemon's reply; `resource:fetched_file` and
+`resource:large_file` stay unestablished because a fetched file needs a
+provider peer the single-subject harness cannot honestly supply.
 
 In `files.json` the validator enforces the contract: every `$name` a step
 reads must be captured by a `save` on an **earlier** step of the same case,
@@ -615,8 +620,10 @@ than `$limits`/`$daemon` is invalid: those bindings are scalar identifiers,
 so the tail resolves against nothing. Binding validation proves the capture
 statement exists and gates which names a step may read; whether a save's
 *source path* resolves at replay is executor behavior — the corpus-wide
-bracket-index notation (`out.files[0].file_id`) predates this contract and
-is settled with the executor work, not here. An unknown reference is invalid rather than an
+bracket-index notation (`out.files[0].file_id`) is RESOLVED by the executor:
+both path engines (`values.mjs` `resolvePath` and the assertion engine's
+wildcard collector) normalize a numeric `[n]` segment to a dot segment, with
+`[*]` keeping its wildcard meaning. An unknown reference is invalid rather than an
 interestingly-named literal: the harness resolves an unbound `$name` to its
 literal string form, which satisfies subset matching and quietly turns the
 step into no evidence at all. Two pre-existing U2-blocked fixtures

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -13,8 +13,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -342,8 +347,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -365,6 +375,15 @@
             "rid": "out.room_id"
           },
           "op_id": "op-share-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
         },
         {
           "call": "file.share",
@@ -475,8 +494,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -498,6 +522,15 @@
             "rid": "out.room_id"
           },
           "op_id": "op-atlimit-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
         },
         {
           "call": "file.share",
@@ -537,8 +570,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -560,6 +598,15 @@
             "rid": "out.room_id"
           },
           "op_id": "op-over-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
         },
         {
           "call": "file.share",
@@ -606,7 +653,7 @@
           "assert": [
             {
               "observe": "bytes_streamed",
-              "call": "step:4",
+              "call": "step:5",
               "value": {
                 "op": "eq",
                 "value": 0
@@ -669,8 +716,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -692,6 +744,15 @@
             "rid": "out.room_id"
           },
           "op_id": "op-liar-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
         },
         {
           "call": "file.share",
@@ -724,7 +785,7 @@
           "assert": [
             {
               "observe": "bytes_streamed",
-              "call": "step:4",
+              "call": "step:5",
               "value": {
                 "op": "eq",
                 "value": "$limit"
@@ -828,7 +889,7 @@
       "targets": [
         "client_adapter"
       ],
-      "intent": "Proves the sixth enforcement point \u2014 the client preflight, which by definition never reaches the daemon \u2014 refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
+      "intent": "Proves the sixth enforcement point — the client preflight, which by definition never reaches the daemon — refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
       "requires": [
         "room:live"
       ],
@@ -1006,8 +1067,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -1029,6 +1095,15 @@
             "rid": "out.room_id"
           },
           "op_id": "op-pairA-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
         },
         {
           "call": "file.share",
@@ -1195,7 +1270,7 @@
       "name": "share_size_null_or_out_of_domain_is_malformed",
       "kind": "malformed",
       "operation": "file.share",
-      "intent": "Proves no JSON null carries meaning on the file path \u2014 a null size is not read as unknown \u2014 and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
+      "intent": "Proves no JSON null carries meaning on the file path — a null size is not read as unknown — and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
       "requires": [
         "subject",
         "room:live"
@@ -1302,8 +1377,13 @@
       "steps": [
         {
           "upgrade": {
-            "query": {},
-            "headers": {}
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
         },
         {
@@ -1793,7 +1873,7 @@
       "name": "fetch_from_a_reachable_provider_holds_the_bytes_locally",
       "kind": "success",
       "operation": "file.fetch",
-      "intent": "Establishes the baseline fetch success shape \u2014 the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response \u2014 catching any regression to v1's directory-taking, path-returning fetch.",
+      "intent": "Establishes the baseline fetch success shape — the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response — catching any regression to v1's directory-taking, path-returning fetch.",
       "requires": [
         "subject",
         "room:live",
@@ -2430,7 +2510,6 @@
           },
           "op_id": "op-budget-floor"
         },
-
         {
           "control": {
             "do": "set_link_rate",
@@ -2938,7 +3017,7 @@
       "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
       "kind": "error",
       "operation": "transfer.cancel",
-      "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error \u2014 the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
+      "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error — the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
       "requires": [
         "subject"
       ],
@@ -4108,7 +4187,7 @@
       "name": "a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch",
       "kind": "error",
       "operation": "file.share",
-      "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch \u2014 accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
+      "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch — accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
       "requires": [
         "subject",
         "room:live",

--- a/conformance/v2/harness/assert.mjs
+++ b/conformance/v2/harness/assert.mjs
@@ -84,6 +84,14 @@ export function subsetMatch(expected, actual, vars) {
     const resolved = resolveValue(expected, vars);
     return deepEqual(resolved, actual);
   }
+  // A computed node (`{$add: …}`, `{$unknown: …}`) resolves to its value —
+  // reply matchers name computed sizes and well-formed-but-unknown ids.
+  if (expected !== null && typeof expected === 'object' && !Array.isArray(expected)) {
+    const keys = Object.keys(expected);
+    if (keys.length === 1 && keys[0].startsWith('$')) {
+      return deepEqual(resolveValue(expected, vars), actual);
+    }
+  }
   if (Array.isArray(expected)) {
     if (!Array.isArray(actual) || actual.length < expected.length) return false;
     return expected.every((el, i) => subsetMatch(el, actual[i], vars));
@@ -95,9 +103,10 @@ export function subsetMatch(expected, actual, vars) {
   return deepEqual(expected, actual);
 }
 
-/** Collect every value at a wildcard path (`a.b[*].c`). Returns array of values. */
+/** Collect every value at a wildcard path (`a.b[*].c`). Returns array of values.
+ * Numeric bracket indices normalize to dot segments alongside the wildcard. */
 export function collectWildcard(root, path) {
-  const parts = String(path).split('.');
+  const parts = String(path).replace(/\[(\d+)\]/g, '.$1').split('.');
   let frontier = [root];
   for (const part of parts) {
     const next = [];
@@ -142,7 +151,7 @@ export function evalValueAssertion(a, ctx) {
   const rawPath = a.path;
   const op = a.op;
   const hasWildcard = String(rawPath).includes('[*]') || String(rawPath).includes('.*');
-  const path = String(rawPath).replace(/\[\*\]/g, '.*');
+  const path = String(rawPath).replace(/\[\*\]/g, '.*').replace(/\[(\d+)\]/g, '.$1');
 
   // Resolve the root: `out`, `err`, `frame`, or a `$var`.
   const [rootName, ...rest] = path.split('.');
@@ -192,10 +201,14 @@ export function evalValueAssertion(a, ctx) {
         if (!expected.some((e) => matchOrEqual(e, v, ctx.vars)))
           throw new AssertFailure(`${label}: ${rawPath} ${JSON.stringify(v)} not in ${JSON.stringify(expected)}`);
         break;
-      case 'type':
-        if (!matchesTypeTag(expected, v))
+      case 'type': {
+        // The DSL writes `type` values bracketless (`"uint"`); accept the
+        // bracketed spelling too so the tag matcher sees one form.
+        const tag = typeof expected === 'string' && !expected.startsWith('<') ? `<${expected}>` : expected;
+        if (!matchesTypeTag(tag, v))
           throw new AssertFailure(`${label}: ${rawPath} not of domain ${expected}`, { got: v });
         break;
+      }
       case 'exact_keys': {
         const want = [...expected].sort();
         const got = v && typeof v === 'object' && !Array.isArray(v) ? Object.keys(v).sort() : null;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -313,7 +313,10 @@ export class Runner {
     if (requires.includes('subject') && !caseEnsuresSubject && !(wantsRoom || wantsLeftRoom || wantsMembers)) {
       const authority = await this.#sessionFor('subject:authority', daemons, sessions, vars);
       const ensured = await authority.call('subject.ensure', {});
-      vars.self_sid = ensured.out?.subject_id;
+      if (!ensured.ok || !ensured.out?.subject_id) {
+        throw new Error(`requires subject: subject.ensure failed: ${JSON.stringify(ensured.err)}`);
+      }
+      vars.self_sid = ensured.out.subject_id;
     }
 
     // `resource:tcp_service` — a loopback TCP echo service a pipe can target;
@@ -533,7 +536,7 @@ export class Runner {
         tracker.wake();
         recordWatcher.catch(() => {});
         s.streams.delete(id);
-        (s.retiredCallIds ||= new Set()).add(id);
+        if (tracker.replySeq !== undefined) (s.retiredCallIds ||= new Set()).add(id);
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
       }
@@ -615,13 +618,17 @@ export class Runner {
         limitBytes: hello.limits?.max_shared_file_bytes,
         inflightBytes: hello.limits?.max_transfer_bytes_inflight,
         stallMs: hello.limits?.transfer_stall_ms,
+        connectAllowanceMs: hello.limits?.transfer_connect_allowance_ms,
+        floorBitsPerSecond: hello.limits?.transfer_floor_bits_per_second,
         timeoutScale: this.timeoutScale,
       });
     } finally {
       s.streams.delete(id);
       // Tombstone the id so a late duplicate terminal reply still violates
-      // exactly-one-terminal after the tracker retires.
-      (s.retiredCallIds ||= new Set()).add(id);
+      // exactly-one-terminal after the tracker retires — only when a reply
+      // was actually received (a timed-out call's late first reply is not a
+      // duplicate).
+      if (tracker.replySeq !== undefined) (s.retiredCallIds ||= new Set()).add(id);
       if (record) {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -160,8 +160,9 @@ export class Runner {
       }
 
       // A connection-fatal binary violation observed after the last tracker
-      // retired must not be outlived by a green verdict.
-      for (const s of sessions.values()) {
+      // retired must not be outlived by a green verdict — replaced (upgraded
+      // away) sessions included.
+      for (const s of [...sessions.values(), ...(vars.__case?.replacedSessions || [])]) {
         if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
       }
 
@@ -612,6 +613,8 @@ export class Runner {
         declaredBytes: input?.declared_bytes,
         maxPayload,
         limitBytes: hello.limits?.max_shared_file_bytes,
+        inflightBytes: hello.limits?.max_transfer_bytes_inflight,
+        stallMs: hello.limits?.transfer_stall_ms,
         timeoutScale: this.timeoutScale,
       });
     } finally {
@@ -682,6 +685,11 @@ export class Runner {
       query.cid = clientId;
     }
     const result = await this.#attemptUpgrade(daemon, query, headers, label, sessions, clientId);
+    // The precheck ran before the await; a violation recorded on the
+    // outgoing connection during the upgrade must still surface, and the
+    // replaced session stays scanned at case end.
+    if (outgoing && outgoing.stickyBinaryViolation) throw outgoing.stickyBinaryViolation;
+    if (outgoing && vars.__case) (vars.__case.replacedSessions ||= []).push(outgoing);
     vars.frame = result.frame || {};
     vars.out = result.body;
     vars.err = result.body;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -296,10 +296,12 @@ export class Runner {
         const reply = await this.#streamCall(authority, 'file.share', input, { send_bytes: 4096 }, {
           opId: `cf-seed-${opIdCounter++}`,
         });
-        if (!reply.ok) {
-          throw new Error(`resource:shared_file setup failed: ${JSON.stringify(reply.err)}`);
+        if (!reply.ok || !reply.out?.file_id) {
+          throw new Error(
+            `resource:shared_file setup failed: ${JSON.stringify(reply.ok ? reply.out : reply.err)}`,
+          );
         }
-        vars.fid = reply.out?.file_id;
+        vars.fid = reply.out.file_id;
       }
     }
 

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -45,10 +45,6 @@ export class Runner {
     this.timeoutScale = timeoutScale;
   }
 
-  __pd() {
-    return this.__pdCurrent;
-  }
-
   log(...args) {
     if (this.verbose) console.log('   ', ...args);
   }
@@ -128,7 +124,7 @@ export class Runner {
       // each step) so no_event_authored / no_durable_mutation compare a real
       // before/after delta instead of passing unconditionally.
       ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
-      ctxState.dirSnapshot = this.#dirStateSignature(daemons);
+      ctxState.dirSnapshot = await this.#stableDirSignature(daemons);
 
       // Execute the steps.
       for (let i = 0; i < fixture.steps.length; i++) {
@@ -136,15 +132,30 @@ export class Runner {
         ctxState.lastCallOk = undefined;
         await this.#runStep(step, i, { daemons, sessions, vars, ctx, ctxState, name });
         // An observation compares against the state just before the observed
-        // operation. A SUCCESSFUL step advances the baselines; a REFUSED one
-        // (an error-replied call, or a raw `send` probe) must not — a refused
-        // operation authors nothing legally, so refreshing after it would
-        // absorb exactly the violation a following no_event_authored /
-        // no_durable_mutation observation exists to catch.
+        // operation. A SUCCESSFUL daemon-interacting step advances the
+        // baselines; a REFUSED one (an error-replied call, or a raw `send`
+        // probe) must not — a refused operation authors nothing legally, so
+        // refreshing after it would absorb exactly the violation a following
+        // no_event_authored / no_durable_mutation observation exists to
+        // catch. Assertion-only (and save-only) steps touch no daemon state
+        // and never refresh, so the pre-refusal baseline survives through
+        // intervening assertions.
         const refused = (step.call && ctxState.lastCallOk === false) || step.send !== undefined;
-        if (!refused) {
-          ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
-          ctxState.dirSnapshot = this.#dirStateSignature(daemons);
+        const interactsWithDaemon =
+          step.call || step.http || step.upgrade || step.send !== undefined || step.await || step.control;
+        if (interactsWithDaemon) {
+          // The DIRECTORY baseline advances after every daemon interaction,
+          // refused or not: a refused op_id operation legally performs one
+          // durable write (its recorded reply in the dedup ledger), so a
+          // strict pre-refusal dir baseline would fail a conformant daemon.
+          // The capture settles first — staging cleanup is asynchronous, and
+          // a baseline taken mid-deletion would read as a later "mutation".
+          ctxState.dirSnapshot = await this.#stableDirSignature(daemons, ctxState.dirSnapshot);
+          // The EVENT baseline is strict: a refused operation may author
+          // nothing, so it never advances past a refusal.
+          if (!refused) {
+            ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
+          }
         }
       }
 
@@ -1036,11 +1047,11 @@ export class Runner {
     }
   }
 
-  /** Whether the primary daemon still accepts TCP connections. */
-  async #daemonReachable() {
+  /** Whether the case's primary daemon still accepts TCP connections. */
+  async #daemonReachable(primary) {
     const net = await import('node:net');
     return new Promise((resolve) => {
-      const sock = net.createConnection(this.__pd().port, '127.0.0.1');
+      const sock = net.createConnection(primary.port, '127.0.0.1');
       sock.once('connect', () => {
         sock.destroy();
         resolve(true);
@@ -1076,8 +1087,31 @@ export class Runner {
     }
   }
 
+  /** The dir signature once it stops changing: two consecutive identical
+   * reads a beat apart, bounded. Asynchronous persistence (staging cleanup,
+   * a lagging ledger fsync under IO load) otherwise races the baseline
+   * capture and reads as a later mutation. An unchanged-from-prior read
+   * returns immediately — settling only costs time when something moved. */
+  async #stableDirSignature(daemons, prior) {
+    let cur = this.#dirStateSignature(daemons);
+    if (prior !== undefined && cur === prior) return cur;
+    const deadline = Date.now() + 4_000 * this.timeoutScale;
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 250));
+      const next = this.#dirStateSignature(daemons);
+      if (next === cur || Date.now() > deadline) return next;
+      cur = next;
+    }
+  }
+
   /** A signature of the data dir's contents (file count + total bytes +
-   * newest mtime), the observable signal for no_durable_mutation. */
+   * newest mtime), the observable signal for no_durable_mutation. Two kinds
+   * of transient state are excluded: the byte-stream staging directory
+   * (cleanup is asynchronous and races the capture; stranded residue is
+   * asserted explicitly by the observation) and `-wal`/`-shm` journal
+   * sidecars (the harness's own observation reads append to the WAL, and a
+   * WAL-resident event mutation is what no_event_authored observes — the
+   * signature tracks committed content files). */
   #dirStateSignature(daemons) {
     try {
       const walk = (dir) => {
@@ -1087,23 +1121,41 @@ export class Runner {
         for (const e of entries) {
           const p = join(dir, e.name);
           if (e.isDirectory()) {
+            if (e.name === 'protocol-v2-stream-staging') continue;
             const sub = walk(p);
             files += sub.files; bytes += sub.bytes; newest = Math.max(newest, sub.newest);
           } else {
+            if (e.name.endsWith('-wal') || e.name.endsWith('-shm')) continue;
             try { const st = statSync(p); files++; bytes += st.size; newest = Math.max(newest, st.mtimeMs); } catch { /* ignore */ }
           }
         }
         return { files, bytes, newest };
       };
-      return JSON.stringify(walk(this.__pd().dataDir));
+      return JSON.stringify(walk(daemons[0].dataDir));
     } catch {
       return null;
     }
   }
 
+  /** Whether the staging directory still holds any file, settled: cleanup is
+   * asynchronous, so residue is only a violation if it persists past a
+   * bounded wait. */
+  async #stagingResidue(daemons) {
+    const dir = join(daemons[0].dataDir, 'protocol-v2-stream-staging');
+    const residue = () => {
+      try { return readdirSync(dir).length > 0; } catch { return false; }
+    };
+    const deadline = Date.now() + 2_000 * this.timeoutScale;
+    while (residue()) {
+      if (Date.now() > deadline) return true;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return false;
+  }
+
   /** Evaluate an `observe` assertion against recorded behaviour. */
   async #evalObserve(a, { sessions, vars, ctxState, name, daemons }) {
-    this.__pdCurrent = (vars.__case || {}).primary;
+    const primary = (vars.__case || {}).primary;
     const obs = a.observe;
     switch (obs) {
       case 'no_event_authored': {
@@ -1121,12 +1173,18 @@ export class Runner {
         return;
       }
       case 'no_durable_mutation': {
-        // Real check: the data dir's content signature must be unchanged.
+        // Real check: the data dir's content signature (staging excluded)
+        // must be unchanged, and the transient staging directory must have
+        // cleaned itself up — an aborted stage leaves no stranded file.
         const before = ctxState.dirSnapshot;
-        if (before === null || before === undefined) return;
-        const now = this.#dirStateSignature(daemons);
-        if (now !== null && now !== before) {
-          throw new AssertFailure(`no_durable_mutation violated: data dir changed`);
+        if (before !== null && before !== undefined) {
+          const now = this.#dirStateSignature(daemons);
+          if (now !== null && now !== before) {
+            throw new AssertFailure(`no_durable_mutation violated: data dir changed ${before} -> ${now}`);
+          }
+        }
+        if (await this.#stagingResidue(daemons)) {
+          throw new AssertFailure('no_durable_mutation violated: stranded byte-stream staging file');
         }
         return;
       }
@@ -1142,7 +1200,7 @@ export class Runner {
         // `on: "none"` asserts the daemon is unreachable (connection refused)
         // — used after daemon.stop to prove it no longer accepts connections.
         if (label === 'none') {
-          const reachable = await this.#daemonReachable();
+          const reachable = await this.#daemonReachable(primary);
           if (reachable) throw new AssertFailure('expected none to be open (daemon still reachable)');
           return;
         }
@@ -1199,10 +1257,10 @@ export class Runner {
         // `daemon.stop` replies first, then tears down after a beat — poll for
         // the exit rather than demanding it be already observed.
         const deadline = Date.now() + 5_000 * this.timeoutScale;
-        while (!this.__pd().exited && Date.now() < deadline) {
+        while (!primary.exited && Date.now() < deadline) {
           await new Promise((r) => setTimeout(r, 50));
         }
-        if (!this.__pd().exited)
+        if (!primary.exited)
           throw new AssertFailure(`expected daemon process to have exited`);
         return;
       }

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -159,6 +159,12 @@ export class Runner {
         }
       }
 
+      // A connection-fatal binary violation observed after the last tracker
+      // retired must not be outlived by a green verdict.
+      for (const s of sessions.values()) {
+        if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
+      }
+
       // A case that ran all steps without a failing assertion passes. A block
       // may name an upstream dependency or a settled record/corpus
       // contradiction awaiting fixture retirement (e.g. the old "op_id is
@@ -550,19 +556,31 @@ export class Runner {
   /** Run one duplex streaming call through the byte-stream executor. */
   async #streamCall(s, op, input, spec, { opId, record } = {}) {
     const hello = s.lastHello || {};
-    const maxPayload = maxDataPayloadBytes(hello.limits?.max_frame_bytes);
-    const { id, reply: replyPromise } = s.startCall(op, input, {
+    const frameLimit = hello.limits?.max_frame_bytes;
+    const maxPayload = maxDataPayloadBytes(frameLimit);
+    const { id, reply: replyPromise, requestBytes } = s.startCall(op, input, {
       opId,
       timeoutMs: 60_000 * this.timeoutScale,
     });
     const tracker = new CallStreamTracker(id);
     s.streams.set(id, tracker);
     const replyState = { done: false, value: undefined, error: undefined, seq: Infinity };
+    // The wire-order stamp is taken synchronously in Session.#onMessage
+    // (tracker.replySeq); the fallback covers settle-without-a-wire-message
+    // (a timeout), which correctly sequences after every delivered record.
     replyPromise.then(
-      (v) => { replyState.seq = ++tracker.seq; replyState.done = true; replyState.value = v; tracker.wake(); },
-      (e) => { replyState.seq = ++tracker.seq; replyState.done = true; replyState.error = e; tracker.wake(); },
+      (v) => { replyState.seq = tracker.replySeq ?? ++tracker.seq; replyState.done = true; replyState.value = v; tracker.wake(); },
+      (e) => { replyState.seq = tracker.replySeq ?? ++tracker.seq; replyState.done = true; replyState.error = e; tracker.wake(); },
     );
     try {
+      // The spec's second readiness condition: a stream-valid max_frame_bytes
+      // must carry the streaming Text request envelope. A daemon serving a
+      // limit this request exceeds must have refused readiness, not answered.
+      if (requestBytes > Number(frameLimit)) {
+        throw new AssertFailure(
+          `served max_frame_bytes ${frameLimit} cannot carry the ${op} request envelope (${requestBytes} bytes)`,
+        );
+      }
       return await runStreamingCall({
         session: s,
         tracker,
@@ -1160,6 +1178,12 @@ export class Runner {
   /** Evaluate an `observe` assertion against recorded behaviour. */
   async #evalObserve(a, { sessions, vars, ctxState, name, daemons }) {
     const primary = (vars.__case || {}).primary;
+    // A sticky binary violation outranks whatever this observation would
+    // have concluded — assertion-only steps never resolve a session, so
+    // this is their surfacing point.
+    for (const s of sessions.values()) {
+      if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
+    }
     const obs = a.observe;
     switch (obs) {
       case 'no_event_authored': {

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -700,6 +700,7 @@ export class Runner {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(url, {
         headers: { Host: `127.0.0.1:${daemon.port}`, ...headers },
+        perMessageDeflate: false,
       });
       ws.binaryType = 'nodebuffer';
       let settled = false;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -12,7 +12,7 @@ import { startDaemon } from './daemon.mjs';
 import { Session } from './session.mjs';
 import { AssertContext, AssertFailure, TransportFailure, evalAssert, subsetMatch } from './assert.mjs';
 import { resolvePath, resolveValue } from './values.mjs';
-import { CallStreamTracker, maxDataPayloadBytes, runStreamingCall } from './stream.mjs';
+import { CallStreamTracker, maxDataPayloadBytes, runStreamingCall, streamWaitMs } from './stream.mjs';
 
 /** The outcome of one case. */
 export const Outcome = {
@@ -536,7 +536,6 @@ export class Runner {
         tracker.wake();
         recordWatcher.catch(() => {});
         s.streams.delete(id);
-        if (tracker.replySeq !== undefined) (s.retiredCallIds ||= new Set()).add(id);
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
       }
@@ -585,9 +584,10 @@ export class Runner {
     const hello = s.lastHello || {};
     const frameLimit = hello.limits?.max_frame_bytes;
     const maxPayload = maxDataPayloadBytes(frameLimit);
+    const waitMs = streamWaitMs(spec, hello.limits || {}, this.timeoutScale);
     const { id, reply: replyPromise, requestBytes } = s.startCall(op, input, {
       opId,
-      timeoutMs: 60_000 * this.timeoutScale,
+      timeoutMs: waitMs,
     });
     const tracker = new CallStreamTracker(id);
     s.streams.set(id, tracker);
@@ -618,17 +618,10 @@ export class Runner {
         limitBytes: hello.limits?.max_shared_file_bytes,
         inflightBytes: hello.limits?.max_transfer_bytes_inflight,
         stallMs: hello.limits?.transfer_stall_ms,
-        connectAllowanceMs: hello.limits?.transfer_connect_allowance_ms,
-        floorBitsPerSecond: hello.limits?.transfer_floor_bits_per_second,
-        timeoutScale: this.timeoutScale,
+        waitMs,
       });
     } finally {
       s.streams.delete(id);
-      // Tombstone the id so a late duplicate terminal reply still violates
-      // exactly-one-terminal after the tracker retires — only when a reply
-      // was actually received (a timed-out call's late first reply is not a
-      // duplicate).
-      if (tracker.replySeq !== undefined) (s.retiredCallIds ||= new Set()).add(id);
       if (record) {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
@@ -1093,9 +1086,14 @@ export class Runner {
       }
       case 'reconnect': {
         const label = c.on || step.on || 'subject:self';
-        const s = await this.#sessionFor(label, env.daemons, sessions, vars);
-        s.close();
-        sessions.delete(label);
+        const s = sessions.get(label);
+        if (s) {
+          s.close();
+          sessions.delete(label);
+          // A violation delivered to the outgoing connection while the
+          // replacement is awaited must survive to the case-end scan.
+          if (vars.__case) (vars.__case.replacedSessions ||= []).push(s);
+        }
         await this.#sessionFor(label, env.daemons, sessions, vars);
         return;
       }

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -510,6 +510,7 @@ export class Runner {
         throw new TransportFailure(`call ${step.call} failed to get a reply${openNote}: ${err.message}`);
       } finally {
         s.streams.delete(id);
+        (s.retiredCallIds ||= new Set()).add(id);
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
       }
@@ -594,10 +595,8 @@ export class Runner {
     } finally {
       s.streams.delete(id);
       // Tombstone the id so a late duplicate terminal reply still violates
-      // exactly-one-terminal after the tracker retires. Streaming ids only —
-      // harness-issued and never reused, so raw-send id-reuse fixtures are
-      // unaffected.
-      (s.retiredStreamCallIds ||= new Set()).add(id);
+      // exactly-one-terminal after the tracker retires.
+      (s.retiredCallIds ||= new Set()).add(id);
       if (record) {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -490,6 +490,12 @@ export class Runner {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
       }
+      if (tracker.failure) {
+        // A binary-routing violation (unparseable message, unbindable record)
+        // observed during this call is connection-fatal class — the Text
+        // reply arriving anyway must not launder it.
+        throw tracker.failure;
+      }
       if (tracker.opened || tracker.queue.length) {
         const what = tracker.opened ? 'an OPEN' : `a ${tracker.queue[0].kindName} record`;
         throw new AssertFailure(

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -482,9 +482,10 @@ export class Runner {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;
       }
-      if (tracker.opened) {
+      if (tracker.opened || tracker.queue.length) {
+        const what = tracker.opened ? 'an OPEN' : `a ${tracker.queue[0].kindName} record`;
         throw new AssertFailure(
-          `call ${step.call} received an OPEN for a stream the fixture declares it must not open`,
+          `call ${step.call} received ${what} for a stream the fixture declares it must not open`,
         );
       }
     }
@@ -537,6 +538,7 @@ export class Runner {
         spec,
         declaredBytes: input?.declared_bytes,
         maxPayload,
+        limitBytes: hello.limits?.max_shared_file_bytes,
         timeoutScale: this.timeoutScale,
       });
     } finally {

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -498,10 +498,29 @@ export class Runner {
       const { id, reply: replyPromise } = s.startCall(step.call, input, { opId });
       const tracker = new CallStreamTracker(id);
       s.streams.set(id, tracker);
+      // Race the reply against Binary delivery: a stream-less call that
+      // receives OPEN (a daemon awaiting bytes that will never come) must
+      // fail as the conformance verdict NOW, not as a reply timeout later.
+      let watcherDone = false;
+      const recordWatcher = (async () => {
+        for (;;) {
+          if (watcherDone) return null;
+          if (tracker.failure) throw tracker.failure;
+          if (tracker.opened || tracker.queue.length) {
+            const what = tracker.opened ? 'an OPEN' : `a ${tracker.queue[0].kindName} record`;
+            throw new AssertFailure(
+              `call ${step.call} received ${what} for a stream the fixture declares it must not open`,
+            );
+          }
+          await new Promise((resolve) => tracker.wakers.push(resolve));
+        }
+      })();
       try {
-        reply = await replyPromise;
+        reply = await Promise.race([replyPromise, recordWatcher]);
         this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)}`);
       } catch (err) {
+        if (err instanceof AssertFailure) throw err;
+        if (err === tracker.failure) throw err;
         // Never a reply — a timeout, a closed socket, or a crash. This is a
         // transport/runner failure, not a matcher verdict: raise a
         // TransportFailure (not an AssertFailure) so a blocked case cannot count
@@ -509,6 +528,9 @@ export class Runner {
         const openNote = tracker.opened ? ' after the daemon opened an unexpected byte stream' : '';
         throw new TransportFailure(`call ${step.call} failed to get a reply${openNote}: ${err.message}`);
       } finally {
+        watcherDone = true;
+        tracker.wake();
+        recordWatcher.catch(() => {});
         s.streams.delete(id);
         (s.retiredCallIds ||= new Set()).add(id);
         record.accepted = tracker.accepted;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -348,10 +348,16 @@ export class Runner {
     await bindSubject('subject:outsider', 'subject:outsider', 'sc', true);
   }
 
-  /** The session for an `on` label, connecting lazily. */
+  /** The session for an `on` label, connecting lazily. Every step path
+   * resolves its session here, so a sticky binary violation recorded on the
+   * connection surfaces before the next interaction of any kind. */
   async #sessionFor(onLabel, daemons, sessions, vars) {
     const label = onLabel || 'subject:self';
-    if (sessions.has(label)) return sessions.get(label);
+    if (sessions.has(label)) {
+      const existing = sessions.get(label);
+      if (existing.stickyBinaryViolation) throw existing.stickyBinaryViolation;
+      return existing;
+    }
     // Route to the second daemon for labels that clearly name a distinct
     // subject (a daemon holds one subject, so second/outsider/peer subjects
     // live on the second daemon).
@@ -453,9 +459,6 @@ export class Runner {
   async #doCall(step, index, env) {
     const { sessions, vars, ctxState } = env;
     const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
-    // A Binary violation recorded while no tracker was installed poisons the
-    // connection; the next daemon interaction surfaces it.
-    if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
     const input = step.in !== undefined ? resolveValue(step.in, vars) : {};
     // CORPUS/SPEC DISCREPANCY: every committed fixture calls stream.subscribe
     // without the spec-required `from` cursor (50/50). The spec (canonical)
@@ -554,10 +557,10 @@ export class Runner {
     });
     const tracker = new CallStreamTracker(id);
     s.streams.set(id, tracker);
-    const replyState = { done: false, value: undefined, error: undefined };
+    const replyState = { done: false, value: undefined, error: undefined, seq: Infinity };
     replyPromise.then(
-      (v) => { replyState.done = true; replyState.value = v; tracker.wake(); },
-      (e) => { replyState.done = true; replyState.error = e; tracker.wake(); },
+      (v) => { replyState.seq = ++tracker.seq; replyState.done = true; replyState.value = v; tracker.wake(); },
+      (e) => { replyState.seq = ++tracker.seq; replyState.done = true; replyState.error = e; tracker.wake(); },
     );
     try {
       return await runStreamingCall({
@@ -925,6 +928,7 @@ export class Runner {
     // Race every open session's next matching frame, plus the frames already
     // in each one's history.
     for (const s of sessions.values()) {
+      if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
       for (const f of s.pushes) {
         if (locate(f)) return f;
       }

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -368,6 +368,14 @@ export class Runner {
       if (existing.stickyBinaryViolation) throw existing.stickyBinaryViolation;
       return existing;
     }
+    // The case authored an upgrade for this label and the daemon refused it;
+    // auto-connecting here would silently substitute a different admission.
+    const refused = vars.__case?.refusedUpgrades?.[label];
+    if (refused !== undefined) {
+      throw new AssertFailure(
+        `the authored upgrade for ${label} was refused (status ${refused}); refusing to substitute an auto-connected session`,
+      );
+    }
     // Route to the second daemon for labels that clearly name a distinct
     // subject (a daemon holds one subject, so second/outsider/peer subjects
     // live on the second daemon).
@@ -575,6 +583,11 @@ export class Runner {
         const rel = path.startsWith('$') ? path.slice(1) : path;
         const { found, value } = resolvePath(root, rel);
         vars[varName] = found ? value : undefined;
+        if (this.verbose) {
+          let shown;
+          try { shown = JSON.stringify(value)?.slice(0, 60); } catch { shown = '[unserializable]'; }
+          this.log(`save ${varName} <- ${path} = ${shown} (found=${found})`);
+        }
       }
     }
   }
@@ -656,7 +669,13 @@ export class Runner {
     const daemon = (vars.__case||{}).primary;
     const u = step.upgrade;
     const query = {};
-    for (const [k, v] of Object.entries(u.query || {})) query[k] = resolveValue(v, vars);
+    for (const [k, v] of Object.entries(u.query || {})) {
+      const resolved = resolveValue(v, vars);
+      // Query values carry the same portfile placeholders headers do
+      // (<daemon_sg>, <token>, …) — substitute them, or an authored admission
+      // silently becomes a refusal.
+      query[k] = typeof resolved === 'string' ? this.#resolveHeaderValue(resolved, daemon, vars) : resolved;
+    }
     const headers = {};
     for (const [k, v] of Object.entries(u.headers || {})) {
       headers[k] = this.#resolveHeaderValue(v, daemon, vars);
@@ -696,6 +715,18 @@ export class Runner {
 
     if (step.expect) {
       this.#matchUpgradeExpect(step.expect, result, vars);
+    } else if (vars.__case) {
+      // A refused no-expect upgrade must not silently degrade into
+      // #sessionFor's auto-connection: mark the label, and the next step
+      // that DEPENDS on this session fails with the refusal. Probe upgrades
+      // and post-stop reachability checks (which never use the session
+      // afterwards) stay expressible.
+      vars.__case.refusedUpgrades ||= Object.create(null);
+      if (result.status === 101) {
+        delete vars.__case.refusedUpgrades[label];
+      } else {
+        vars.__case.refusedUpgrades[label] = result.status;
+      }
     }
     if (step.save) {
       for (const [varName, path] of Object.entries(step.save)) {
@@ -712,6 +743,7 @@ export class Runner {
     return v
       .replace('<bearer_from_portfile>', daemon.token)
       .replace('<token>', daemon.token)
+      .replace('<daemon_sg>', String(daemon.storageGeneration))
       .replace('<port>', String(daemon.port))
       .replace(/\$([A-Za-z_][A-Za-z0-9_.]*)/g, (m, name) => {
         const { found, value } = resolvePath(vars, name);
@@ -886,8 +918,15 @@ export class Runner {
     if (step.expect) this.#matchUpgradeExpect(step.expect, result, vars);
     if (step.save) {
       for (const [varName, p] of Object.entries(step.save)) {
-        const { found, value } = resolvePath({ body, ...body }, p);
+        // The corpus roots http captures at `out` (and sometimes `body`);
+        // both alias the response body.
+        const { found, value } = resolvePath({ body, out: body, ...body }, p);
         vars[varName] = found ? value : undefined;
+        if (this.verbose) {
+          let shown;
+          try { shown = JSON.stringify(value)?.slice(0, 60); } catch { shown = '[unserializable]'; }
+          this.log(`save ${varName} <- ${p} = ${shown} (found=${found})`);
+        }
       }
     }
   }

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -649,6 +649,10 @@ export class Runner {
     // same-principal reconnect (op_id replay cases) silently miss the ledger.
     // A probing upgrade (any expect) sends exactly what the fixture wrote.
     const label = step.on || 'subject:self';
+    // A same-label upgrade replaces the registered session; a sticky
+    // violation on the outgoing connection must not vanish with it.
+    const outgoing = sessions.get(label);
+    if (outgoing && outgoing.stickyBinaryViolation) throw outgoing.stickyBinaryViolation;
     let clientId = null;
     if (!step.expect && query.cid === undefined && query.ct === undefined && vars.__case) {
       vars.__case.clientIds ||= Object.create(null);

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -630,6 +630,7 @@ export class Runner {
         maxPayload,
         limitBytes: hello.limits?.max_shared_file_bytes,
         inflightBytes: hello.limits?.max_transfer_bytes_inflight,
+        concurrentLimit: hello.limits?.max_concurrent_transfers,
         stallMs: hello.limits?.transfer_stall_ms,
         waitMs,
       });

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -133,11 +133,19 @@ export class Runner {
       // Execute the steps.
       for (let i = 0; i < fixture.steps.length; i++) {
         const step = fixture.steps[i];
+        ctxState.lastCallOk = undefined;
         await this.#runStep(step, i, { daemons, sessions, vars, ctx, ctxState, name });
-        // A `step`-scoped observation compares against the state just before
-        // this step; refresh the baseline after each step completes.
-        ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
-        ctxState.dirSnapshot = this.#dirStateSignature(daemons);
+        // An observation compares against the state just before the observed
+        // operation. A SUCCESSFUL step advances the baselines; a REFUSED one
+        // (an error-replied call, or a raw `send` probe) must not — a refused
+        // operation authors nothing legally, so refreshing after it would
+        // absorb exactly the violation a following no_event_authored /
+        // no_durable_mutation observation exists to catch.
+        const refused = (step.call && ctxState.lastCallOk === false) || step.send !== undefined;
+        if (!refused) {
+          ctxState.eventSnapshot = await this.#roomEventTotal(vars, sessions);
+          ctxState.dirSnapshot = this.#dirStateSignature(daemons);
+        }
       }
 
       // A case that ran all steps without a failing assertion passes. A block
@@ -495,6 +503,7 @@ export class Runner {
     vars.err = reply.err;
     vars.frame = reply;
     if (reply.err) vars.last_error = reply.err;
+    ctxState.lastCallOk = !!reply.ok;
 
     if (mutating && reply.ok) ctxState.eventAuthored++;
     ctxState.networkActivity++;
@@ -1090,8 +1099,9 @@ export class Runner {
     switch (obs) {
       case 'no_event_authored': {
         // Real check: the room's committed event total must not have grown
-        // since the baseline snapshot (case start for `case` scope, the prior
-        // step for `step` scope).
+        // since the last SUCCESSFUL step's baseline — the refresh skips
+        // refused operations, so the observed refusal cannot absorb an
+        // illegally authored event.
         if (ctxState.eventSnapshot === null || ctxState.eventSnapshot === undefined) return;
         const now = await this.#roomEventTotal(vars, sessions);
         if (now !== null && now > ctxState.eventSnapshot) {

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -593,6 +593,11 @@ export class Runner {
       });
     } finally {
       s.streams.delete(id);
+      // Tombstone the id so a late duplicate terminal reply still violates
+      // exactly-one-terminal after the tracker retires. Streaming ids only —
+      // harness-issued and never reused, so raw-send id-reuse fixtures are
+      // unaffected.
+      (s.retiredStreamCallIds ||= new Set()).add(id);
       if (record) {
         record.accepted = tracker.accepted;
         record.opened = tracker.opened;

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -442,6 +442,9 @@ export class Runner {
   async #doCall(step, index, env) {
     const { sessions, vars, ctxState } = env;
     const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
+    // A Binary violation recorded while no tracker was installed poisons the
+    // connection; the next daemon interaction surfaces it.
+    if (s.stickyBinaryViolation) throw s.stickyBinaryViolation;
     const input = step.in !== undefined ? resolveValue(step.in, vars) : {};
     // CORPUS/SPEC DISCREPANCY: every committed fixture calls stream.subscribe
     // without the spec-required `from` cursor (50/50). The spec (canonical)
@@ -1219,8 +1222,10 @@ export class Runner {
           if (!m) throw new AssertFailure(`bytes_streamed selector ${JSON.stringify(a.call)} is not step:<n>`);
           rec = records.find((r) => r.step === Number(m[1]));
         } else {
-          // Default: the most recent call on the same session.
-          const pool = a.on ? records.filter((r) => r.label === a.on) : records;
+          // Default: the most recent call on the same session (the
+          // observation's session label, subject:self when unnamed).
+          const label = a.on || 'subject:self';
+          const pool = records.filter((r) => r.label === label);
           rec = pool[pool.length - 1];
         }
         if (!rec) {

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -12,6 +12,7 @@ import { startDaemon } from './daemon.mjs';
 import { Session } from './session.mjs';
 import { AssertContext, AssertFailure, TransportFailure, evalAssert, subsetMatch } from './assert.mjs';
 import { resolvePath, resolveValue } from './values.mjs';
+import { CallStreamTracker, maxDataPayloadBytes, runStreamingCall } from './stream.mjs';
 
 /** The outcome of one case. */
 export const Outcome = {
@@ -86,6 +87,9 @@ export class Runner {
       eventAuthored: 0,
       durableMutation: 0,
       pushesByRoom: new Map(),
+      // One record per `call` step: {step (1-based), label, accepted, opened}.
+      // `bytes_streamed` observations read receiver-accepted bytes from here.
+      callRecords: [],
     };
 
     const cleanup = async () => {
@@ -251,6 +255,39 @@ export class Runner {
         const left = await authority.call('room.create', { name: 'left room' });
         vars.rid_left = left.out?.room_id;
       }
+
+      // `resource:shared_file` — a real file genuinely streamed into the room
+      // through the byte-stream executor; binds `$fid`. This is live setup
+      // evidence, not a stub: the daemon stages, digests, and authors the
+      // share exactly as any client upload.
+      if (requires.includes('resource:shared_file')) {
+        const input = {
+          room_id: vars.rid,
+          name: 'seed.bin',
+          declared_bytes: 4096,
+          declared_content_type: 'application/octet-stream',
+        };
+        const reply = await this.#streamCall(authority, 'file.share', input, { send_bytes: 4096 }, {
+          opId: `cf-seed-${opIdCounter++}`,
+        });
+        if (!reply.ok) {
+          throw new Error(`resource:shared_file setup failed: ${JSON.stringify(reply.err)}`);
+        }
+        vars.fid = reply.out?.file_id;
+      }
+    }
+
+    // Bare `subject` means the daemon's one subject exists (`subject:none` is
+    // the absence form). Room/member setup ensures it as a side effect. A case
+    // whose own steps call subject.ensure manages the lifecycle itself (some
+    // assert on the `created` flag); otherwise ensure it here so a
+    // subject-requiring error case observes its intended error rather than
+    // subject_absent.
+    const caseEnsuresSubject = (fixture.steps || []).some((st) => st.call === 'subject.ensure');
+    if (requires.includes('subject') && !caseEnsuresSubject && !(wantsRoom || wantsLeftRoom || wantsMembers)) {
+      const authority = await this.#sessionFor('subject:authority', daemons, sessions, vars);
+      const ensured = await authority.call('subject.ensure', {});
+      vars.self_sid = ensured.out?.subject_id;
     }
 
     // `resource:tcp_service` — a loopback TCP echo service a pipe can target;
@@ -346,7 +383,7 @@ export class Runner {
       return;
     }
     if (step.call) {
-      await this.#doCall(step, env);
+      await this.#doCall(step, index, env);
       return;
     }
     if (step.send !== undefined) {
@@ -389,8 +426,12 @@ export class Runner {
     // no-op for the runner.
   }
 
-  /** A `call` step: invoke an operation, match the reply, save captures. */
-  async #doCall(step, env) {
+  /** A `call` step: invoke an operation, match the reply, save captures. A
+   * step carrying `stream` runs as one duplex operation via the byte-stream
+   * executor; every call (streaming or not) gets a tracker so
+   * `bytes_streamed` observes real receiver-accepted counts and an
+   * unexpected OPEN on a stream-less call is caught, not dropped. */
+  async #doCall(step, index, env) {
     const { sessions, vars, ctxState } = env;
     const s = await this.#sessionFor(step.on, env.daemons, sessions, vars);
     const input = step.in !== undefined ? resolveValue(step.in, vars) : {};
@@ -414,16 +455,38 @@ export class Runner {
       step.call,
     );
 
+    const streamSpec = step.stream !== undefined ? resolveValue(step.stream, vars) : null;
+    const record = { step: index + 1, label: step.on || 'subject:self', accepted: 0, opened: false };
+    ctxState.callRecords.push(record);
+
     let reply;
-    try {
-      reply = await s.call(step.call, input, { opId });
-      this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)}`);
-    } catch (err) {
-      // Never a reply — a timeout, a closed socket, or a crash. This is a
-      // transport/runner failure, not a matcher verdict: raise a
-      // TransportFailure (not an AssertFailure) so a blocked case cannot count
-      // a dead daemon as its expected blocked assertion.
-      throw new TransportFailure(`call ${step.call} failed to get a reply: ${err.message}`);
+    if (streamSpec) {
+      reply = await this.#streamCall(s, step.call, input, streamSpec, { opId, record });
+      this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)} (accepted ${record.accepted})`);
+    } else {
+      const { id, reply: replyPromise } = s.startCall(step.call, input, { opId });
+      const tracker = new CallStreamTracker(id);
+      s.streams.set(id, tracker);
+      try {
+        reply = await replyPromise;
+        this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)}`);
+      } catch (err) {
+        // Never a reply — a timeout, a closed socket, or a crash. This is a
+        // transport/runner failure, not a matcher verdict: raise a
+        // TransportFailure (not an AssertFailure) so a blocked case cannot count
+        // a dead daemon as its expected blocked assertion.
+        const openNote = tracker.opened ? ' after the daemon opened an unexpected byte stream' : '';
+        throw new TransportFailure(`call ${step.call} failed to get a reply${openNote}: ${err.message}`);
+      } finally {
+        s.streams.delete(id);
+        record.accepted = tracker.accepted;
+        record.opened = tracker.opened;
+      }
+      if (tracker.opened) {
+        throw new AssertFailure(
+          `call ${step.call} received an OPEN for a stream the fixture declares it must not open`,
+        );
+      }
     }
 
     // Expose the reply under the assertion roots.
@@ -447,6 +510,40 @@ export class Runner {
         const rel = path.startsWith('$') ? path.slice(1) : path;
         const { found, value } = resolvePath(root, rel);
         vars[varName] = found ? value : undefined;
+      }
+    }
+  }
+
+  /** Run one duplex streaming call through the byte-stream executor. */
+  async #streamCall(s, op, input, spec, { opId, record } = {}) {
+    const hello = s.lastHello || {};
+    const maxPayload = maxDataPayloadBytes(hello.limits?.max_frame_bytes);
+    const { id, reply: replyPromise } = s.startCall(op, input, {
+      opId,
+      timeoutMs: 60_000 * this.timeoutScale,
+    });
+    const tracker = new CallStreamTracker(id);
+    s.streams.set(id, tracker);
+    const replyState = { done: false, value: undefined, error: undefined };
+    replyPromise.then(
+      (v) => { replyState.done = true; replyState.value = v; tracker.wake(); },
+      (e) => { replyState.done = true; replyState.error = e; tracker.wake(); },
+    );
+    try {
+      return await runStreamingCall({
+        session: s,
+        tracker,
+        replyState,
+        spec,
+        declaredBytes: input?.declared_bytes,
+        maxPayload,
+        timeoutScale: this.timeoutScale,
+      });
+    } finally {
+      s.streams.delete(id);
+      if (record) {
+        record.accepted = tracker.accepted;
+        record.opened = tracker.opened;
       }
     }
   }
@@ -488,8 +585,21 @@ export class Runner {
     // Perform the upgrade; it may be refused (non-101). A successful upgrade
     // becomes the `on` session's live connection so a following `await` reads
     // THIS connection's hello, not a stale one from before the upgrade.
+    // A setup upgrade (no expect) is the label's ordinary admitted
+    // connection, so it presents the label's STABLE client id exactly as
+    // #sessionFor does — an omitted `cid` is an ephemeral per-connection
+    // dedup principal on the daemon, which would make every later
+    // same-principal reconnect (op_id replay cases) silently miss the ledger.
+    // A probing upgrade (any expect) sends exactly what the fixture wrote.
     const label = step.on || 'subject:self';
-    const result = await this.#attemptUpgrade(daemon, query, headers, label, sessions);
+    let clientId = null;
+    if (!step.expect && query.cid === undefined && query.ct === undefined && vars.__case) {
+      vars.__case.clientIds ||= Object.create(null);
+      vars.__case.clientIds[label] ||= `cf-client-${opIdCounter++}`;
+      clientId = vars.__case.clientIds[label];
+      query.cid = clientId;
+    }
+    const result = await this.#attemptUpgrade(daemon, query, headers, label, sessions, clientId);
     vars.frame = result.frame || {};
     vars.out = result.body;
     vars.err = result.body;
@@ -521,7 +631,7 @@ export class Runner {
 
   /** Attempt a WS upgrade, returning {status, body, frame}. On admission the
    * socket stays open and is registered as the `label` session's connection. */
-  async #attemptUpgrade(daemon, query, headers, label, sessions) {
+  async #attemptUpgrade(daemon, query, headers, label, sessions, clientId = null) {
     const params = new URLSearchParams();
     for (const [k, v] of Object.entries(query)) params.set(k, String(v));
     const url = `${daemon.wsBase}?${params.toString()}`;
@@ -543,13 +653,12 @@ export class Runner {
       };
       ws.once('open', () => {
         opened = true;
-        const session = new Session(label);
+        const session = new Session(label, clientId);
         session.ws = ws;
         session.open = true;
-        ws.on('message', (data) => session.__onMessage(data));
+        ws.on('message', (data, isBinary) => session.__onMessage(data, isBinary));
         ws.on('close', (code) => {
-          session.open = false;
-          session.closeCode = code;
+          session.__onClose(code);
           if (!settled) fail(`upgrade connection closed before hello (${code})`);
         });
         ws.on('error', (err) => {
@@ -1080,8 +1189,43 @@ export class Runner {
         // A timing assertion needs sub-step latency instrumentation; treated
         // as non-blocking here (recorded, not asserted).
         return;
-      case 'bytes_streamed':
+      case 'bytes_streamed': {
+        // Receiver-ACCEPTED payload bytes for one call: the daemon's
+        // cumulative CREDIT/ABORT acknowledgement for an upload, the harness
+        // sink's accepted count for a download. A pre-OPEN terminal refusal
+        // (and a faithful replay, which opens no stream) records zero.
+        const records = ctxState.callRecords;
+        let rec;
+        if (a.call !== undefined) {
+          const m = /^step:([1-9][0-9]*)$/.exec(String(a.call));
+          if (!m) throw new AssertFailure(`bytes_streamed selector ${JSON.stringify(a.call)} is not step:<n>`);
+          rec = records.find((r) => r.step === Number(m[1]));
+        } else {
+          // Default: the most recent call on the same session.
+          const pool = a.on ? records.filter((r) => r.label === a.on) : records;
+          rec = pool[pool.length - 1];
+        }
+        if (!rec) {
+          throw new AssertFailure(`bytes_streamed: no call recorded for ${a.call ?? 'the most recent call'}`);
+        }
+        const cmp = a.value;
+        const want = Number(resolveValue(cmp.value, vars));
+        const got = rec.accepted;
+        const ok =
+          cmp.op === 'eq' ? got === want
+          : cmp.op === 'ne' ? got !== want
+          : cmp.op === 'lt' ? got < want
+          : cmp.op === 'lte' ? got <= want
+          : cmp.op === 'gt' ? got > want
+          : cmp.op === 'gte' ? got >= want
+          : false;
+        if (!ok) {
+          throw new AssertFailure(
+            `bytes_streamed ${got} !${cmp.op} ${want}${a.call ? ` (${a.call})` : ''}`,
+          );
+        }
         return;
+      }
       default:
         throw new AssertFailure(`unsupported observe ${obs}`);
     }

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -63,7 +63,10 @@ export class Session {
     for (const [k, v] of Object.entries(connectQuery)) params.set(k, String(v));
     const url = `${daemon.wsBase}?${params.toString()}`;
     const hdrs = { Host: `127.0.0.1:${daemon.port}`, ...headers };
-    this.ws = new WebSocket(url, { headers: hdrs });
+    // Never offer per-message compression: the daemon must not negotiate it,
+    // and a compressed transport would decouple max_frame_bytes from the
+    // actual message payload the harness measures.
+    this.ws = new WebSocket(url, { headers: hdrs, perMessageDeflate: false });
     this.ws.binaryType = 'nodebuffer';
     this.ws.on('message', (data, isBinary) => this.#onMessage(data, isBinary));
     this.ws.on('close', (code) => {

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -154,6 +154,11 @@ export class Session {
           return;
         }
         tracker.replySeq = ++tracker.seq;
+      } else if (this.retiredStreamCallIds && this.retiredStreamCallIds.has(frame.id)) {
+        // A late duplicate for a COMPLETED streaming call — the tracker is
+        // gone, but exactly-one-terminal still binds the request id.
+        this.#binaryViolation(`daemon sent a late duplicate terminal reply for streaming request ${frame.id}`);
+        return;
       }
       const waiter = this.pending.get(frame.id);
       if (waiter) {

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -145,9 +145,16 @@ export class Session {
       // A reply. Stamp its wire-order sequence SYNCHRONOUSLY — the promise
       // .then that consumes it runs as a microtask, after any Binary record
       // delivered later in this same receive batch would otherwise have
-      // taken a smaller sequence number.
+      // taken a smaller sequence number. A second terminal reply for a
+      // still-tracked request violates exactly-one-terminal.
       const tracker = this.streams.get(frame.id);
-      if (tracker) tracker.replySeq = ++tracker.seq;
+      if (tracker) {
+        if (tracker.replySeq !== undefined) {
+          this.#binaryViolation(`daemon sent a second terminal reply for request ${frame.id}`);
+          return;
+        }
+        tracker.replySeq = ++tracker.seq;
+      }
       const waiter = this.pending.get(frame.id);
       if (waiter) {
         this.pending.delete(frame.id);

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -9,7 +9,7 @@
 
 import WebSocket from 'ws';
 import { AssertFailure } from './assert.mjs';
-import { decodeRecord } from './stream.mjs';
+import { MAGIC, decodeRecord } from './stream.mjs';
 
 /** Serialize a value, splicing any `{__rawJson}` subtrees in verbatim. */
 function serializeWithRaw(value) {
@@ -120,7 +120,13 @@ export class Session {
     try {
       frame = JSON.parse(data.toString());
     } catch {
-      return; // undeliverable frame; nothing to correlate
+      // A stream record in a Text message is malformed by class. Anything
+      // else unparseable is undeliverable with nothing to correlate.
+      const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      if (buf.length >= MAGIC.length && buf.subarray(0, MAGIC.length).equals(MAGIC)) {
+        this.#binaryViolation('daemon sent a byte-stream record as a Text message');
+      }
+      return;
     }
     if (frame.t === 'hello') {
       this.lastHello = frame;

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -8,6 +8,7 @@
 // each in-flight request has its own waiter.
 
 import WebSocket from 'ws';
+import { AssertFailure } from './assert.mjs';
 import { decodeRecord } from './stream.mjs';
 
 /** Serialize a value, splicing any `{__rawJson}` subtrees in verbatim. */
@@ -95,12 +96,24 @@ export class Session {
 
   #onMessage(data, isBinary) {
     // The session layer preserves the WebSocket Text/Binary bit: a Binary
-    // message is exactly one byte-stream record, never JSON.
+    // message is exactly one byte-stream record, never JSON. An unparseable
+    // message or a record with no outstanding streaming binding is the
+    // connection-fatal-4007 class of daemon violation — fail the active
+    // streams loudly rather than forgetting it.
     if (isBinary) {
       const record = decodeRecord(data);
-      if (record.malformed) return; // nothing correlatable; executors time out
+      if (record.malformed) {
+        this.#binaryViolation(`daemon sent an unparseable Binary message (${record.malformed})`);
+        return;
+      }
       const tracker = this.streams.get(record.id);
-      if (tracker) tracker.deliver(record);
+      if (!tracker) {
+        this.#binaryViolation(
+          `daemon sent ${record.kindName} for request ${record.id} with no outstanding streaming binding`,
+        );
+        return;
+      }
+      tracker.deliver(record);
       return;
     }
     let frame;
@@ -150,6 +163,13 @@ export class Session {
         w.resolve(frame);
       }
     }
+  }
+
+  #binaryViolation(message) {
+    this.binaryViolations ||= [];
+    this.binaryViolations.push(message);
+    const err = new AssertFailure(message);
+    for (const t of this.streams.values()) t.fail(err);
   }
 
   #failAll(err) {

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -28,7 +28,10 @@ function serializeWithRaw(value) {
   return text;
 }
 
-let nextRequestId = 1;
+// Harness-issued envelope ids start far above any hand-authored fixture id
+// (raw `send` steps use small integers), so completed-call tombstones can
+// never collide with a fixture's deliberate id reuse.
+let nextRequestId = 1_000_000;
 
 /** Allocate a process-unique envelope id. */
 export function requestId() {
@@ -157,10 +160,12 @@ export class Session {
           return;
         }
         tracker.replySeq = ++tracker.seq;
-      } else if (this.retiredStreamCallIds && this.retiredStreamCallIds.has(frame.id)) {
-        // A late duplicate for a COMPLETED streaming call — the tracker is
+      } else if (this.retiredCallIds && this.retiredCallIds.has(frame.id)) {
+        // A late duplicate for a COMPLETED harness call — the tracker is
         // gone, but exactly-one-terminal still binds the request id.
-        this.#binaryViolation(`daemon sent a late duplicate terminal reply for streaming request ${frame.id}`);
+        // Harness ids never collide with fixture-authored raw-send ids
+        // (disjoint ranges), so deliberate id-reuse probes are unaffected.
+        this.#binaryViolation(`daemon sent a late duplicate terminal reply for request ${frame.id}`);
         return;
       }
       const waiter = this.pending.get(frame.id);

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -172,6 +172,9 @@ export class Session {
       if (waiter) {
         this.pending.delete(frame.id);
         clearTimeout(waiter.timer);
+        // Retire the id SYNCHRONOUSLY — a second reply later in this same
+        // receive batch must find the tombstone, not a microtask gap.
+        (this.retiredCallIds ||= new Set()).add(frame.id);
         waiter.resolve(frame);
       }
       this.#notifyFrame(frame);
@@ -204,6 +207,13 @@ export class Session {
     // must still fail the next daemon interaction on this connection.
     this.stickyBinaryViolation ||= err;
     for (const t of this.streams.values()) t.fail(err);
+    // Direct calls (setup/observation) fail NOW as the conformance verdict,
+    // not later as a reply-timeout transport error.
+    for (const [, p] of this.pending) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
   }
 
   #failAll(err) {
@@ -224,12 +234,9 @@ export class Session {
    * completed call tombstones its id, so a late duplicate terminal reply is
    * a violation even for setup and observation calls with no tracker. */
   async call(op, input, { opId, timeoutMs = 10_000 } = {}) {
-    const { id, reply } = this.startCall(op, input, { opId, timeoutMs });
-    const result = await reply;
-    // Tombstone only on a RECEIVED reply — a timed-out call's late first
-    // reply is not a duplicate.
-    (this.retiredCallIds ||= new Set()).add(id);
-    return result;
+    // Retirement happens synchronously in #onMessage when the reply is
+    // delivered, so a same-batch duplicate always finds the tombstone.
+    return this.startCall(op, input, { opId, timeoutMs }).reply;
   }
 
   /** Send one request envelope, returning its id and pending reply promise —

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -220,9 +220,16 @@ export class Session {
     for (const t of this.streams.values()) t.fail(err);
   }
 
-  /** Send one request envelope and wait for its correlated reply. */
+  /** Send one request envelope and wait for its correlated reply. Every
+   * completed call tombstones its id, so a late duplicate terminal reply is
+   * a violation even for setup and observation calls with no tracker. */
   async call(op, input, { opId, timeoutMs = 10_000 } = {}) {
-    return this.startCall(op, input, { opId, timeoutMs }).reply;
+    const { id, reply } = this.startCall(op, input, { opId, timeoutMs });
+    const result = await reply;
+    // Tombstone only on a RECEIVED reply — a timed-out call's late first
+    // reply is not a duplicate.
+    (this.retiredCallIds ||= new Set()).add(id);
+    return result;
   }
 
   /** Send one request envelope, returning its id and pending reply promise —

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -8,6 +8,7 @@
 // each in-flight request has its own waiter.
 
 import WebSocket from 'ws';
+import { decodeRecord } from './stream.mjs';
 
 /** Serialize a value, splicing any `{__rawJson}` subtrees in verbatim. */
 function serializeWithRaw(value) {
@@ -47,6 +48,10 @@ export class Session {
     this.open = false;
     // How many received pushes have been consumed by `await push` steps.
     this.pushCursor = 0;
+    // Byte-stream routing: request id -> CallStreamTracker. Binary records
+    // are routed by envelope id; the (id, stream_id) pair is validated by the
+    // executor once OPEN installs it.
+    this.streams = new Map();
   }
 
   /** Connect and wait for the hello frame. `query` is the v/sg/token map. */
@@ -59,7 +64,7 @@ export class Session {
     const hdrs = { Host: `127.0.0.1:${daemon.port}`, ...headers };
     this.ws = new WebSocket(url, { headers: hdrs });
     this.ws.binaryType = 'nodebuffer';
-    this.ws.on('message', (data) => this.#onMessage(data));
+    this.ws.on('message', (data, isBinary) => this.#onMessage(data, isBinary));
     this.ws.on('close', (code) => {
       this.open = false;
       this.closeCode = code;
@@ -76,11 +81,28 @@ export class Session {
   }
 
   /** Public wrapper so the upgrade path can attach an externally-opened socket. */
-  __onMessage(data) {
-    this.#onMessage(data);
+  __onMessage(data, isBinary) {
+    this.#onMessage(data, isBinary);
   }
 
-  #onMessage(data) {
+  /** Public close hook for externally-attached sockets: mirror the connect()
+   * close path so pending replies and active streams fail fast. */
+  __onClose(code) {
+    this.open = false;
+    this.closeCode = code;
+    this.#failAll(new Error(`connection closed (${code})`));
+  }
+
+  #onMessage(data, isBinary) {
+    // The session layer preserves the WebSocket Text/Binary bit: a Binary
+    // message is exactly one byte-stream record, never JSON.
+    if (isBinary) {
+      const record = decodeRecord(data);
+      if (record.malformed) return; // nothing correlatable; executors time out
+      const tracker = this.streams.get(record.id);
+      if (tracker) tracker.deliver(record);
+      return;
+    }
     let frame;
     try {
       frame = JSON.parse(data.toString());
@@ -141,15 +163,23 @@ export class Session {
       p.reject(err);
     }
     this.pending.clear();
+    for (const t of this.streams.values()) t.fail(err);
   }
 
   /** Send one request envelope and wait for its correlated reply. */
   async call(op, input, { opId, timeoutMs = 10_000 } = {}) {
+    return this.startCall(op, input, { opId, timeoutMs }).reply;
+  }
+
+  /** Send one request envelope, returning its id and pending reply promise —
+   * the duplex form a streaming call needs (the reply stays pending while
+   * Binary records flow). */
+  startCall(op, input, { opId, timeoutMs = 10_000 } = {}) {
     const id = requestId();
     this.lastRequestId = id;
     const env = { id, op, in: input };
     if (opId !== undefined) env.op_id = opId;
-    const replyPromise = new Promise((resolve, reject) => {
+    const reply = new Promise((resolve, reject) => {
       const timer = setTimeout(
         () => reject(new Error(`reply for ${op} (id ${id}) timed out`)),
         timeoutMs,
@@ -157,7 +187,12 @@ export class Session {
       this.pending.set(id, { resolve, reject, timer });
     });
     this.ws.send(JSON.stringify(env));
-    return replyPromise;
+    return { id, reply };
+  }
+
+  /** Send one Binary byte-stream record. */
+  sendBinary(buf) {
+    this.ws.send(buf, { binary: true });
   }
 
   /** Send raw bytes/text that may not be a valid frame. A `{__rawJson}` marker

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -142,7 +142,12 @@ export class Session {
       return;
     }
     if (frame.id !== undefined) {
-      // A reply.
+      // A reply. Stamp its wire-order sequence SYNCHRONOUSLY — the promise
+      // .then that consumes it runs as a microtask, after any Binary record
+      // delivered later in this same receive batch would otherwise have
+      // taken a smaller sequence number.
+      const tracker = this.streams.get(frame.id);
+      if (tracker) tracker.replySeq = ++tracker.seq;
       const waiter = this.pending.get(frame.id);
       if (waiter) {
         this.pending.delete(frame.id);
@@ -215,8 +220,9 @@ export class Session {
       );
       this.pending.set(id, { resolve, reject, timer });
     });
-    this.ws.send(JSON.stringify(env));
-    return { id, reply };
+    const payload = JSON.stringify(env);
+    this.ws.send(payload);
+    return { id, reply, requestBytes: Buffer.byteLength(payload, 'utf8') };
   }
 
   /** Send one Binary byte-stream record. */

--- a/conformance/v2/harness/session.mjs
+++ b/conformance/v2/harness/session.mjs
@@ -169,6 +169,9 @@ export class Session {
     this.binaryViolations ||= [];
     this.binaryViolations.push(message);
     const err = new AssertFailure(message);
+    // Sticky: a violation observed with no tracker installed (between calls)
+    // must still fail the next daemon interaction on this connection.
+    this.stickyBinaryViolation ||= err;
     for (const t of this.streams.values()) t.fail(err);
   }
 

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -290,17 +290,25 @@ function validateAbort(rec, sentBound, allowedReasons) {
  * pick the legal-END discipline, never to bound the generator). Returns the
  * terminal reply envelope; the tracker carries the byte accounting.
  */
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, connectAllowanceMs, floorBitsPerSecond, timeoutScale = 1 }) {
-  // Harness patience: at least 60 s, or the served absolute budget (with
-  // headroom) when the legal budget for this total is longer — a conforming
-  // slow-floor transfer must not lose its reply promise early. Enforcement
-  // of the deadline itself belongs to deadline-designed fixtures.
+/** Harness patience for one streaming call: at least 60 s, extended toward
+ * the served absolute budget (with headroom) when the legal budget for this
+ * total is longer, and capped under the 90 s case watchdog — the watchdog is
+ * the harness's deliberate anti-hang bound and reports ERROR, never a
+ * conformance verdict. Deadline ENFORCEMENT belongs to deadline-designed
+ * fixtures. */
+export function streamWaitMs(spec, servedLimits = {}, timeoutScale = 1) {
+  const allowance = servedLimits.transfer_connect_allowance_ms;
+  const floor = servedLimits.transfer_floor_bits_per_second;
   const total = Number(spec.send_bytes ?? spec.receive_bytes);
-  let waitMs = 60_000 * timeoutScale;
-  if (Number.isInteger(connectAllowanceMs) && Number.isInteger(floorBitsPerSecond) && floorBitsPerSecond > 0 && Number.isFinite(total)) {
-    const budgetMs = connectAllowanceMs + Math.ceil((total * 8 * 1000) / floorBitsPerSecond);
+  let waitMs = 60_000;
+  if (Number.isInteger(allowance) && Number.isInteger(floor) && floor > 0 && Number.isFinite(total)) {
+    const budgetMs = allowance + Math.ceil((total * 8 * 1000) / floor);
     waitMs = Math.max(waitMs, Math.ceil(budgetMs * 1.2));
   }
+  return Math.min(waitMs, 80_000) * timeoutScale;
+}
+
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs = 60_000 }) {
   if (spec.send_bytes !== undefined) {
     return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs });
   }
@@ -314,7 +322,14 @@ export async function runStreamingCall({ session, tracker, replyState, spec, dec
  * budget before admission — an OPEN beyond the sole-active budget proves an
  * admission its own limits forbid. */
 function checkInflightBudget(openTotal, inflightBytes) {
-  if (Number.isInteger(inflightBytes) && openTotal > inflightBytes) {
+  // The limits contract serves JSON integers; a non-integer bound is a
+  // nonconforming configuration, never treated as no bound.
+  if (typeof inflightBytes !== 'number' || !Number.isInteger(inflightBytes) || inflightBytes < 0) {
+    throw new AssertFailure(
+      `served max_transfer_bytes_inflight ${JSON.stringify(inflightBytes)} is unusable for byte streaming`,
+    );
+  }
+  if (openTotal > inflightBytes) {
     throw new AssertFailure(
       `daemon admitted an OPEN total ${openTotal} beyond its served max_transfer_bytes_inflight ${inflightBytes}`,
     );

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -299,9 +299,21 @@ function validateAbort(rec, sentBound, allowedReasons) {
 export function streamWaitMs(spec, servedLimits = {}, timeoutScale = 1) {
   const allowance = servedLimits.transfer_connect_allowance_ms;
   const floor = servedLimits.transfer_floor_bits_per_second;
+  // A zero (or non-integer) served floor is an invalid configuration the
+  // daemon must refuse readiness over — deadline arithmetic divides by it.
+  if (typeof floor !== 'number' || !Number.isInteger(floor) || floor <= 0) {
+    throw new AssertFailure(
+      `served transfer_floor_bits_per_second ${JSON.stringify(floor)} is an invalid configuration`,
+    );
+  }
+  if (typeof allowance !== 'number' || !Number.isInteger(allowance) || allowance < 0) {
+    throw new AssertFailure(
+      `served transfer_connect_allowance_ms ${JSON.stringify(allowance)} is an invalid configuration`,
+    );
+  }
   const total = Number(spec.send_bytes ?? spec.receive_bytes);
   let waitMs = 60_000;
-  if (Number.isInteger(allowance) && Number.isInteger(floor) && floor > 0 && Number.isFinite(total)) {
+  if (Number.isFinite(total)) {
     const budgetMs = allowance + Math.ceil((total * 8 * 1000) / floor);
     waitMs = Math.max(waitMs, Math.ceil(budgetMs * 1.2));
   }

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -290,15 +290,49 @@ function validateAbort(rec, sentBound, allowedReasons) {
  * pick the legal-END discipline, never to bound the generator). Returns the
  * terminal reply envelope; the tracker carries the byte accounting.
  */
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, timeoutScale = 1 }) {
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, timeoutScale = 1 }) {
   const waitMs = 60_000 * timeoutScale;
   if (spec.send_bytes !== undefined) {
-    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, waitMs });
+    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs });
   }
   if (spec.receive_bytes !== undefined) {
-    return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, waitMs });
+    return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, inflightBytes, stallMs, waitMs });
   }
   throw new Error(`stream spec has neither send_bytes nor receive_bytes: ${JSON.stringify(spec)}`);
+}
+
+/** The daemon reserves the OPEN total against its served aggregate inflight
+ * budget before admission — an OPEN beyond the sole-active budget proves an
+ * admission its own limits forbid. */
+function checkInflightBudget(openTotal, inflightBytes) {
+  if (Number.isInteger(inflightBytes) && openTotal > inflightBytes) {
+    throw new AssertFailure(
+      `daemon admitted an OPEN total ${openTotal} beyond its served max_transfer_bytes_inflight ${inflightBytes}`,
+    );
+  }
+}
+
+/** Accepted-progress stall tracking: the daemon must abort a stream whose
+ * accepted progress stops for transfer_stall_ms, so a SUCCESS after an
+ * observed gap of more than twice that budget proves the timer never ran.
+ * The 2x slack absorbs harness-side scheduling pauses. */
+function makeStallGauge(stallMs) {
+  let last = Date.now();
+  let maxGap = 0;
+  return {
+    progress() {
+      const now = Date.now();
+      maxGap = Math.max(maxGap, now - last);
+      last = now;
+    },
+    checkOnSuccess() {
+      if (Number.isInteger(stallMs) && maxGap > 2 * stallMs) {
+        throw new AssertFailure(
+          `stream succeeded after an accepted-progress gap of ${maxGap}ms, over twice the served transfer_stall_ms ${stallMs}`,
+        );
+      }
+    },
+  };
 }
 
 /** Byte-bound on the local outbound socket queue; sends pause above it so an
@@ -315,7 +349,7 @@ async function yieldAfterSend(session, tracker) {
 }
 
 /** Upload: race a pre-OPEN terminal reply against OPEN, then honour CREDIT. */
-async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, waitMs }) {
+async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     // Terminal before admission: zero bytes, no stream. A `stream`-carrying
@@ -339,6 +373,8 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       `upload OPEN total ${tracker.openTotal} disagrees with declared_bytes ${declaredBytes}`,
     );
   }
+  checkInflightBudget(tracker.openTotal, inflightBytes);
+  const stallGauge = makeStallGauge(stallMs);
 
   // Producer state. `acceptedThrough`/`sendThrough` mirror the daemon's
   // cumulative CREDIT; `sent` is our contiguous DATA high-water mark. A
@@ -452,6 +488,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
           );
         }
         creditSeen = true;
+        if (rec.offset > acceptedThrough) stallGauge.progress();
         acceptedThrough = rec.offset;
         sendThrough = rec.value;
         tracker.accepted = acceptedThrough;
@@ -509,6 +546,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     // Success is only sent after the daemon receives and finalizes END.
     throw new AssertFailure('file.share replied success before the client sent END');
   }
+  if (reply && reply.ok) stallGauge.checkOnSuccess();
   if (reply && !reply.ok && !endSent && !abortSeen) {
     // While the stream is ACTIVE, a daemon terminal error must be preceded
     // by daemon ABORT and our ACK; only a post-END finalization error may
@@ -527,7 +565,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
  * on sink acceptance, validate END, and ACK a daemon ABORT with the final
  * accepted count. Requires OPEN.total, END.offset, the terminal `out.bytes`,
  * and the fixture's N to agree. */
-async function runDownload({ session, tracker, replyState, receiveBytes, maxPayload, waitMs }) {
+async function runDownload({ session, tracker, replyState, receiveBytes, maxPayload, inflightBytes, stallMs, waitMs }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     const reply = await settleReply(replyState);
@@ -546,6 +584,8 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
   if (total !== receiveBytes) {
     throw new AssertFailure(`file.read OPEN total ${total} disagrees with the fixture's receive_bytes ${receiveBytes}`);
   }
+  checkInflightBudget(total, inflightBytes);
+  const stallGauge = makeStallGauge(stallMs);
 
   // Bounded window; the sink is a counter (the harness never collects the
   // whole file). Client credit MUST NOT exceed the OPEN total. Every
@@ -587,6 +627,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         }
         if (rec.value !== 0) throw new AssertFailure('daemon DATA carried a nonzero value field');
         tracker.accepted += len;
+        stallGauge.progress();
         // An END already queued at grant time was sent before this CREDIT
         // could possibly arrive — the producer did not wait for every DATA
         // byte to be acknowledged.
@@ -646,6 +687,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
     // the fixture's N must agree — a success with a missing or disagreeing
     // leg is a conformance failure, never a pass.
     if (!endSeen) throw new AssertFailure('file.read replied success without a daemon END');
+    stallGauge.checkOnSuccess();
     if (!reply.out || reply.out.bytes !== total) {
       throw new AssertFailure(
         `terminal out.bytes ${reply.out?.bytes} disagrees with the streamed total ${total}`,

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -410,9 +410,12 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
             `daemon CREDIT acknowledged ${rec.offset}, inside a DATA record rather than on a record boundary`,
           );
         }
-        if (rec.value > sentinelCap) {
+        if (rec.value > limit + 1) {
+          // The wire bound on upload credit is max_shared_file_bytes + 1;
+          // min(declared, limit) + 1 is the mandatory probe TARGET, not a
+          // ceiling — a conforming daemon may grant a larger bounded window.
           throw new AssertFailure(
-            `daemon CREDIT send_through ${rec.value} exceeds the sentinel cap ${sentinelCap}`,
+            `daemon CREDIT send_through ${rec.value} exceeds max_shared_file_bytes + 1 (${limit + 1})`,
           );
         }
         creditSeen = true;
@@ -436,6 +439,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
           throw new AssertFailure(
             `daemon ABORT accepted count ${rec.offset} regressed below the credited ${acceptedThrough}`,
           );
+        }
+        if (tracker.replySeq !== undefined) {
+          // The reply was already on the wire when we processed ABORT — the
+          // daemon did not wait for our ACK (reply only after ACK).
+          throw new AssertFailure('daemon sent its terminal reply before receiving the ABORT acknowledgement');
         }
         abortSeen = rec;
         tracker.accepted = rec.offset;
@@ -535,6 +543,12 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         }
         if (rec.value !== 0) throw new AssertFailure('daemon DATA carried a nonzero value field');
         tracker.accepted += len;
+        // An END already queued at grant time was sent before this CREDIT
+        // could possibly arrive — the producer did not wait for every DATA
+        // byte to be acknowledged.
+        if (tracker.queue.some((r) => r.kind === KIND.END)) {
+          throw new AssertFailure('daemon sent END before receiving the final cumulative CREDIT');
+        }
         sendThrough = grant(tracker.accepted);
         break;
       }
@@ -557,6 +571,9 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
           throw new AssertFailure(
             `daemon ABORT offset ${rec.offset} matches no accepted_through this receiver issued`,
           );
+        }
+        if (tracker.replySeq !== undefined) {
+          throw new AssertFailure('daemon sent its terminal reply before receiving the ABORT acknowledgement');
         }
         session.sendBinary(
           encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: tracker.accepted, value: 0x05 }),

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -452,6 +452,13 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
             `daemon ABORT accepted count ${rec.offset} regressed below the credited ${acceptedThrough}`,
           );
         }
+        if (rec.offset > tracker.openTotal) {
+          // The probe byte may be sent but never accepted — same bound as
+          // CREDIT acknowledgments.
+          throw new AssertFailure(
+            `daemon ABORT accepted count ${rec.offset} exceeds the OPEN total ${tracker.openTotal}`,
+          );
+        }
         if (tracker.replySeq !== undefined) {
           // The reply was already on the wire when we processed ABORT — the
           // daemon did not wait for our ACK (reply only after ACK).

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -233,6 +233,26 @@ function checkAbortReplyCorrelation(abortRec, reply, { accepted, total } = {}) {
   }
 }
 
+/** Error codes only determinable on an ADMITTED stream — a pre-OPEN reply
+ * carrying one is fabricated: the daemon never observed the bytes that
+ * outcome describes. */
+const STREAM_ONLY_ERRORS = new Set([
+  'declared_size_mismatch',
+  'transfer_stalled',
+  'transfer_deadline_exceeded',
+  'stream_aborted',
+]);
+
+function checkPreOpenError(reply, op) {
+  if (!reply || reply.ok) return;
+  const err = reply.err || {};
+  if (STREAM_ONLY_ERRORS.has(err.code) || (err.code === 'file_too_large' && err.enforced_at === 'stage_stream')) {
+    throw new AssertFailure(
+      `${op} replied ${err.code}${err.enforced_at ? `@${err.enforced_at}` : ''} before OPEN — that outcome requires an admitted stream`,
+    );
+  }
+}
+
 async function settleReply(replyState) {
   if (replyState.error) {
     throw new TransportFailure(`streaming call failed to get a terminal reply: ${replyState.error.message}`);
@@ -310,6 +330,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     if (reply && reply.ok) {
       throw new AssertFailure('file.share replied success before OPEN on a streamed call');
     }
+    checkPreOpenError(reply, 'file.share');
     return reply;
   }
   validateOpen(tracker, first.record, session);
@@ -517,6 +538,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
     if (reply && reply.ok) {
       throw new AssertFailure('file.read replied success without OPEN or any streamed byte');
     }
+    checkPreOpenError(reply, 'file.read');
     return reply;
   }
   validateOpen(tracker, first.record, session);

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -354,8 +354,15 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       }
       case KIND.ABORT: {
         // The daemon (the upload's receiver) aborted: its offset is its local
-        // accepted count. Stop producing and echo it in ACK (value 0x05).
+        // accepted count — which, with atomic DATA acceptance, must be zero
+        // or an emitted record endpoint. Stop producing and echo it in ACK
+        // (value 0x05).
         validateAbort(rec, sent);
+        if (!dataEndpoints.has(rec.offset)) {
+          throw new AssertFailure(
+            `daemon ABORT accepted count ${rec.offset} is inside a DATA record rather than on a record boundary`,
+          );
+        }
         abortSeen = rec;
         tracker.accepted = rec.offset;
         session.sendBinary(

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -410,6 +410,13 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
             `daemon CREDIT acknowledged ${rec.offset}, inside a DATA record rather than on a record boundary`,
           );
         }
+        if (rec.offset > tracker.openTotal) {
+          // The probe byte may be sent but never accepted: acknowledged
+          // bytes can never exceed the admitted OPEN total.
+          throw new AssertFailure(
+            `daemon CREDIT acknowledged ${rec.offset} beyond the OPEN total ${tracker.openTotal}`,
+          );
+        }
         if (rec.value > limit + 1) {
           // The wire bound on upload credit is max_shared_file_bytes + 1;
           // min(declared, limit) + 1 is the mandatory probe TARGET, not a
@@ -548,6 +555,12 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         // byte to be acknowledged.
         if (tracker.queue.some((r) => r.kind === KIND.END)) {
           throw new AssertFailure('daemon sent END before receiving the final cumulative CREDIT');
+        }
+        // An ABORT already on the wire ends crediting: the recipient stops
+        // granting, and the new accepted offset is NOT issued — the producer
+        // cannot have observed it, so an ABORT echoing it stays invalid.
+        if (tracker.queue.some((r) => r.kind === KIND.ABORT)) {
+          break;
         }
         sendThrough = grant(tracker.accepted);
         break;

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -31,11 +31,17 @@ export const ABORT_REASON = {
   operation_error: 0x05,
 };
 
-/** The DATA payload bound: `min(65_536, max_frame_bytes - 48)`. */
+/** The DATA payload bound: `min(65_536, max_frame_bytes - 48)`, subtraction
+ * checked before use. A served limit that cannot carry a record is an invalid
+ * configuration the daemon must refuse readiness over — never papered over. */
 export function maxDataPayloadBytes(maxFrameBytes) {
   const frame = Number(maxFrameBytes);
-  const cap = Number.isFinite(frame) && frame > STREAM_HEADER_BYTES ? frame - STREAM_HEADER_BYTES : 65_536;
-  return Math.min(65_536, cap);
+  if (!Number.isFinite(frame) || frame <= STREAM_HEADER_BYTES) {
+    throw new AssertFailure(
+      `served max_frame_bytes ${JSON.stringify(maxFrameBytes)} cannot carry a byte-stream record`,
+    );
+  }
+  return Math.min(65_536, frame - STREAM_HEADER_BYTES);
 }
 
 /** Encode one record. `streamId` is a 16-byte Buffer (zeros before OPEN). */
@@ -123,9 +129,13 @@ export class CallStreamTracker {
   async next(replyState, timeoutMs, what) {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
+      // Order matters: drain records first (delivery order is evidence), then
+      // surface a recorded violation, and only then honour the settled reply —
+      // a connection-fatal violation must not be laundered by a reply that
+      // arrived in the same batch.
       if (this.queue.length) return { record: this.queue.shift() };
-      if (replyState.done) return { reply: replyState };
       if (this.failure) throw this.failure;
+      if (replyState.done) return { reply: replyState };
       const remain = deadline - Date.now();
       if (remain <= 0) {
         const openNote = this.opened ? '' : ' (no OPEN was received)';
@@ -204,12 +214,23 @@ async function settleReply(replyState) {
   return replyState.value;
 }
 
-/** A daemon ABORT must be a bare record with a closed reason and a plausible
- * accepted count (never beyond what this side sent, for an upload). */
-function validateAbort(rec, sentBound = null) {
+/** Reasons a daemon may claim, by its role: an upload receiver has no source
+ * (never 0x02); a download producer has no sink (never 0x03). */
+const UPLOAD_DAEMON_ABORT_REASONS = new Set([0x01, 0x03, 0x04, 0x05]);
+const DOWNLOAD_DAEMON_ABORT_REASONS = new Set([0x01, 0x02, 0x04, 0x05]);
+
+/** A daemon ABORT must be a bare record with a closed, directionally possible
+ * reason and a plausible accepted count (never beyond what this side sent,
+ * for an upload). */
+function validateAbort(rec, sentBound, allowedReasons) {
   if (rec.payload) throw new AssertFailure('daemon ABORT carried a payload');
   if (rec.value < 0x01 || rec.value > 0x05) {
     throw new AssertFailure(`daemon ABORT reason ${rec.value} is outside the closed 0x01..0x05 set`);
+  }
+  if (!allowedReasons.has(rec.value)) {
+    throw new AssertFailure(
+      `daemon ABORT reason ${ABORT_REASON_NAME[rec.value] || rec.value} is impossible for this stream direction`,
+    );
   }
   if (sentBound !== null && rec.offset > sentBound) {
     throw new AssertFailure(`daemon ABORT accepted count ${rec.offset} exceeds the ${sentBound} bytes sent`);
@@ -323,6 +344,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     if (ev.reply) break;
     const rec = ev.record;
     checkBinding(tracker, rec);
+    // Per-direction ordering means nothing delivered after the daemon's ABORT
+    // can be an older in-flight record — the binding is retired.
+    if (abortSeen) {
+      throw new AssertFailure(`daemon sent ${rec.kindName} after its ABORT retired the stream`);
+    }
     switch (rec.kind) {
       case KIND.CREDIT: {
         if (rec.payload) throw new AssertFailure('daemon CREDIT carried a payload');
@@ -354,13 +380,18 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       }
       case KIND.ABORT: {
         // The daemon (the upload's receiver) aborted: its offset is its local
-        // accepted count — which, with atomic DATA acceptance, must be zero
-        // or an emitted record endpoint. Stop producing and echo it in ACK
-        // (value 0x05).
-        validateAbort(rec, sent);
+        // accepted count — which, with atomic DATA acceptance, must be an
+        // emitted record endpoint at or above the CREDIT high-water it
+        // already acknowledged. Stop producing and echo it in ACK (0x05).
+        validateAbort(rec, sent, UPLOAD_DAEMON_ABORT_REASONS);
         if (!dataEndpoints.has(rec.offset)) {
           throw new AssertFailure(
             `daemon ABORT accepted count ${rec.offset} is inside a DATA record rather than on a record boundary`,
+          );
+        }
+        if (rec.offset < acceptedThrough) {
+          throw new AssertFailure(
+            `daemon ABORT accepted count ${rec.offset} regressed below the credited ${acceptedThrough}`,
           );
         }
         abortSeen = rec;
@@ -375,6 +406,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     }
   }
   const reply = await settleReply(replyState);
+  if (reply && reply.ok && abortSeen) {
+    // ABORT is the daemon's terminal failure selection — even when our END
+    // was already in flight, an ABORT means the failure path won the race.
+    throw new AssertFailure('file.share replied success after the daemon ABORTed the stream');
+  }
   if (reply && reply.ok && !endSent) {
     // Success is only sent after the daemon receives and finalizes END.
     throw new AssertFailure('file.share replied success before the client sent END');
@@ -468,7 +504,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
       case KIND.ABORT: {
         // We are the receiver: ACK carries OUR final accepted count. The
         // producer's ABORT offset must echo an accepted_through we issued.
-        validateAbort(rec);
+        validateAbort(rec, null, DOWNLOAD_DAEMON_ABORT_REASONS);
         if (!issuedAccepted.has(rec.offset)) {
           throw new AssertFailure(
             `daemon ABORT offset ${rec.offset} matches no accepted_through this receiver issued`,
@@ -500,7 +536,11 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         `terminal out.bytes ${reply.out?.bytes} disagrees with the streamed total ${total}`,
       );
     }
-  } else if (reply && !reply.ok && !endSeen) {
+  } else if (reply && !reply.ok) {
+    if (endSeen) {
+      // A valid END commits the completed download; only success may follow.
+      throw new AssertFailure('file.read completed its byte stream with END but replied an error');
+    }
     // While the stream is ACTIVE, a daemon terminal error must be preceded
     // by daemon ABORT and our ACK.
     throw new AssertFailure(

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -35,13 +35,14 @@ export const ABORT_REASON = {
  * checked before use. A served limit that cannot carry a record is an invalid
  * configuration the daemon must refuse readiness over — never papered over. */
 export function maxDataPayloadBytes(maxFrameBytes) {
-  const frame = Number(maxFrameBytes);
-  if (!Number.isFinite(frame) || frame <= STREAM_HEADER_BYTES) {
+  // The limits contract serves JSON integers — a numeric string or fraction
+  // is a nonconforming configuration, never coerced.
+  if (typeof maxFrameBytes !== 'number' || !Number.isInteger(maxFrameBytes) || maxFrameBytes <= STREAM_HEADER_BYTES) {
     throw new AssertFailure(
       `served max_frame_bytes ${JSON.stringify(maxFrameBytes)} cannot carry a byte-stream record`,
     );
   }
-  return Math.min(65_536, frame - STREAM_HEADER_BYTES);
+  return Math.min(65_536, maxFrameBytes - STREAM_HEADER_BYTES);
 }
 
 /** Encode one record. `streamId` is a 16-byte Buffer (zeros before OPEN). */
@@ -300,8 +301,12 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     // Terminal before admission: zero bytes, no stream. A `stream`-carrying
     // step is a fresh execution (the corpus runs faithful replays as
     // non-streaming calls), so a pre-OPEN SUCCESS is a daemon violation —
-    // a fresh execution has exactly one OPEN.
+    // a fresh execution has exactly one OPEN. Anything still queued was
+    // sequenced AFTER the terminal reply and violates the settled refusal.
     const reply = await settleReply(replyState);
+    if (tracker.queue.length) {
+      throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after its pre-OPEN terminal reply`);
+    }
     if (reply && reply.ok) {
       throw new AssertFailure('file.share replied success before OPEN on a streamed call');
     }
@@ -327,12 +332,12 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   // The served shared-file limit is load-bearing for the sentinel math; a
   // daemon that fails to serve it as a usable integer fails, never gets an
   // invented cap.
-  const limit = Number(limitBytes);
-  if (!Number.isFinite(limit) || limit < 0) {
+  if (typeof limitBytes !== 'number' || !Number.isInteger(limitBytes) || limitBytes < 0) {
     throw new AssertFailure(
       `served max_shared_file_bytes ${JSON.stringify(limitBytes)} is unusable for byte streaming`,
     );
   }
+  const limit = limitBytes;
   // The daemon may not extend send_through past min(declared, limit) + 1 (the
   // observation sentinel).
   const sentinelCap = Math.min(Number.isFinite(declared) ? declared : Infinity, limit) + 1;
@@ -498,6 +503,9 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     const reply = await settleReply(replyState);
+    if (tracker.queue.length) {
+      throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after its pre-OPEN terminal reply`);
+    }
     // file.read has no op_id dedup, so there is no legal streamless success.
     if (reply && reply.ok) {
       throw new AssertFailure('file.read replied success without OPEN or any streamed byte');

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -290,8 +290,17 @@ function validateAbort(rec, sentBound, allowedReasons) {
  * pick the legal-END discipline, never to bound the generator). Returns the
  * terminal reply envelope; the tracker carries the byte accounting.
  */
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, timeoutScale = 1 }) {
-  const waitMs = 60_000 * timeoutScale;
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, connectAllowanceMs, floorBitsPerSecond, timeoutScale = 1 }) {
+  // Harness patience: at least 60 s, or the served absolute budget (with
+  // headroom) when the legal budget for this total is longer — a conforming
+  // slow-floor transfer must not lose its reply promise early. Enforcement
+  // of the deadline itself belongs to deadline-designed fixtures.
+  const total = Number(spec.send_bytes ?? spec.receive_bytes);
+  let waitMs = 60_000 * timeoutScale;
+  if (Number.isInteger(connectAllowanceMs) && Number.isInteger(floorBitsPerSecond) && floorBitsPerSecond > 0 && Number.isFinite(total)) {
+    const budgetMs = connectAllowanceMs + Math.ceil((total * 8 * 1000) / floorBitsPerSecond);
+    waitMs = Math.max(waitMs, Math.ceil(budgetMs * 1.2));
+  }
   if (spec.send_bytes !== undefined) {
     return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs });
   }
@@ -324,6 +333,11 @@ function makeStallGauge(stallMs) {
       const now = Date.now();
       maxGap = Math.max(maxGap, now - last);
       last = now;
+    },
+    /** Measure the trailing interval at the action that ends ACTIVE, without
+     * counting it as progress (FINALIZING time stays excluded). */
+    mark() {
+      maxGap = Math.max(maxGap, Date.now() - last);
     },
     checkOnSuccess() {
       if (Number.isInteger(stallMs) && maxGap > 2 * stallMs) {
@@ -437,6 +451,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       sent === sendBytes &&
       (shortStream || (creditSeen && acceptedThrough >= sendBytes && probeSatisfied))
     ) {
+      stallGauge.mark();
       session.sendBinary(
         encodeRecord({ kind: KIND.END, id: tracker.id, streamId: tracker.streamId, offset: sendBytes }),
       );
@@ -651,6 +666,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
             `daemon END at ${rec.offset} disagrees with OPEN total ${total} / accepted ${tracker.accepted}`,
           );
         }
+        stallGauge.mark();
         endSeen = true;
         break;
       }

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -192,10 +192,10 @@ function validateAbort(rec, sentBound = null) {
  * pick the legal-END discipline, never to bound the generator). Returns the
  * terminal reply envelope; the tracker carries the byte accounting.
  */
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, timeoutScale = 1 }) {
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, timeoutScale = 1 }) {
   const waitMs = 60_000 * timeoutScale;
   if (spec.send_bytes !== undefined) {
-    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, waitMs });
+    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, waitMs });
   }
   if (spec.receive_bytes !== undefined) {
     return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, waitMs });
@@ -203,8 +203,21 @@ export async function runStreamingCall({ session, tracker, replyState, spec, dec
   throw new Error(`stream spec has neither send_bytes nor receive_bytes: ${JSON.stringify(spec)}`);
 }
 
+/** Byte-bound on the local outbound socket queue; sends pause above it so an
+ * upload never enqueues unbounded data while waiting for the peer. */
+const OUTBOUND_QUEUE_BOUND = 4 * 65_536;
+
+/** Yield to the event loop after a DATA write (so interleaved CREDIT, ABORT,
+ * and the reply are serviced between records) and apply socket backpressure. */
+async function yieldAfterSend(session, tracker) {
+  await new Promise((resolve) => setImmediate(resolve));
+  while (session.ws && session.ws.bufferedAmount > OUTBOUND_QUEUE_BOUND && !tracker.failure) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 /** Upload: race a pre-OPEN terminal reply against OPEN, then honour CREDIT. */
-async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, waitMs }) {
+async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, waitMs }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     // Terminal before admission: zero bytes, no stream. A `stream`-carrying
@@ -234,6 +247,10 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   // WebSocket ordering makes the daemon's observed_bytes deterministic.
   const declared = Number(declaredBytes);
   const shortStream = Number.isFinite(declared) && sendBytes < declared;
+  // The daemon may not extend send_through past min(declared, limit) + 1 (the
+  // observation sentinel).
+  const sentinelCap =
+    Math.min(Number.isFinite(declared) ? declared : Infinity, Number.isFinite(Number(limitBytes)) ? Number(limitBytes) : Infinity) + 1;
   let acceptedThrough = 0;
   let sendThrough = 0;
   let sent = 0;
@@ -242,7 +259,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   let abortSeen = null;
 
   for (;;) {
-    while (!abortSeen && !replyState.done && sent < sendBytes && sendThrough > sent) {
+    // One DATA record per pass, yielding after each so interleaved CREDIT,
+    // ABORT, and the terminal reply are serviced between records and the
+    // outbound queue stays byte-bounded — a queued record is processed
+    // before the next send.
+    if (!abortSeen && !replyState.done && sent < sendBytes && sendThrough > sent && tracker.queue.length === 0) {
       const len = Math.min(maxPayload, sendBytes - sent, sendThrough - sent);
       const payload = patternChunk(sent, len);
       tracker.generated += len;
@@ -251,6 +272,8 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       );
       tracker.socketSent += len;
       sent += len;
+      await yieldAfterSend(session, tracker);
+      continue;
     }
     if (!abortSeen && !endSent && sent === sendBytes && (shortStream || (creditSeen && acceptedThrough >= sendBytes))) {
       session.sendBinary(
@@ -276,6 +299,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
         if (rec.offset > sent) {
           throw new AssertFailure(
             `daemon CREDIT acknowledged ${rec.offset} bytes beyond the ${sent} actually sent`,
+          );
+        }
+        if (rec.value > sentinelCap) {
+          throw new AssertFailure(
+            `daemon CREDIT send_through ${rec.value} exceeds the sentinel cap ${sentinelCap}`,
           );
         }
         creditSeen = true;
@@ -304,6 +332,14 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     // Success is only sent after the daemon receives and finalizes END.
     throw new AssertFailure('file.share replied success before the client sent END');
   }
+  if (reply && !reply.ok && !endSent && !abortSeen) {
+    // While the stream is ACTIVE, a daemon terminal error must be preceded
+    // by daemon ABORT and our ACK; only a post-END finalization error may
+    // arrive bare.
+    throw new AssertFailure(
+      `file.share replied ${JSON.stringify(reply.err?.code)} on an active stream with no daemon ABORT`,
+    );
+  }
   return reply;
 }
 
@@ -328,10 +364,14 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
   }
 
   // Bounded window; the sink is a counter (the harness never collects the
-  // whole file). Client credit MUST NOT exceed the OPEN total.
+  // whole file). Client credit MUST NOT exceed the OPEN total. Every
+  // accepted_through we issue is remembered: a producer ABORT offset must
+  // equal one of them.
   const window = maxPayload;
+  const issuedAccepted = new Set();
   const grant = (accepted) => {
     const send = Math.min(accepted + window, total);
+    issuedAccepted.add(accepted);
     session.sendBinary(
       encodeRecord({ kind: KIND.CREDIT, id: tracker.id, streamId: tracker.streamId, offset: accepted, value: send }),
     );
@@ -378,12 +418,21 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         break;
       }
       case KIND.ABORT: {
-        // We are the receiver: ACK carries OUR final accepted count.
+        // We are the receiver: ACK carries OUR final accepted count. The
+        // producer's ABORT offset must echo an accepted_through we issued.
         validateAbort(rec);
+        if (!issuedAccepted.has(rec.offset)) {
+          throw new AssertFailure(
+            `daemon ABORT offset ${rec.offset} matches no accepted_through this receiver issued`,
+          );
+        }
         session.sendBinary(
           encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: tracker.accepted, value: 0x05 }),
         );
         const reply = await settleReplyAfter(tracker, replyState, waitMs);
+        if (reply && reply.ok) {
+          throw new AssertFailure('download stream was ABORTed but the request replied success');
+        }
         return reply;
       }
       default:
@@ -402,17 +451,24 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         `terminal out.bytes ${reply.out?.bytes} disagrees with the streamed total ${total}`,
       );
     }
+  } else if (reply && !reply.ok && !endSeen) {
+    // While the stream is ACTIVE, a daemon terminal error must be preceded
+    // by daemon ABORT and our ACK.
+    throw new AssertFailure(
+      `file.read replied ${JSON.stringify(reply.err?.code)} on an active stream with no daemon ABORT`,
+    );
   }
   return reply;
 }
 
-/** Wait for the reply to settle after the stream's binary side concluded. */
+/** Wait for the reply to settle after the stream's binary side concluded.
+ * `next` prefers queued records over the settled reply, so a record that
+ * arrived batched with (or after) the reply is still examined — any record
+ * after END/ACK is a daemon violation of the retired binding. */
 async function settleReplyAfter(tracker, replyState, waitMs) {
-  while (!replyState.done) {
-    await tracker.next(replyState, waitMs, 'the terminal reply');
-    if (replyState.done) break;
-    // A late record after END/ACK is a daemon violation of the retired binding.
-    throw new AssertFailure('daemon sent a record after the stream concluded');
+  const ev = await tracker.next(replyState, waitMs, 'the terminal reply');
+  if (ev.record) {
+    throw new AssertFailure(`daemon sent ${ev.record.kindName} after the stream concluded`);
   }
   return settleReply(replyState);
 }

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -154,7 +154,7 @@ function checkBinding(tracker, rec) {
   }
 }
 
-function validateOpen(tracker, rec) {
+function validateOpen(tracker, rec, session) {
   if (rec.kind !== KIND.OPEN) {
     throw new AssertFailure(`daemon sent ${rec.kindName} before OPEN on request ${rec.id}`);
   }
@@ -162,8 +162,39 @@ function validateOpen(tracker, rec) {
     throw new AssertFailure('daemon OPEN is malformed (nonzero offset/reserved or zero stream id)');
   }
   if (rec.payload) throw new AssertFailure('daemon OPEN carried a payload');
+  // Stream ids are unique and never reused within one WebSocket connection.
+  const sidHex = rec.streamId.toString('hex');
+  session.seenStreamIds ||= new Set();
+  if (session.seenStreamIds.has(sidHex)) {
+    throw new AssertFailure(`daemon reused stream id ${sidHex} on this connection`);
+  }
+  session.seenStreamIds.add(sidHex);
   tracker.streamId = rec.streamId;
   tracker.openTotal = rec.value;
+}
+
+const ABORT_REASON_NAME = { 1: 'cancelled', 2: 'source_failed', 3: 'sink_failed', 4: 'protocol_error' };
+
+/** A daemon ABORT's reason binds the terminal reply: 0x01-0x03 resolve to
+ * stream_aborted with the matching reason, 0x04 to malformed_frame, and 0x05
+ * (operation_error) to the authoritative typed operation error — never
+ * stream_aborted. */
+function checkAbortReplyCorrelation(abortRec, reply) {
+  if (!reply || reply.ok) return;
+  const code = reply.err?.code;
+  if (abortRec.value === ABORT_REASON.operation_error) {
+    if (code === 'stream_aborted') {
+      throw new AssertFailure('daemon ABORT operation_error must resolve to a typed operation error, got stream_aborted');
+    }
+  } else if (abortRec.value === ABORT_REASON.protocol_error) {
+    if (code !== 'malformed_frame') {
+      throw new AssertFailure(`daemon ABORT protocol_error must resolve to malformed_frame, got ${JSON.stringify(code)}`);
+    }
+  } else if (code !== 'stream_aborted' || reply.err?.reason !== ABORT_REASON_NAME[abortRec.value]) {
+    throw new AssertFailure(
+      `daemon ABORT ${ABORT_REASON_NAME[abortRec.value]} must resolve to stream_aborted with that reason, got ${JSON.stringify(reply.err)}`,
+    );
+  }
 }
 
 async function settleReply(replyState) {
@@ -230,7 +261,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     }
     return reply;
   }
-  validateOpen(tracker, first.record);
+  validateOpen(tracker, first.record, session);
   if (Number.isFinite(Number(declaredBytes)) && tracker.openTotal !== Number(declaredBytes)) {
     throw new AssertFailure(
       `upload OPEN total ${tracker.openTotal} disagrees with declared_bytes ${declaredBytes}`,
@@ -257,6 +288,9 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   let creditSeen = false;
   let endSent = false;
   let abortSeen = null;
+  // DATA acceptance is atomic, so a CREDIT acknowledgement may only land on
+  // an emitted record boundary (or stay at zero).
+  const dataEndpoints = new Set([0]);
 
   for (;;) {
     // One DATA record per pass, yielding after each so interleaved CREDIT,
@@ -272,6 +306,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       );
       tracker.socketSent += len;
       sent += len;
+      dataEndpoints.add(sent);
       await yieldAfterSend(session, tracker);
       continue;
     }
@@ -299,6 +334,11 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
         if (rec.offset > sent) {
           throw new AssertFailure(
             `daemon CREDIT acknowledged ${rec.offset} bytes beyond the ${sent} actually sent`,
+          );
+        }
+        if (!dataEndpoints.has(rec.offset)) {
+          throw new AssertFailure(
+            `daemon CREDIT acknowledged ${rec.offset}, inside a DATA record rather than on a record boundary`,
           );
         }
         if (rec.value > sentinelCap) {
@@ -340,6 +380,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       `file.share replied ${JSON.stringify(reply.err?.code)} on an active stream with no daemon ABORT`,
     );
   }
+  if (abortSeen) checkAbortReplyCorrelation(abortSeen, reply);
   return reply;
 }
 
@@ -357,7 +398,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
     }
     return reply;
   }
-  validateOpen(tracker, first.record);
+  validateOpen(tracker, first.record, session);
   const total = tracker.openTotal;
   if (total !== receiveBytes) {
     throw new AssertFailure(`file.read OPEN total ${total} disagrees with the fixture's receive_bytes ${receiveBytes}`);
@@ -433,6 +474,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         if (reply && reply.ok) {
           throw new AssertFailure('download stream was ABORTed but the request replied success');
         }
+        checkAbortReplyCorrelation(rec, reply);
         return reply;
       }
       default:

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -320,12 +320,12 @@ export function streamWaitMs(spec, servedLimits = {}, timeoutScale = 1) {
   return Math.min(waitMs, 80_000) * timeoutScale;
 }
 
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs = 60_000 }) {
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs = 60_000 }) {
   if (spec.send_bytes !== undefined) {
-    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs });
+    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs });
   }
   if (spec.receive_bytes !== undefined) {
-    return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, inflightBytes, stallMs, waitMs });
+    return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, inflightBytes, concurrentLimit, stallMs, waitMs });
   }
   throw new Error(`stream spec has neither send_bytes nor receive_bytes: ${JSON.stringify(spec)}`);
 }
@@ -333,12 +333,24 @@ export async function runStreamingCall({ session, tracker, replyState, spec, dec
 /** The daemon reserves the OPEN total against its served aggregate inflight
  * budget before admission — an OPEN beyond the sole-active budget proves an
  * admission its own limits forbid. */
-function checkInflightBudget(openTotal, inflightBytes) {
+function checkInflightBudget(openTotal, inflightBytes, concurrentLimit) {
   // The limits contract serves JSON integers; a non-integer bound is a
   // nonconforming configuration, never treated as no bound.
   if (typeof inflightBytes !== 'number' || !Number.isInteger(inflightBytes) || inflightBytes < 0) {
     throw new AssertFailure(
       `served max_transfer_bytes_inflight ${JSON.stringify(inflightBytes)} is unusable for byte streaming`,
+    );
+  }
+  if (typeof concurrentLimit !== 'number' || !Number.isInteger(concurrentLimit) || concurrentLimit < 0) {
+    throw new AssertFailure(
+      `served max_concurrent_transfers ${JSON.stringify(concurrentLimit)} is unusable for byte streaming`,
+    );
+  }
+  if (concurrentLimit < 1) {
+    // This sole active transfer already exceeds the advertised count budget;
+    // admission should have been refused pre-OPEN.
+    throw new AssertFailure(
+      `daemon admitted a stream with served max_concurrent_transfers ${concurrentLimit}`,
     );
   }
   if (openTotal > inflightBytes) {
@@ -353,6 +365,13 @@ function checkInflightBudget(openTotal, inflightBytes) {
  * observed gap of more than twice that budget proves the timer never ran.
  * The 2x slack absorbs harness-side scheduling pauses. */
 function makeStallGauge(stallMs) {
+  // The served stall budget must be a positive JSON integer — a malformed
+  // value is an invalid configuration, never a disabled check.
+  if (typeof stallMs !== 'number' || !Number.isInteger(stallMs) || stallMs <= 0) {
+    throw new AssertFailure(
+      `served transfer_stall_ms ${JSON.stringify(stallMs)} is an invalid configuration`,
+    );
+  }
   let last = Date.now();
   let maxGap = 0;
   return {
@@ -367,7 +386,7 @@ function makeStallGauge(stallMs) {
       maxGap = Math.max(maxGap, Date.now() - last);
     },
     checkOnSuccess() {
-      if (Number.isInteger(stallMs) && maxGap > 2 * stallMs) {
+      if (maxGap > 2 * stallMs) {
         throw new AssertFailure(
           `stream succeeded after an accepted-progress gap of ${maxGap}ms, over twice the served transfer_stall_ms ${stallMs}`,
         );
@@ -390,7 +409,7 @@ async function yieldAfterSend(session, tracker) {
 }
 
 /** Upload: race a pre-OPEN terminal reply against OPEN, then honour CREDIT. */
-async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, inflightBytes, stallMs, waitMs }) {
+async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     // Terminal before admission: zero bytes, no stream. A `stream`-carrying
@@ -414,7 +433,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       `upload OPEN total ${tracker.openTotal} disagrees with declared_bytes ${declaredBytes}`,
     );
   }
-  checkInflightBudget(tracker.openTotal, inflightBytes);
+  checkInflightBudget(tracker.openTotal, inflightBytes, concurrentLimit);
   const stallGauge = makeStallGauge(stallMs);
 
   // Producer state. `acceptedThrough`/`sendThrough` mirror the daemon's
@@ -607,7 +626,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
  * on sink acceptance, validate END, and ACK a daemon ABORT with the final
  * accepted count. Requires OPEN.total, END.offset, the terminal `out.bytes`,
  * and the fixture's N to agree. */
-async function runDownload({ session, tracker, replyState, receiveBytes, maxPayload, inflightBytes, stallMs, waitMs }) {
+async function runDownload({ session, tracker, replyState, receiveBytes, maxPayload, inflightBytes, concurrentLimit, stallMs, waitMs }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     const reply = await settleReply(replyState);
@@ -626,7 +645,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
   if (total !== receiveBytes) {
     throw new AssertFailure(`file.read OPEN total ${total} disagrees with the fixture's receive_bytes ${receiveBytes}`);
   }
-  checkInflightBudget(total, inflightBytes);
+  checkInflightBudget(total, inflightBytes, concurrentLimit);
   const stallGauge = makeStallGauge(stallMs);
 
   // Bounded window; the sink is a counter (the harness never collects the

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -188,10 +188,13 @@ const ABORT_REASON_NAME = { 1: 'cancelled', 2: 'source_failed', 3: 'sink_failed'
 /** A daemon ABORT's reason binds the terminal reply: 0x01-0x03 resolve to
  * stream_aborted with the matching reason, 0x04 to malformed_frame, and 0x05
  * (operation_error) to the authoritative typed operation error — never
- * stream_aborted. */
-function checkAbortReplyCorrelation(abortRec, reply) {
+ * stream_aborted. The reply's byte accounting is bound too: any
+ * transferred_bytes must equal the proven receiver-accepted count and a
+ * known total must equal the OPEN total. */
+function checkAbortReplyCorrelation(abortRec, reply, { accepted, total } = {}) {
   if (!reply || reply.ok) return;
-  const code = reply.err?.code;
+  const err = reply.err || {};
+  const code = err.code;
   if (abortRec.value === ABORT_REASON.operation_error) {
     if (code === 'stream_aborted') {
       throw new AssertFailure('daemon ABORT operation_error must resolve to a typed operation error, got stream_aborted');
@@ -200,10 +203,24 @@ function checkAbortReplyCorrelation(abortRec, reply) {
     if (code !== 'malformed_frame') {
       throw new AssertFailure(`daemon ABORT protocol_error must resolve to malformed_frame, got ${JSON.stringify(code)}`);
     }
-  } else if (code !== 'stream_aborted' || reply.err?.reason !== ABORT_REASON_NAME[abortRec.value]) {
+  } else if (code !== 'stream_aborted' || err.reason !== ABORT_REASON_NAME[abortRec.value]) {
     throw new AssertFailure(
       `daemon ABORT ${ABORT_REASON_NAME[abortRec.value]} must resolve to stream_aborted with that reason, got ${JSON.stringify(reply.err)}`,
     );
+  }
+  if (accepted !== undefined && err.transferred_bytes !== undefined && err.transferred_bytes !== accepted) {
+    throw new AssertFailure(
+      `terminal transferred_bytes ${err.transferred_bytes} disagrees with the receiver-accepted ${accepted}`,
+    );
+  }
+  if (
+    total !== undefined &&
+    err.total &&
+    typeof err.total === 'object' &&
+    err.total.state === 'known' &&
+    err.total.bytes !== total
+  ) {
+    throw new AssertFailure(`terminal total ${err.total.bytes} disagrees with the OPEN total ${total}`);
   }
 }
 
@@ -331,7 +348,16 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       await yieldAfterSend(session, tracker);
       continue;
     }
-    if (!abortSeen && !endSent && sent === sendBytes && (shortStream || (creditSeen && acceptedThrough >= sendBytes))) {
+    // The exact-length path also requires the daemon's mandatory one-byte
+    // probe: cumulative credit must have reached min(declared, limit) + 1
+    // before END, or a daemon omitting the probe would pass unnoticed.
+    const probeSatisfied = !Number.isFinite(declared) || sendThrough >= sentinelCap;
+    if (
+      !abortSeen &&
+      !endSent &&
+      sent === sendBytes &&
+      (shortStream || (creditSeen && acceptedThrough >= sendBytes && probeSatisfied))
+    ) {
       session.sendBinary(
         encodeRecord({ kind: KIND.END, id: tracker.id, streamId: tracker.streamId, offset: sendBytes }),
       );
@@ -423,7 +449,9 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       `file.share replied ${JSON.stringify(reply.err?.code)} on an active stream with no daemon ABORT`,
     );
   }
-  if (abortSeen) checkAbortReplyCorrelation(abortSeen, reply);
+  if (abortSeen) {
+    checkAbortReplyCorrelation(abortSeen, reply, { accepted: abortSeen.offset, total: tracker.openTotal });
+  }
   return reply;
 }
 
@@ -517,7 +545,7 @@ async function runDownload({ session, tracker, replyState, receiveBytes, maxPayl
         if (reply && reply.ok) {
           throw new AssertFailure('download stream was ABORTed but the request replied success');
         }
-        checkAbortReplyCorrelation(rec, reply);
+        checkAbortReplyCorrelation(rec, reply, { accepted: tracker.accepted, total });
         return reply;
       }
       default:

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -355,6 +355,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
     if (
       !abortSeen &&
       !endSent &&
+      !replyState.done &&
       sent === sendBytes &&
       (shortStream || (creditSeen && acceptedThrough >= sendBytes && probeSatisfied))
     ) {

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -1,0 +1,418 @@
+// The byte-stream executor for the v2 conformance harness (the framing
+// section of docs/protocol-v2.md, #233).
+//
+// Encodes and decodes JBS2 records and drives the client half of the two
+// legal stream shapes: `stream: {send_bytes: N}` uploads (file.share) and
+// `stream: {receive_bytes: N}` downloads (file.read). A call carrying
+// `stream` runs as one duplex operation — the Text request is sent with its
+// reply promise kept pending, Binary records are routed by request id, and
+// the terminal Text reply settles the call. `send_bytes` is deliberately
+// independent of `in.declared_bytes`: short, long, and over-limit streams
+// stay expressible, which is how declared_size_mismatch and stage_stream
+// are reached.
+//
+// Counters are kept separately per call (generated, socket-sent, received,
+// receiver-accepted); `observe: bytes_streamed` reports receiver-ACCEPTED
+// payload bytes only — the daemon's cumulative CREDIT/ABORT acknowledgement
+// for an upload, the harness sink's accepted count for a download. A
+// terminal pre-OPEN reply records zero without an OPEN.
+
+import { AssertFailure, TransportFailure } from './assert.mjs';
+
+export const STREAM_HEADER_BYTES = 48;
+export const MAGIC = Buffer.from('JBS2', 'ascii'); // 4a 42 53 32
+export const KIND = { OPEN: 0x01, DATA: 0x02, CREDIT: 0x03, END: 0x04, ABORT: 0x05, ACK: 0x06 };
+const KIND_NAME = { 1: 'OPEN', 2: 'DATA', 3: 'CREDIT', 4: 'END', 5: 'ABORT', 6: 'ACK' };
+export const ABORT_REASON = {
+  cancelled: 0x01,
+  source_failed: 0x02,
+  sink_failed: 0x03,
+  protocol_error: 0x04,
+  operation_error: 0x05,
+};
+
+/** The DATA payload bound: `min(65_536, max_frame_bytes - 48)`. */
+export function maxDataPayloadBytes(maxFrameBytes) {
+  const frame = Number(maxFrameBytes);
+  const cap = Number.isFinite(frame) && frame > STREAM_HEADER_BYTES ? frame - STREAM_HEADER_BYTES : 65_536;
+  return Math.min(65_536, cap);
+}
+
+/** Encode one record. `streamId` is a 16-byte Buffer (zeros before OPEN). */
+export function encodeRecord({ kind, id, streamId, offset = 0, value = 0, payload = null }) {
+  const buf = Buffer.alloc(STREAM_HEADER_BYTES + (payload ? payload.length : 0));
+  MAGIC.copy(buf, 0);
+  buf.writeUInt8(kind, 4);
+  // Bytes 5..8 are reserved and stay zero (alloc zero-fills).
+  buf.writeBigUInt64BE(BigInt(id), 8);
+  streamId.copy(buf, 16);
+  buf.writeBigUInt64BE(BigInt(offset), 32);
+  buf.writeBigUInt64BE(BigInt(value), 40);
+  if (payload) payload.copy(buf, STREAM_HEADER_BYTES);
+  return buf;
+}
+
+/** Decode one Binary message into a record, or `{malformed}` when it cannot
+ * carry one. u64 fields are safe as Numbers here: offsets and totals are
+ * bounded by the served file limit and ids by 2^53-1. */
+export function decodeRecord(data) {
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  if (buf.length < STREAM_HEADER_BYTES) {
+    return { malformed: `binary message of ${buf.length} bytes is shorter than the ${STREAM_HEADER_BYTES}-byte header` };
+  }
+  if (!buf.subarray(0, 4).equals(MAGIC)) return { malformed: 'bad magic' };
+  const kind = buf.readUInt8(4);
+  return {
+    kind,
+    kindName: KIND_NAME[kind] || `0x${kind.toString(16)}`,
+    reservedZero: buf.readUInt8(5) === 0 && buf.readUInt8(6) === 0 && buf.readUInt8(7) === 0,
+    id: Number(buf.readBigUInt64BE(8)),
+    streamId: Buffer.from(buf.subarray(16, 32)),
+    offset: Number(buf.readBigUInt64BE(32)),
+    value: Number(buf.readBigUInt64BE(40)),
+    payload: buf.length > STREAM_HEADER_BYTES ? Buffer.from(buf.subarray(STREAM_HEADER_BYTES)) : null,
+  };
+}
+
+const ZERO_STREAM_ID = Buffer.alloc(16);
+
+/** The deterministic upload generator: byte at zero-based offset i is i mod 251. */
+export function patternChunk(offset, len) {
+  const b = Buffer.allocUnsafe(len);
+  for (let j = 0; j < len; j++) b[j] = (offset + j) % 251;
+  return b;
+}
+
+/**
+ * Per-call stream state. One tracker exists for EVERY `call` step (streaming
+ * or not), so `bytes_streamed` can observe zero for a pre-OPEN refusal and an
+ * unexpected OPEN on a non-streaming call (e.g. an unfaithful op_id replay)
+ * is recorded rather than silently dropped.
+ */
+export class CallStreamTracker {
+  constructor(id) {
+    this.id = id;
+    this.streamId = null;
+    this.opened = false;
+    this.openTotal = null;
+    this.generated = 0;
+    this.socketSent = 0;
+    this.received = 0;
+    this.accepted = 0;
+    this.queue = [];
+    this.failure = null;
+    this.wakers = [];
+  }
+
+  deliver(record) {
+    if (record.kind === KIND.OPEN) this.opened = true;
+    this.queue.push(record);
+    this.wake();
+  }
+
+  fail(err) {
+    if (!this.failure) this.failure = err;
+    this.wake();
+  }
+
+  wake() {
+    for (const w of this.wakers.splice(0)) w();
+  }
+
+  /** Wait for the next record or the reply settling, whichever first. */
+  async next(replyState, timeoutMs, what) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (this.queue.length) return { record: this.queue.shift() };
+      if (replyState.done) return { reply: replyState };
+      if (this.failure) throw this.failure;
+      const remain = deadline - Date.now();
+      if (remain <= 0) {
+        const openNote = this.opened ? '' : ' (no OPEN was received)';
+        throw new TransportFailure(`stream call (id ${this.id}) timed out waiting for ${what}${openNote}`);
+      }
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, remain);
+        this.wakers.push(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    }
+  }
+}
+
+/** Validate a daemon record's binding against the installed pair. */
+function checkBinding(tracker, rec) {
+  if (!tracker.streamId || !rec.streamId.equals(tracker.streamId)) {
+    throw new AssertFailure(
+      `daemon sent ${rec.kindName} for request ${rec.id} with a stream id that does not match the OPEN-installed pair`,
+    );
+  }
+  if (!rec.reservedZero) {
+    throw new AssertFailure(`daemon sent ${rec.kindName} with nonzero reserved bytes`);
+  }
+}
+
+function validateOpen(tracker, rec) {
+  if (rec.kind !== KIND.OPEN) {
+    throw new AssertFailure(`daemon sent ${rec.kindName} before OPEN on request ${rec.id}`);
+  }
+  if (!rec.reservedZero || rec.offset !== 0 || rec.streamId.equals(ZERO_STREAM_ID)) {
+    throw new AssertFailure('daemon OPEN is malformed (nonzero offset/reserved or zero stream id)');
+  }
+  if (rec.payload) throw new AssertFailure('daemon OPEN carried a payload');
+  tracker.streamId = rec.streamId;
+  tracker.openTotal = rec.value;
+}
+
+async function settleReply(replyState) {
+  if (replyState.error) {
+    throw new TransportFailure(`streaming call failed to get a terminal reply: ${replyState.error.message}`);
+  }
+  return replyState.value;
+}
+
+/** A daemon ABORT must be a bare record with a closed reason and a plausible
+ * accepted count (never beyond what this side sent, for an upload). */
+function validateAbort(rec, sentBound = null) {
+  if (rec.payload) throw new AssertFailure('daemon ABORT carried a payload');
+  if (rec.value < 0x01 || rec.value > 0x05) {
+    throw new AssertFailure(`daemon ABORT reason ${rec.value} is outside the closed 0x01..0x05 set`);
+  }
+  if (sentBound !== null && rec.offset > sentBound) {
+    throw new AssertFailure(`daemon ABORT accepted count ${rec.offset} exceeds the ${sentBound} bytes sent`);
+  }
+}
+
+/**
+ * Drive one streaming call to its terminal Text reply. `spec` is the resolved
+ * fixture `stream` value: `{send_bytes: N}` or `{receive_bytes: N}`.
+ * `declaredBytes` is the resolved `in.declared_bytes` (uploads; used only to
+ * pick the legal-END discipline, never to bound the generator). Returns the
+ * terminal reply envelope; the tracker carries the byte accounting.
+ */
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, timeoutScale = 1 }) {
+  const waitMs = 60_000 * timeoutScale;
+  if (spec.send_bytes !== undefined) {
+    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, waitMs });
+  }
+  if (spec.receive_bytes !== undefined) {
+    return runDownload({ session, tracker, replyState, receiveBytes: Number(spec.receive_bytes), maxPayload, waitMs });
+  }
+  throw new Error(`stream spec has neither send_bytes nor receive_bytes: ${JSON.stringify(spec)}`);
+}
+
+/** Upload: race a pre-OPEN terminal reply against OPEN, then honour CREDIT. */
+async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, waitMs }) {
+  const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
+  if (first.reply) {
+    // Terminal before admission: zero bytes, no stream. A `stream`-carrying
+    // step is a fresh execution (the corpus runs faithful replays as
+    // non-streaming calls), so a pre-OPEN SUCCESS is a daemon violation —
+    // a fresh execution has exactly one OPEN.
+    const reply = await settleReply(replyState);
+    if (reply && reply.ok) {
+      throw new AssertFailure('file.share replied success before OPEN on a streamed call');
+    }
+    return reply;
+  }
+  validateOpen(tracker, first.record);
+  if (Number.isFinite(Number(declaredBytes)) && tracker.openTotal !== Number(declaredBytes)) {
+    throw new AssertFailure(
+      `upload OPEN total ${tracker.openTotal} disagrees with declared_bytes ${declaredBytes}`,
+    );
+  }
+
+  // Producer state. `acceptedThrough`/`sendThrough` mirror the daemon's
+  // cumulative CREDIT; `sent` is our contiguous DATA high-water mark. A
+  // stream that matches the declaration sends END only after every sent byte
+  // is CREDIT-acknowledged (the legal sequence). A deliberately SHORT stream
+  // (send_bytes < declared_bytes) can never be fully acknowledged — the
+  // daemon's refill policy has no partial-window acknowledgement — so END
+  // rides the socket directly behind the last DATA record; per-direction
+  // WebSocket ordering makes the daemon's observed_bytes deterministic.
+  const declared = Number(declaredBytes);
+  const shortStream = Number.isFinite(declared) && sendBytes < declared;
+  let acceptedThrough = 0;
+  let sendThrough = 0;
+  let sent = 0;
+  let creditSeen = false;
+  let endSent = false;
+  let abortSeen = null;
+
+  for (;;) {
+    while (!abortSeen && !replyState.done && sent < sendBytes && sendThrough > sent) {
+      const len = Math.min(maxPayload, sendBytes - sent, sendThrough - sent);
+      const payload = patternChunk(sent, len);
+      tracker.generated += len;
+      session.sendBinary(
+        encodeRecord({ kind: KIND.DATA, id: tracker.id, streamId: tracker.streamId, offset: sent, payload }),
+      );
+      tracker.socketSent += len;
+      sent += len;
+    }
+    if (!abortSeen && !endSent && sent === sendBytes && (shortStream || (creditSeen && acceptedThrough >= sendBytes))) {
+      session.sendBinary(
+        encodeRecord({ kind: KIND.END, id: tracker.id, streamId: tracker.streamId, offset: sendBytes }),
+      );
+      endSent = true;
+    }
+    if (replyState.done && tracker.queue.length === 0) break;
+
+    const what = endSent || abortSeen ? 'the terminal reply' : 'CREDIT, ABORT, or the terminal reply';
+    const ev = await tracker.next(replyState, waitMs, what);
+    if (ev.reply) break;
+    const rec = ev.record;
+    checkBinding(tracker, rec);
+    switch (rec.kind) {
+      case KIND.CREDIT: {
+        if (rec.payload) throw new AssertFailure('daemon CREDIT carried a payload');
+        if (rec.offset < acceptedThrough || rec.value < sendThrough || rec.offset > rec.value) {
+          throw new AssertFailure(
+            `daemon CREDIT regressed or inverted: (${rec.offset}, ${rec.value}) after (${acceptedThrough}, ${sendThrough})`,
+          );
+        }
+        if (rec.offset > sent) {
+          throw new AssertFailure(
+            `daemon CREDIT acknowledged ${rec.offset} bytes beyond the ${sent} actually sent`,
+          );
+        }
+        creditSeen = true;
+        acceptedThrough = rec.offset;
+        sendThrough = rec.value;
+        tracker.accepted = acceptedThrough;
+        break;
+      }
+      case KIND.ABORT: {
+        // The daemon (the upload's receiver) aborted: its offset is its local
+        // accepted count. Stop producing and echo it in ACK (value 0x05).
+        validateAbort(rec, sent);
+        abortSeen = rec;
+        tracker.accepted = rec.offset;
+        session.sendBinary(
+          encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: rec.offset, value: 0x05 }),
+        );
+        break;
+      }
+      default:
+        throw new AssertFailure(`daemon sent unexpected ${rec.kindName} on an upload stream`);
+    }
+  }
+  const reply = await settleReply(replyState);
+  if (reply && reply.ok && !endSent) {
+    // Success is only sent after the daemon receives and finalizes END.
+    throw new AssertFailure('file.share replied success before the client sent END');
+  }
+  return reply;
+}
+
+/** Download: grant a bounded window, accept DATA, advance cumulative CREDIT
+ * on sink acceptance, validate END, and ACK a daemon ABORT with the final
+ * accepted count. Requires OPEN.total, END.offset, the terminal `out.bytes`,
+ * and the fixture's N to agree. */
+async function runDownload({ session, tracker, replyState, receiveBytes, maxPayload, waitMs }) {
+  const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
+  if (first.reply) {
+    const reply = await settleReply(replyState);
+    // file.read has no op_id dedup, so there is no legal streamless success.
+    if (reply && reply.ok) {
+      throw new AssertFailure('file.read replied success without OPEN or any streamed byte');
+    }
+    return reply;
+  }
+  validateOpen(tracker, first.record);
+  const total = tracker.openTotal;
+  if (total !== receiveBytes) {
+    throw new AssertFailure(`file.read OPEN total ${total} disagrees with the fixture's receive_bytes ${receiveBytes}`);
+  }
+
+  // Bounded window; the sink is a counter (the harness never collects the
+  // whole file). Client credit MUST NOT exceed the OPEN total.
+  const window = maxPayload;
+  const grant = (accepted) => {
+    const send = Math.min(accepted + window, total);
+    session.sendBinary(
+      encodeRecord({ kind: KIND.CREDIT, id: tracker.id, streamId: tracker.streamId, offset: accepted, value: send }),
+    );
+    return send;
+  };
+  let sendThrough = grant(0);
+  let endSeen = false;
+
+  while (!endSeen) {
+    // Drain queued records before honouring the settled reply: END and the
+    // Text reply can land in one batched delivery, and honouring the reply
+    // first would skip the spec-mandated END validation.
+    if (replyState.done && tracker.queue.length === 0) break;
+    const ev = await tracker.next(replyState, waitMs, 'DATA, END, ABORT, or the terminal reply');
+    if (ev.reply) break;
+    const rec = ev.record;
+    checkBinding(tracker, rec);
+    switch (rec.kind) {
+      case KIND.DATA: {
+        const len = rec.payload ? rec.payload.length : 0;
+        tracker.received += len;
+        if (len === 0) throw new AssertFailure('daemon sent an empty DATA record');
+        if (len > maxPayload) throw new AssertFailure(`daemon DATA payload of ${len} bytes exceeds the ${maxPayload}-byte bound`);
+        if (rec.offset !== tracker.accepted) {
+          throw new AssertFailure(`daemon DATA offset ${rec.offset} is not contiguous with accepted ${tracker.accepted}`);
+        }
+        if (rec.offset + len > sendThrough) {
+          throw new AssertFailure(`daemon DATA through ${rec.offset + len} exceeds granted credit ${sendThrough}`);
+        }
+        if (rec.value !== 0) throw new AssertFailure('daemon DATA carried a nonzero value field');
+        tracker.accepted += len;
+        sendThrough = grant(tracker.accepted);
+        break;
+      }
+      case KIND.END: {
+        if (rec.payload) throw new AssertFailure('daemon END carried a payload');
+        if (rec.value !== 0) throw new AssertFailure('daemon END carried a nonzero value field');
+        if (rec.offset !== total || tracker.accepted !== total) {
+          throw new AssertFailure(
+            `daemon END at ${rec.offset} disagrees with OPEN total ${total} / accepted ${tracker.accepted}`,
+          );
+        }
+        endSeen = true;
+        break;
+      }
+      case KIND.ABORT: {
+        // We are the receiver: ACK carries OUR final accepted count.
+        validateAbort(rec);
+        session.sendBinary(
+          encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: tracker.accepted, value: 0x05 }),
+        );
+        const reply = await settleReplyAfter(tracker, replyState, waitMs);
+        return reply;
+      }
+      default:
+        throw new AssertFailure(`daemon sent unexpected ${rec.kindName} on a download stream`);
+    }
+  }
+
+  const reply = endSeen ? await settleReplyAfter(tracker, replyState, waitMs) : await settleReply(replyState);
+  if (reply && reply.ok) {
+    // The spec's executor contract: OPEN.total, END, terminal out.bytes, and
+    // the fixture's N must agree — a success with a missing or disagreeing
+    // leg is a conformance failure, never a pass.
+    if (!endSeen) throw new AssertFailure('file.read replied success without a daemon END');
+    if (!reply.out || reply.out.bytes !== total) {
+      throw new AssertFailure(
+        `terminal out.bytes ${reply.out?.bytes} disagrees with the streamed total ${total}`,
+      );
+    }
+  }
+  return reply;
+}
+
+/** Wait for the reply to settle after the stream's binary side concluded. */
+async function settleReplyAfter(tracker, replyState, waitMs) {
+  while (!replyState.done) {
+    await tracker.next(replyState, waitMs, 'the terminal reply');
+    if (replyState.done) break;
+    // A late record after END/ACK is a daemon violation of the retired binding.
+    throw new AssertFailure('daemon sent a record after the stream concluded');
+  }
+  return settleReply(replyState);
+}

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -108,10 +108,14 @@ export class CallStreamTracker {
     this.queue = [];
     this.failure = null;
     this.wakers = [];
+    // Delivery sequence, shared by records and the terminal reply, so their
+    // wire order survives batched delivery.
+    this.seq = 0;
   }
 
   deliver(record) {
     if (record.kind === KIND.OPEN) this.opened = true;
+    record.seq = ++this.seq;
     this.queue.push(record);
     this.wake();
   }
@@ -129,11 +133,15 @@ export class CallStreamTracker {
   async next(replyState, timeoutMs, what) {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      // Order matters: drain records first (delivery order is evidence), then
-      // surface a recorded violation, and only then honour the settled reply —
-      // a connection-fatal violation must not be laundered by a reply that
-      // arrived in the same batch.
-      if (this.queue.length) return { record: this.queue.shift() };
+      // Order matters: deliver records and the reply in WIRE order (both are
+      // sequence-stamped), and surface a recorded violation before honouring
+      // the settled reply — a connection-fatal violation must not be
+      // laundered by a reply that arrived in the same batch. A record
+      // delivered AFTER the reply stays queued for the post-terminal checks.
+      const head = this.queue[0];
+      if (head && (!replyState.done || head.seq < replyState.seq)) {
+        return { record: this.queue.shift() };
+      }
       if (this.failure) throw this.failure;
       if (replyState.done) return { reply: replyState };
       const remain = deadline - Date.now();
@@ -316,10 +324,18 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   // WebSocket ordering makes the daemon's observed_bytes deterministic.
   const declared = Number(declaredBytes);
   const shortStream = Number.isFinite(declared) && sendBytes < declared;
+  // The served shared-file limit is load-bearing for the sentinel math; a
+  // daemon that fails to serve it as a usable integer fails, never gets an
+  // invented cap.
+  const limit = Number(limitBytes);
+  if (!Number.isFinite(limit) || limit < 0) {
+    throw new AssertFailure(
+      `served max_shared_file_bytes ${JSON.stringify(limitBytes)} is unusable for byte streaming`,
+    );
+  }
   // The daemon may not extend send_through past min(declared, limit) + 1 (the
   // observation sentinel).
-  const sentinelCap =
-    Math.min(Number.isFinite(declared) ? declared : Infinity, Number.isFinite(Number(limitBytes)) ? Number(limitBytes) : Infinity) + 1;
+  const sentinelCap = Math.min(Number.isFinite(declared) ? declared : Infinity, limit) + 1;
   let acceptedThrough = 0;
   let sendThrough = 0;
   let sent = 0;
@@ -431,6 +447,9 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
       default:
         throw new AssertFailure(`daemon sent unexpected ${rec.kindName} on an upload stream`);
     }
+  }
+  if (tracker.queue.length) {
+    throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after the terminal reply`);
   }
   const reply = await settleReply(replyState);
   if (reply && reply.ok && abortSeen) {
@@ -587,6 +606,9 @@ async function settleReplyAfter(tracker, replyState, waitMs) {
   const ev = await tracker.next(replyState, waitMs, 'the terminal reply');
   if (ev.record) {
     throw new AssertFailure(`daemon sent ${ev.record.kindName} after the stream concluded`);
+  }
+  if (tracker.queue.length) {
+    throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after the terminal reply`);
   }
   return settleReply(replyState);
 }

--- a/conformance/v2/harness/values.mjs
+++ b/conformance/v2/harness/values.mjs
@@ -72,10 +72,12 @@ export function matchesTypeTag(tag, value) {
   }
 }
 
-/** Resolve a dotted path against a root object. Returns {found, value}. */
+/** Resolve a dotted path against a root object. Returns {found, value}.
+ * Numeric bracket indices (`files[0].file_id`) normalize to dot segments;
+ * `[*]` wildcards stay with the caller (collectWildcard). */
 export function resolvePath(root, path) {
   if (path === '' || path === undefined || path === null) return { found: true, value: root };
-  const parts = String(path).split('.');
+  const parts = String(path).replace(/\[(\d+)\]/g, '.$1').split('.');
   let cur = root;
   for (const part of parts) {
     if (cur === null || cur === undefined) return { found: false, value: undefined };

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -7,9 +7,15 @@
     "structural_validation": true,
     "selected_json_envelope_subject_slice": {
       "status": "partial",
-      "ci_selected_cases": 14
+      "ci_selected_cases": 22
     },
-    "binary_byte_stream_executor": "unimplemented",
+    "binary_byte_stream_executor": {
+      "status": "partial",
+      "send_bytes": "implemented",
+      "receive_bytes": "implemented_no_executable_case",
+      "bytes_streamed_observation": "implemented",
+      "raw_record_and_fault_controls": "unimplemented"
+    },
     "adapter_targeted_declarative_cases": "declarative_only"
   },
   "rules": {

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -1355,7 +1355,13 @@ if (isObject(manifest)) {
       status: "partial",
       ci_selected_cases: ciSelectedCases,
     },
-    binary_byte_stream_executor: "unimplemented",
+    binary_byte_stream_executor: {
+      status: "partial",
+      send_bytes: "implemented",
+      receive_bytes: "implemented_no_executable_case",
+      bytes_streamed_observation: "implemented",
+      raw_record_and_fault_controls: "unimplemented",
+    },
     adapter_targeted_declarative_cases: "declarative_only",
   };
   if (!sameJson(manifest.replayable, replayability)) {


### PR DESCRIPTION
Implements the protocol-v2 binary byte-stream executor in the Node replay harness — the harness slice of #233, on top of the merged Rust ends (#241/#242/#243) and the #244 fixture/validator repair. `docs/protocol-v2.md`'s byte-stream-framing section is the implemented spec; the Rust runtimes were used only as conformance targets.

## What this adds

**Byte-stream executor** (`conformance/v2/harness/stream.mjs`, new):
- JBS2 record codec: 48-byte big-endian header, OPEN/DATA/CREDIT/END/ABORT/ACK, DATA bound `min(65_536, max_frame_bytes − 48)`.
- `stream: {send_bytes: N}` uploads: the Text request is sent with its reply pending, a pre-OPEN terminal reply races OPEN, OPEN.total is validated against `declared_bytes`, CREDIT is honoured cumulatively (byte `i` is `i mod 251`, generated incrementally; an acknowledgment beyond the bytes actually sent fails), and END follows full CREDIT acknowledgment on the exactly-declared path. `send_bytes` stays independent of `declared_bytes`; a deliberately short stream sends END directly behind its last DATA record (per-direction WebSocket ordering makes the daemon's `observed_bytes` deterministic — the daemon's refill policy has no partial-window acknowledgment, so waiting would stall), and an over-declared stream is carried to the daemon's ABORT, which the executor ACKs with the echoed offset.
- `stream: {receive_bytes: N}` downloads: bounded window never exceeding the OPEN total, counting sink (no whole-file collection), cumulative CREDIT on each acceptance, final cumulative CREDIT → daemon END → Text reply, ABORT answered by ACK with the final accepted count. Binary ACK is ABORT-only. A success reply without OPEN, without END, or disagreeing with OPEN.total/`out.bytes`/N fails — never passes.
- `observe: bytes_streamed` is now a real observation (it was a silent no-op pass): receiver-accepted payload bytes per call, `step:<n>` selectors (1-based), zero for pre-OPEN refusals. Every call gets a tracker, so a stream-less call that receives an OPEN fails loudly instead of dropping the record.
- The session layer preserves the WebSocket Text/Binary bit (it previously `JSON.parse`d and silently dropped every Binary message).

**Engine repairs the file cases depend on:**
- Numeric bracket-index path resolution (`out.files[0].file_id`) in both engines — `values.mjs` `resolvePath` and `assert.mjs` (`evalValueAssertion` + `collectWildcard`) — normalizing `[n]` to a dot segment with `[*]` semantics intact. This settles the README's deferred save-source RESOLUTION.
- `subsetMatch` resolves single-`$`-key computed nodes (`{"$add": …}`, `{"$unknown": …}`) in reply matchers.
- `op: "type"` maps the DSL's bracketless tag names (`"uint"`) onto the tag matcher.
- Setup upgrades (an `upgrade` step with no `expect`) now present the label's STABLE client id, exactly as `#sessionFor` connections do. An omitted `cid` is an ephemeral per-connection dedup principal on the daemon, so without this every post-upgrade reconnect silently changed principal and op_id-replay cases could never observe the ledger. Probing upgrades (any `expect`) still send exactly what the fixture wrote.
- Requires: bare `subject` now ensures the daemon subject (the corpus's absence form is `subject:none`) unless the case's own steps call `subject.ensure` (some assert on the `created` flag); `resource:shared_file` is genuinely established by streaming a 4096-byte seed file through the executor, binding `$fid`.

**Fixture setup repairs** (`files.json`; no expectation was edited):
- 7 empty `upgrade {query:{}, headers:{}}` setup steps in the executable file cases now spell out admission (`v`/`sg`/Bearer) exactly as the live-green subject-daemon fixtures do — the daemon refuses an empty-query upgrade with 426, and these steps are setup, not admission probes.
- 5 cases created a room and never activated it while their own `requires` say `room:live`; a minimal `room.activate` step is inserted after each case-local `room.create`, and the two `bytes_streamed` `step:4` selectors those insertions shift are renumbered to `step:5`.

**CI slice 14 → 22** (each selector resolves exactly once; all verified locally against a fresh `cargo build --locked -p jeliyad`):
`handshake_serves_the_file_and_transfer_limits_as_integers`, `share_one_byte_past_the_served_limit_is_refused_at_stage_declared`, `share_size_refusal_is_never_reported_as_digest_mismatch`, `share_completed_result_replays_without_a_second_stream_and_authors_once` (live 2048-byte streamed upload, then a same-principal reconnect replay that returns the recorded result with no second OPEN and `bytes_streamed` 0), `a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch` (live upload ending below its declaration → `declared_size_mismatch`), `list_of_a_room_that_is_not_available_answers_room_not_available`, `fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown`, `transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown`.

**Recompute-and-align, in this PR:** the validator's pinned `replayable` literal, `manifest.json` (`ci_selected_cases: 22`, `binary_byte_stream_executor` now a structured honest status), the README matrix rows, the bracket-index RESOLUTION paragraph, the precondition-bindings paragraph, and the ci.yml step-name parenthetical all change together.

## Evidence

- The exact CI command (all 22 selectors) passes locally: `22 passed, 0 failed, 0 errors`, exit 0.
- The two 100-MiB cases pass locally in ~23 s combined and stay out of CI by weight: `share_at_exactly_the_served_limit_is_accepted` (sentinel-credit success at the bound) and `share_declared_within_limit_but_stream_exceeds_it_aborts_at_stage_stream` (`bytes_streamed` = exactly the served limit, then daemon ABORT → ACK → `file_too_large` at `stage_stream`).
- Full-corpus audit on the same jeliyad build: main's harness 98/341 passed → this branch 122/341 (at `--jobs 8`); the per-case diff shows only improvements plus one pre-existing timing flake (`pipe_revoke` replay across a second boundary — passes repeatedly in isolation; possibly a daemon replay re-deriving `revoked_at`). Several improvements came from pre-existing harness defects the review rounds exposed: a shared current-daemon pointer that under parallel jobs read another case's data dir; upgrade QUERY values never receiving portfile placeholder substitution (every handshake fixture's authored `<daemon_sg>` admission was silently refused and ran on an auto-connected substitute); and http saves unable to resolve `out.`-rooted capture paths (the session-ticket flow's `$ticket` never bound, so its ct-upgrade was never genuinely exercised — it now is). Three transfer cases now advance past previously-failing expects and honestly ERROR at the still-unsupported `start_transfers` control (one of them a U2-blocked case whose recorded mode moves from expected-fail to setup-error; the control stays out of scope with the U2 family). Blocked cases still fail, never skip; the only blocked-pass is the known pre-existing `room_peers_ignores_a_stale_generation_teardown` stale marker.
- Download path: no fixture is executable single-subject (see below), so it is proven two ways — the live daemon's pre-OPEN `file_not_fetched` refusal records zero, and a scratch mock speaking the Rust runtime's stop-and-wait producer semantics validates the happy path (200 000 bytes, multi-chunk, final cumulative CREDIT → END → reply) and the ABORT→ACK path.
- An adversarial review round (four lenses, per-finding verification) ran before publication, and five Codex review rounds ran on the PR itself; every confirmed finding is fixed (terminal-path strictness, ABORT reason/accounting correlation, stream-id uniqueness, credit boundary discipline, the mandatory probe credit, baseline-absorption closure, and the shared-daemon-pointer race), with one finding refuted on spec evidence (short-stream END discipline).

## Daemon conformance findings this executor surfaced (out of scope here, follow-ups under #233)

1. **`invalid_argument` loses the field path.** A non-uint `declared_bytes` yields `{"field": "in", "reason": {"state": "type", "expected": "u"}}` where the corpus (and the taxonomy's intent) expect `{"field": "in.declared_bytes", …, "expected": "uint"}`. This keeps `share_declared_size_as_a_formatted_string_is_malformed` and `share_size_null_or_out_of_domain_is_malformed` red.
2. **`fetchable` for a self-hosted-only file.** The daemon lists the sharer's own file as `self_hosted: true, fetchable: false` (sole provider is the caller itself, link `never_dialed`); the fixture `share_below_the_served_limit_succeeds` expects `fetchable: true`. The spec separates the two facts and reads daemon-side to me, so this is recorded as a fixture-expectation repair to settle in a spec-derived fixture pass — expectation edits are out of this PR's scope either way. (The case's streamed upload itself succeeds live; only the trailing `file.list` expectation disagrees.)
3. **`file.share` demands a live room.** The daemon answers `room_not_live` for a share into a plain room, while the spec's liveness list (protocol-v2.md, capabilities section) names only `file.fetch`, `pipe.connect`, and `room.peers`. Not settled here: the executable share fixtures required `room:live` all along, so they now activate the room they create; whether share should require liveness is a spec-vs-daemon question for #233's follow-up.

An earlier candidate finding — "op_id replay of a completed share opens a second stream" — turned out to be a harness defect, not a daemon one: the upgrade-created connection presented no `cid` (an ephemeral dedup principal), so the post-reconnect replay arrived under a different principal and the daemon legally started fresh. With stable client identity on setup upgrades, the daemon's replay behavior is exactly to spec, and that case is now live CI evidence.

## What remains open on #233

- The raw-record, credit-pause/release, client-ABORT, and transport-drop fault controls the spec's harness section names (malformed/crossed-terminal/backpressure cases) — `binary_byte_stream_executor.raw_record_and_fault_controls: "unimplemented"` stays honest about this.
- An executable `receive_bytes` fixture: `file.read` serves only fetched files (verified live: a self-shared file answers `file_not_fetched`), and `resource:fetched_file`/`link:*` need a provider peer the single-subject harness cannot honestly supply.
- The `PRECONDITION_GAP_CASES` requires repair (separate spec-derived follow-up), the three findings above, and the U2/U3 transfer families (including daemon-side `bytes_streamed` observation for `file.fetch`, whose stream is daemon-to-provider and invisible to the client connection).

Do **not** close #233 on merge.

Refs #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
