### PR TITLE
feat(jeliya-ui): resolve copy helpers across modules in the literal-copy gate

### DIFF
--- a/scripts/check-jeliya-ui-i18n.test.mjs
+++ b/scripts/check-jeliya-ui-i18n.test.mjs
@@ -11,12 +11,16 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildCopyModuleIndex,
   checkCatalogs,
   checkJeliyaUiI18n,
   componentFiles,
   DEFAULT_REPO_ROOT,
   identityExemption,
+  moduleForFile,
   parseCatalog,
+  resolveCall,
+  resolveCopyReachableFns,
   scanComponentLiterals,
   slotsEqual,
 } from './lib/jeliya-ui-catalog.mjs';
@@ -2180,6 +2184,171 @@ test('literal scan: a structural attr computed as if/else is NOT flagged; a copy
   assert.ok(
     scanComponentLiterals('x.rs', copy).some((f) => f.code === 'copy-attribute'),
     'a copy-bearing attr (label) computed as if/else still carries copy that must be flagged',
+  );
+});
+
+// ── #275 cross-module copy-helper resolution ─────────────────────────────────
+
+test('cross-module: moduleForFile maps src paths to qualified Rust module paths (#275 unit-modulepath)', () => {
+  assert.equal(moduleForFile('crates/jeliya-ui/src/state.rs'), 'crate::state');
+  assert.equal(moduleForFile('crates/jeliya-ui/src/l10n/mod.rs'), 'crate::l10n');
+  assert.equal(moduleForFile('crates/jeliya-ui/src/components/dialog.rs'), 'crate::components::dialog');
+  assert.equal(moduleForFile('crates/jeliya-ui/src/lib.rs'), 'crate');
+  assert.equal(moduleForFile('crates/jeliya-ui/src/bin/web.rs'), 'bin:web');
+  assert.equal(moduleForFile('src/lib.rs'), null, 'path outside a known crate src root → null');
+  assert.equal(moduleForFile('crates/other/src/lib.rs'), null, 'path under a different crate → null');
+});
+
+test('cross-module: resolveCall resolves crate-qualified call by module path, not terminal name (#275 unit-resolvecall)', () => {
+  const fixtures = [
+    {
+      file: 'crates/jeliya-ui/src/app.rs',
+      source: `fn C() -> Element { rsx! { div { {crate::state::hardcoded()} } } }`,
+    },
+    { file: 'crates/jeliya-ui/src/state.rs', source: `pub fn hardcoded() -> &'static str { "Delete account" }` },
+    { file: 'crates/jeliya-ui/src/other.rs', source: `pub fn hardcoded() -> &'static str { "Impostor" }` },
+  ];
+  const index = buildCopyModuleIndex(fixtures);
+  const hits = resolveCall('crate::state::hardcoded', 'crate::app', index);
+  assert.ok(hits.length > 0, 'crate::state::hardcoded must resolve to at least one key');
+  assert.ok(
+    hits.every((k) => k.startsWith('crate::state ')),
+    `resolved keys must be in crate::state, got: ${JSON.stringify(hits)}`,
+  );
+  const otherHits = resolveCall('crate::other::hardcoded', 'crate::app', index);
+  assert.ok(
+    otherHits.every((k) => k.startsWith('crate::other ')),
+    'a same-named fn in another module resolves to THAT module, not crate::state',
+  );
+  assert.ok(
+    !hits.some((k) => k.startsWith('crate::other ')),
+    'crate::state::hardcoded must not reach crate::other::hardcoded',
+  );
+});
+
+test('cross-module: resolveCall returns empty for an unknown module (#275 unit-resolvecall-unknown)', () => {
+  const index = buildCopyModuleIndex([]);
+  assert.deepEqual(resolveCall('crate::nonexistent::fn_name', 'crate::app', index), []);
+});
+
+test('cross-module: resolveCopyReachableFns follows a two-hop chain across three files (#275 unit-reachable)', () => {
+  const fixtures = [
+    {
+      file: 'crates/jeliya-ui/src/app.rs',
+      source: `fn C() -> Element { rsx! { div { {crate::a::outer()} } } }`,
+    },
+    { file: 'crates/jeliya-ui/src/a.rs', source: `pub fn outer() -> String { crate::b::inner().to_owned() }` },
+    { file: 'crates/jeliya-ui/src/b.rs', source: `pub fn inner() -> &'static str { "Delete account" }` },
+  ];
+  const index = buildCopyModuleIndex(fixtures);
+  const reachable = resolveCopyReachableFns(index);
+  assert.ok(
+    [...reachable].some((k) => k.startsWith('crate::a ') && k.endsWith(' outer')),
+    'outer (the direct RSX root) must be reachable',
+  );
+  assert.ok(
+    [...reachable].some((k) => k.startsWith('crate::b ') && k.endsWith(' inner')),
+    'inner (two hops from the RSX root) must be transitively reachable',
+  );
+});
+
+test('cross-module: resolveCopyReachableFns terminates on a cycle (#275 unit-cycle)', () => {
+  const fixtures = [
+    {
+      file: 'crates/jeliya-ui/src/app.rs',
+      source: `fn C() -> Element { rsx! { div { {crate::x::foo()} } } }`,
+    },
+    {
+      file: 'crates/jeliya-ui/src/x.rs',
+      source: `pub fn foo() -> &'static str { bar() } pub fn bar() -> &'static str { foo() }`,
+    },
+  ];
+  const index = buildCopyModuleIndex(fixtures);
+  const reachable = resolveCopyReachableFns(index);
+  assert.ok([...reachable].some((k) => k.endsWith(' foo')), 'foo is reachable');
+  assert.ok([...reachable].some((k) => k.endsWith(' bar')), 'bar is reached before the cycle closes');
+});
+
+test('driver: crate::state::hardcoded() cross-module literal is flagged (#275 case-1)', () => {
+  const files = new Map([
+    [
+      'crates/jeliya-ui/src/app.rs',
+      `fn C() -> Element { rsx! { div { {crate::state::hardcoded()} } } }`,
+    ],
+    [
+      'crates/jeliya-ui/src/state.rs',
+      `pub fn hardcoded() -> &'static str { "Delete account" }`,
+    ],
+  ]);
+  const findings = checkJeliyaUiI18n({ only: ['literals'], files });
+  assert.ok(
+    findings.some((f) => f.code === 'rust-text' && /Delete account/.test(f.message) && /state\.rs$/.test(f.file)),
+    `expected rust-text for "Delete account" in state.rs; got: ${JSON.stringify(findings)}`,
+  );
+});
+
+test('driver: crate::labels::title() does not falsely flag an unrelated fn title() in another module (#275 case-2)', () => {
+  // A name-only index would mark every `fn title` body as copy and wrongly flag
+  // "selected-state". Qualified-module keying prevents this: only crate::labels::title
+  // is a copy-helper root — crate::state::title is never reached.
+  const files = new Map([
+    [
+      'crates/jeliya-ui/src/app.rs',
+      `fn C() -> Element { rsx! { div { {crate::labels::title()} } } }`,
+    ],
+    [
+      'crates/jeliya-ui/src/labels.rs',
+      `pub fn title(strings: &dyn Catalog) -> String { strings.title() }`,
+    ],
+    [
+      'crates/jeliya-ui/src/state.rs',
+      `pub fn title() -> &'static str { "selected-state" }`,
+    ],
+  ]);
+  const findings = checkJeliyaUiI18n({ only: ['literals'], files });
+  assert.ok(
+    !findings.some((f) => /selected-state/.test(f.message)),
+    `crate::state::title must not be reached via crate::labels::title(); got: ${JSON.stringify(findings)}`,
+  );
+});
+
+test('driver: transitive cross-file copy-helper chain is flagged (#275 case-3)', () => {
+  const files = new Map([
+    [
+      'crates/jeliya-ui/src/app.rs',
+      `fn C() -> Element { rsx! { div { {crate::a::outer()} } } }`,
+    ],
+    [
+      'crates/jeliya-ui/src/a.rs',
+      `pub fn outer() -> String { crate::b::inner().to_owned() }`,
+    ],
+    [
+      'crates/jeliya-ui/src/b.rs',
+      `pub fn inner() -> &'static str { "Delete account" }`,
+    ],
+  ]);
+  const findings = checkJeliyaUiI18n({ only: ['literals'], files });
+  assert.ok(
+    findings.some((f) => f.code === 'rust-text' && /Delete account/.test(f.message) && /b\.rs$/.test(f.file)),
+    `expected rust-text for "Delete account" in b.rs; got: ${JSON.stringify(findings)}`,
+  );
+});
+
+test('driver: i18n-exempt silences a cross-module helper-body literal (#275 exempt)', () => {
+  const files = new Map([
+    [
+      'crates/jeliya-ui/src/app.rs',
+      `fn C() -> Element { rsx! { div { {crate::state::hardcoded()} } } }`,
+    ],
+    [
+      'crates/jeliya-ui/src/state.rs',
+      `pub fn hardcoded() -> &'static str {\n    // i18n-exempt: technical identifier\n    "Delete account"\n}`,
+    ],
+  ]);
+  const findings = checkJeliyaUiI18n({ only: ['literals'], files });
+  assert.ok(
+    !findings.some((f) => /Delete account/.test(f.message)),
+    `an i18n-exempt cross-module helper literal must be silenced; got: ${JSON.stringify(findings)}`,
   );
 });
 

--- a/scripts/lib/jeliya-ui-catalog.mjs
+++ b/scripts/lib/jeliya-ui-catalog.mjs
@@ -1489,8 +1489,147 @@ function testItemSpans(skeleton) {
   return spans;
 }
 
-/** Report user-visible literals in one Rust component/app source. */
-export function scanComponentLiterals(file, source) {
+/** Every `fn NAME(params) { body }` definition in a Rust skeleton, as
+ *  `{ name, fnStart, paramsStart, bodyOpen, bodyClose }` (all code-unit offsets;
+ *  `bodyClose` is the matching `}`). A bodyless declaration — a `trait` method
+ *  `fn foo(&self) -> &str;` — is SKIPPED: taking its "first `{`" would swallow the
+ *  next item's body, corrupting resolution. The body `{` is found at
+ *  paren/bracket depth 0 so a `;` inside a return type (`-> [u8; 4]`) is not
+ *  mistaken for a declaration terminator. Nested (inner) `fn`s are not enumerated
+ *  separately (their calls are still seen as part of the enclosing body); this is
+ *  the documented one-fn-per-scope shape. Shared by the per-file helper resolver
+ *  and the cross-module index so the two never disagree about where a body is. */
+export function enumerateFnDefs(skeleton) {
+  const defs = [];
+  const re = /\bfn\s+([A-Za-z_]\w*)\s*\(/g;
+  for (let m = re.exec(skeleton); m; m = re.exec(skeleton)) {
+    const fnStart = m.index;
+    const name = m[1];
+    const paramsStart = m.index + m[0].length - 1; // at the opening '('
+    let i = paramsStart;
+    let depth = 0;
+    for (; i < skeleton.length; i += 1) {
+      if (skeleton[i] === '(') depth += 1;
+      else if (skeleton[i] === ')') {
+        depth -= 1;
+        if (depth === 0) {
+          i += 1;
+          break;
+        }
+      }
+    }
+    // From the param close, the body `{` is the first `{` at paren/bracket depth 0.
+    // A depth-0 `;` first ⇒ a bodyless declaration (trait method) — skip it.
+    let bodyOpen = -1;
+    let d = 0;
+    for (let j = i; j < skeleton.length; j += 1) {
+      const c = skeleton[j];
+      if (c === '(' || c === '[') d += 1;
+      else if (c === ')' || c === ']') d -= 1;
+      else if (d === 0 && c === ';') break;
+      else if (d === 0 && c === '{') {
+        bodyOpen = j;
+        break;
+      }
+    }
+    if (bodyOpen === -1) {
+      re.lastIndex = Math.max(i, paramsStart + 1);
+      continue;
+    }
+    const bodyClose = matchingBrace(skeleton, bodyOpen);
+    if (bodyClose === -1) {
+      re.lastIndex = bodyOpen + 1;
+      continue;
+    }
+    defs.push({ name, fnStart, paramsStart, bodyOpen, bodyClose });
+    re.lastIndex = bodyClose; // resume after this body (nested fns fold into it)
+  }
+  return defs;
+}
+
+/** The raw call PATHS that sit in an RSX COPY position of a scanned skeleton —
+ *  expression children `{ helper() }` / `{ Recv::helper() }` and copy-bearing
+ *  attribute values `label: helper()` (gated by `COPY_ATTRS`). Structural
+ *  positions (`id: id_for()`) are deliberately excluded. `inTest`/`inRsx` are the
+ *  same predicates the per-file scanner uses. This is the ONE implementation of
+ *  the fiddly in-RSX / in-test / copy-attribute detection, shared by
+ *  `scanComponentLiterals` (its local roots) and `buildCopyModuleIndex` (the
+ *  global roots) so they cannot drift. */
+function rsxCopyHelperPaths(skeleton, inTest, inRsx) {
+  const paths = [];
+  // Expression-CHILD calls: `{ helper() }` — the `{` follows the element body `{`,
+  // a sibling child's `}`, or a sibling string (blanked to `"`).
+  const childCallRe = /[{}"]\s*\{\s*((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
+  for (let m = childCallRe.exec(skeleton); m; m = childCallRe.exec(skeleton)) {
+    const at = m.index + m[0].lastIndexOf('{');
+    if (inTest(at) || !inRsx(at)) continue;
+    paths.push(m[1]);
+  }
+  // Copy-ATTRIBUTE call values: `label: helper()` / `label: Recv::helper()`.
+  const attrCallRe = /([A-Za-z_]\w*)\s*:\s*((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
+  for (let m = attrCallRe.exec(skeleton); m; m = attrCallRe.exec(skeleton)) {
+    if (inTest(m.index) || !inRsx(m.index)) continue;
+    if (COPY_ATTRS.has(normalizeAttrName(m[1]))) paths.push(m[2]);
+  }
+  return paths;
+}
+
+/** Public wrapper over `rsxCopyHelperPaths`: scan one source and return its RSX
+ *  copy-position helper call paths as `[{ path }]`. Exported for unit tests and
+ *  reused as the index's per-file root collector. */
+export function collectRsxCopyHelperCalls(source) {
+  const { skeleton } = scanRustSource(source);
+  const testSpans = testItemSpans(skeleton);
+  const inTest = (pos) => testSpans.some(([s, e]) => pos >= s && pos < e);
+  const ranges = rsxRanges(skeleton);
+  const inRsx = (pos) => ranges.some(([start, end]) => pos >= start && pos < end);
+  return rsxCopyHelperPaths(skeleton, inTest, inRsx).map((path) => ({ path }));
+}
+
+/** The concrete impl/type receiver a `fn` at `fnStart` is scoped to, or `null` for
+ *  a free / module-level fn. Generalizes the per-file `scopeMatches` walk to
+ *  RETURN the receiver instead of testing a candidate: walk out to the innermost
+ *  enclosing `{`, and if its header is an `impl`, the LAST identifier (after
+ *  stripping generic args) is the implementing type (`impl Trait for Type` → Type,
+ *  `impl Type` → Type). An enclosing inline `mod`/block contributes to the module
+ *  path, not a receiver, so it yields `null` (deeper inline modules are a
+ *  documented partial — see the cross-module index notes). */
+function enclosingReceiver(skeleton, fnStart) {
+  let depth = 0;
+  for (let i = fnStart - 1; i >= 0; i -= 1) {
+    const c = skeleton[i];
+    if (c === '}') {
+      depth += 1;
+    } else if (c === '{') {
+      if (depth === 0) {
+        let s = i - 1;
+        while (s >= 0 && !'{};'.includes(skeleton[s])) s -= 1;
+        const header = skeleton.slice(s + 1, i).replace(/<[^>]*>/g, ' ');
+        if (/\bimpl\b/.test(header)) {
+          const ids = (header.match(/[A-Za-z_]\w*/g) || []).filter(
+            (t) => !['impl', 'for', 'where', 'dyn'].includes(t),
+          );
+          return ids.length ? ids[ids.length - 1] : null;
+        }
+        return null; // module-level (inline mod / free fn)
+      }
+      depth -= 1;
+    }
+  }
+  return null;
+}
+
+/** Report user-visible literals in one Rust component/app source.
+ *
+ *  `options.seedCopyHelpers` is an optional array of `{ name, receiver }` that
+ *  this file must treat as copy-helper ROOTS in addition to those it collects from
+ *  its own RSX — the seam the cross-module driver uses to say "a helper defined in
+ *  THIS file is invoked as copy from ANOTHER module". Everything downstream
+ *  (`scopeMatches`, `helperBodies`, the body-literal judgement) is reused
+ *  unchanged, so a seeded helper is judged exactly like a locally-invoked one and
+ *  the finding is attributed to the file the literal lives in. Default `[]` ⇒
+ *  byte-identical to the historical two-argument behavior. */
+export function scanComponentLiterals(file, source, options = {}) {
   const { skeleton, literals, comments } = scanRustSource(source);
   const lines = source.split('\n');
   // Test-only items are not shipped copy — but production code can FOLLOW an inline
@@ -1653,19 +1792,18 @@ export function scanComponentLiterals(file, source) {
     const { name, receiver } = parsePath(path);
     if (name) copyHelpers.set(`${receiver ?? ''}\0${name}`, { name, receiver });
   };
-  // Expression-CHILD calls: `{ helper() }` / `{ Recv::helper() }` — the `{` follows the
-  // element body `{`, a sibling child's `}`, or a sibling string (blanked to `"`).
-  const childCallRe = /[{}"]\s*\{\s*((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
-  for (let m = childCallRe.exec(skeleton); m; m = childCallRe.exec(skeleton)) {
-    const at = m.index + m[0].lastIndexOf('{');
-    if (inTest(at) || !inRsx(at)) continue;
-    addHelper(m[1]);
-  }
-  // Copy-ATTRIBUTE call values: `label: helper()` / `label: Recv::helper()`.
-  const attrCallRe = /([A-Za-z_]\w*)\s*:\s*((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
-  for (let m = attrCallRe.exec(skeleton); m; m = attrCallRe.exec(skeleton)) {
-    if (inTest(m.index) || !inRsx(m.index)) continue;
-    if (COPY_ATTRS.has(normalizeAttrName(m[1]))) addHelper(m[2]);
+  // Local RSX copy-helper roots (shared detection with the cross-module index).
+  for (const path of rsxCopyHelperPaths(skeleton, inTest, inRsx)) addHelper(path);
+  // Cross-module SEEDS: helpers defined in THIS file that the driver found to be
+  // reachable from an RSX copy position in ANOTHER module. Adding them to
+  // `copyHelpers` makes their bodies resolve here just like a local root, so a
+  // literal hidden in a helper invoked via a qualified path (`crate::state::x()`)
+  // is flagged against the file it lives in. Default `[]` ⇒ no change.
+  for (const seed of options.seedCopyHelpers ?? []) {
+    if (seed && seed.name) {
+      const receiver = seed.receiver ?? null;
+      copyHelpers.set(`${receiver ?? ''}\0${seed.name}`, { name: seed.name, receiver });
+    }
   }
   // Whether the `fn` starting at `fnPos` lives inside an `impl`/`mod` block whose header
   // names `receiver` — so `Recv::name` resolves only Recv's method. A bare call
@@ -1693,6 +1831,7 @@ export function scanComponentLiterals(file, source) {
   // receiver), TRANSITIVELY: a copy helper that calls another helper renders that
   // callee's literal too, so follow the calls each resolved body makes. `visited` (keyed
   // by receiver+name) bounds it and breaks cycles; unresolved names are harmless no-ops.
+  const allFnDefs = enumerateFnDefs(skeleton);
   const helperBodies = [];
   const visited = new Set();
   const pending = [...copyHelpers.values()];
@@ -1701,32 +1840,16 @@ export function scanComponentLiterals(file, source) {
     const key = `${receiver ?? ''}\0${name}`;
     if (visited.has(key)) continue;
     visited.add(key);
-    const defRe = new RegExp(`\\bfn\\s+${name}\\s*\\(`, 'g');
-    for (let m = defRe.exec(skeleton); m; m = defRe.exec(skeleton)) {
-      if (!scopeMatches(m.index, receiver)) continue;
-      let i = m.index + m[0].length - 1; // at the opening '('
-      let depth = 0;
-      for (; i < skeleton.length; i += 1) {
-        if (skeleton[i] === '(') depth += 1;
-        else if (skeleton[i] === ')') {
-          depth -= 1;
-          if (depth === 0) {
-            i += 1;
-            break;
-          }
-        }
-      }
-      while (i < skeleton.length && skeleton[i] !== '{') i += 1;
-      const close = matchingBrace(skeleton, i);
-      if (close !== -1) {
-        helperBodies.push([i, close]);
-        const body = skeleton.slice(i, close);
-        const bodyCallRe = /((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
-        for (let c = bodyCallRe.exec(body); c; c = bodyCallRe.exec(body)) {
-          const parsed = parsePath(c[1]);
-          if (parsed.name && !visited.has(`${parsed.receiver ?? ''}\0${parsed.name}`)) {
-            pending.push(parsed);
-          }
+    for (const def of allFnDefs) {
+      if (def.name !== name) continue;
+      if (!scopeMatches(def.fnStart, receiver)) continue;
+      helperBodies.push([def.bodyOpen, def.bodyClose]);
+      const body = skeleton.slice(def.bodyOpen, def.bodyClose);
+      const bodyCallRe = /((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
+      for (let c = bodyCallRe.exec(body); c; c = bodyCallRe.exec(body)) {
+        const parsed = parsePath(c[1]);
+        if (parsed.name && !visited.has(`${parsed.receiver ?? ''}\0${parsed.name}`)) {
+          pending.push(parsed);
         }
       }
     }
@@ -2277,6 +2400,214 @@ export function componentFiles(repoRoot) {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-module copy-helper resolution (#275)
+//
+// The per-file scanner resolves a copy helper only against fn bodies in the SAME
+// file, so copy hidden in a helper in one module and invoked via a qualified path
+// from another (`div { {crate::state::hardcoded()} }`, body in `state.rs`) slips
+// the gate. These pure helpers build a whole-crate index of fn definitions and the
+// RSX copy roots, resolve calls by QUALIFIED MODULE PATH (never terminal name, so
+// `crate::labels::title` is not conflated with an unrelated `fn title` elsewhere),
+// and compute the transitive copy-reachable set across files. The driver then
+// SEEDS each per-file scan with the reachable helpers defined in it, so the body
+// literal is judged and reported by the existing per-file classifier — one
+// classifier, two body-finders.
+//
+// Documented residual gaps (#275 non-goals — not full Rust name resolution):
+//   1. Re-exports (`pub use`) and glob imports (`use other::*`) are not followed;
+//      only qualified `crate::<mod>::<fn>` and same-module bare / `Recv::` calls
+//      resolve. A helper laundered through a re-export can still hide copy.
+//   2. Macro-generated modules/functions are invisible to the text scan.
+//   3. Inline nested `mod` blocks contribute only the file's module path; a call
+//      qualified past an inline submodule may under-resolve (the common jeliya-ui
+//      shape is one module per file).
+//   4. Inherent-method receivers across modules (`crate::state::Widget::label`) are
+//      modeled for the single-segment tail shape only; trait dispatch and
+//      multi-segment type paths are not.
+//   5. `bin/*.rs` are ISOLATED namespaces (module key `bin:<name>`): a bin's
+//      `crate::` never resolves into the library and vice-versa (faithful to Rust).
+//   6. A match-pattern literal in a resolved helper body is judged exactly as the
+//      per-file scanner judges it (§2/§3 of the spec) — a shared pre-existing
+//      limitation, not introduced here.
+// ---------------------------------------------------------------------------
+
+/** Map a repo-relative `*.rs` path to its Rust module path, or `null` when it is
+ *  not under a crate `src` root. The heuristic covers the common
+ *  `crate::<file>::<fn>` shape (see gap 3 for inline submodules):
+ *   - `state.rs → crate::state`, `components/dialog.rs → crate::components::dialog`
+ *   - a directory module `l10n/mod.rs → crate::l10n` (trailing `mod` dropped)
+ *   - a top-level `lib.rs`/`main.rs → crate` (the crate root sentinel)
+ *   - `bin/<name>.rs → bin:<name>` (a SEPARATE binary crate namespace, gap 5). */
+export function moduleForFile(repoRelPath) {
+  const p = String(repoRelPath).split(sep).join('/');
+  for (const rootRaw of LITERAL_SCAN_ROOTS) {
+    const rootStr = String(rootRaw).split(sep).join('/');
+    // Only a `<crate-dir>/src` root defines a module tree; a bare `.rs` scan root
+    // (a single file) has no module path.
+    if (!/(^|\/)src$/.test(rootStr)) continue;
+    const prefix = `${rootStr}/`;
+    if (!p.startsWith(prefix)) continue;
+    let rel = p.slice(prefix.length);
+    if (!rel.endsWith('.rs')) return null;
+    rel = rel.slice(0, -3);
+    let segs = rel.split('/').filter(Boolean);
+    if (segs.length > 1 && segs[segs.length - 1] === 'mod') segs = segs.slice(0, -1);
+    if (segs[0] === 'bin' && segs.length >= 2) return `bin:${segs.slice(1).join('::')}`;
+    if (segs.length === 0) return 'crate';
+    if (segs.length === 1 && (segs[0] === 'lib' || segs[0] === 'main')) return 'crate';
+    return `crate::${segs.join('::')}`;
+  }
+  return null;
+}
+
+/** The multimap key for a resolved fn: `(module, receiver, name)`. Module strings
+ *  never contain a space, so a space separator is unambiguous. */
+const copyDefKey = (module, receiver, name) => `${module} ${receiver ?? ''} ${name}`;
+
+const copyRootOf = (module) => (module && module.startsWith('bin:') ? module : 'crate');
+const copyModuleSegments = (module) => {
+  if (!module || module === 'crate' || module.startsWith('bin:')) return [];
+  return module.replace(/^crate::/, '').split('::');
+};
+const copyModuleString = (root, segs) => {
+  if (root.startsWith('bin:')) return root;
+  return segs.length ? `crate::${segs.join('::')}` : 'crate';
+};
+
+/** Build the whole-crate copy index from `[{ file, source }]` (repo-relative path +
+ *  text). Returns `{ defsByKey, keysByModuleName, knownModules, roots }`:
+ *   - `defsByKey`: `copyDefKey → def[]` where a def is `{ module, name, receiver,
+ *     calls }` (`calls` = the raw outgoing call paths in the body, for transitive
+ *     tracing). A multimap because a name may be defined in several impls.
+ *   - `keysByModuleName`: `"module\0name" → Set<defKey>` for bare-call resolution
+ *     (any receiver in the caller module).
+ *   - `knownModules`: every indexed module path AND all its ancestor prefixes, for
+ *     longest-prefix qualifier matching.
+ *   - `roots`: `{ path, callerModule }` for every RSX copy-position call. */
+export function buildCopyModuleIndex(files) {
+  const defsByKey = new Map();
+  const keysByModuleName = new Map();
+  const knownModules = new Set();
+  const roots = [];
+  const addKnown = (module) => {
+    if (module.startsWith('bin:')) {
+      knownModules.add(module);
+      return;
+    }
+    knownModules.add('crate');
+    const segs = copyModuleSegments(module);
+    for (let k = 1; k <= segs.length; k += 1) knownModules.add(`crate::${segs.slice(0, k).join('::')}`);
+  };
+  for (const { file, source } of files) {
+    const module = moduleForFile(file);
+    if (module === null) continue;
+    addKnown(module);
+    const { skeleton } = scanRustSource(source);
+    const testSpans = testItemSpans(skeleton);
+    const inTest = (pos) => testSpans.some(([s, e]) => pos >= s && pos < e);
+    const ranges = rsxRanges(skeleton);
+    const inRsx = (pos) => ranges.some(([start, end]) => pos >= start && pos < end);
+    for (const path of rsxCopyHelperPaths(skeleton, inTest, inRsx)) roots.push({ path, callerModule: module });
+    for (const def of enumerateFnDefs(skeleton)) {
+      if (inTest(def.fnStart)) continue; // test-only fns are not shipped copy
+      const receiver = enclosingReceiver(skeleton, def.fnStart);
+      const body = skeleton.slice(def.bodyOpen, def.bodyClose);
+      const calls = [];
+      const bodyCallRe = /((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(/g;
+      for (let c = bodyCallRe.exec(body); c; c = bodyCallRe.exec(body)) calls.push(c[1]);
+      const key = copyDefKey(module, receiver, def.name);
+      if (!defsByKey.has(key)) defsByKey.set(key, []);
+      defsByKey.get(key).push({ module, name: def.name, receiver, calls });
+      const mn = `${module}\0${def.name}`;
+      if (!keysByModuleName.has(mn)) keysByModuleName.set(mn, new Set());
+      keysByModuleName.get(mn).add(key);
+    }
+  }
+  return { defsByKey, keysByModuleName, knownModules, roots };
+}
+
+/** Resolve one call `path` made from `callerModule` to the `copyDefKey`s it can
+ *  reach in `index`. Returns only keys that actually exist (an unresolvable path
+ *  is a harmless `[]`).
+ *   - bare `name()` → any receiver's `name` in the caller module.
+ *   - `crate::…` absolute from the caller's crate root; `self::…` relative to the
+ *     caller module; `super::…` relative to its parent.
+ *   - a concrete qualifier `a::b::…::Last` → the longest prefix that is a known
+ *     module is the module, the remaining tail (0 or 1 segment) is the receiver;
+ *     if no qualifier prefix is a known module, the last segment is treated as a
+ *     receiver in the caller module (the same-file `Recv::helper()` behavior). */
+export function resolveCall(path, callerModule, index) {
+  const segs = String(path)
+    .split('::')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (segs.length === 0) return [];
+  const name = segs[segs.length - 1];
+  const qual = segs.slice(0, -1);
+  const keyIfExists = (key) => (index.defsByKey.has(key) ? [key] : []);
+
+  if (qual.length === 0) {
+    const set = index.keysByModuleName.get(`${callerModule}\0${name}`);
+    return set ? [...set] : [];
+  }
+
+  const root = copyRootOf(callerModule);
+  const head = qual[0];
+  let absSegs;
+  let allowRootBase; // a `crate`/`self`/`super` head explicitly names the root
+  if (head === 'crate') {
+    absSegs = qual.slice(1);
+    allowRootBase = true;
+  } else if (head === 'self') {
+    absSegs = copyModuleSegments(callerModule).concat(qual.slice(1));
+    allowRootBase = true;
+  } else if (head === 'super') {
+    absSegs = copyModuleSegments(callerModule).slice(0, -1).concat(qual.slice(1));
+    allowRootBase = true;
+  } else {
+    absSegs = qual.slice();
+    allowRootBase = false;
+  }
+
+  const minK = allowRootBase ? 0 : 1;
+  for (let k = absSegs.length; k >= minK; k -= 1) {
+    const candidate = copyModuleString(root, absSegs.slice(0, k));
+    if (!index.knownModules.has(candidate)) continue;
+    const tail = absSegs.slice(k);
+    if (tail.length === 0) return keyIfExists(copyDefKey(candidate, null, name));
+    if (tail.length === 1) return keyIfExists(copyDefKey(candidate, tail[0], name));
+    return []; // deeper than the supported single-receiver tail (gap 3/4)
+  }
+  // No qualifier prefix is a known module: treat the last segment as a receiver in
+  // the caller module (a `Recv::helper()` on a type local to the caller).
+  return keyIfExists(copyDefKey(callerModule, absSegs[absSegs.length - 1], name));
+}
+
+/** The closed set of copy-returning `copyDefKey`s: the direct RSX roots and every
+ *  fn transitively reachable from them across module boundaries. BFS over a finite
+ *  key space with a `visited` set (breaks cycles). */
+export function resolveCopyReachableFns(index) {
+  const visited = new Set();
+  const worklist = [];
+  for (const { path, callerModule } of index.roots) {
+    for (const key of resolveCall(path, callerModule, index)) worklist.push(key);
+  }
+  while (worklist.length > 0) {
+    const key = worklist.pop();
+    if (visited.has(key)) continue;
+    visited.add(key);
+    for (const def of index.defsByKey.get(key) ?? []) {
+      for (const callPath of def.calls) {
+        for (const next of resolveCall(callPath, def.module, index)) {
+          if (!visited.has(next)) worklist.push(next);
+        }
+      }
+    }
+  }
+  return visited;
+}
+
+// ---------------------------------------------------------------------------
 // Driver
 // ---------------------------------------------------------------------------
 
@@ -2289,6 +2620,27 @@ function toRepoPath(repoRoot, path) {
   return relative(repoRoot, path).split(sep).join('/');
 }
 
+/** The `[{ file, source }]` list the literal scan runs over (repo-relative paths).
+ *  From the in-memory `files` seam when provided (filtered to the literal-scan
+ *  roots, excluding the locale catalogs, matching `componentFiles`), else read
+ *  from disk. One read per file, reused by both the cross-module index and the
+ *  per-file scan. */
+function literalScanFiles(root, files) {
+  if (files) {
+    const localeSet = new Set(Object.values(LOCALE_FILES));
+    const underScanRoot = (p) =>
+      LITERAL_SCAN_ROOTS.some((r) => (/\.rs$/.test(r) ? p === r : p.startsWith(`${r}/`)));
+    return [...files.entries()]
+      .filter(([p]) => underScanRoot(p) && !localeSet.has(p))
+      .map(([file, source]) => ({ file, source }))
+      .sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+  }
+  return componentFiles(root).map((absolute) => ({
+    file: toRepoPath(root, absolute),
+    source: readFileSync(absolute, 'utf8'),
+  }));
+}
+
 /** Run the selected rule groups against a repository tree and return sorted
  *  findings. `only` is a subset of {'catalog','typography','literals'}; default
  *  runs all three. `allowlist` is a parameter so the companion test can drive
@@ -2297,11 +2649,16 @@ export function checkJeliyaUiI18n({
   repoRoot = DEFAULT_REPO_ROOT,
   only = ['catalog', 'typography', 'literals'],
   allowlist = IDENTICAL_ALLOWLIST,
+  files = null,
 } = {}) {
   const root = resolve(repoRoot);
   const groups = new Set(only);
   const findings = [];
+  // Optional in-memory seam: `files` is a `Map<repoRelPath, source>` that bypasses
+  // disk entirely (additive; absent ⇒ today's `readFileSync` behavior), so a
+  // driver-level test can run hermetically without a temp tree.
   const read = (relativePath) => {
+    if (files) return files.get(relativePath) ?? null;
     const absolute = resolve(root, relativePath);
     return existsSync(absolute) ? readFileSync(absolute, 'utf8') : null;
   };
@@ -2324,9 +2681,28 @@ export function checkJeliyaUiI18n({
   }
 
   if (groups.has('literals')) {
-    for (const absolute of componentFiles(root)) {
-      const file = toRepoPath(root, absolute);
-      findings.push(...scanComponentLiterals(file, readFileSync(absolute, 'utf8')));
+    // Two-phase: build the cross-module copy index and resolve the reachable
+    // copy-fn set ONCE, then run each per-file scan SEEDED with the reachable
+    // helpers defined in it (so a literal in `state.rs`, reached only via a
+    // qualified call from another module, is flagged against `state.rs`).
+    const list = literalScanFiles(root, files);
+    const index = buildCopyModuleIndex(list);
+    const reachable = resolveCopyReachableFns(index);
+    // Group the reachable helpers by defining module, deduped by receiver+name.
+    const seedsByModule = new Map();
+    for (const key of reachable) {
+      for (const def of index.defsByKey.get(key) ?? []) {
+        if (!seedsByModule.has(def.module)) seedsByModule.set(def.module, new Map());
+        seedsByModule.get(def.module).set(`${def.receiver ?? ''}\0${def.name}`, {
+          name: def.name,
+          receiver: def.receiver,
+        });
+      }
+    }
+    for (const { file, source } of list) {
+      const module = moduleForFile(file);
+      const seeds = module !== null && seedsByModule.has(module) ? [...seedsByModule.get(module).values()] : [];
+      findings.push(...scanComponentLiterals(file, source, { seedCopyHelpers: seeds }));
     }
   }
 

--- a/specs/jeliya-ui-cross-module-copy-helper-resolution.md
+++ b/specs/jeliya-ui-cross-module-copy-helper-resolution.md
@@ -1,0 +1,234 @@
+# Spec — Cross-module copy-helper resolution for the jeliya-ui literal-copy gate (#275)
+
+- **Issue:** kortiene/jeliya#275 — `[Rust][jeliya-ui] Cross-module copy-helper resolution for the literal-copy gate`
+- **Split out of:** #177 (`specs/dioxus-web-l10n-tokens-a11y-foundations.md`). Round 26 of #177 landed a first-cut cross-file index (`copyReturningFnNames` + a name-only `crossFileCopyFns` set); round 27 review showed it inadequate and it was **reverted**. This issue does it correctly.
+- **Surface owned by this issue:** `scripts/lib/jeliya-ui-catalog.mjs` (the shared gate implementation) and `scripts/check-jeliya-ui-i18n.test.mjs` (its companion tests). No Rust production code changes; the crate is only fixture material.
+- **Gate this feeds:** the `ui-literal-copy` CI context (`node scripts/check-jeliya-ui-i18n.mjs --only=literals`), one of the three independently-required jeliya-ui i18n contexts.
+- **Owner role:** UI/foundations maintainers (the #177 owners).
+- **Status of this document:** planning/spec only. **No production code is to be written for this issue by the planning phase.**
+
+> Where this spec and the actual behavior of `scripts/lib/jeliya-ui-catalog.mjs` disagree, the code is authoritative and this spec has a bug — say which in the PR. The gate reads the Rust catalogs and components **as text** on purpose (a gate that imports the crate it gates can be argued out of its own findings, and `scripts/` has no Rust build step); this issue keeps that property.
+
+---
+
+## 1. Outcome
+
+Make the jeliya-ui literal-copy gate resolve copy helpers **across modules**, so copy hidden in a helper in one file and invoked via a qualified path from another —
+
+```rust
+// crates/jeliya-ui/src/app.rs
+div { {crate::state::hardcoded()} }
+
+// crates/jeliya-ui/src/state.rs
+pub fn hardcoded() -> &'static str { "Delete account" }   // must be FLAGGED
+```
+
+— cannot bypass the gate. The literal `"Delete account"` lives in `state.rs`, outside any `rsx!` block and never assigned to an interpolated binding, so today it is invisible to the gate: the per-file scan of `app.rs` collects the call `crate::state::hardcoded()` as a copy helper but can only resolve `fn` bodies **inside `app.rs`**, and the per-file scan of `state.rs` sees a literal that is neither in RSX nor in a locally-invoked copy-helper body. The result is a real catalog bypass.
+
+The cross-module resolver must match the fidelity the per-file scanner already has **within** a file — qualified, receiver-scoped helper resolution (so `A::label` and `B::label` do not collide) and transitive helper tracing (`outer() { inner() }`, `inner() { "…" }`) — extended across the whole `crates/jeliya-ui/src` module tree.
+
+---
+
+## 2. What this issue is, and is not
+
+**In scope**
+
+1. A cross-module index that reads **every production module** under `crates/jeliya-ui/src` (`state.rs`, `l10n/*`, `compose.rs`, `components/*`, `app.rs`, …), not only the component roots.
+2. Keying resolved helpers by **qualified module path** (a file-path → Rust-module-path heuristic), never by terminal name, so a catalog-backed `crate::labels::title()` is not conflated with an unrelated `fn title()` elsewhere.
+3. **Transitive** reachability computed through calls **across files**, not just directly-literal-bearing functions.
+4. A driver-level regression test through `checkJeliyaUiI18n` for the documented case, the collision case, and the transitive case.
+
+**Explicitly not in scope (non-goals, per the issue)**
+
+- Full Rust name resolution. **Re-exports** (`pub use`), **glob imports** (`use other::*;` bringing a helper into bare scope), and **macro-generated modules/functions** are not resolved. A file-path → module-path heuristic that covers the common `crate::<file>::<fn>` shape is acceptable; residual gaps are documented (§7).
+- Changing **how** a literal inside a resolved helper body is classified. Cross-module resolution changes only **where** helper bodies are found (this file vs. any file); the body-literal judgement (bare-letters test, `i18n-exempt`, attribute/child classification) is reused **byte-for-byte** from the existing per-file path, so a helper behaves identically whether it is local or cross-module. This is what "match that fidelity" means and it also means any later refinement of the body classifier benefits both paths at once.
+- Following helper calls that reach copy only through a **binding** (`let w = helper(); "{w}"`). Today the copy-helper roots are the calls that sit **directly** in an RSX copy position; that root set is unchanged. Binding-flow into a helper call remains out of scope (it is not what #275 is about, and widening it would change the clean-tree baseline).
+- The catalog locale modules `l10n/en.rs` / `l10n/fr.rs`. They **are** the catalog; their literals are governed by the catalog rules, and they stay excluded from the copy index (§4.2), exactly as `componentFiles` already excludes them from the literal scan.
+
+---
+
+## 3. Current behavior (what exists today)
+
+All line references are to `scripts/lib/jeliya-ui-catalog.mjs` at the branch head.
+
+- **`scanRustSource(source)`** → `{ skeleton, literals, comments }`. `skeleton` is the source with string/char **contents** and comments blanked (newlines preserved, code-unit offsets stable), so structural look-behind cannot trip over a brace/colon inside copy. Byte-string/char literals are masked but not recorded. This is the one tokenizer both paths use.
+- **`scanComponentLiterals(file, source)`** (≈L1493) scans **one** file. Its copy-helper machinery (≈L1628–L1734):
+  - `copyHelpers: Map<"receiver\0name", {name, receiver}>` — calls collected from **RSX copy positions only**: expression children `{ helper() }` / `{ Recv::helper() }` (`childCallRe`) and copy-bearing attribute values `label: helper()` (`attrCallRe`, gated by `COPY_ATTRS`). Structural positions (`id: id_for()`) are deliberately not collected.
+  - `parsePath(path)` splits a `::` path into `{ name = last segment, receiver = second-to-last }`, folding the context-relative qualifiers `Self`/`self`/`crate`/`super` (`PSEUDO_RECEIVERS`) to `receiver = null` so they resolve globally like a bare call.
+  - `scopeMatches(fnPos, receiver)` walks out from a candidate `fn` to its enclosing `impl`/`mod` header and confirms it names `receiver` — this is the receiver scoping that keeps `A::label` from resolving `B::label`.
+  - Resolution loop: for each helper, `defRe = /\bfn <name>\s*\(/g` is run **against this file's skeleton only**; each scope-matching definition's body span `[open, close]` is pushed to `helperBodies`, and the body's own calls are pushed to `pending` for **transitive** tracing (bounded by `visited`).
+  - `inCopyHelperBody(pos)` is `helperBodies.some(...)`. In the main literal loop (≈L1760), a literal **outside** RSX that is `inCopyHelperBody && bareLetters && !exempt` is reported as `rust-text` (“copy returned by a helper is not in the catalog”).
+- **`componentFiles(repoRoot)`** (≈L2256) walks `crates/jeliya-ui/src`, returning every `*.rs` **except** `l10n/en.rs` and `l10n/fr.rs`.
+- **`checkJeliyaUiI18n({ repoRoot, only, allowlist })`** (≈L2296) is the driver. For the `literals` group it calls `scanComponentLiterals(file, readFileSync(...))` for each `componentFiles` entry and returns the sorted union.
+
+**The gap.** `defRe` is scoped to the single file being scanned. A helper defined in another module is never found, so its literal is never marked as copy — neither from the calling file (can't see the body) nor from the defining file (nothing local invokes it in RSX). Requirements 1–3 of the issue are the three ways the reverted name-only fix failed to close this while staying honest.
+
+**Two facts that constrain the fix** (verified against the current tree, and why the clean-tree test stays green):
+
+- The only cross-module `crate::l10n::...::fn(...)` call in the crate is `crate::l10n::wire::status_for(...)` at `app.rs:296`, and it sits in a **plain Rust `let` binding inside an async closure — not an RSX copy position** — so it is not (and must not become) a copy-helper root. The `wire::*` label helpers are likewise called only as `let status_word = wire::status_for(...)`. No cross-module helper is invoked directly in an RSX copy position today, so a correct resolver adds **zero** findings to the current tree.
+- `l10n/wire.rs` helpers carry **match-scrutinee** literals (`"authority" => …`, `"direct" => …`) that are input values, not rendered copy, and return `strings.<method>()` catalog calls. The existing per-file body-literal loop does **not** distinguish a match-pattern (LHS of `=>`) from a returned literal. Because §2 forbids changing that classifier, the resolver must not special-case these either; parity with the per-file scanner is the contract. This is safe today (nothing renders those helpers cross-module in a copy slot) and is called out as a shared, pre-existing limitation (§7), not something this issue introduces or fixes.
+
+---
+
+## 4. Design
+
+The driver becomes **two-phase**: build a cross-module copy index and resolve the reachable copy-fn set **once**, then run the existing per-file scan with each file **seeded** by the reachable helpers defined in it. All new logic lives in `scripts/lib/jeliya-ui-catalog.mjs`.
+
+### 4.1 The guiding principle — one classifier, two body-finders
+
+The per-file scanner already knows how to (a) find a helper `fn`'s body in a file given `{name, receiver}` and (b) judge the literals inside it. The cross-module feature must **not** duplicate (b). It only widens (a): a helper body may now be found in **another** module. Concretely, `scanComponentLiterals` gains an optional seed of `{name, receiver}` helpers that this file must treat as copy-helper roots **in addition to** the ones it collects from its own RSX. Everything downstream (`scopeMatches`, `helperBodies`, `inCopyHelperBody`, the `rust-text` finding) is reused unchanged, so local and cross-module helpers are judged by identical rules and reported against the file where the literal actually lives.
+
+### 4.2 The module set and the file-path → module-path map
+
+- **Module set.** Reuse `componentFiles(repoRoot)` as the exact set of files indexed and scanned, so the index and the scan never disagree about which files exist. `en.rs`/`fr.rs` remain excluded (they are the catalog).
+- **`moduleForFile(repoRelPath) -> string | null`** — a new pure helper mapping a repo-relative `*.rs` path to its Rust module path:
+  1. Require the path to be under a crate `src` root of the form `<crate-dir>/src/` (derive the prefix from `LITERAL_SCAN_ROOTS`; today `crates/jeliya-ui/src`). A path not under such a root → `null` (out of scope for cross-module resolution).
+  2. Strip the `src/` prefix and the `.rs` suffix, split on `/`.
+  3. Drop a trailing `mod` segment (directory module: `l10n/mod` → `l10n`).
+  4. A top-level `lib` or `main` segment is the **crate root**: map to the sentinel `crate` (empty module path).
+  5. Otherwise join the remaining segments with `::` and prefix `crate::`.
+  6. **`bin/<name>.rs`** is a **separate binary crate root**, not part of the library module tree (it depends on the lib as the external crate `jeliya_ui::…`, and its own `crate::` refers to the bin). Give each `bin/<name>.rs` an isolated namespace (e.g. module key `bin:<name>`) so a `crate::…` inside a bin resolves only within that bin and never collides with the library's `crate`. This is faithful to Rust and keeps bins from cross-contaminating lib resolution (§7).
+
+  Worked results for the current tree: `state.rs → crate::state`, `app.rs → crate::app`, `compose.rs → crate::compose`, `components/mod.rs → crate::components`, `components/dialog.rs → crate::components::dialog`, `l10n/wire.rs → crate::l10n::wire`, `lib.rs → crate` (root), `bin/web.rs → bin:web`.
+
+### 4.3 The index
+
+**`buildCopyModuleIndex(files) -> Index`** where `files` is `[{ file, source }]` (repo-relative path + text). For each file:
+
+1. `moduleForFile(file)`; skip files that map to `null`.
+2. `scanRustSource(source)` → `{ skeleton, literals, comments }`.
+3. **Function definitions.** Enumerate every `fn <name>(` in the skeleton (reuse the balanced param-and-body walk already used for catalog methods / helper resolution — factor it into a shared `enumerateFnDefs(skeleton)` returning `{ name, paramsStart, bodyOpen, bodyClose }`). For each definition record:
+   - `module` (from step 1), `name`, and `receiver` — the enclosing `impl <Type>` / `mod <name>` header token, computed with the **existing** `scopeMatches` walk generalized to *return* the receiver name (or `null` for a free/module-level fn). A file-level `mod <name> { … }` nesting also contributes to the module path; for the common one-module-per-file shape this is just the file's module, and deeper inline `mod`s are a documented partial (§7).
+   - `bodyOpen`, `bodyClose`, and the **outgoing call paths** in the body: every `((?:[A-Za-z_]\w*\s*::\s*)*[A-Za-z_]\w*)\s*\(` match (the same body-call regex the per-file transitive tracer uses), captured as raw path strings for later resolution with caller context.
+   - Store under a key `defKey(module, receiver, name)` (e.g. `` `${module} ${receiver ?? ''} ${name}` ``). Keep a **multimap** (a name may be defined in several arms/impls) — reachability marks the key, and §4.1's per-file body-finder re-locates every matching body in the defining file.
+4. **RSX copy-helper roots.** Collect the calls that sit in an RSX copy position — **exactly** the `childCallRe` + `attrCallRe`/`COPY_ATTRS` collection the per-file scanner performs. Factor that collection into a shared `collectRsxCopyHelperCalls(file, source) -> [{ path, callerModule }]` used by **both** `scanComponentLiterals` (for its local roots) and the index (for the global roots), so the fiddly in-RSX/in-test/copy-attribute detection has one implementation and cannot drift.
+
+`Index` exposes: `defs` (the multimap above), `roots` (all `{ path, callerModule }` across files), and the set of known module paths (for longest-prefix qualifier matching).
+
+### 4.4 Resolution — a call path + caller module → a `defKey` set
+
+**`resolveCall(path, callerModule, index) -> defKey[]`.** Split `path` on `::` into segments; `name` = last; `qualifier` = the rest.
+
+- **No qualifier** (bare `name()`): resolve within `callerModule` (a free fn or any impl method in that module) → keys `defKey(callerModule, *, name)`. (Bare calls to `use`-imported cross-module items are a non-goal; see §7.)
+- **Context-relative head** `crate` / `self` / `super`:
+  - `crate::…` → resolve the remaining qualifier as an **absolute** module path from the crate root.
+  - `self::…` → relative to `callerModule`; `super::…` → relative to `callerModule`'s parent (drop the last `::` segment).
+  - After rebasing, apply the absolute rule below to the rebased qualifier.
+- **Absolute / concrete qualifier** (`a::b::…::Last`): find the **longest prefix** of the qualifier segments that is a **known module path** in the index. The remaining tail (0 or 1 segment in the supported shape) is the **receiver**:
+  - tail empty → `defKey(module, null, name)` (free fn in that module — the `crate::state::hardcoded` case).
+  - tail one segment `Recv` → `defKey(module, Recv, name)` (an inherent method — the `crate::state::Widget::label` shape; a supported partial).
+  - No prefix is a known module → treat the last qualifier segment as a **receiver in the caller module** (`defKey(callerModule, Recv, name)`), matching the current same-file `Recv::helper()` behavior; if that yields nothing it is an unresolved no-op (harmless).
+
+Resolution returns **all** matching `defKey`s (multimap). Unresolvable paths return `[]` and are harmless — the gate only ever adds findings for a helper it can both reach **and** locate a body for.
+
+### 4.5 Reachability (transitive, across files)
+
+**`resolveCopyReachableFns(index) -> Set<defKey>`.** Seed a worklist from `index.roots`: for each `{ path, callerModule }`, push every `resolveCall(path, callerModule, index)` key. Then BFS: pop a `defKey`, add to the reachable set (dedup = `visited`), look up its definition(s) in `index.defs`, and for each outgoing call path in each body call `resolveCall(callPath, thatDef.module, index)` and push the results. Terminate when the worklist drains (bounded by the finite `defKey` space; `visited` breaks cycles). The result is the closed set of copy-returning functions — the direct RSX roots **and** everything transitively reachable from them, across module boundaries.
+
+This subsumes the per-file transitive tracer for cross-file edges; within-file edges are still followed by `scanComponentLiterals` itself (§4.6), so the two together cover every edge.
+
+### 4.6 Wiring it into the scan
+
+- **`scanComponentLiterals(file, source, options = {})`** — add an optional third argument `options.seedCopyHelpers`: an array of `{ name, receiver }` that this file must treat as copy-helper roots **in addition to** those collected from its own RSX. Implementation: initialize the existing `copyHelpers` map / `pending` worklist with these seeds before the resolution loop runs. Everything else is unchanged. Default `[]` ⇒ **byte-identical to today's behavior**, so every existing one/two-argument test call is unaffected.
+  - The seed for a file is derived from the reachable set: `{ receiver, name }` for each `defKey` in `resolveCopyReachableFns(index)` whose `module === moduleForFile(file)`.
+- **`checkJeliyaUiI18n`** — in the `literals` branch:
+  1. Read every `componentFiles(root)` entry into `[{ file, source }]` (one read each; reused by both index and scan).
+  2. `index = buildCopyModuleIndex(files)`; `reachable = resolveCopyReachableFns(index)`.
+  3. Precompute `seedsByModule: Map<module, {name,receiver}[]>` from `reachable`.
+  4. For each file, call `scanComponentLiterals(file, source, { seedCopyHelpers: seedsByModule.get(moduleForFile(file)) ?? [] })` and collect findings.
+  - The catalog/typography branches are untouched.
+
+Because the reachable set is computed before any per-file scan, a downstream file (e.g. `state.rs`) is seeded with `hardcoded` even though nothing **in `state.rs`** invokes it — that is exactly what makes the literal in `state.rs` get flagged, and the finding is attributed to `state.rs:<line>` where the literal lives.
+
+### 4.7 Optional in-memory driver seam (recommended for testability)
+
+To let driver-level tests run without a temp directory, extend `checkJeliyaUiI18n` with an optional `files` override: `checkJeliyaUiI18n({ only, files })` where `files` is a `Map<repoRelPath, source>`. When provided, `componentFiles`/`readFileSync` are bypassed and the literal scan iterates `files` directly (catalog/typography still read `LOCALE_FILES` from `files` when present). This is additive and backward-compatible (absent ⇒ today's disk behavior) and keeps the required test "through `checkJeliyaUiI18n`" while staying hermetic. If the reviewers prefer not to widen the driver signature, fall back to the `mkdtempSync` fixture harness in §6.1 — both satisfy the verification.
+
+---
+
+## 5. Worked cases (the three required behaviors)
+
+1. **Documented cross-module case (must flag).** `app.rs` RSX: `div { {crate::state::hardcoded()} }`; `state.rs`: `pub fn hardcoded() -> &'static str { "Delete account" }`. Root `resolveCall("crate::state::hardcoded", "crate::app")` → `defKey(crate::state, null, hardcoded)`; reachable. `state.rs` seeded with `{name:"hardcoded", receiver:null}` ⇒ its body literal `"Delete account"` (bare-letters, not exempt, outside RSX) → **`rust-text`** finding at `crates/jeliya-ui/src/state.rs`.
+
+2. **Collision case (must NOT flag).** `app.rs` RSX: `div { {crate::labels::title()} }`, where `crate::labels::title` is catalog-backed (`fn title(strings) -> String { strings.title() }`, no bare literal); a different module (say `state.rs`) has an unrelated `fn title() -> &str { "selected-state" }`. `resolveCall("crate::labels::title", …)` resolves **only** `defKey(crate::labels, null, title)` — the qualified module path. `crate::state`'s `title` is **not** reached (no RSX call qualifies it), so `"selected-state"` is **not** flagged. A name-only index (the reverted approach) would have marked every `fn title` body as copy and wrongly flagged `"selected-state"`.
+
+3. **Transitive cross-file case (must flag).** `app.rs` RSX: `div { {crate::a::outer()} }`; `a.rs`: `pub fn outer() -> String { inner() }`; `b.rs` (reached from `a.rs` via `crate::b::inner`, or same-module `inner`): `pub fn inner() -> &'static str { "Delete account" }`. BFS: root `outer` reachable → its body call resolves `inner` → reachable. The file defining `inner` is seeded ⇒ `"Delete account"` → **`rust-text`** finding at that file.
+
+---
+
+## 6. Test plan
+
+All tests in `scripts/check-jeliya-ui-i18n.test.mjs`. Every new assertion must fail **before** the implementation (red-before-green) — verify by writing the test against the current code and observing the miss/false-flag first.
+
+### 6.1 Driver-level tests (the issue's required verification)
+
+Use the in-memory `files` seam (§4.7) if adopted, else a `mkdtempSync(tmpdir())` fixture that writes the files under `<tmp>/crates/jeliya-ui/src/…` and calls `checkJeliyaUiI18n({ repoRoot: tmp, only: ['literals'] })` (the `literals` group needs no catalogs). Cleanup with `rmSync(tmp, { recursive: true })`.
+
+1. **`hardcoded()` cross-module is flagged.** Files: `app.rs` (component with `div { {crate::state::hardcoded()} }` inside `rsx!`), `state.rs` (`pub fn hardcoded() -> &'static str { "Delete account" }`). Assert a finding with `code === 'rust-text'`, `/Delete account/`, and `file` ending `state.rs`. **Fails today** (no cross-module resolution).
+2. **Collision is not falsely flagged.** Files: `app.rs` (`div { {crate::labels::title()} }`), `labels.rs` (catalog-backed `title`, no bare literal), `state.rs` (unrelated `fn title() -> &str { "selected-state" }`). Assert **no** finding matches `/selected-state/`. Must be green with the qualified-path index (and would be **red** under a name-only index — keep a comment saying so).
+3. **Transitive cross-file is flagged.** Files: `app.rs` (`div { {crate::a::outer()} }`), `a.rs` (`outer` calls `crate::b::inner`), `b.rs` (`inner` returns `"Delete account"`). Assert a `rust-text` / `/Delete account/` finding at `b.rs`. **Fails today**.
+
+### 6.2 Unit tests for the new pure helpers
+
+- **`moduleForFile`**: `state.rs → crate::state`, `l10n/mod.rs → crate::l10n`, `components/dialog.rs → crate::components::dialog`, `lib.rs → crate`, `bin/web.rs → bin:web`, a path outside a `src` root → `null`.
+- **`resolveCall`**: `crate::state::hardcoded` from `crate::app` → `[defKey(crate::state,null,hardcoded)]`; `self::inner`/`super::x` rebasing; `A::label` vs `B::label` do not cross; a bare `helper()` resolves only within the caller module; an unknown module → `[]`.
+- **`resolveCopyReachableFns`**: a two-hop chain across three files is fully reached; a cycle terminates; an unrelated same-named fn in another module is **not** reached.
+
+### 6.3 Regression / non-regression
+
+- **Backward-compat of `scanComponentLiterals`.** The existing `scanComponentLiterals('x.rs', source)` (two-arg) calls must be untouched — assert the new third arg defaults to no seeds by keeping the whole existing suite green.
+- **Clean-tree invariant.** `test('the real jeliya-ui tree is clean across all groups')` (≈L2186) must still return `[]`. This is the load-bearing check that the resolver adds no false positives to real code (§3 explains why it holds: no cross-module helper is invoked in an RSX copy slot today).
+- **`i18n-exempt` still silences** a cross-module helper-body literal (the body-literal loop already honors `exempt`; add one fixture proving an exempted cross-module literal is not flagged).
+
+### 6.4 Local gate
+
+From `scripts/`-adjacent root: `node --test scripts/check-jeliya-ui-i18n.test.mjs`. The full canonical gate (`npm run verify` in `adw_sdlc/`) is unrelated to this repo path; the relevant CI contexts here are the jeliya `ui-literal-copy` / `ui-catalog` / `ui-french-typography` checks driven by `scripts/check-jeliya-ui-i18n.mjs`.
+
+---
+
+## 7. Documented residual gaps (non-goals made explicit)
+
+These are acceptable per the issue's non-goals; record them as comments at the new index/resolver and, if a `docs/` decision note for #177 tracks gate limitations, add a line there.
+
+1. **Re-exports / glob imports.** `pub use other::helper;` and `use other::*;` that bring a helper into bare or renamed scope are not resolved; only qualified `crate::<mod>::<fn>` (and same-module bare/`Recv::`) calls resolve. A helper laundered through a re-export can still hide copy — a known ceiling, not a regression (today nothing resolves cross-module at all).
+2. **Macro-generated modules/functions.** Functions or modules produced by macros are invisible to the text scan.
+3. **Inline nested `mod` blocks** deeper than one-module-per-file contribute only a partial module path (the file's module); a call qualified past an inline submodule may under-resolve. The common jeliya-ui shape is one module per file, so this is rarely hit.
+4. **Inherent-method receivers across modules** (`crate::state::Widget::label`) are supported for the single-receiver tail shape only; trait-method dispatch and multi-segment type paths are not modeled.
+5. **Binary crates** (`bin/*.rs`) are isolated namespaces; a bin's `crate::` never resolves into the library and vice-versa. Correct for Rust, but means bin-only copy helpers are scanned per-file only (as today).
+6. **Match-pattern literals in a resolved helper body** are judged exactly as the per-file scanner judges them (§2, §3) — a shared pre-existing limitation, not introduced here. If a future issue teaches the body classifier to skip LHS-of-`=>` scrutinee literals, both the local and cross-module paths inherit it for free.
+
+---
+
+## 8. Acceptance criteria
+
+1. A driver-level test **through `checkJeliyaUiI18n`** proves `crate::state::hardcoded()` invoked in a component file, resolving to a copy literal in `state.rs`, is flagged (`rust-text`) against `state.rs`.
+2. The collision case (`crate::labels::title()` catalog-backed vs. an unrelated `fn title()` returning a literal elsewhere) is **not** flagged, and the test documents that a name-only index would have failed it.
+3. The transitive cross-file case (`outer() { inner() }`, `inner() { "…" }` across files) is flagged.
+4. Resolution keys by **qualified module path** via a file-path → module-path heuristic (`moduleForFile`), never by terminal name; unit tests cover the map and `resolveCall`.
+5. `scanComponentLiterals`'s existing two-argument call sites are unchanged in behavior (the whole existing suite stays green), and the new seed argument defaults to a no-op.
+6. The real-tree cleanliness test stays green (no new false positives on production code).
+7. Residual gaps (§7) are documented in-code (and in the #177 gate-limitations note if one exists).
+8. Every new test fails before the implementation and passes after (red-before-green), verified explicitly.
+
+---
+
+## 9. Risks and mitigations
+
+- **False positives on real code breaking the required CI context.** The one realistic vector is a legitimate cross-module helper (e.g. `l10n/wire::*`) becoming a copy-helper root. Mitigation: roots are unchanged (direct RSX copy positions only), and §3 verifies none exist today; the clean-tree test (6.3) is the guard, and any future legitimate cross-module render of a catalog-backed helper will resolve to a body with no bare literal.
+- **Collapsing distinct helpers (the reverted bug).** Mitigation: qualified-module keying with longest-prefix module matching and receiver scoping; the collision test (6.1.2) locks it in.
+- **Runaway/backtracking scans.** Mitigation: reachability is a BFS over a finite `defKey` space with a `visited` set; all body/param walks reuse the existing bounded balanced-brace scanners.
+- **Silent under-resolution (a gap hiding copy).** Accepted per non-goals and enumerated in §7; the honest position is that this issue **narrows** the bypass surface (qualified cross-module calls now covered) without claiming full name resolution.
+- **Index/scan divergence.** Mitigation: both consume the same `componentFiles` set, the same `scanRustSource` tokenizer, and the shared `collectRsxCopyHelperCalls` / `enumerateFnDefs` extractors — one implementation, no drift.
+
+---
+
+## 10. Implementation checklist (for the executing agent)
+
+1. Add `moduleForFile(repoRelPath)` (+ crate-src-root derivation from `LITERAL_SCAN_ROOTS`).
+2. Factor `enumerateFnDefs(skeleton)` and `collectRsxCopyHelperCalls(file, source)` out of the existing per-file logic; re-point `scanComponentLiterals` at them (no behavior change).
+3. Add `buildCopyModuleIndex(files)`, `resolveCall(path, callerModule, index)`, `resolveCopyReachableFns(index)` (all pure, all exported for unit tests).
+4. Add `options.seedCopyHelpers` to `scanComponentLiterals`; seed `copyHelpers`/`pending` before the resolution loop; default `[]`.
+5. Two-phase the `literals` branch of `checkJeliyaUiI18n`; optionally add the `files` in-memory seam (§4.7).
+6. Tests per §6 (driver-level first — they are the acceptance evidence), red-before-green.
+7. In-code residual-gap comments (§7); update the #177 gate-limitations note if present.
+8. Run `node --test scripts/check-jeliya-ui-i18n.test.mjs`; confirm the clean-tree test and the full suite are green.


### PR DESCRIPTION
# PR DRAFT — jeliya #275 (staged locally, NOT posted)

- Branch: feat/275-7c8241b9-... | Worktree: /home/sekou/AGI/jeliya-wt/7c8241b9
- Base: main @ 9555eb9 | Commit: 7182937 | Run cost: $16.09

## Orchestrator verification (independent, in worktree)
- node scripts/check-jeliya-ui-i18n.test.mjs: PASS (134/134)
- node scripts/check-jeliya-ui-i18n.mjs: PASS (gate green on repo)
- node scripts/check-docs.mjs: PASS
- cargo gates: not applicable — no Rust files touched (workspace invariant, main baseline green)

## Cross-review (DSH subagent, read-only adversarial): concerns
- F1/F2 (medium, false negatives): closure captures and IIFEs still bypass bodyCallRe — a DIFFERENT evasion class than the qualified-path bypass this issue scoped. Tests exercise the REAL gate entry point (verified, unlike #276). Cycles and determinism verified safe.
- F3/F4/F5 (low/theoretical): resolveCall fallback on opaque qualifiers; empty-receiver key edge; super:: at crate root untested.
- Maintainer decision: extend scope to closure/IIFE evasion, or land as-is and track separately?

## Switchyard-generated PR body

# [Rust][jeliya-ui] Cross-module copy-helper resolution for the literal-copy gate

Closes #275.

## What & why

The `ui-literal-copy` gate (`scripts/lib/jeliya-ui-catalog.mjs`) resolved copy
helpers only against `fn` bodies **inside the file being scanned**. That left a
real catalog bypass: copy hidden in a helper in one module and invoked via a
qualified path from another rendered as UI copy but was invisible to the gate.

```rust
// crates/jeliya-ui/src/app.rs
div { {crate::state::hardcoded()} }

// crates/jeliya-ui/src/state.rs
pub fn hardcoded() -> &'static str { "Delete account" }   // now FLAGGED
```

This makes the gate resolve copy helpers **across modules** with the same
fidelity the per-file scanner already has within a file (qualified,
receiver-scoped resolution + transitive tracing), matching the round-27 review
findings from #177 that reverted the first-cut name-only attempt.

## How

The `literals` branch of `checkJeliyaUiI18n` becomes two-phase:

1. **Index once.** `buildCopyModuleIndex(files)` reads *every* production module
   (`state.rs`, `l10n/*`, `compose.rs`, `components/*`, `app.rs`, …) and records
   each `fn` (module, receiver, outgoing calls) plus every RSX copy-position
   root. Shared `enumerateFnDefs` / `rsxCopyHelperPaths` extractors mean the
   index and the per-file scan cannot drift.
2. **Resolve once.** `resolveCopyReachableFns(index)` is a cycle-safe BFS over a
   finite key space computing the closed copy-returning set — direct RSX roots
   plus everything transitively reachable across files.
3. **Seed the scan.** Each per-file scan runs with the reachable helpers defined
   in that file as extra copy-helper roots (`options.seedCopyHelpers`).
   Everything downstream (`scopeMatches`, `helperBodies`, the body-literal
   judgement, `i18n-exempt`) is reused unchanged, so a seeded helper is judged
   identically to a locally-invoked one and the finding is attributed to the
   file the literal lives in. **One classifier, two body-finders.**

Resolution keys by **qualified module path** (`moduleForFile`: `state.rs ->
crate::state`, `components/dialog.rs -> crate::components::dialog`, `lib.rs ->
crate`, `bin/web.rs -> bin:web`), never terminal name — so a catalog-backed
`crate::labels::title()` is not conflated with an unrelated `fn title()`
elsewhere. `resolveCall` does longest-known-prefix module matching with
`crate`/`self`/`super` rebasing and a single-segment receiver tail; unresolvable
paths return `[]` and are harmless.

`scanComponentLiterals`'s new third argument defaults to a no-op, so every
existing two-argument call site is byte-identical to before.

## Scope

Confined to `scripts/lib/jeliya-ui-catalog.mjs` and its companion test
`scripts/check-jeliya-ui-i18n.test.mjs`, plus the planning spec
`specs/jeliya-ui-cross-module-copy-helper-resolution.md`. **No Rust production
code changes** — the crate is fixture material only.

## Non-goals (documented in-code)

Not full Rust name resolution: re-exports (`pub use`), glob imports
(`use other::*`), macro-generated modules/functions, deep inline submodules,
trait dispatch, and cross-crate `bin`/lib bleed are not modeled. The heuristic
covers the common `crate::<mod>::<fn>` shape; residual gaps are enumerated as
comments at the index/resolver. This **narrows** the bypass surface without
claiming complete resolution.

## Tests

`node --test scripts/check-jeliya-ui-i18n.test.mjs` → **134 pass / 0 fail.**

Driver-level (through `checkJeliyaUiI18n`, via an additive in-memory `files`
seam so tests stay hermetic):

- **case-1** — `crate::state::hardcoded()` in a component resolving to a literal
  in `state.rs` is flagged (`rust-text`) against `state.rs`.
- **case-2** — the collision case (`crate::labels::title()` catalog-backed vs an
  unrelated `fn title() { "selected-state" }`) is **not** flagged; the test
  documents that a name-only index would have failed it (verified: only
  `crate::labels title` is reachable, `crate::state title` is not).
- **case-3** — the transitive cross-file chain (`outer() { crate::b::inner() }`,
  `inner() { "…" }`) is flagged at `b.rs`.
- **exempt** — an `i18n-exempt` cross-module helper-body literal is silenced.

Unit tests cover `moduleForFile`, `resolveCall` (qualified/unknown/collision),
and `resolveCopyReachableFns` (two-hop chain, cycle termination).

The **real-tree cleanliness invariant** (`the real jeliya-ui tree is clean
across all groups`) stays green — the load-bearing guard that the resolver adds
no false positives to production code (the `l10n/wire.rs` match-scrutinee
literals are not reachable from any RSX copy root today).

## Reviewer notes

- **case-2 is a green-before/green-after guard**, not a red-before-green
  regression (cross-module resolution never flagged `selected-state`); it locks
  in the qualified-vs-name-only distinction, exactly as the spec frames it.
  case-1, case-3, and the new exported helpers are genuinely red before this
  change (both cross-module resolution and the `files` seam are new).
- Bare-call and nested-`fn` handling **over-approximate** reachability (more
  seeds), which is the safe direction for a gate; the clean-tree test is the
  guard and passes.