### PR TITLE
docs(security): add native update, signing, and anti-rollback policy (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Verify documentation profile and navigation
         run: |
           set -euo pipefail
-          node --test scripts/check-docs.test.mjs
+          node --test scripts/check-docs.test.mjs scripts/native-update-policy.test.mjs
           node scripts/check-docs.mjs
 
       - name: Verify secret-storage boundaries

--- a/docs/dioxus-architecture.md
+++ b/docs/dioxus-architecture.md
@@ -3,7 +3,7 @@ type: "Decision"
 title: "Dioxus clean-slate architecture"
 description: "Decision record for the clean-slate typed Rust client stack on Dioxus system-WebView rendering, the protocol and storage generation it defines, the single embedded web artifact every daemon target ships, and the retirement of React, Flutter, the Dart protocol package, and the C ABI."
 tags: ["architecture", "clean-slate", "dioxus", "protocol", "release"]
-timestamp: "2026-07-28T02:20:00Z"
+timestamp: "2026-08-10T00:00:00Z"
 status: "canonical"
 implementation_status: "planned"
 verification_status: "unverified"
@@ -378,7 +378,8 @@ record, a new threat model, and a separately approved backlog** (#113,
 - **Performance budgets** — #198.
 - **Legal, privacy, and compliance gates for public distribution** — #118.
 - **Native update channels, signing trust, and anti-rollback policy** —
-  #121.
+  #121, now decided in the
+  [native update, signing, and anti-rollback policy](native-update-policy.md).
 - **What replaces the retired cross-client design-token, localization, and
   accessibility gates** — #177, #197. Retiring React and Flutter removes
   working enforcement before its replacement exists; that verification loss

--- a/docs/first-release-distribution.md
+++ b/docs/first-release-distribution.md
@@ -180,7 +180,7 @@ the two that survive are reframed rather than inherited.
 | #122 | Closed — filesystem confinement is fixed, and protocol v2 removed daemon paths from the wire entirely |
 | #126 | Closed — the surviving unsafe-boundary criterion moved to #203 |
 | **#118** | **Retained** as the public-publication legal and compliance gate |
-| **#121** | **Retained, reframed** around native update-channel trust, signing, and anti-rollback — with no compatibility window, mixed-version period, or N/N-1 behavior, none of which a single-generation clean slate has |
+| **#121** | **Retained, reframed** around native update-channel trust, signing, and anti-rollback — with no compatibility window, mixed-version period, or N/N-1 behavior, none of which a single-generation clean slate has. Now decided in the [native update, signing, and anti-rollback policy](native-update-policy.md). |
 
 ## What this record does not decide
 

--- a/docs/first-release-distribution.md
+++ b/docs/first-release-distribution.md
@@ -3,7 +3,7 @@ type: "Decision"
 title: "First-release distribution boundary"
 description: "Decision record for how the first release is delivered: one content-addressed Dioxus artifact served by the trusted local daemon and embedded in packaged desktop targets, the trust boundary each surface sits on, the operator-pasted pairing code that authenticates an ordinary browser, and the hosted-origin and delegated-browser work deferred behind a new architecture decision."
 tags: ["architecture", "clean-slate", "dioxus", "release", "security"]
-timestamp: "2026-07-28T20:10:00Z"
+timestamp: "2026-08-10T00:00:00Z"
 status: "canonical"
 implementation_status: "planned"
 verification_status: "unverified"

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ retained as a valid, dated evidence record about the revision it examined.
 - [v0.6.1 evidence boundary](evidence/v0.6.1/index.md) - Empty qualification boundary reserved for fresh, signed v0.6.1 manifests after candidate designation.
 - [Historical Gate A result](gate-a-result.md) - Older direct-connectivity evidence that does not certify the v0.5.0 candidate.
 - [Signing and notarization](signing-notarization.md) - Release-security plan for macOS and Windows artifacts.
+- [Native update, signing, and anti-rollback policy](native-update-policy.md) - Decision record for whether each published native channel has an updater, how update artifacts and metadata are authenticated, and the single-generation anti-rollback, fail-closed UX, recovery, diagnostics, and evidence contract. Decided and not yet built.
 
 ## Language, identity, and governance
 

--- a/docs/native-update-policy.md
+++ b/docs/native-update-policy.md
@@ -1,0 +1,356 @@
+---
+type: "Decision"
+title: "Native update, signing, and anti-rollback policy"
+description: "Decision record for whether each published native Jeliya channel has an updater, how update artifacts and metadata are authenticated, the single-generation anti-rollback and version-monotonicity rule, and the fail-closed UX, recovery, diagnostics, and evidence contract for unsupported, revoked, tampered, offline, and downgrade states."
+tags: ["release", "security", "signing", "update", "clean-slate", "dioxus"]
+timestamp: "2026-08-10T00:00:00Z"
+status: "canonical"
+implementation_status: "planned"
+verification_status: "unverified"
+release_status: "unreleased"
+audience: ["contributors", "maintainers", "release-engineers", "security-reviewers"]
+---
+
+# Native update, signing, and anti-rollback policy
+
+**Nothing in this record is built.** It is a canonical decision about unwritten
+code, exactly like [the clean-slate architecture](dioxus-architecture.md) and
+[the first-release distribution boundary](first-release-distribution.md). It
+satisfies issue #121 as reframed by
+[first-release-distribution.md](first-release-distribution.md#amendment-disposition)
+("Retained, reframed around native update-channel trust, signing, and
+anti-rollback — with no compatibility window, mixed-version period, or N/N-1
+behavior"). It changes no production code, and it is the record that
+[the architecture](dioxus-architecture.md#what-this-record-does-not-decide)
+points to when it defers native update, signing, and anti-rollback policy to
+#121.
+
+For every published native package this record decides four things:
+
+1. whether the channel has an updater, or an explicit **no-updater** decision;
+2. how update metadata and artifacts are authenticated — signing roots, trusted
+   metadata, rotation, revocation, and channel separation;
+3. the **anti-rollback** policy and version monotonicity;
+4. **actionable failure UX** for unsupported, revoked, too-old, and can't-update
+   states, plus offline and interrupted recovery, operator and support commands,
+   and privacy-bounded version diagnostics.
+
+The original issue assumed web-origin ↔ companion version skew. #113 removed
+that architecture. Exact protocol and storage-generation mismatch rejection is
+owned elsewhere (#157, #161, #164, #170, #172, #199) and is **referenced, not
+re-decided** here. The downstream per-platform packaging (#186–#190) and
+qualification (#199) consume this policy but do **not** block it.
+
+## Channels and the update decision
+
+### Channel inventory
+
+This is the authoritative list of published native channels, derived from
+[`../packaging/README.md`](../packaging/README.md) and the
+[platform matrix](platform-matrix.md#decided-dioxus-targets). Every channel is
+enumerated and every channel is decided.
+
+| Platform | Channel | Artifact today | Clean-slate successor / owner |
+|---|---|---|---|
+| macOS | `curl \| sh` (`install.sh`) | `jeliyad` `.tar.gz` + `.sha256` | #186 |
+| macOS | Homebrew formula (`jeliya.rb`, tap) | `jeliyad` | #186 |
+| macOS | Homebrew cask (`jeliya-app.rb`) | unpublished future DMG app | #186 |
+| macOS | direct browser download (DMG/archive) | future signed/notarized DMG | #186 / #1 |
+| Windows | `install.ps1` (PowerShell) | `jeliyad` `.zip` + `.sha256` | #188 (scope undecided) |
+| Windows | direct browser download | future signed installer/zip | #188 / #2 |
+| Linux | `curl \| sh` (`install.sh`) | `jeliyad` `.tar.gz` + `.sha256` | #187 |
+| Linux | Homebrew (Linuxbrew) | `jeliyad` | #187 |
+| Linux | source tarball (`package-linux.mjs`) | unsigned dev package | #187 |
+| Android | Google Play (AAB) | none published | #190 / #194 / #160 |
+| Android | sideload APK (per-ABI) | dev build only | #190 / #194 / #160 |
+
+Channels **not** on this list — distribution-specific repositories, Flatpak,
+AppImage, WinGet, the Microsoft Store, the App Store, a Sparkle appcast, and iOS
+— are **not published channels** in the first release and therefore carry **no
+update claim**. Adding a new channel requires an added row in this table and its
+own evidence (see [Evidence contract](#evidence-contract-and-downstream-integration))
+before it may ship.
+
+### Updater vs. no-updater, per channel
+
+**Decision: no in-app or bundled auto-updater on any native channel for the
+first release.** Updates delegate to each channel's own authenticated
+mechanism. "No in-app updater" is a *decision*, not an omission. The rationale:
+
+- it honors the non-goals — no claimed automatic update where the channel gives
+  none, and no updater that bypasses platform signing authority;
+- the single-generation clean slate removes the compatibility machinery a
+  self-updater usually justifies (see
+  [Anti-rollback](#anti-rollback-and-version-monotonicity));
+- a bundled updater is a new privileged network-plus-write surface that the
+  WebView boundary review (#196) and
+  [the threat model](security-threat-model.md#trust-boundaries) have not
+  covered, so it is out of scope until separately reviewed.
+
+| Channel | Decision | Update mechanism that IS authoritative |
+|---|---|---|
+| Homebrew formula/cask | **no in-app updater** | `brew upgrade`; the digest pinned in the reviewed tap commit is the authenticity root |
+| `install.sh` / `install.ps1` | **no in-app updater** | operator re-runs the installer; the `.sha256` sidecar is verified **before extraction**, fail-closed |
+| macOS DMG / browser download | **no in-app updater** (no Sparkle) | Gatekeeper + stapled notarization ticket; operator re-downloads |
+| Windows installer / browser download (if Windows ships) | **no in-app updater** (no Squirrel) | Authenticode + SmartScreen reputation; operator re-downloads |
+| Google Play (AAB) | **platform updater** — Play's own auto-update *is* the updater | Play App Signing + Play delivery |
+| Sideload APK | **no updater**, and re-sign **breaks signature continuity** | operator manually installs a same-key APK; a key change forces uninstall/reinstall (data loss), warned below |
+
+Google Play is the **only** channel where an automatic updater is claimed —
+because it is the platform's updater, not Jeliya's. The sideload APK row carries
+a required warning: Android refuses to upgrade an installed app in place when the
+signing key changes, so any upload-key change forces an uninstall and reinstall,
+which discards app-private state; operators must be told this before they change
+keys.
+
+**Windows is conditional.** [The architecture](dioxus-architecture.md) leaves
+Windows an *undecided* first-release target: #188 must explicitly include or
+formally defer Windows. The two Windows rows above therefore state the policy
+that applies **if Windows ships**; they assert no committed Windows channel.
+
+## Signing roots, metadata trust, rotation, revocation, channel separation
+
+### Signing roots (supplied by #1/#2, referenced not owned)
+
+| Platform | Signing root | State today |
+|---|---|---|
+| macOS | Developer ID Application certificate + notarization (`notarytool`) | planned; see [signing and notarization](signing-notarization.md) — #1 |
+| Windows | Authenticode (EV preferred for SmartScreen reputation) | planned; see [Windows Authenticode signing](signing-notarization.md#windows-authenticode-signing) — #2 |
+| Android | Play App Signing (distribution key held by Google); the local keystore is the **upload** key | planned; #190 / #194 |
+| Linux | **no publisher signature today** | the daemon archives are unsigned; the checksum sidecar is integrity-only |
+
+### Metadata trust — integrity is not authenticity
+
+This is the load-bearing honesty point of the record. A `.sha256` sidecar
+**fetched from the same origin as the artifact proves integrity, not
+authenticity**: it detects a corrupted or truncated download, but it does not
+defend against a compromised origin, because an attacker who can replace the
+artifact can replace the sidecar beside it. Authenticity comes only from:
+
+- **(a)** platform code signatures — macOS Developer ID + notarization, Windows
+  Authenticode (#1/#2); or
+- **(b)** the Homebrew formula/cask digest committed in a **reviewed tap
+  change**, whose authenticity root is the reviewed Git history, not the
+  download origin; or
+- **(c)** Play App Signing.
+
+This record must never imply the same-origin sidecar defends a compromised
+origin. Where a channel has only the sidecar (the Linux `curl | sh` and source
+tarball paths today), the record states plainly that it provides integrity, not
+publisher authenticity, and that adding a publisher signature is owed by #187.
+
+### Rotation
+
+Signing keys and certificates live in GitHub Actions repository or environment
+secrets (per [signing and notarization](signing-notarization.md)) and are
+**never committed**. The role that rotates each root is the **release
+maintainer**, coordinating with the platform authority (Apple, the Windows CA,
+Google Play). Rotation must not silently invalidate installed builds: when a
+rotation changes what a user's platform will trust, the failure must surface as
+[actionable UX](#fail-closed-states-and-actionable-ux) that points to the
+current download, not as an opaque launch failure. This makes concrete the
+[roadmap NEXT commitment](known-gaps-roadmap.md) to "operate signing,
+notarization, and evidence keys with documented custody, rotation, and incident
+response" for the update dimension.
+
+### Revocation — two layers
+
+1. **Platform-level, OS-honored:** Apple certificate/notarization revocation,
+   Authenticode CRL/OCSP, and Play takedown or key rotation. Jeliya does not
+   reimplement these; it relies on the operating system to honor them.
+2. **Application-level, network-independent:** a compiled **minimum-supported
+   build floor** in `jeliyad` and the app. A build below the floor **fails
+   closed with actionable UX, without a network call and without executing
+   untrusted bytes.** An optional build-time-embedded revocation list of
+   known-bad build digests is a documented extension; the recommendation for the
+   first release is **floor-only**, with the digest list available if a specific
+   bad build must be denied before the floor advances.
+
+### Channel separation / anti-substitution
+
+One reserved application or bundle identifier and one signing identity **per
+packaged target** (per the `package identity` rule in
+[the architecture](dioxus-architecture.md), Decision 3). This ensures a
+foreign- or legacy-channel install cannot upgrade in place into the new
+generation, and a cross-channel artifact swap fails the platform's own identity
+check. The reserved identifier must be one no retiring client already ships, so a
+legacy install cannot masquerade as the new generation.
+
+## Anti-rollback and version monotonicity
+
+Two distinct cases; they are kept separate.
+
+- **Cross-generation downgrade** — a build of a *different* protocol/storage
+  generation. This already **fails closed before mutation** at the v2 handshake
+  and the namespaced-storage gate (#161, #164, #170, #173, #178, #185). It is
+  referenced, not re-specified here. There is no data-preserving rollback (see
+  [the architecture](dioxus-architecture.md), Decision 2).
+- **Same-generation downgrade** — an *older build* of the *same* generation.
+  This is this record's own decision. The new namespaced storage generation
+  records a **monotonic on-disk marker**: a `written_by` build number and a
+  `min_reader` floor. A build refuses to open state written by a strictly newer
+  build, **failing closed with the actionable reset path shown, never migrating
+  and never silently downgrading**. This is anti-rollback that fits the clean
+  slate: it is local, it prevents a downgraded binary from operating on newer
+  state, and it retains no legacy compatibility.
+
+The concrete on-disk key or field name is owned by #185 (desktop), #178
+(browser), and #173 (Android); this record references those and deliberately
+invents no key name, because a replacement key must be a name no retiring client
+ever wrote.
+
+The invariant, stated plainly: **version is monotonic per generation; a rollback
+that would reinterpret newer state fails closed.**
+
+## Fail-closed states and actionable UX
+
+For each fail-closed state the record fixes the user-facing message shape and the
+recovery action. The wording below is the canonical intent; exact EN/FR strings
+follow [internationalization](i18n.md) and are finalized with the UI
+localization work. In every case the reset path is **shown, not taken** — no
+unverified directory is deleted on the user's behalf.
+
+| State | Fail-closed behavior | Actionable UX |
+|---|---|---|
+| unsupported generation / old client | reject at handshake, before mutation | "This build is too old for your data. Reset to continue: `<reset path>`." |
+| below minimum-supported floor / revoked build | refuse to start; no network required | "This version is no longer supported. Download the current version from `<channel>`." |
+| tampered artifact (bad checksum/signature) | installer refuses **before extraction** | "Download failed verification and was not installed. Retry from `<channel>`." |
+| newer state, older binary (downgrade) | refuse to open state | "This install is older than your data. Update, or reset: `<reset path>`." |
+| offline | the prior verified install keeps running; no partial artifact is executed | "You're offline; the installed version is unchanged." |
+| interrupted download | checksum mismatch → fail closed → safe retry | "Update didn't complete. Your current version is intact; retry." |
+
+## Offline and interrupted recovery
+
+Recovery must **never execute untrusted bytes.** The prior verified install stays
+runnable until a replacement verifies; **verification precedes extraction**; and
+where an updater exists (Google Play only), the OS owns download atomicity and
+rollback of a failed install.
+
+- **Offline.** No channel here performs a background self-update, so an offline
+  machine simply keeps running its installed, already-verified build. Nothing
+  partial is fetched or executed.
+- **Interrupted download.** The installer scripts verify the `.sha256` sidecar
+  before extraction and are idempotent with atomic replace, so a partial or
+  interrupted download fails the checksum, is discarded, and leaves the current
+  install intact; the operator re-runs the installer. Homebrew and Play recover
+  through their own resumable, verified delivery.
+
+Because only the Google Play channel has an updater, it is the only channel with
+an updater-owned interrupted-install recovery; every other channel recovers by
+re-running an operator-initiated, verify-before-extract install.
+
+## Operator commands and privacy-bounded diagnostics
+
+The record specifies a diagnostics surface — recommended as an extension of
+`jeliyad --version` / a `jeliya version` command — that reports, per platform:
+
+- package/app version, artifact **digest**, channel, signing identity /
+  notarization state, storage **generation**, and (device evidence only) the
+  system WebView version;
+- a **verify/support command** that re-checks the installed artifact's digest
+  against the published sidecar and reports signature validity, so support can
+  confirm a build's identity without transmitting anything sensitive.
+
+**Privacy bound.** Diagnostics must contain **no** identity keys, daemon tokens,
+invite tickets, IP addresses, room or member data, or file contents — consistent
+with the evidence-sanitization rule in
+[verification evidence](verification-evidence.md#evidence-schema-2-source-build-contract)
+and the secrets rule in [the documentation profile](PROFILE.md). This bound is
+stated as a requirement, not a recommendation.
+
+## Evidence contract and downstream integration
+
+This record is the **authority** for the update-case evidence schema. The
+applicable rows are carried by the per-platform packaging issues #186–#190 and
+per-platform qualification #199; those downstream implementations do not block
+this policy.
+
+**Case matrix, per claimed channel:** current, older, newer, revoked, tampered,
+offline, interrupted, downgrade.
+
+**Retained per case** (sanitized and revision-bound per
+[verification evidence](verification-evidence.md#evidence-schema-2-source-build-contract),
+carrying nothing secret-bearing):
+
+- package **digest**,
+- **signing identity**,
+- **metadata/version**,
+- the **command run**, and
+- the **result**.
+
+**Where rows live.** This document defines the schema; the evidence rows are
+carried by #186–#190 and #199. In the docs bundle, the
+[platform matrix](platform-matrix.md#decided-dioxus-targets) "Decided Dioxus
+targets" rows cross-reference this policy. These results are **enforced evidence,
+not certification**, and **a missing per-channel update gate blocks only that
+channel's publication row** — there is no all-platform barrier, consistent with
+#199.
+
+"Tested," for the anti-rollback and fail-closed criteria, means this record
+**defines** the case matrix and the retained-evidence schema. Executing the
+matrix on real packages is downstream qualification work (#186–#190, #199), not
+part of authoring this policy.
+
+<!-- Editing the GitHub issue bodies of #186–#190 and #199 is the
+orchestrator's/maintainer's job, not this document's. The documentation side of
+the evidence criterion is satisfied in-repo by defining the schema here and
+cross-referencing it from the platform matrix; see the Open questions note. -->
+
+## Non-goals
+
+Reproduced so no reviewer re-adds them:
+
+- No N/N-1 compatibility windows, grace periods, migrations, dual protocol
+  support, mixed-version windows, canaries, or legacy rollback artifacts. The
+  single-generation clean slate has none (see
+  [the architecture](dioxus-architecture.md), Decision 2 and "Rejected and
+  deferred alternatives").
+- No hosted-web/companion skew flow.
+- Do **not** claim automatic updates where the channel provides none.
+- Do **not** let any updater bypass platform signing authority.
+- Do **not** re-decide exact protocol/storage-generation mismatch rejection
+  (#157, #161, #164, #170, #172, #199) — reference it.
+- This record does not decide legal/compliance publication gating (#118) or the
+  build/provenance format of the embedded artifact (#183).
+
+**No compatibility window, migration, or legacy rollback requirement remains.**
+
+## What this record does not decide
+
+- **Signing and notarization authority** — #1 and #2. This record references the
+  roots; it does not own or generate them.
+- **The embedded artifact's build, provenance format, and qualification
+  evidence** — #183 and #199 (see
+  [the embedded artifact](first-release-distribution.md#the-embedded-artifact)).
+- **Exact protocol and storage-generation mismatch rejection** — #157, #161,
+  #164, #170, #172, #173, #178, #185.
+- **The concrete on-disk generation marker key or field name** — #185 (desktop),
+  #178 (browser), #173 (Android).
+- **Legal, privacy, and compliance gates for public publication** — #118.
+- **Whether Windows ships in the first release** — #188; this record's Windows
+  rows are conditional on that answer.
+- **The exact EN/FR wording** of the fail-closed messages — finalized with the
+  UI localization work under [internationalization](i18n.md).
+
+## Citations
+
+- [Dioxus clean-slate architecture](dioxus-architecture.md) — the
+  single-generation policy, `package identity` rule, per-platform WebView floors,
+  and the #121 pointer this record satisfies.
+- [First-release distribution boundary](first-release-distribution.md) — the
+  artifact-origin trust boundary, exact-digest fail-closed rule, "no renderer
+  rollback artifact," and the "#121 retained, reframed" disposition.
+- [Signing and notarization](signing-notarization.md) — the macOS Developer ID +
+  notarization and Windows Authenticode plans and their secret custody.
+- [Security and threat model](security-threat-model.md) — the trust boundaries
+  this policy extends.
+- [Platform matrix](platform-matrix.md) — the "Decided Dioxus targets" rows this
+  policy annotates.
+- [Known gaps and roadmap](known-gaps-roadmap.md) — the NEXT key-custody
+  commitment this policy makes concrete for updates.
+- [Verification evidence](verification-evidence.md) — the sanitized,
+  revision-bound evidence-ledger contract the update-case rows follow.
+- [Internationalization](i18n.md) — the EN/FR rule the fail-closed messages
+  follow.
+- [Packaging and distribution](../packaging/README.md) — the actual current
+  channels and the checksum-sidecar behavior.

--- a/docs/native-update-policy.md
+++ b/docs/native-update-policy.md
@@ -99,9 +99,12 @@ mechanism. "No in-app updater" is a *decision*, not an omission. The rationale:
 Google Play is the **only** channel where an automatic updater is claimed —
 because it is the platform's updater, not Jeliya's. The sideload APK row carries
 a required warning: Android refuses to upgrade an installed app in place when the
-signing key changes, so any upload-key change forces an uninstall and reinstall,
-which discards app-private state; operators must be told this before they change
-keys.
+signing key changes, so changing the key that signs the sideloaded APK forces an
+uninstall and reinstall, which discards app-private state; operators must be told
+this before they change that key. Under Play App Signing this is distinct from
+the upload key: resetting or rotating the upload key does not change the
+Google-held app-signing key and does not affect installed users (see the
+signing-roots table below).
 
 **Windows is conditional.** [The architecture](dioxus-architecture.md) leaves
 Windows an *undecided* first-release target: #188 must explicitly include or
@@ -135,15 +138,23 @@ artifact can replace the sidecar beside it. Authenticity comes only from:
 - **(c)** Play App Signing.
 
 This record must never imply the same-origin sidecar defends a compromised
-origin. Where a channel has only the sidecar (the Linux `curl | sh` and source
+origin. Where a channel has only the sidecar (the `curl | sh` and source
 tarball paths today), the record states plainly that it provides integrity, not
-publisher authenticity, and that adding a publisher signature is owed by #187.
+publisher authenticity, and that adding a publisher signature is owed by #187 —
+and the piped installer script itself is same-origin, pre-verification
+executable content with the same exposure.
 
 ### Rotation
 
-Signing keys and certificates live in GitHub Actions repository or environment
-secrets (per [signing and notarization](signing-notarization.md)) and are
-**never committed**. The role that rotates each root is the **release
+Signing material is **never committed**, and custody differs per root (per
+[signing and notarization](signing-notarization.md)): locally held material —
+the macOS Developer ID `.p12` and notarization credentials, the Android
+**upload** keystore, and a Windows `.pfx` only in the least-preferred mode —
+lives in GitHub Actions repository or environment secrets; the Play
+**distribution** key is held by Google and never enters Actions; and
+remote/HSM-backed Windows signing keeps the private key in the signing service,
+with only service credentials or a key reference held as secrets. The role that
+rotates each root is the **release
 maintainer**, coordinating with the platform authority (Apple, the Windows CA,
 Google Play). Rotation must not silently invalidate installed builds: when a
 rotation changes what a user's platform will trust, the failure must surface as
@@ -165,16 +176,32 @@ response" for the update dimension.
    known-bad build digests is a documented extension; the recommendation for the
    first release is **floor-only**, with the digest list available if a specific
    bad build must be denied before the floor advances.
+   **Reachability limit.** The floor and digest list ship only inside builds
+   compiled *after* a revocation decision; under this record's no-updater policy
+   nothing delivers an advanced floor to an already-installed binary. An
+   installed revoked build therefore keeps starting normally until the operator
+   installs a newer build, or until it encounters newer on-disk state or a newer
+   counterpart component whose floor rejects it. Post-publication denial of an
+   *installed* build comes only from layer 1 as honored by the OS — and on
+   Linux, which has no publisher signature today, from no layer at all.
 
 ### Channel separation / anti-substitution
 
 One reserved application or bundle identifier and one signing identity **per
 packaged target** (per the `package identity` rule in
-[the architecture](dioxus-architecture.md), Decision 3). This ensures a
-foreign- or legacy-channel install cannot upgrade in place into the new
-generation, and a cross-channel artifact swap fails the platform's own identity
-check. The reserved identifier must be one no retiring client already ships, so a
-legacy install cannot masquerade as the new generation.
+[the architecture](dioxus-architecture.md), Decision 3). On channels whose
+platform enforces package identity — the signed macOS and Windows packages and
+Android signature continuity (see
+[Signing roots](#signing-roots-supplied-by-12-referenced-not-owned)) — this
+ensures a foreign- or legacy-channel install cannot upgrade in place into the
+new generation, and a cross-channel artifact swap fails the platform's own
+identity check. The unsigned Linux archive channels (`curl | sh`, source
+tarball) have no platform identity check today: substitution there is bounded
+only by the integrity-only sidecar (see
+[Metadata trust](#metadata-trust--integrity-is-not-authenticity)) until #187
+supplies a publisher-signature mechanism. The reserved identifier must be one no
+retiring client already ships, so a legacy install cannot masquerade as the new
+generation.
 
 ## Anti-rollback and version monotonicity
 
@@ -212,8 +239,8 @@ unverified directory is deleted on the user's behalf.
 
 | State | Fail-closed behavior | Actionable UX |
 |---|---|---|
-| unsupported generation / old client | reject at handshake, before mutation | "This build is too old for your data. Reset to continue: `<reset path>`." |
-| below minimum-supported floor / revoked build | refuse to start; no network required | "This version is no longer supported. Download the current version from `<channel>`." |
+| unsupported generation / old client | reject at handshake, before mutation | "This app is too old to connect. Download the current version from `<channel>`. Old data is not carried over; the reset path is `<reset path>`." |
+| below minimum-supported floor / revoked build | a newer build, installer, or counterpart refuses the below-floor artifact without a network call; an already-installed revoked build is reached only by platform-level revocation (layer 1) | "This version is no longer supported. Download the current version from `<channel>`." |
 | tampered artifact (bad checksum/signature) | installer refuses **before extraction** | "Download failed verification and was not installed. Retry from `<channel>`." |
 | newer state, older binary (downgrade) | refuse to open state | "This install is older than your data. Update, or reset: `<reset path>`." |
 | offline | the prior verified install keeps running; no partial artifact is executed | "You're offline; the installed version is unchanged." |
@@ -224,15 +251,28 @@ unverified directory is deleted on the user's behalf.
 Recovery must **never execute untrusted bytes.** The prior verified install stays
 runnable until a replacement verifies; **verification precedes extraction**; and
 where an updater exists (Google Play only), the OS owns download atomicity and
-rollback of a failed install.
+rollback of a failed install. One bootstrap limitation is stated plainly: on the
+`curl | sh` and `install.ps1` channels the installer script itself is fetched
+from the download origin and piped into the shell with only TLS-to-origin trust,
+before any verification logic exists — a compromised origin or response
+substitutes the script and bypasses every later checksum check. The
+never-execute-untrusted-bytes guarantee therefore covers artifacts handled by an
+already-obtained installer, not the script bootstrap; an authenticated installer
+bootstrap is owed alongside the publisher signature by #187, and operators who
+need more today can download the script, inspect it, and run it from disk.
 
 - **Offline.** No channel here performs a background self-update, so an offline
   machine simply keeps running its installed, already-verified build. Nothing
   partial is fetched or executed.
 - **Interrupted download.** The installer scripts verify the `.sha256` sidecar
-  before extraction and are idempotent with atomic replace, so a partial or
+  before extraction and are idempotent (safe to re-run), so a partial or
   interrupted download fails the checksum, is discarded, and leaves the current
-  install intact; the operator re-runs the installer. Homebrew and Play recover
+  install intact; the operator re-runs the installer. The final binary
+  replacement itself is not guaranteed atomic — `install.sh` stages in a temp
+  directory that may be on a different filesystem from the install directory,
+  and `install.ps1` copies over the existing binary — so an interruption during
+  that final step can leave the installed binary missing or partial; re-running
+  the installer restores a verified build. Homebrew and Play recover
   through their own resumable, verified delivery.
 
 Because only the Google Play channel has an updater, it is the only channel with
@@ -282,9 +322,15 @@ carrying nothing secret-bearing):
 carried by #186–#190 and #199. In the docs bundle, the
 [platform matrix](platform-matrix.md#decided-dioxus-targets) "Decided Dioxus
 targets" rows cross-reference this policy. These results are **enforced evidence,
-not certification**, and **a missing per-channel update gate blocks only that
-channel's publication row** — there is no all-platform barrier, consistent with
-#199.
+not certification**, and there is no all-platform barrier, consistent with #199.
+Gating is per **published artifact**, not per nominal channel: channels that
+consume the same release asset share one publication boundary — the `install.sh`
+archive is also the direct-download archive (and `install.sh` resolves the
+*latest* release by default), and the cask DMG is also the direct-download DMG —
+so a shared asset may be published only when **every** channel gate that
+consumes it passes. Only a channel with its own separate publication step (the
+reviewed tap commit, Play submission) can be withheld independently after the
+asset is public.
 
 "Tested," for the anti-rollback and fail-closed criteria, means this record
 **defines** the case matrix and the retained-evidence schema. Executing the

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -3,7 +3,7 @@ type: "Status Report"
 title: "Platform matrix"
 description: "Implementation, verification, packaging, and release status for every Jeliya runtime and target platform."
 tags: ["dioxus", "packaging", "platforms", "release", "verification"]
-timestamp: "2026-07-27T22:58:56Z"
+timestamp: "2026-08-10T00:00:00Z"
 status: "canonical"
 implementation_status: "partial"
 verification_status: "partial"
@@ -94,6 +94,15 @@ extending the certified v0.6.0 rows above.
 | Linux | WebKitGTK | minimum glibc and WebKitGTK floors to be enforced, build and runtime dependencies pinned, and the actual linked system libraries recorded in package evidence | planned, unverified, unreleased (#187) |
 | Windows | WebView2 | **not yet a committed target** — #188 must explicitly include *or formally defer* Windows, and the supported Windows versions plus the evergreen or fixed-runtime policy are recorded only there | scope undecided; planned, unverified, unreleased (#188) |
 | Android | system WebView, with `DirectClient` running `jeliya-core` in process — no socket, token, or portfile on that path | **none decided** — the WebView version is captured as device evidence only, and no floor or evergreen policy exists | planned, unverified, unreleased; open gap (#160, #194) |
+
+The published native channel for every target row above — its updater or
+no-updater decision, signing trust, anti-rollback rule, and fail-closed update
+UX — is governed by the
+[native update, signing, and anti-rollback policy](native-update-policy.md). Its
+per-channel update-case evidence (current, older, newer, revoked, tampered,
+offline, interrupted, downgrade) is **enforced evidence, not certification**,
+and a missing per-channel update gate blocks only that channel's publication row
+(#199); it withholds no other row.
 
 Treating Windows as a supported target because a bundle command runs is an
 explicit non-goal, and the desktop qualification matrix is blocked on #188

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -101,8 +101,10 @@ UX — is governed by the
 [native update, signing, and anti-rollback policy](native-update-policy.md). Its
 per-channel update-case evidence (current, older, newer, revoked, tampered,
 offline, interrupted, downgrade) is **enforced evidence, not certification**,
-and a missing per-channel update gate blocks only that channel's publication row
-(#199); it withholds no other row.
+and a missing update gate withholds no other platform's rows (#199); within a
+platform, channels that consume the same release asset share one publication
+gate, so a shared asset is published only when every consuming channel's gate
+passes.
 
 Treating Windows as a supported target because a bundle command runs is an
 explicit non-goal, and the desktop qualification matrix is blocked on #188

--- a/scripts/native-update-policy.test.mjs
+++ b/scripts/native-update-policy.test.mjs
@@ -62,30 +62,63 @@ test('H1 title matches frontmatter title', () => {
 // Channel inventory completeness (AC-1)
 // ---------------------------------------------------------------------------
 
-// The spec §4.1 lists exactly 11 channel rows; every one must appear in the
-// policy body so no channel is silently omitted.
-const EXPECTED_CHANNELS = [
-  // macOS
-  'install.sh',
-  'jeliya.rb',         // Homebrew formula
-  'jeliya-app.rb',     // Homebrew cask
-  // macOS DMG / direct download — described as "macOS DMG" in the policy
-  'macOS DMG',
-  // Windows
-  'install.ps1',
-  // Linux
-  'package-linux.mjs',
-  // Android
-  'Google Play',
-  'sideload APK',
+// The spec §4.1 lists exactly 11 channel rows; assert them against the
+// inventory table itself, not document-wide mentions, so deleting a row cannot
+// pass on the strength of the same term appearing in another section.
+const EXPECTED_ROWS = [
+  ['macOS', 'install.sh'],
+  ['macOS', 'jeliya.rb'],
+  ['macOS', 'jeliya-app.rb'],
+  ['macOS', 'direct browser download'],
+  ['Windows', 'install.ps1'],
+  ['Windows', 'direct browser download'],
+  ['Linux', 'install.sh'],
+  ['Linux', 'Linuxbrew'],
+  ['Linux', 'package-linux.mjs'],
+  ['Android', 'Google Play'],
+  ['Android', 'sideload APK'],
 ];
 
-for (const channel of EXPECTED_CHANNELS) {
-  test(`channel inventory includes "${channel}"`, () => {
-    assert.ok(policy.includes(channel),
-      `docs/native-update-policy.md must mention channel identifier "${channel}"`);
+const inventorySection = policy.split('### Channel inventory')[1].split('\n### ')[0];
+const inventoryRows = inventorySection.split('\n')
+  .filter((l) => l.startsWith('|') && !l.startsWith('|---'))
+  .slice(1); // drop the header row
+
+test('channel inventory table has exactly the 11 expected rows', () => {
+  assert.equal(inventoryRows.length, EXPECTED_ROWS.length,
+    `inventory table must have exactly ${EXPECTED_ROWS.length} channel rows`);
+});
+
+for (const [platform, label] of EXPECTED_ROWS) {
+  test(`channel inventory has a ${platform} row for "${label}"`, () => {
+    assert.ok(inventoryRows.some((r) => {
+      // Cell text may contain escaped pipes (`curl \| sh`); shield them from
+      // the column split, then restore for the label match.
+      const cells = r.replaceAll('\\|', '\u0001').split('|')
+        .map((c) => c.trim().replaceAll('\u0001', '\\|'));
+      return cells[1] === platform && cells[2].includes(label);
+    }), `inventory table must contain a ${platform} row whose Channel cell mentions "${label}"`);
   });
 }
+
+// Honesty qualifiers added in review must stay load-bearing: the revocation
+// floor's reachability limit, the installer-bootstrap trust limitation, and
+// the shared-asset publication boundary may not be silently dropped.
+test('policy states the revocation floor cannot reach already-installed builds', () => {
+  assert.ok(/[Rr]eachability limit/.test(policy) && policy.includes('already-installed'),
+    'policy must state the floor/digest list cannot reach already-installed builds');
+});
+
+test('policy states the piped installer bootstrap runs before any verification', () => {
+  assert.ok(/bootstrap/i.test(policy) && /piped into the shell/.test(policy),
+    'policy must state the installer-script bootstrap limitation');
+});
+
+test('policy gates shared release assets across every consuming channel', () => {
+  assert.ok(policy.includes('share one publication boundary')
+    && /every\*\* channel gate that\s+consumes it/.test(policy),
+    'policy must state the shared-asset publication rule');
+});
 
 // The policy must explicitly enumerate more than one platform.
 test('channel table covers macOS, Linux, Windows, and Android platforms', () => {

--- a/scripts/native-update-policy.test.mjs
+++ b/scripts/native-update-policy.test.mjs
@@ -1,0 +1,416 @@
+// Focused tests for docs/native-update-policy.md (issue #121).
+//
+// These tests verify structural and content-level invariants of the policy
+// document that the generic check-docs gate cannot prove: channel completeness,
+// per-channel updater decisions, the integrity-vs-authenticity distinction,
+// version monotonicity, fail-closed UX states, privacy bounds, and the
+// non-goals that must not re-appear.
+//
+// The tests read the real files from the repository; they do not construct
+// fixtures. Run with: node --test scripts/native-update-policy.test.mjs
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { parseFrontmatter, validateDocumentation } from './check-docs.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const POLICY_PATH = fileURLToPath(new URL('../docs/native-update-policy.md', import.meta.url));
+
+const policy = readFileSync(POLICY_PATH, 'utf8');
+const { data: frontmatter, errors: fmErrors } = parseFrontmatter(policy);
+
+// ---------------------------------------------------------------------------
+// Frontmatter and profile compliance (AC-0: must pass the docs CI gate)
+// ---------------------------------------------------------------------------
+
+test('native-update-policy.md has no frontmatter parse errors', () => {
+  assert.deepEqual(fmErrors, []);
+});
+
+test('native-update-policy.md passes the full docs-CI gate on the real repo', () => {
+  const findings = validateDocumentation({ repoRoot: REPO_ROOT });
+  const policyFindings = findings.filter((f) => f.file === 'docs/native-update-policy.md');
+  assert.deepEqual(policyFindings, [],
+    `docs gate reported issues for native-update-policy.md: ${JSON.stringify(policyFindings, null, 2)}`);
+});
+
+test('frontmatter type is Decision and status is canonical', () => {
+  assert.equal(frontmatter.type, 'Decision');
+  assert.equal(frontmatter.status, 'canonical');
+});
+
+test('frontmatter makes no overclaiming built or verified assertions (AC-0 clean-slate)', () => {
+  // Nothing is built or tested yet; the status axes must reflect that.
+  assert.equal(frontmatter.implementation_status, 'planned',
+    'implementation_status must be "planned" — nothing is built yet');
+  assert.equal(frontmatter.verification_status, 'unverified',
+    'verification_status must be "unverified" — no evidence has been recorded');
+  assert.equal(frontmatter.release_status, 'unreleased',
+    'release_status must be "unreleased" — the policy is not yet in a public release');
+});
+
+test('H1 title matches frontmatter title', () => {
+  const h1 = policy.match(/^# (.+)$/m)?.[1];
+  assert.equal(h1, frontmatter.title,
+    'H1 heading must be byte-identical to the frontmatter title field');
+});
+
+// ---------------------------------------------------------------------------
+// Channel inventory completeness (AC-1)
+// ---------------------------------------------------------------------------
+
+// The spec §4.1 lists exactly 11 channel rows; every one must appear in the
+// policy body so no channel is silently omitted.
+const EXPECTED_CHANNELS = [
+  // macOS
+  'install.sh',
+  'jeliya.rb',         // Homebrew formula
+  'jeliya-app.rb',     // Homebrew cask
+  // macOS DMG / direct download — described as "macOS DMG" in the policy
+  'macOS DMG',
+  // Windows
+  'install.ps1',
+  // Linux
+  'package-linux.mjs',
+  // Android
+  'Google Play',
+  'sideload APK',
+];
+
+for (const channel of EXPECTED_CHANNELS) {
+  test(`channel inventory includes "${channel}"`, () => {
+    assert.ok(policy.includes(channel),
+      `docs/native-update-policy.md must mention channel identifier "${channel}"`);
+  });
+}
+
+// The policy must explicitly enumerate more than one platform.
+test('channel table covers macOS, Linux, Windows, and Android platforms', () => {
+  assert.ok(policy.includes('macOS'), 'macOS must appear in channel table');
+  assert.ok(policy.includes('Linux'), 'Linux must appear in channel table');
+  assert.ok(policy.includes('Windows'), 'Windows must appear in channel table');
+  assert.ok(policy.includes('Android'), 'Android must appear in channel table');
+});
+
+// ---------------------------------------------------------------------------
+// Updater vs. no-updater decisions (AC-1)
+// ---------------------------------------------------------------------------
+
+test('policy states no in-app or bundled auto-updater on any native channel', () => {
+  // The decision phrase the spec requires:
+  assert.ok(policy.includes('no in-app'), 'policy must state "no in-app" updater decision');
+});
+
+test('Google Play is the only channel where an automatic updater is claimed', () => {
+  // The spec is explicit: "the Play row is the only channel where an automatic
+  // updater is claimed — because it is the platform's, not Jeliya's."
+  assert.ok(policy.includes('platform updater') || policy.includes('platform\'s own'),
+    'policy must attribute the Play updater to the platform');
+
+  // The "no in-app updater" text must appear more than once (one per non-Play channel).
+  const noUpdaterCount = (policy.match(/no in-app updater/g) ?? []).length;
+  assert.ok(noUpdaterCount >= 3,
+    `expected at least 3 "no in-app updater" decisions (one per non-Play channel group), got ${noUpdaterCount}`);
+});
+
+test('Windows rows are conditioned on Windows shipping', () => {
+  // Architecture leaves Windows undecided; this doc must reflect that.
+  assert.ok(policy.includes('#188') || policy.match(/[Ww]indows.{0,60}(?:undecided|conditional|if.*ships|scope)/),
+    'policy must mark Windows rows as conditional on #188 deciding whether Windows ships');
+});
+
+test('sideload APK warns about key-change forced uninstall data loss', () => {
+  // The spec requires a warning that an Android signing-key change forces
+  // uninstall/reinstall, which discards app-private state.
+  assert.ok(
+    policy.match(/[Kk]ey.{0,40}(?:uninstall|data loss|reinstall)/) ||
+    policy.match(/(?:uninstall|data loss|reinstall).{0,40}[Kk]ey/),
+    'sideload APK section must warn about key-change forcing uninstall and data loss',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Signing roots, metadata trust, rotation, revocation, channel separation (AC-2)
+// ---------------------------------------------------------------------------
+
+test('policy documents macOS Developer ID and notarization signing root', () => {
+  assert.ok(policy.includes('Developer ID') || policy.includes('notarization'),
+    'policy must document the macOS Developer ID signing root');
+});
+
+test('policy documents Android Play App Signing with local upload key', () => {
+  assert.ok(policy.includes('Play App Signing'),
+    'policy must document the Android Play App Signing root');
+  assert.ok(policy.includes('upload') && policy.includes('key'),
+    'policy must clarify that the local keystore is the upload key, not the distribution key');
+});
+
+test('policy states Linux daemon archives have no publisher signature', () => {
+  // The spec is explicit: Linux has "no publisher signature today" — this must
+  // be stated, not silently omitted.
+  assert.ok(
+    policy.match(/[Ll]inux.{0,200}no publisher signature/s) ||
+    policy.match(/no publisher signature.{0,200}[Ll]inux/s),
+    'policy must state that Linux daemon archives have no publisher signature today',
+  );
+});
+
+test('policy distinguishes integrity from authenticity for the checksum sidecar', () => {
+  // This is the "load-bearing honesty point" of the spec: a same-origin
+  // .sha256 sidecar proves integrity, not authenticity.
+  assert.ok(
+    policy.includes('integrity') && policy.includes('authenticity'),
+    'policy must use both "integrity" and "authenticity" to distinguish the sidecar claim',
+  );
+  assert.ok(
+    policy.match(/sha256.{0,120}integrity/s) || policy.match(/integrity.{0,120}sha256/s) ||
+    policy.match(/sidecar.{0,120}integrity/s) || policy.match(/integrity.{0,120}sidecar/s),
+    'policy must associate the .sha256 sidecar with integrity (not authenticity)',
+  );
+});
+
+test('policy covers two revocation layers: platform-level and application-level', () => {
+  // Platform-level: OS-honored (Apple, Authenticode, Play takedown).
+  // Application-level: compiled minimum-supported build floor (network-independent).
+  assert.ok(
+    policy.match(/[Pp]latform.{0,30}level/) || policy.includes('OS-honored') ||
+    policy.includes('operating system'),
+    'policy must document platform-level revocation honored by the OS',
+  );
+  assert.ok(
+    policy.match(/[Mm]inimum.{0,30}(?:supported|build|floor)/) ||
+    policy.includes('min_reader') || policy.includes('build floor'),
+    'policy must document an application-level minimum-supported build floor',
+  );
+  assert.ok(
+    policy.includes('without a network') || policy.includes('no network'),
+    'application-level revocation must fail closed without a network call',
+  );
+});
+
+test('policy states channel separation via distinct application/bundle identifiers', () => {
+  assert.ok(
+    policy.includes('bundle identifier') || policy.includes('application identifier') ||
+    policy.includes('package identity') || policy.includes('bundle id'),
+    'policy must require distinct application/bundle identifiers per packaged target',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Anti-rollback and version monotonicity (AC-3)
+// ---------------------------------------------------------------------------
+
+test('policy separates cross-generation and same-generation downgrade cases', () => {
+  assert.ok(
+    policy.match(/[Cc]ross.{0,20}generation/) || policy.includes('cross-generation'),
+    'policy must address cross-generation downgrade',
+  );
+  assert.ok(
+    policy.match(/[Ss]ame.{0,20}generation/) || policy.includes('same-generation'),
+    'policy must address same-generation downgrade',
+  );
+});
+
+test('policy states version-monotonicity invariant explicitly', () => {
+  // The spec requires: "version is monotonic per generation; a rollback that
+  // would reinterpret newer state fails closed."
+  assert.ok(
+    policy.includes('monotonic') || policy.includes('monotonicity'),
+    'policy must state version monotonicity',
+  );
+  assert.ok(
+    policy.includes('fails closed') || policy.includes('fail closed') || policy.includes('fail-closed'),
+    'policy must state that a rollback that reinterprets newer state fails closed',
+  );
+});
+
+test('policy references the on-disk monotonic marker concept', () => {
+  // The spec recommends a "written_by build number and a min_reader floor".
+  assert.ok(
+    policy.includes('written_by') || policy.includes('min_reader') ||
+    policy.match(/monotonic.{0,60}(?:marker|floor)/s) ||
+    policy.match(/(?:marker|floor).{0,60}monotonic/s),
+    'policy must reference the on-disk monotonic marker (written_by / min_reader)',
+  );
+});
+
+test('policy defers the concrete marker key name to downstream issues', () => {
+  // The key name is owned by #185/#178/#173; this doc must not invent one.
+  assert.ok(
+    policy.includes('#185') || policy.includes('#178') || policy.includes('#173'),
+    'policy must defer the concrete on-disk key name to the downstream issues (#185, #178, #173)',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed states and actionable UX (AC-4)
+// ---------------------------------------------------------------------------
+
+const FAIL_CLOSED_STATES = [
+  { label: 'unsupported generation / old client', pattern: /unsupported.*generation|old client|too old/i },
+  { label: 'below minimum-supported floor / revoked build', pattern: /minimum.supported|revoked.build|no longer supported/i },
+  { label: 'tampered artifact', pattern: /tampered|bad checksum|failed verification/i },
+  { label: 'newer state / older binary (downgrade)', pattern: /newer state|older than your data|downgrade/i },
+  { label: 'offline', pattern: /offline/i },
+  { label: 'interrupted download', pattern: /interrupted|didn.t complete|update didn/i },
+];
+
+for (const { label, pattern } of FAIL_CLOSED_STATES) {
+  test(`fail-closed UX table covers: ${label}`, () => {
+    assert.ok(pattern.test(policy),
+      `policy must document the fail-closed state and actionable UX for: ${label}`);
+  });
+}
+
+test('fail-closed recovery path is shown, not taken on behalf of the user', () => {
+  // The spec says "the reset path is shown, not taken — no unverified directory
+  // is deleted on the user's behalf."
+  assert.ok(
+    policy.includes('reset path') || policy.includes('shown, not taken') ||
+    policy.match(/shown.{0,40}not taken/s),
+    'policy must state that the reset path is shown, not automatically taken',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Offline and interrupted recovery (AC-5)
+// ---------------------------------------------------------------------------
+
+test('offline recovery keeps the prior verified install running', () => {
+  assert.ok(
+    policy.match(/offline.{0,200}(?:verified install|unchanged|keeps running)/s) ||
+    policy.match(/(?:verified install|unchanged|installed version).{0,200}offline/s),
+    'policy must state that an offline machine keeps running its prior verified build',
+  );
+});
+
+test('recovery must never execute untrusted bytes', () => {
+  assert.ok(
+    policy.includes('untrusted bytes') || policy.includes('without executing'),
+    'policy must state that recovery never executes untrusted bytes',
+  );
+});
+
+test('verification precedes extraction for installer scripts', () => {
+  assert.ok(
+    policy.match(/verif.{0,30}extract|extract.{0,30}verif/i),
+    'policy must state that verification precedes extraction',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Operator commands and privacy-bounded diagnostics
+// ---------------------------------------------------------------------------
+
+test('policy defines required diagnostics fields (digest, channel, signing identity)', () => {
+  assert.ok(
+    policy.includes('digest') && policy.includes('channel') &&
+    (policy.includes('signing identity') || policy.includes('notarization')),
+    'policy must define diagnostics fields: digest, channel, and signing identity',
+  );
+});
+
+test('privacy bound for diagnostics excludes identity keys, daemon tokens, and room data', () => {
+  // The spec requires "no identity keys, daemon tokens, invite tickets, IP
+  // addresses, room or member data, or file contents."
+  assert.ok(
+    policy.includes('Privacy') || policy.includes('privacy') || policy.includes('Privacy bound'),
+    'policy must state a privacy bound for diagnostics output',
+  );
+  const privacySection = policy.slice(policy.toLowerCase().indexOf('privacy'));
+  const privacyCoverage = [
+    'daemon token',
+    'invite',
+    'IP address',
+    'room',
+  ];
+  for (const term of privacyCoverage) {
+    assert.ok(
+      privacySection.toLowerCase().includes(term.toLowerCase()),
+      `privacy-bound section must exclude: ${term}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Evidence contract and downstream integration (AC-6)
+// ---------------------------------------------------------------------------
+
+test('evidence case matrix covers current, older, newer, revoked, tampered, offline, interrupted, downgrade', () => {
+  const requiredCases = ['current', 'older', 'newer', 'revoked', 'tampered', 'offline', 'interrupted', 'downgrade'];
+  for (const c of requiredCases) {
+    assert.ok(policy.includes(c),
+      `evidence case matrix must include case: "${c}"`);
+  }
+});
+
+test('evidence schema retains digest, signing identity, metadata/version, command, and result', () => {
+  const evidenceFields = ['digest', 'signing identity', 'command', 'result'];
+  for (const field of evidenceFields) {
+    assert.ok(policy.includes(field),
+      `evidence schema must retain field: "${field}"`);
+  }
+});
+
+test('policy references downstream evidence owners #186–#190 and #199', () => {
+  for (const issue of ['#186', '#187', '#188', '#190', '#199']) {
+    assert.ok(policy.includes(issue),
+      `policy must reference downstream evidence owner ${issue}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Non-goals — must not be re-introduced (AC-7)
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_NON_GOALS = [
+  { label: 'N/N-1 compatibility window', pattern: /N\/N-1|N.N-1 compat|compatibility window/i },
+  { label: 'migration', pattern: /migrations?|migration plan|migration path|migrate.{0,40}(state|data)/i },
+  { label: 'legacy rollback artifact', pattern: /legacy rollback|rollback artifact/i },
+  { label: 'dual protocol support', pattern: /dual protocol/i },
+  { label: 'hosted-web companion skew', pattern: /companion.{0,30}skew|skew.{0,30}companion/i },
+];
+
+// Verify non-goals are stated explicitly (they must appear in the Non-goals section).
+test('non-goals section exists and lists prohibited patterns', () => {
+  assert.ok(policy.includes('## Non-goals') || policy.includes('Non-goals'),
+    'policy must include a Non-goals section');
+});
+
+for (const { label, pattern } of FORBIDDEN_NON_GOALS) {
+  test(`non-goal is documented (not silently omitted): "${label}"`, () => {
+    // The pattern should appear in the document — but only in the non-goals
+    // section that explicitly names and rejects it.
+    assert.ok(pattern.test(policy),
+      `policy must name and reject the non-goal: "${label}"`);
+  });
+}
+
+test('policy states no compatibility window, migration, or legacy rollback requirement remains', () => {
+  // This is the AC-7 required phrase (from the spec and issue).
+  assert.ok(
+    policy.match(/no compatibility window/i) ||
+    policy.match(/no.{0,30}migration.{0,30}requirement/i) ||
+    policy.match(/No compatibility window.*migration.*legacy rollback/s),
+    'policy must state that no compatibility window, migration, or legacy rollback requirement remains',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Cross-reference integrity
+// ---------------------------------------------------------------------------
+
+test('policy cites dioxus-architecture.md, first-release-distribution.md, and signing-notarization.md', () => {
+  for (const doc of ['dioxus-architecture.md', 'first-release-distribution.md', 'signing-notarization.md']) {
+    assert.ok(policy.includes(doc),
+      `policy must cite: ${doc}`);
+  }
+});
+
+test('policy cites verification-evidence.md for the evidence schema contract', () => {
+  assert.ok(policy.includes('verification-evidence.md'),
+    'policy must cite verification-evidence.md for the evidence ledger contract');
+});

--- a/specs/native-update-channels-signing-anti-rollback.md
+++ b/specs/native-update-channels-signing-anti-rollback.md
@@ -1,0 +1,424 @@
+# Spec: Native update channels, signing trust, and anti-rollback policy (#121)
+
+> **This is an implementation plan, not the deliverable.** The deliverable of
+> issue #121 is a single canonical **Decision** document in `docs/`. This spec
+> tells another engineer/agent exactly what that document must decide, how to
+> author it against the repository's documentation contract, how it links to the
+> existing records, and how it is verified. It changes no production code.
+
+## 1. Summary
+
+Issue #121 (reframed by [`docs/first-release-distribution.md`](../docs/first-release-distribution.md)
+§"Amendment disposition") asks Jeliya to **define**, for every published native
+package, four things:
+
+1. whether the channel has an updater or an explicit **no-updater** decision;
+2. how update metadata and artifacts are authenticated (signing roots, trusted
+   metadata, rotation, revocation, channel separation);
+3. the **downgrade / anti-rollback** policy and version monotonicity;
+4. **actionable failure UX** for unsupported / revoked / too-old / can't-update
+   states, plus offline/interrupted recovery, operator/support commands, and
+   privacy-bounded version diagnostics.
+
+The original issue assumed web-origin ↔ companion version skew. #113 removed that
+architecture. Exact protocol/storage-generation mismatch rejection is already
+owned elsewhere (#157/#161/#164/#170/#172/#199) and is **referenced, not
+re-decided** here. The enduring, still-unowned question is the *native package*
+update/trust/rollback model. This is a **policy definition**; the downstream
+per-platform packaging (#186–#190) and qualification (#199) consume it but do
+**not** block it.
+
+**Recommended deliverable:** `docs/native-update-policy.md`, `type: "Decision"`,
+`status: "canonical"`, `implementation_status: "planned"`,
+`verification_status: "unverified"`, `release_status: "unreleased"`. It is a
+canonical decision about **unwritten code**, exactly like
+[`docs/dioxus-architecture.md`](../docs/dioxus-architecture.md) and
+[`docs/first-release-distribution.md`](../docs/first-release-distribution.md).
+
+## 2. Owning surface and where this fits
+
+- **Primary artifact:** a new page in the `docs/` OKF wiki. `docs/` is
+  CI-validated by `scripts/check-docs.mjs` (the
+  [documentation profile](../docs/PROFILE.md) is the contract).
+- **Inputs it must cite, not restate:**
+  - [`dioxus-architecture.md`](../docs/dioxus-architecture.md) — the
+    single-generation clean-slate policy (Decision 2), per-platform system
+    WebView floors (Decision 6), `package identity` / bundle-identifier rule
+    (Decision 3), and the `#121` pointer in "What this record does not decide"
+    (this new doc *satisfies* that pointer). Architecture/version inputs
+    #157/#161.
+  - [`first-release-distribution.md`](../docs/first-release-distribution.md) —
+    the artifact-origin trust boundary, exact-digest fail-closed, "no renderer
+    rollback artifact," and the "#121 retained, reframed" disposition.
+  - [`signing-notarization.md`](../docs/signing-notarization.md) — macOS
+    Developer ID + notarization and Windows Authenticode plans; signing roots
+    are supplied by #1/#2.
+  - [`security-threat-model.md`](../docs/security-threat-model.md) — the trust
+    boundaries this policy extends (artifact origin, storage generation, daemon
+    token custody, release/CI supply chain), and the release boundary.
+  - [`platform-matrix.md`](../docs/platform-matrix.md) — the "Decided Dioxus
+    targets" rows for macOS(#186)/Linux(#187)/Windows(#188)/Android(#160,#194),
+    which this policy annotates.
+  - [`known-gaps-roadmap.md`](../docs/known-gaps-roadmap.md) — the NEXT bullet
+    "operate signing, notarization, and evidence keys with documented custody,
+    rotation, and incident response," which this policy makes concrete for the
+    update dimension.
+  - [`verification-evidence.md`](../docs/verification-evidence.md) — the
+    sanitized, revision-bound evidence-ledger contract the update-case evidence
+    rows must follow.
+  - [`../packaging/README.md`](../packaging/README.md) — the *actual* current
+    channels (`install.sh`, `install.ps1`, `jeliya.rb`, `jeliya-app.rb`,
+    `package-linux.mjs`, Android AAB/APK) and the checksum-sidecar behavior.
+- **Downstream consumers (do not block this policy):** #186–#190 packaging and
+  #199 per-platform qualification carry the applicable evidence rows.
+
+## 3. Non-goals (carry verbatim into the doc)
+
+Reproduce these so no reviewer re-adds them:
+
+- No N/N-1 compatibility windows, grace periods, migrations, dual protocol
+  support, mixed-version windows, canaries, or legacy rollback artifacts (the
+  single-generation clean slate has none — see `dioxus-architecture.md`
+  Decision 2 and "Rejected and deferred alternatives").
+- No hosted-web/companion skew flow.
+- Do **not** claim automatic updates where the channel provides none.
+- Do **not** let any updater bypass platform signing authority.
+- Do not re-decide exact protocol/storage-generation mismatch rejection
+  (#157/#161/#164/#170/#172/#199) — reference it.
+- This doc does not decide legal/compliance publication gating (#118) or the
+  build/provenance format of the embedded artifact (#183).
+
+## 4. Decisions the document must record
+
+The doc must be **decisive**. Where the repository has not yet chosen a value
+(e.g. macOS/Android WebView floors, Windows scope), record the *policy* and mark
+the value **open with an owner**, never waive it. The following are the
+recommended positions; the author confirms them with maintainers and records the
+rationale.
+
+### 4.1 Channel inventory (authoritative list)
+
+The doc must enumerate **every published native channel** and give each an
+explicit decision. Recommended inventory, derived from `packaging/README.md`,
+`platform-matrix.md`, and the Dioxus targets:
+
+| Platform | Channel | Artifact today | Clean-slate successor / owner |
+|---|---|---|---|
+| macOS | `curl \| sh` (`install.sh`) | `jeliyad` `.tar.gz` + `.sha256` | #186 |
+| macOS | Homebrew formula (`jeliya.rb`, tap) | `jeliyad` | #186 |
+| macOS | Homebrew cask (`jeliya-app.rb`) | unpublished future DMG app | #186 |
+| macOS | direct browser download (DMG/archive) | future signed/notarized DMG | #186 / #1 |
+| Windows | `install.ps1` (PowerShell) | `jeliyad` `.zip` + `.sha256` | #188 (scope undecided) |
+| Windows | direct browser download | future signed installer/zip | #188 / #2 |
+| Linux | `curl \| sh` (`install.sh`) | `jeliyad` `.tar.gz` + `.sha256` | #187 |
+| Linux | Homebrew (Linuxbrew) | `jeliyad` | #187 |
+| Linux | source tarball (`package-linux.mjs`) | unsigned dev package | #187 |
+| Android | Google Play (AAB) | none published | #190 / #194 / #160 |
+| Android | sideload APK (per-ABI) | dev build only | #190 / #194 / #160 |
+
+The doc must state that channels not on this list (distro repos, Flatpak,
+AppImage, WinGet, Microsoft Store, App Store, Sparkle appcast, iOS) are **not
+published channels** in the first release and therefore carry no update claim; a
+new channel requires an added row and its own evidence before it may ship.
+
+### 4.2 Updater vs. no-updater, per channel (AC-1)
+
+Recommended baseline — **no in-app / bundled auto-updater on any native channel
+for the first release**; updates delegate to the channel's own authenticated
+mechanism. Rationale to record:
+
+- it honors the non-goals ("no claimed automatic update where the channel gives
+  none"; "no updater bypasses platform signing authority");
+- the single-generation clean slate removes the compatibility machinery a
+  self-updater usually justifies;
+- a bundled updater is a new privileged network-plus-write surface that the
+  WebView boundary review (#196) and the threat model have not covered, so it is
+  out of scope until separately reviewed.
+
+Per-channel decision the doc must state explicitly:
+
+| Channel | Decision | Update mechanism that IS authoritative |
+|---|---|---|
+| Homebrew formula/cask | **no in-app updater** | `brew upgrade`; digest pinned in the reviewed tap commit is the authenticity root |
+| `install.sh` / `install.ps1` | **no in-app updater** | operator re-runs the installer; `.sha256` sidecar verified **before extraction**, fail-closed |
+| macOS DMG / browser download | **no in-app updater** (no Sparkle) | Gatekeeper + stapled notarization ticket; operator re-downloads |
+| Windows installer / browser download | **no in-app updater** (no Squirrel) | Authenticode + SmartScreen reputation; operator re-downloads |
+| Google Play (AAB) | **platform updater** — Play's own auto-update *is* the updater | Play App Signing + Play delivery |
+| Sideload APK | **no updater**, and re-sign **breaks signature continuity** | operator manually installs a same-key APK; a key change forces uninstall/reinstall (data loss), which the doc must warn about |
+
+The doc must be explicit that "no in-app updater" is a *decision*, not an
+omission, and that the Play row is the **only** channel where an automatic
+updater is claimed — because it is the platform's, not Jeliya's.
+
+### 4.3 Signing roots, trusted metadata, rotation, revocation, channel
+separation (AC-2)
+
+The doc must document, per platform:
+
+- **Signing roots (supplied by #1/#2, referenced not owned):** macOS Developer
+  ID Application certificate + notarization (`notarytool`), Windows Authenticode
+  (EV preferred), Android Play App Signing (Google-held) with the local keystore
+  as *upload* key. Linux daemon archives have **no publisher signature today** —
+  the doc must say so and name the checksum sidecar as integrity-only.
+- **Metadata trust — and the integrity-vs-authenticity distinction (critical
+  honesty point):** a `.sha256` sidecar fetched from the same origin as the
+  artifact proves **integrity, not authenticity** — it does not defend against a
+  compromised origin. Authenticity comes from (a) platform code signatures
+  (#1/#2), (b) the Homebrew formula/cask digest committed in a reviewed tap
+  change, or (c) Play App Signing. The doc must not overclaim the sidecar.
+- **Rotation:** where keys/certs live (GitHub Actions secrets per
+  `signing-notarization.md`; never committed), who rotates them, and that
+  rotation must not silently invalidate installed builds without an actionable
+  message.
+- **Revocation — two layers:**
+  1. *Platform-level:* Apple certificate/notarization revocation, Authenticode
+     CRL/OCSP, Play takedown/key rotation — honored by the OS.
+  2. *Application-level, network-independent:* a compiled **minimum-supported
+     build floor** in `jeliyad`/the app, plus an optional build-time-embedded
+     revocation list of known-bad build digests. A build below the floor or on
+     the list **fails closed** with actionable UX **without a network call and
+     without executing untrusted bytes**.
+- **Channel separation / anti-substitution:** one reserved application/bundle
+  identifier and one signing identity **per packaged target** (per
+  `dioxus-architecture.md` Decision 3 `package identity` row), so a foreign- or
+  legacy-channel install cannot upgrade in place into the new generation and a
+  cross-channel artifact swap fails the platform's own identity check.
+
+### 4.4 Downgrade / anti-rollback and version monotonicity (AC-3)
+
+Two distinct cases; keep them separate in the doc:
+
+- **Cross-generation downgrade** (a build of a *different* protocol/storage
+  generation): already fails closed **before mutation** at the v2 handshake and
+  the namespaced-storage gate (#161/#164/#170/#173/#178/#185). Reference it;
+  do not re-specify. There is no data-preserving rollback (`dioxus-architecture.md`
+  Decision 2).
+- **Same-generation downgrade** (an *older build* of the *same* generation) —
+  this doc's own decision. Recommended: the new namespaced storage generation
+  records a **monotonic on-disk marker** (a `written_by` build number and a
+  `min_reader` floor). A build refuses to open state written by a strictly newer
+  build, **failing closed with the actionable reset path shown, never migrating
+  or silently downgrading**. This is anti-rollback that fits the clean slate: it
+  prevents a downgraded binary from operating on newer state, it is local, and
+  it retains no legacy compatibility. The concrete key/name is owned by #185
+  (desktop), #178 (browser), #173 (Android); the doc references those and must
+  not invent a key name any retiring client wrote.
+
+The doc must state the invariant plainly: **version is monotonic per generation;
+a rollback that would reinterpret newer state fails closed.**
+
+### 4.5 Actionable failure UX (AC-4) and offline/interrupted recovery (AC-5)
+
+For each fail-closed state, the doc must specify a user-facing message shape and
+the recovery action (short, EN/FR-ready per [`i18n.md`](../docs/i18n.md)):
+
+| State | Fail-closed behavior | Actionable UX |
+|---|---|---|
+| unsupported generation / old client | reject at handshake, before mutation | "This build is too old for your data. Reset to continue: `<reset path>`." (path shown, not taken — per clean-slate) |
+| below minimum-supported floor / revoked build | refuse to start; no network required | "This version is no longer supported. Download the current version from `<channel>`." |
+| tampered artifact (bad checksum/signature) | installer refuses **before extraction** | "Download failed verification and was not installed. Retry from `<channel>`." |
+| newer state, older binary (downgrade) | refuse to open state | "This install is older than your data. Update, or reset: `<reset path>`." |
+| offline | prior verified install keeps running; no partial artifact executed | "You're offline; the installed version is unchanged." |
+| interrupted download | checksum mismatch → fail closed → safe retry (installers are idempotent, atomic replace) | "Update didn't complete. Your current version is intact; retry." |
+
+**Recovery must never execute untrusted bytes.** The prior verified install
+stays runnable until the replacement verifies; verification precedes extraction;
+where an updater exists (Play), the OS owns atomicity. This is the
+"recovery path that does not require executing untrusted bytes" requirement.
+
+### 4.6 Operator/support commands and privacy-bounded diagnostics (AC scope)
+
+The doc must define a diagnostics surface (recommend extending `jeliyad
+--version` / a `jeliya version` output) reporting, per platform:
+
+- package/app version, artifact **digest**, channel, signing identity /
+  notarization state, storage **generation**, and (device evidence only) the
+  system WebView version.
+- a verify/support command that re-checks the installed artifact digest against
+  the published sidecar and reports signature validity.
+
+**Privacy bound:** diagnostics must contain **no** identity keys, daemon tokens,
+invite tickets, IP addresses, room/member data, or file contents — consistent
+with the evidence-sanitization rule in `verification-evidence.md` and the
+secrets rule in `PROFILE.md` §"Markdown and citations." State this bound
+explicitly.
+
+### 4.7 Evidence contract and downstream integration (AC-6)
+
+The doc must define the **update-case evidence schema** and where rows land:
+
+- **Case matrix per claimed channel:** current, older, newer, revoked, tampered,
+  offline, interrupted, downgrade.
+- **Retained per case (sanitized, revision-bound per `verification-evidence.md`):**
+  package **digest**, **signing identity**, **metadata/version**, **command
+  run**, and **result** — and nothing secret-bearing.
+- **Where rows live:** the doc is the *authority*; the applicable evidence rows
+  are carried by the per-platform packaging issues #186–#190 and per-platform
+  qualification #199. In the docs bundle, the author must (a) add a
+  cross-reference from each `platform-matrix.md` "Decided Dioxus targets" row to
+  this policy, and (b) note that these results are **enforced evidence, not
+  certification**, and that **a missing per-channel update gate blocks only that
+  channel's publication row** (no all-platform barrier) — consistent with #199.
+
+> **Phase boundary note:** editing the GitHub issue bodies of #186–#190/#199 is
+> the orchestrator's/maintainer's job, not this doc's. The doc satisfies AC-6 on
+> the documentation side by defining the schema and adding the cross-references
+> in-repo; see Open Questions for the issue-body follow-up.
+
+## 5. Authoring constraints (the docs CI contract)
+
+The new page must pass `node scripts/check-docs.mjs`. Enforced constraints:
+
+1. **Exactly the 10 required frontmatter fields**, in the restricted YAML subset
+   (double-quoted JSON-compatible strings; `tags`/`audience` non-empty flow
+   arrays of unique lowercase-hyphenated tokens; no nesting/anchors/implicit
+   scalars; no unknown fields). Recommended block:
+
+   ```yaml
+   ---
+   type: "Decision"
+   title: "Native update, signing, and anti-rollback policy"
+   description: "Decision record for whether each published native Jeliya channel has an updater, how update artifacts and metadata are authenticated, the single-generation anti-rollback and version-monotonicity rule, and the fail-closed UX, recovery, diagnostics, and evidence contract for unsupported, revoked, tampered, offline, and downgrade states."
+   tags: ["release", "security", "signing", "update", "clean-slate", "dioxus"]
+   timestamp: "2026-08-10T00:00:00Z"
+   status: "canonical"
+   implementation_status: "planned"
+   verification_status: "unverified"
+   release_status: "unreleased"
+   audience: ["contributors", "maintainers", "release-engineers", "security-reviewers"]
+   ---
+   ```
+
+   (Use a real UTC instant for `timestamp`. `description` must be one sentence.
+   `type` = `"Decision"`; do not invent a new type — the two-document rule
+   forbids it. Keep `implementation_status: "planned"` and
+   `verification_status: "unverified"` because nothing is built or tested.)
+
+2. **Exactly one `#` H1, immediately after the frontmatter, byte-identical to
+   `title`.** Start internal structure at `##`.
+3. **File-relative links only** (`dioxus-architecture.md`,
+   `signing-notarization.md#...`, `../packaging/README.md`); never a leading
+   slash. Local paths and heading fragments must resolve. External links, if
+   any, must be credential-free `https://` URLs in a final `## Citations`
+   section.
+4. **Reachability:** add one descriptive link from `docs/index.md` (recommended
+   under "Operations and release evidence," adjacent to
+   `signing-notarization.md`), or CI fails on an orphan.
+5. No raw HTML (comments allowed). GitHub-style tables/task lists are fine.
+6. Keep secrets/tokens/tickets/keys out of every example.
+
+## 6. Step-by-step implementation
+
+1. **Create `specs/`** (this file) — done by this plan.
+2. **Confirm channel inventory and the updater decisions** in §4.1–4.2 with the
+   release maintainer; record any deviation and its rationale in the doc.
+3. **Write `docs/native-update-policy.md`** with sections mapping 1:1 to §4:
+   - `## Channels and the update decision` (AC-1, table from §4.1–4.2)
+   - `## Signing roots, metadata trust, rotation, revocation, channel
+     separation` (AC-2, §4.3)
+   - `## Anti-rollback and version monotonicity` (AC-3, §4.4)
+   - `## Fail-closed states and actionable UX` (AC-4, §4.5)
+   - `## Offline and interrupted recovery` (AC-5, §4.5)
+   - `## Operator commands and privacy-bounded diagnostics` (§4.6)
+   - `## Evidence contract and downstream integration` (AC-6, §4.7)
+   - `## Non-goals` (§3; AC-7 lives here — "no compatibility window, migration,
+     or legacy rollback requirement remains")
+   - `## What this record does not decide` (defer to #1/#2/#118/#183/#161 etc.)
+   - `## Citations` (repo docs inline; external platform docs here if cited)
+4. **Add the index link** in `docs/index.md` (§5.4).
+5. **Cross-reference the policy** from:
+   - `dioxus-architecture.md` "What this record does not decide" — change the
+     `#121` line to link the new doc (it now *is* decided). **Bump that file's
+     `timestamp`** because its meaning changes.
+   - each `platform-matrix.md` "Decided Dioxus targets" row (add a policy link).
+     Bump its `timestamp`.
+   - optionally `signing-notarization.md` and `known-gaps-roadmap.md` NEXT.
+     Bump `timestamp` on any file whose meaning changes.
+6. **Run the gate:** `node scripts/check-docs.mjs` (from repo root); fix any
+   frontmatter/link/reachability failures.
+7. **Self-review round** (see memory: review rounds are load-bearing). Re-read
+   against each AC in §7; verify every internal link and heading fragment
+   resolves; verify no non-goal was silently re-added; verify the doc claims
+   nothing built or verified.
+
+## 7. Acceptance criteria → where satisfied
+
+| # | AC | Satisfied by |
+|---|---|---|
+| 1 | Every published native channel has an explicit updater / no-updater decision | §4.1–4.2 tables (all channels enumerated; each decided) |
+| 2 | Signing roots, trusted metadata, rotation, revocation, channel boundaries documented | §4.3 |
+| 3 | Downgrade/rollback policy explicit and tested | §4.4 policy + §4.7 case matrix (`downgrade`, `older`, `newer`) |
+| 4 | Unsupported/tampered/revoked fail closed with actionable UX | §4.5 table |
+| 5 | Offline/interrupted recovery defined where an updater exists | §4.5 (offline/interrupted rows) + §4.2 (only Play has an updater) |
+| 6 | #186–#190 and #199 contain the applicable evidence rows | §4.7 schema + platform-matrix cross-references; issue-body edits flagged as orchestrator follow-up |
+| 7 | No compatibility window, migration, or legacy rollback requirement remains | §3 non-goals reproduced in the doc's `## Non-goals` |
+
+"Tested" for AC-3/AC-4/AC-5 means the doc **defines** the case matrix and the
+retained-evidence schema; executing the matrix on real packages is downstream
+qualification work (#186–#190/#199), not part of authoring the policy.
+
+## 8. Test / verification strategy
+
+- **Machine gate:** `node scripts/check-docs.mjs` must pass (frontmatter, four
+  status axes, single-H1, link/fragment resolution, index reachability,
+  UTF-8/symlink boundaries).
+- **Review obligations the gate does not cover** (per `PROFILE.md` §"CI
+  contract"): one-sentence `description`, meaningful `timestamp`, citation
+  completeness, and — specific to this doc — that every channel row has a
+  decision, that non-goals are intact, and that no built/verified claim is made.
+- **No production code, tests, or CI workflows change.** If any cross-referenced
+  file's meaning changes, bump only its `timestamp` and re-run the gate.
+
+## 9. Risks
+
+- **Overclaiming authenticity.** Treating a same-origin `.sha256` sidecar as
+  authenticity is the most likely error; §4.3 forces the integrity-vs-authenticity
+  distinction. A reviewer must confirm the doc never implies the sidecar defends
+  a compromised origin.
+- **Accidentally re-introducing a non-goal.** N/N-1 windows, migrations, or a
+  rollback artifact can slip in via the "recovery" or "downgrade" sections.
+  §3/§4.4/§4.5 are written to fail closed instead; AC-7 review guards it.
+- **Scope creep into #1/#2/#183/#161.** The doc must reference, not re-own,
+  signing roots, artifact build/provenance, and protocol-generation rejection.
+- **Stale cross-references.** Editing `dioxus-architecture.md` /
+  `platform-matrix.md` without bumping `timestamp` or fixing links breaks the
+  gate; step 5/6 covers it. (Memory: never trust a stated count in this repo —
+  recompute the channel list from `packaging/README.md` at author time.)
+- **AC-6 boundary.** The documentation side is in-repo; the GitHub issue-body
+  evidence rows are an orchestrator/maintainer follow-up (Open Questions).
+
+## 10. Assumptions
+
+- The `docs/` OKF wiki is the correct home; #121 is a `documentation`-labeled
+  policy, and `dioxus-architecture.md` already routes the `#121` decision to a
+  doc record. (This spec lives in `specs/` only because the ADW workflow asks
+  for a plan artifact; it is not part of the docs bundle and must not be linked
+  from `docs/index.md`.)
+- The recommended "no in-app updater" baseline is subject to release-maintainer
+  confirmation; the spec records it as the recommended position with rationale.
+- `#186–#190`, `#199`, `#1`, `#2`, `#113`, `#157`, `#161` retain the meanings
+  recorded in the cited docs as of 2026-08-10.
+
+## 11. Open questions
+
+1. **Windows scope.** `dioxus-architecture.md` Decision 6 leaves Windows as an
+   *undecided* first-release target (#188 must include or formally defer it).
+   The policy should give Windows a **conditional** decision ("if Windows ships,
+   then …") rather than assert a committed channel. Confirm with #188's owner.
+2. **Application-level revocation list.** Is a build-time-embedded bad-digest
+   list in scope for the first release, or is the minimum-supported-build floor
+   sufficient? (§4.3 offers both; recommend floor-only for the first release,
+   list as a documented option.)
+3. **AC-6 issue bodies.** Adding the evidence rows to the GitHub issues
+   #186–#190/#199 is outside this phase's git/gh boundary. Confirm the
+   orchestrator/maintainer will mirror the §4.7 schema into those issues, or
+   whether a `platform-matrix.md` table is the accepted in-repo substitute.
+4. **Diagnostics surface owner.** Does the `jeliyad --version` / `jeliya
+   version` diagnostics extension belong to this policy as a requirement, or is
+   it a separate small implementation issue the policy merely *specifies*?
+   (Recommend: policy specifies the required fields and privacy bound; a
+   follow-up issue implements it.)
+5. **French UX strings.** The §4.5 messages need EN/FR per `i18n.md`; confirm
+   whether the policy fixes canonical wording or defers exact strings to the UI
+   localization work.
+```

--- a/specs/native-update-channels-signing-anti-rollback.md
+++ b/specs/native-update-channels-signing-anti-rollback.md
@@ -177,12 +177,18 @@ The doc must document, per platform:
      build floor** in `jeliyad`/the app, plus an optional build-time-embedded
      revocation list of known-bad build digests. A build below the floor or on
      the list **fails closed** with actionable UX **without a network call and
-     without executing untrusted bytes**.
+     without executing untrusted bytes**. Reachability limit (added in review):
+     the floor/list ships only in builds compiled after the revocation
+     decision, and the no-updater policy delivers nothing to an
+     already-installed binary — post-publication denial of an installed build
+     comes only from layer 1.
 - **Channel separation / anti-substitution:** one reserved application/bundle
   identifier and one signing identity **per packaged target** (per
   `dioxus-architecture.md` Decision 3 `package identity` row), so a foreign- or
   legacy-channel install cannot upgrade in place into the new generation and a
-  cross-channel artifact swap fails the platform's own identity check.
+  cross-channel artifact swap fails the platform's own identity check on
+  channels whose platform enforces package identity; the unsigned Linux archive
+  channels have no such check until #187 supplies a publisher signature.
 
 ### 4.4 Downgrade / anti-rollback and version monotonicity (AC-3)
 


### PR DESCRIPTION
# Define native update channels, signing trust, and anti-rollback policy (#121)

## What this is

A **documentation-only** deliverable for #121: a single canonical Decision
record, [`docs/native-update-policy.md`](docs/native-update-policy.md), plus the
cross-references, index link, and a focused test that gate it. It changes no
production code.

The original issue assumed web-origin ↔ companion version skew; #113 removed that
architecture. This policy answers the enduring, still-unowned question: for every
**published native package**, does the channel have an updater, how are update
metadata/artifacts authenticated, and how are unsafe downgrade and unsupported
states handled? Exact protocol/storage-generation mismatch rejection is owned
elsewhere (#157/#161/#164/#170/#172/#199) and is **referenced, not re-decided**.

## Decisions recorded

- **Updater vs. no-updater (AC-1):** every native channel enumerated and decided.
  **No in-app/bundled auto-updater** on any channel for the first release;
  **Google Play is the only channel with an automatic updater** (it is the
  platform's, not Jeliya's). Windows rows are **conditional on #188** deciding
  whether Windows ships. The sideload-APK row warns that an Android signing-key
  change forces uninstall/reinstall and discards app-private state.
- **Signing, trust, revocation, separation (AC-2):** signing roots referenced
  from #1/#2; the **integrity-vs-authenticity** honesty point (a same-origin
  `.sha256` sidecar proves integrity, not authenticity); Linux archives have no
  publisher signature today; two revocation layers (OS-honored platform
  revocation and a **network-independent, fail-closed minimum-supported build
  floor**); channel separation via one bundle identity per packaged target.
- **Anti-rollback and monotonicity (AC-3):** same-generation downgrade fails
  closed via a **monotonic on-disk marker** that never migrates and never
  silently downgrades (concrete key name deferred to #185/#178/#173);
  cross-generation downgrade is referenced, not re-specified.
- **Fail-closed UX + recovery (AC-4/AC-5):** actionable UX for
  unsupported/revoked/tampered/downgrade/offline/interrupted states (reset path
  **shown, not taken**); recovery **never executes untrusted bytes**;
  verification precedes extraction.
- **Diagnostics + evidence (AC-6):** privacy-bounded version diagnostics (no
  keys/tokens/tickets/IPs/room data); an update-case evidence schema whose rows
  land in #186-#190/#199, cross-referenced from the platform matrix.
- **Non-goals (AC-7):** reproduced verbatim so no compatibility window,
  migration, or legacy rollback requirement can creep back in.

## Files changed

| File | Change |
|---|---|
| `docs/native-update-policy.md` | New — the canonical Decision record |
| `scripts/native-update-policy.test.mjs` | New — 52 content-invariant assertions |
| `docs/index.md` | Added reachability entry under Operations and release evidence |
| `docs/dioxus-architecture.md` | "What this record does not decide" now links the new doc as satisfying #121 |
| `docs/platform-matrix.md` | "Decided Dioxus targets" section includes a cross-reference paragraph to the update policy |
| `docs/first-release-distribution.md` | #121 amendment-disposition row updated to link the new policy that satisfies it |
| `specs/native-update-channels-signing-anti-rollback.md` | The authoring plan (intermediate spec, not a wiki page) |
| `.github/workflows/ci.yml` | New test file wired into the docs verification step |

## CI wiring

The new test passed locally but would not have run in CI: `ci.yml` invokes an
explicit list of `*.test.mjs` files (no glob), and the new file was in none of
them, so its unique content-level coverage was inert. Added it to the existing
"Verify documentation profile and navigation" step. The doc's structural validity
was already gated by `node scripts/check-docs.mjs`; this closes the
content-regression gap the test was written to protect.

## Verification

```
node scripts/check-docs.mjs                                      # OK
node --test scripts/check-docs.test.mjs \
  scripts/native-update-policy.test.mjs                          # 74 pass / 0 fail
```

Factual spot-checks against `packaging/install.sh` and `install.ps1` confirm the
"verify `.sha256` before extraction, fail-closed" claim.

## Scope boundary

AC-6 is satisfied on the documentation side (schema + platform-matrix
cross-references). Mirroring the evidence rows into the GitHub issue bodies of
#186-#190 and #199 is an orchestrator/maintainer follow-up. Downstream
packaging/qualification implementations consume this policy but do not block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)