### PR TITLE
chore(adw): add Switchyard project pack and ignore managed run state

### DIFF
--- a/.adw/README.md
+++ b/.adw/README.md
@@ -22,7 +22,14 @@ What this pack pins:
   no `--test-cmd`, at CI's pinned toolchain (ci.yml pins Rust 1.96.0; a newer
   local default toolchain's clippy false-fails `-D warnings`). If toolchain
   1.96.0 is not installed the gate fails loudly — install it or pass an
-  explicit `--test-cmd`.
+  explicit `--test-cmd`. **Scope: the Rust workspace only.** Runs that touch
+  `ui/`, `app/`, or the Node contract scripts must pass an explicit
+  per-surface `--test-cmd`; the deliberately narrow default keeps ad-hoc runs
+  cheap and deterministic in a cold linked worktree (the UI/Flutter suites are
+  slow there and the Flutter widget tests are timing-flaky, which would burn
+  the orchestrator's repair loops), while the required CI checks — which
+  Switchyard watches and repairs via its ci-fix phase — remain the
+  authoritative multi-surface gate before any merge.
 - **`commands.defaultFinalizeGates`** — fmt and clippy (CI `rust-runtime`
   parity), then `scripts/check-docs.mjs`, because the orchestrator's document
   phase appends to `docs/` and this repo's docs profile (frontmatter contract,

--- a/.adw/README.md
+++ b/.adw/README.md
@@ -1,0 +1,43 @@
+# Switchyard (ADW) project pack
+
+`config.json` configures [Switchyard](https://github.com/kortiene/switchyard)
+runs that target this repository (`--project-root <this repo>`). Switchyard
+deep-merges this file over its built-in defaults, so only deviations are
+recorded here; everything omitted (providers, models, prompts, phases) inherits
+the orchestrator's defaults. JSON records merge key-by-key; **arrays replace
+wholesale** — which is why `gates.e2e.hints` is a complete list, not additions.
+
+What this pack pins:
+
+- **`project`** — identity used in run state and progress comments.
+- **`branching.labelPrefixes`** — adds `enhancement → feat` and
+  `github_actions → ci` to the default label→branch-prefix map (`bug → fix`,
+  `documentation → docs`, … are inherited).
+- **`gates.e2e.hints`** — this repo's domain vocabulary (rooms, invites,
+  presence, transfers, pipes, byte-stream framing, conformance corpus, QR
+  pairing, signing/trust) so protocol-touching changes trigger the e2e phase.
+  Matching is whole-word over a lowercased signal, so singular and plural
+  forms are listed separately.
+- **`commands.defaultTestCommand`** — the fallback test gate when a run passes
+  no `--test-cmd`, at CI's pinned toolchain (ci.yml pins Rust 1.96.0; a newer
+  local default toolchain's clippy false-fails `-D warnings`). If toolchain
+  1.96.0 is not installed the gate fails loudly — install it or pass an
+  explicit `--test-cmd`.
+- **`commands.defaultFinalizeGates`** — fmt and clippy (CI `rust-runtime`
+  parity), then `scripts/check-docs.mjs`, because the orchestrator's document
+  phase appends to `docs/` and this repo's docs profile (frontmatter contract,
+  index reachability) is CI-enforced.
+
+**Gate strings are argv-split, not shell-evaluated.** Switchyard tokenizes each
+gate with a quote-aware splitter and `spawnSync`s it directly — shell operators
+like `&&` are passed to the program as literal arguments and fail. Keep every
+gate one command per string (the finalize list runs each entry separately). A
+`--test-cmd` that genuinely needs a chain must be wrapped:
+`--test-cmd 'bash -lc "cmd1 && cmd2"'`.
+
+The root `.gitignore` ignores `/agents/`: Switchyard writes per-run state to
+`agents/<adw-id>/` inside the (work)tree, and its `--worktree` preflight
+hard-fails if that path is not ignored.
+
+Do not put secrets in this file; it is committed, and Switchyard treats a
+project pack as executable configuration.

--- a/.adw/config.json
+++ b/.adw/config.json
@@ -14,6 +14,10 @@
     "e2e": {
       "hints": [
         "daemon",
+        "subject",
+        "subjects",
+        "file",
+        "files",
         "room",
         "rooms",
         "invite",

--- a/.adw/config.json
+++ b/.adw/config.json
@@ -1,0 +1,73 @@
+{
+  "version": 1,
+  "project": {
+    "id": "jeliya",
+    "name": "Jeliya"
+  },
+  "branching": {
+    "labelPrefixes": {
+      "enhancement": "feat",
+      "github_actions": "ci"
+    }
+  },
+  "gates": {
+    "e2e": {
+      "hints": [
+        "daemon",
+        "room",
+        "rooms",
+        "invite",
+        "invites",
+        "invitation",
+        "invitations",
+        "membership",
+        "presence",
+        "transfer",
+        "transfers",
+        "pipe",
+        "pipes",
+        "stream",
+        "streams",
+        "frame",
+        "frames",
+        "framing",
+        "websocket",
+        "conformance",
+        "corpus",
+        "protocol",
+        "handshake",
+        "pairing",
+        "signing",
+        "signed",
+        "signature",
+        "trust",
+        "policy",
+        "sandbox",
+        "artifact",
+        "exec",
+        "login",
+        "sync",
+        "crypto",
+        "encryption",
+        "decryption",
+        "auth",
+        "authentication",
+        "consent",
+        "qr",
+        "offline",
+        "backup",
+        "recovery",
+        "ipc",
+        "matrix"
+      ]
+    }
+  },
+  "commands": {
+    "defaultTestCommand": "cargo +1.96.0 test --locked --workspace",
+    "defaultFinalizeGates": [
+      "cargo +1.96.0 fmt --all --check",
+      "cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings",
+      "node scripts/check-docs.mjs"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ docs/evidence/**/*.private.*
 # Local agent/tooling metadata; not part of product source.
 .claude/
 
+# Switchyard (ADW) per-run state, written to agents/<adw-id>/ inside the
+# (work)tree. Its --worktree preflight hard-fails when this is not ignored.
+/agents/
+
 # impeccable live-mode ephemeral session state (config.json + design.json are shared)
 .impeccable/live/sessions/
 


### PR DESCRIPTION
## What

Initializes this repository as a Switchyard (ADW) target:

- **`.adw/config.json`** — project pack, deep-merged over the orchestrator's defaults (records merge, arrays replace). Pins: project identity; `enhancement→feat` / `github_actions→ci` branch-prefix additions; a complete e2e-phase hint vocabulary in this repo's protocol domain (rooms/invites/presence/transfers/pipes/framing/conformance/QR/signing — singular and plural, since matching is whole-word over a lowercased signal); default test gate `cargo +1.96.0 test --locked --workspace` (CI's pinned toolchain — fails loudly if the toolchain is absent, never falsely); finalize gates fmt → clippy → `scripts/check-docs.mjs`, so the orchestrator's document-phase appends are held to the CI-enforced docs profile before any commit finalizes.
- **`.adw/README.md`** — records the pack contract, including the load-bearing one: gate strings are **argv-split, not shell-evaluated** — one command per string, `&&` chains must be wrapped in `bash -lc`.
- **`.gitignore`** — anchored `/agents/`: Switchyard writes per-run state to `agents/<adw-id>/` inside the worktree, and its `--worktree` preflight hard-fails when that path is not ignored.

## Why

Switchyard runs against a pack-less repo on built-in defaults, but then every run needs full per-run flags and there is no repo-recorded gate policy. This pack makes ad-hoc runs safe by default and is a prerequisite for the managed-worktree lane plan (the preflight ignore rule is a hard requirement).

## Verification

- `parseAdwConfig` accepts the file (exercised via a real `--dry-run` against this repo; the resolved test gate prints the pack default).
- Preflight ignore check passes: `git check-ignore --no-index --quiet -- agents/x/commit_message.txt` → 0; `/agents/` matches no tracked path (`git ls-files`).
- `node scripts/check-docs.mjs` green (docs validator walks `docs/` only; `.adw/README.md` is out of scope by design).
- An adversarial review round against the orchestrator source caught and fixed one merge-blocker pre-PR: the original default test command used a `&&` chain, which the orchestrator's argv tokenizer passes to cargo as a literal argument; gates are now one command per string.
- No required check touches `.adw/` or the `.gitignore` addition (verified against each job's file scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)