### PR TITLE
chore(dependabot): ignore React-family majors for the legacy ui/ client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,19 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # The React UI stays on 18.x: a React 19 migration is not planned for
+      # this legacy client (superseded by the Dioxus rewrite), and partial
+      # react-dom/@types bumps produce an unresolvable npm tree (see #142).
+      # Minors and patches still flow.
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: pub
     directory: /app


### PR DESCRIPTION
Dependabot's multi-dependency PR #142 (react-dom 18→19 + @types/react-dom 18→19, with react/@types/react left at ^18) is unresolvable by construction — npm ERESOLVE in every job — and `@dependabot ignore this major version` is unavailable on multi-dependency PRs. This encodes the decision in config instead: the legacy React client stays on 18.x pending the Dioxus rewrite; **majors** for react, react-dom, @types/react, @types/react-dom are ignored while minors/patches keep flowing.

Closes nothing automatically; #142 is closed via `@dependabot close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)