### PR TITLE
build(deps): bump nanoid to 3.3.18 in /ui to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2368,9 +2368,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

The `dependency security (Cargo + npm)` required check audits the `ui/` npm lockfile on every run. The advisory **GHSA-2v37-7h3g-55p8** (nanoid <3.3.17) went live against the pinned `nanoid@3.3.16`, which retroactively fails every fresh CI run repo-wide — including all open dependabot PRs once rebased.

## What

Lockfile-only bump of the transitive `nanoid` dependency 3.3.16 → 3.3.18, within the existing `^3.3.16` range. No code or manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)