### PR TITLE
fix(daemon): pipe.revoke idempotency race and flaky serve test (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,34 @@
 
 ### Fixed
 
+- `pipe.revoke` is now **idempotent at the room-fact layer**: a second (or Nth)
+  revoke of an already-withdrawn pipe replays the **original** withdrawal —
+  returning the first revoke's exact `event_id`, `pos`, and `revoked_at` — and
+  authors **nothing** further. Previously the daemon published a fresh signed
+  `pipe.closed` on every revoke (the op_id dedup ledger only covers a *same*-
+  op_id replay, not a genuinely distinct second request), so an already-revoked
+  pipe grew a second committed `pipe_revoked` event; under concurrent load the
+  two authors could straddle a millisecond boundary and the second's differing
+  instant broke the "returns the original withdrawal" guarantee — a correctness
+  defect that surfaced as a flaky conformance case. `RoomSupervisor::pipe_close`
+  now consults the canonically-earliest committed `pipe.closed` (after, not
+  before, the unknown-pipe and publisher-only guards, so `pipe_unknown` /
+  `pipe_not_publisher` are unchanged — including for a non-publisher re-revoking
+  a closed pipe) and returns it without authoring; the withdrawal-event lookup
+  selects the first canonical-order match rather than the last; and concurrent
+  distinct-op_id revokes of the same pipe are serialized per `(room, pipe)` so a
+  check-then-author cannot interleave into two withdrawals. No wire/schema,
+  op_id-ledger, or `pipe.connect`/`pipe.list`/`pipe.release` change. Issue #271.
+
+- The serve-crate test
+  `websocket_file_share_progress_resets_stall_but_not_absolute_deadline` now
+  drives its stall/deadline timers off a **paused** virtual clock
+  (`tokio::time::pause()` + `advance`), matching its two siblings, instead of a
+  real `tokio::time::sleep`. The real sleep drifted against the daemon's
+  `Instant`-based timers under concurrent CI load and intermittently reordered
+  the CREDIT/ABORT records; the conversion asserts the same observable sequence
+  and post-conditions and passes deterministically under load. Issue #271.
+
 - A room list backed by a daemon that supplies **no** `last_event_ts` can raise
   an unread dot again. Nothing seeded a baseline for such a room, and the
   unread predicate reads an unseeded room as not-unread, so no dot could ever

--- a/crates/jeliya-core/src/supervisor.rs
+++ b/crates/jeliya-core/src/supervisor.rs
@@ -306,6 +306,12 @@ pub(crate) struct RoomSession {
     is_owner: bool,
 }
 
+/// Per-`(room, pipe)` async guard cells that serialize concurrent revokes of
+/// the same pipe (see [`RoomSupervisor::pipe_close`]). The outer std mutex is
+/// held only for the get-or-insert of the per-key cell; the inner
+/// [`TokioMutex`] is what is held across the author/poll critical section.
+type RevokeGuards = StdMutex<HashMap<(RoomId, [u8; SHORT_ID_LEN]), Arc<TokioMutex<()>>>>;
+
 /// The daemon's room supervisor: shared data dir + one session per open room.
 ///
 /// `sessions` sits behind a *std* mutex that is only ever held for the brief
@@ -332,6 +338,15 @@ pub(crate) struct RoomSupervisor {
     /// maintains the same fold incrementally (`Node::snapshot`), so the cache
     /// can never go stale against a growing open room.
     snapshot_cache: StdMutex<HashMap<RoomId, (u64, MembershipSnapshot)>>,
+    /// Serializes concurrent revokes of the SAME pipe so a check-then-author
+    /// cannot interleave into two withdrawals. Keyed per `(room, pipe)`;
+    /// distinct pipes and rooms never contend. In-memory, like the op_id
+    /// dedup ledger, and bounded by the number of distinct pipes ever revoked
+    /// on this daemon (a pipe id is 16 bytes, so the count is tiny). The map's
+    /// std mutex is held only for the get-or-insert; the per-key async mutex is
+    /// what is held across `node.pipe_close` + the `find_pipe_event` poll, so no
+    /// std guard ever crosses an `.await`.
+    revoke_guards: RevokeGuards,
     #[cfg(test)]
     fold_invocations: AtomicUsize,
 }
@@ -442,6 +457,7 @@ impl RoomSupervisor {
             sessions: StdMutex::new(HashMap::new()),
             structural: TokioMutex::new(()),
             snapshot_cache: StdMutex::new(HashMap::new()),
+            revoke_guards: StdMutex::new(HashMap::new()),
             #[cfg(test)]
             fold_invocations: AtomicUsize::new(0),
         })
@@ -3220,6 +3236,38 @@ impl RoomSupervisor {
             }
         }
 
+        // Serialize concurrent revokes of the SAME pipe so the
+        // read-existing-close -> author critical section below is atomic per
+        // pipe: two distinct-op_id revokes of one pipe cannot both read
+        // "not yet closed" and both author. Acquired only after the ownership
+        // guard, so a non-publisher never contends here. Only the per-key async
+        // mutex is held across the awaits; the map's std mutex is dropped first.
+        let authoring_cell = {
+            let mut guards = self
+                .revoke_guards
+                .lock()
+                .expect("revoke guard map poisoned");
+            guards.entry((room_id, pipe_id)).or_default().clone()
+        };
+        let _authoring = authoring_cell.lock().await;
+
+        // Idempotent replay: an already-withdrawn pipe returns its ORIGINAL
+        // withdrawal and authors nothing further, so a second (or Nth) revoke of
+        // a closed pipe is a pure local read serving the first revoke's exact
+        // event id / pos / instant. This runs only after the publisher relation
+        // is confirmed above, so a non-publisher re-revoking a closed pipe still
+        // gets pipe_not_publisher, never a laundered success. `release_pipe_
+        // connections` is intentionally skipped on this path (the first revoke
+        // already released them; the pipe is closed, so no live connection
+        // remains). Sync scope: the !Sync store never crosses the await.
+        {
+            let store = self.open_store()?;
+            if let Some(event_id) = original_pipe_closed(&store, &room_id, pipe_id)? {
+                return Ok(event_id);
+            }
+        }
+
+        // First withdrawal: author exactly one signed pipe.closed.
         let session = self.session(&room_id)?;
         session
             .node
@@ -3241,9 +3289,13 @@ impl RoomSupervisor {
         Ok(event_id)
     }
 
-    /// Find the freshest persisted pipe event of `ty` for `pipe_id` (the
-    /// engine persists synchronously on publish; a short retry covers WAL
-    /// visibility across connections).
+    /// Find the **canonically-earliest** persisted pipe event of `ty` for
+    /// `pipe_id` (the engine persists synchronously on publish; a short retry
+    /// covers WAL visibility across connections). Returning the first
+    /// `(lamport, event_id)`-ordered match — not the last — keeps the served
+    /// id/pos/instant identical to the ORIGINAL event if two `pipe.closed` rows
+    /// ever coexist; a pipe has exactly one `pipe.opened`, so the publish path
+    /// is unaffected.
     async fn find_pipe_event(
         &self,
         room_id: &RoomId,
@@ -3268,7 +3320,19 @@ impl RoomSupervisor {
                         _ => false,
                     };
                     if matches {
+                        // First canonical-order match wins. `by_type` orders
+                        // causally-complete rows ascending by `(lamport,
+                        // event_id)` (the same order `room_tail` and
+                        // `committed_pos_and_instant` rank over), so the first
+                        // match is the ORIGINAL event. Should two `pipe.closed`
+                        // rows ever coexist (a legacy store, or a lost author
+                        // race before the per-pipe guard) the earliest is
+                        // returned, keeping the served id/pos/instant stable
+                        // rather than flaky. A pipe has exactly one
+                        // `pipe.opened`, so the publish-path lookup is
+                        // unaffected.
                         found = Some(bare_event_hex(&se.event_id));
+                        break;
                     }
                 }
                 found
@@ -4142,6 +4206,44 @@ fn open_pipe(
             if let Content::PipeOpened(p) = ev.content {
                 if p.pipe_id == pipe_id {
                     return Ok(Some(p));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// The bare event-id hex of the **original** `pipe.closed` for `pipe_id` in
+/// canonical timeline order, or `None` if the pipe has never been closed in the
+/// local log.
+///
+/// "Original" is the first *committed* close in the same `room_tail`-ordered,
+/// [`is_committed`](crate::projection::is_committed)-filtered scan that
+/// [`TypedSupervisor::committed_pos_and_instant`](crate::typed) ranks over — the
+/// canonical `(lamport, event_id)` order. Deriving the replayed id from that
+/// exact order is what makes a re-revoke serve the same `pos`/`revoked_at` the
+/// first revoke served, rather than a `by_type` "last wins" pick. Read-only and
+/// sync-scoped, matching the surrounding pipe helpers (no `!Sync` store borrow
+/// crosses an await).
+fn original_pipe_closed(
+    store: &EventStore,
+    room_id: &RoomId,
+    pipe_id: [u8; SHORT_ID_LEN],
+) -> CoreResult<Option<String>> {
+    let rows = store.room_tail(room_id, u32::MAX).map_err(|e| {
+        internal(
+            "could not read the room tail for the original pipe.closed",
+            e,
+        )
+    })?;
+    for se in &rows {
+        if !crate::projection::is_committed(se) {
+            continue; // a non-committed close holds no position and is not "the original"
+        }
+        if let Ok(ev) = SignedEvent::decode(&se.wire.signed) {
+            if let Content::PipeClosed(p) = ev.content {
+                if p.pipe_id == pipe_id {
+                    return Ok(Some(bare_event_hex(&se.event_id)));
                 }
             }
         }
@@ -6778,5 +6880,261 @@ mod tests {
         assert_eq!(err.kind, ErrorKind::InvalidParams);
 
         sup.close_room(&room_id).await.unwrap();
+    }
+
+    /// A second (or Nth) `pipe.close` with a *distinct* logical op must replay
+    /// the ORIGINAL withdrawal rather than authoring a fresh `pipe.closed` event.
+    /// The store must contain exactly one committed `pipe.closed` for the pipe
+    /// after any number of sequential revokes, and both calls must return the
+    /// same event id.
+    ///
+    /// Regression for #271: before the idempotent-replay fix the second call
+    /// always authored a second committed `pipe.closed`, causing `revoked_at` to
+    /// drift under concurrent CI load and failing the corpus case
+    /// `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_close_of_an_already_closed_pipe_replays_the_original_and_authors_nothing() {
+        let dir = tempdir().unwrap();
+        let profile = crate::identity::create(dir.path()).unwrap();
+        let sup = RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = sup.create_room("Idempotent Revoke").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        sup.open_room(&room_id_str, &[]).await.unwrap();
+
+        let self_id: iroh_rooms::identity::IdentityKey = profile.identity_id.parse().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target = listener.local_addr().unwrap();
+        let (pipe_id, _) = sup
+            .pipe_expose_multi(&room_id, target, &target.to_string(), &[self_id])
+            .await
+            .unwrap();
+        let pipe_id_hex = hex::encode(pipe_id);
+
+        // First revoke: must author exactly one committed `pipe.closed`.
+        let event_id_1 = sup.pipe_close(&room_id_str, &pipe_id_hex).await.unwrap();
+        {
+            let store = sup.open_store().unwrap();
+            let pipe_closed_count = store
+                .by_type(&room_id, EventType::PipeClosed)
+                .unwrap()
+                .iter()
+                .filter(|se| {
+                    SignedEvent::decode(&se.wire.signed)
+                        .ok()
+                        .and_then(|ev| {
+                            if let Content::PipeClosed(p) = ev.content {
+                                Some(p)
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|p| p.pipe_id == pipe_id)
+                        .unwrap_or(false)
+                })
+                .count();
+            assert_eq!(
+                pipe_closed_count, 1,
+                "first revoke must author exactly one pipe.closed"
+            );
+        }
+
+        // Second revoke (distinct logical request; domain-state idempotency, not
+        // op_id dedup): must return the ORIGINAL event id without authoring a new
+        // `pipe.closed`.
+        let event_id_2 = sup.pipe_close(&room_id_str, &pipe_id_hex).await.unwrap();
+        assert_eq!(
+            event_id_2, event_id_1,
+            "second revoke must replay the ORIGINAL event id, not author a fresh one"
+        );
+        {
+            let store = sup.open_store().unwrap();
+            let pipe_closed_count = store
+                .by_type(&room_id, EventType::PipeClosed)
+                .unwrap()
+                .iter()
+                .filter(|se| {
+                    SignedEvent::decode(&se.wire.signed)
+                        .ok()
+                        .and_then(|ev| {
+                            if let Content::PipeClosed(p) = ev.content {
+                                Some(p)
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|p| p.pipe_id == pipe_id)
+                        .unwrap_or(false)
+                })
+                .count();
+            assert_eq!(
+                pipe_closed_count, 1,
+                "second revoke must not author a new pipe.closed — domain-state idempotency"
+            );
+        }
+
+        sup.close_room(&room_id_str).await.unwrap();
+        drop(listener);
+    }
+
+    /// Two concurrent `pipe.close` calls with distinct logical op contexts
+    /// (no shared op_id dedup) must converge on a single withdrawal: both
+    /// return the same event id, and the store contains exactly one committed
+    /// `pipe.closed`. Closes the concurrent-distinct-op_id window from #271
+    /// §2.3 via the per-`(room, pipe)` `RevokeGuards` mutex that makes the
+    /// check-then-author section atomic per pipe.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_close_concurrent_distinct_op_revokes_converge_on_one_withdrawal() {
+        let dir = tempdir().unwrap();
+        let profile = crate::identity::create(dir.path()).unwrap();
+        let sup = Arc::new(RoomSupervisor::new(dir.path().to_path_buf(), true).unwrap());
+        let room_id_str = sup.create_room("Concurrent Revoke").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        sup.open_room(&room_id_str, &[]).await.unwrap();
+
+        let self_id: iroh_rooms::identity::IdentityKey = profile.identity_id.parse().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target = listener.local_addr().unwrap();
+        let (pipe_id, _) = sup
+            .pipe_expose_multi(&room_id, target, &target.to_string(), &[self_id])
+            .await
+            .unwrap();
+        let pipe_id_hex = hex::encode(pipe_id);
+
+        // Fire two concurrent revokes for the same pipe from the same publisher.
+        let sup_a = Arc::clone(&sup);
+        let room_str_a = room_id_str.clone();
+        let hex_a = pipe_id_hex.clone();
+        let sup_b = Arc::clone(&sup);
+        let room_str_b = room_id_str.clone();
+        let hex_b = pipe_id_hex.clone();
+        let (result_a, result_b) = tokio::join!(
+            async move { sup_a.pipe_close(&room_str_a, &hex_a).await },
+            async move { sup_b.pipe_close(&room_str_b, &hex_b).await },
+        );
+
+        let id_a = result_a.unwrap();
+        let id_b = result_b.unwrap();
+        assert_eq!(
+            id_a, id_b,
+            "concurrent distinct-op_id revokes must converge on the same event id"
+        );
+
+        // Exactly one `pipe.closed` must have been committed.
+        {
+            let store = sup.open_store().unwrap();
+            let closed_count = store
+                .by_type(&room_id, EventType::PipeClosed)
+                .unwrap()
+                .into_iter()
+                .filter(|se| {
+                    SignedEvent::decode(&se.wire.signed)
+                        .ok()
+                        .and_then(|ev| {
+                            if let Content::PipeClosed(p) = ev.content {
+                                Some(p)
+                            } else {
+                                None
+                            }
+                        })
+                        .map(|p| p.pipe_id == pipe_id)
+                        .unwrap_or(false)
+                })
+                .count();
+            assert_eq!(
+                closed_count, 1,
+                "concurrent revokes must converge on exactly one withdrawal"
+            );
+        }
+
+        sup.close_room(&room_id_str).await.unwrap();
+        drop(listener);
+    }
+
+    /// A non-publisher revoking an *already-closed* pipe must still receive
+    /// `PipeDenied` (→ `pipe_not_publisher`), never a laundered success from
+    /// the idempotent-replay path. The ownership guard runs before the
+    /// replay-lookup in `pipe_close`, so a closed pipe never becomes a
+    /// confirmation oracle. Extends
+    /// `pipe_close_refuses_a_room_authority_that_did_not_publish` to cover the
+    /// already-closed case added by the #271 fix.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_close_of_an_already_closed_pipe_refuses_non_publisher() {
+        let owner_dir = tempdir().unwrap();
+        let owner_profile = crate::identity::create(owner_dir.path()).unwrap();
+        let owner = RoomSupervisor::new(owner_dir.path().to_path_buf(), true).unwrap();
+        let room_id_str = owner.create_room("Closed Pipe Auth").unwrap();
+        let room_id: RoomId = room_id_str.parse().unwrap();
+        let opened = owner.open_room(&room_id_str, &[]).await.unwrap();
+        let owner_addr = opened["endpoint"]["addr"].as_str().unwrap().to_owned();
+
+        let member_dir = tempdir().unwrap();
+        let member_profile = crate::identity::create(member_dir.path()).unwrap();
+        let member = RoomSupervisor::new(member_dir.path().to_path_buf(), true).unwrap();
+        let ticket = owner
+            .create_invite(&room_id_str, &member_profile.identity_id, "member", None)
+            .await
+            .unwrap();
+        member
+            .join_room(&ticket, None, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        member
+            .open_room(&room_id_str, std::slice::from_ref(&owner_addr))
+            .await
+            .unwrap();
+        wait_member_status(&owner, &room_id_str, &member_profile.identity_id, "active").await;
+
+        // MEMBER publishes a pipe with the owner as audience.
+        let owner_id: iroh_rooms::identity::IdentityKey =
+            owner_profile.identity_id.parse().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target = listener.local_addr().unwrap();
+        let (pipe_id, _) = member
+            .pipe_expose_multi(
+                &room_id,
+                target,
+                &target.to_string(),
+                std::slice::from_ref(&owner_id),
+            )
+            .await
+            .unwrap();
+        let pipe_id_hex = hex::encode(pipe_id);
+
+        // Wait for the pipe.opened to reach the owner's store.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let pipes = owner.pipe_list(&room_id_str).await.unwrap();
+            if pipes
+                .iter()
+                .any(|p| p["pipe_id"].as_str() == Some(pipe_id_hex.as_str()))
+            {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for the member's pipe.opened to reach the owner"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        // Publisher (member) closes the pipe first.
+        member.pipe_close(&room_id_str, &pipe_id_hex).await.unwrap();
+
+        // Non-publisher (owner) must still get PipeDenied on the closed pipe.
+        // The ownership guard runs before the idempotent-replay lookup, so the
+        // closed pipe must never become a laundered success for a non-publisher.
+        let err = owner
+            .pipe_close(&room_id_str, &pipe_id_hex)
+            .await
+            .expect_err("non-publisher must not get success on a closed pipe");
+        assert_eq!(
+            err.kind,
+            ErrorKind::PipeDenied,
+            "pipe_not_publisher must be returned even when the pipe is already closed"
+        );
+
+        member.close_room(&room_id_str).await.unwrap();
+        owner.close_room(&room_id_str).await.unwrap();
+        drop(listener);
     }
 }

--- a/crates/jeliyad/src/serve.rs
+++ b/crates/jeliyad/src/serve.rs
@@ -4924,13 +4924,28 @@ mod tests {
         )
         .await;
 
-        tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+        // Drive the timers off a PAUSED virtual clock (matching this test's two
+        // paused-clock siblings), so concurrent CI load cannot drift a real
+        // sleep against the daemon's `Instant`-based stall/deadline timers. The
+        // clock is frozen only after OPEN/staging completes on the real clock,
+        // the same point the siblings freeze, so paused time never races the
+        // asynchronous staging setup.
+        tokio::time::pause();
+
+        // Advance to the mid-transfer progress point (~800 ms after OPEN),
+        // crossing no timer boundary, then send the single DATA byte.
+        tokio::time::advance(std::time::Duration::from_millis(800)).await;
+        tokio::task::yield_now().await;
         client
             .send(Message::Binary(
                 stream_data_wire(REQUEST_ID, identity.stream_id().get(), 0, b"x").into(),
             ))
             .await
             .unwrap();
+        // Await the CREDIT before advancing further: it proves the byte was
+        // durably accepted and the stall timer was reset (to ~1,800 ms). If the
+        // clock jumped first, the reset would not yet have happened and the
+        // stall/deadline race would re-enter.
         let Message::Binary(sentinel_credit) = next_socket_message(&mut client).await else {
             panic!("durably accepted progress must advance CREDIT");
         };
@@ -4945,6 +4960,14 @@ mod tests {
             }
         );
 
+        // Cross the ABSOLUTE deadline (1,600 ms from OPEN) while staying below
+        // the reset stall boundary (~1,800 ms): only the absolute deadline may
+        // fire, so the ABORT carries `accepted_through: 1`. Bracket the advance
+        // with the record it triggers — the paused-clock siblings use exactly
+        // this advance-then-await cadence so the clock never crosses two timer
+        // boundaries in one step.
+        tokio::time::advance(std::time::Duration::from_millis(DEADLINE_BUDGET_MS - 800)).await;
+        tokio::task::yield_now().await;
         let Message::Binary(abort) = next_socket_message(&mut client).await else {
             panic!("absolute deadline must receive daemon ABORT after progress");
         };
@@ -5687,6 +5710,218 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), server)
             .await
             .expect("connection teardown")
+            .expect("serve task");
+    }
+
+    // ── #271 pipe.revoke idempotency e2e ─────────────────────────────────────
+
+    /// Exercises the full WebSocket → serve.rs → TypedSupervisor → RoomSupervisor
+    /// path for `pipe.revoke` idempotency.  A second revoke with a **distinct**
+    /// `op_id` (domain-state idempotency, not op_id-replay) must return the
+    /// ORIGINAL `event_id`, `revoked_at`, and `pos` and must not author a second
+    /// `pipe.closed` event.  Regression for #271: before the fix the second
+    /// revoke authored a fresh event, causing `revoked_at` to drift under load.
+    ///
+    /// Also confirms `pipe.list` returns `pipes: []` after revocation.
+    #[tokio::test]
+    async fn websocket_pipe_revoke_idempotency_with_distinct_op_id() {
+        let (_dir, state) = test_state(SOCKET_FRAME_BYTES as u64);
+
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::SubjectEnsure(
+                jeliya_api::SubjectEnsure {},
+            ))
+            .await
+            .reply
+            .expect("subject.ensure");
+        let created = state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomCreate(
+                jeliya_api::RoomCreate {
+                    name: "pipe-revoke-idempotency".into(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.create");
+        let jeliya_core::typed::TypedReply::RoomCreate(created) = created else {
+            panic!("wrong room.create reply");
+        };
+        let room_id = created.room_id.clone();
+        state
+            .engine
+            .execute(jeliya_core::typed::TypedCall::RoomActivate(
+                jeliya_api::RoomActivate {
+                    room_id: room_id.clone(),
+                },
+            ))
+            .await
+            .reply
+            .expect("room.activate");
+
+        // Loopback TCP listener — the only address family pipe.publish accepts.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_port = listener.local_addr().unwrap().port();
+
+        let (mut client, server) = socket_pair(state).await;
+        assert!(matches!(client.next().await, Some(Ok(Message::Text(_)))));
+
+        // 1. pipe.publish
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 10,
+                    "op_id": "op-publish-1",
+                    "op": "pipe.publish",
+                    "in": {
+                        "room_id": room_id,
+                        "target": { "host": "127.0.0.1", "port": target_port },
+                        "audience": { "state": "room" },
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(publish_msg) = next_socket_message(&mut client).await else {
+            panic!("pipe.publish must reply with Text JSON");
+        };
+        let publish_reply: jeliya_codec::Reply = serde_json::from_str(&publish_msg).unwrap();
+        assert_eq!(publish_reply.id, 10);
+        assert!(
+            publish_reply.ok,
+            "pipe.publish must succeed: {:?}",
+            publish_reply.err
+        );
+        let pipe_id = publish_reply
+            .out
+            .as_ref()
+            .and_then(|o| o["pipe_id"].as_str())
+            .expect("pipe.publish out must contain pipe_id")
+            .to_owned();
+
+        // 2. First pipe.revoke — authors the withdrawal.
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 11,
+                    "op_id": "op-revoke-first",
+                    "op": "pipe.revoke",
+                    "in": { "room_id": room_id, "pipe_id": pipe_id }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(revoke1_msg) = next_socket_message(&mut client).await else {
+            panic!("first pipe.revoke must reply with Text JSON");
+        };
+        let revoke1: jeliya_codec::Reply = serde_json::from_str(&revoke1_msg).unwrap();
+        assert_eq!(revoke1.id, 11);
+        assert!(
+            revoke1.ok,
+            "first pipe.revoke must succeed: {:?}",
+            revoke1.err
+        );
+        let out1 = revoke1.out.as_ref().expect("first pipe.revoke out");
+        let event_id_1 = out1["event_id"]
+            .as_str()
+            .expect("event_id in first revoke out")
+            .to_owned();
+        let revoked_at_1 = out1["revoked_at"]
+            .as_str()
+            .expect("revoked_at in first revoke out")
+            .to_owned();
+        let pos_1 = out1["pos"].as_u64().expect("pos in first revoke out");
+
+        // 3. Second pipe.revoke with a DISTINCT op_id — domain-state idempotency
+        //    (§2.1), not op_id-replay dedup.  Must replay the ORIGINAL withdrawal.
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 12,
+                    "op_id": "op-revoke-distinct",
+                    "op": "pipe.revoke",
+                    "in": { "room_id": room_id, "pipe_id": pipe_id }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(revoke2_msg) = next_socket_message(&mut client).await else {
+            panic!("second pipe.revoke must reply with Text JSON");
+        };
+        let revoke2: jeliya_codec::Reply = serde_json::from_str(&revoke2_msg).unwrap();
+        assert_eq!(revoke2.id, 12);
+        assert!(
+            revoke2.ok,
+            "distinct-op_id second pipe.revoke must succeed idempotently: {:?}",
+            revoke2.err
+        );
+        let out2 = revoke2.out.as_ref().expect("second pipe.revoke out");
+        assert_eq!(
+            out2["event_id"].as_str().unwrap(),
+            event_id_1,
+            "second revoke must replay the ORIGINAL event_id, not author a fresh one"
+        );
+        assert_eq!(
+            out2["revoked_at"].as_str().unwrap(),
+            revoked_at_1,
+            "second revoke must return the FIRST revocation instant"
+        );
+        assert_eq!(
+            out2["pos"].as_u64().unwrap(),
+            pos_1,
+            "second revoke must return the FIRST timeline position"
+        );
+
+        // 4. pipe.list must be empty — the pipe is settled as revoked.
+        client
+            .send(Message::Text(
+                serde_json::json!({
+                    "id": 13,
+                    "op": "pipe.list",
+                    "in": {
+                        "room_id": room_id,
+                        "cursor": { "state": "start" },
+                        "direction": "forward",
+                        "limit": 50,
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .unwrap();
+        let Message::Text(list_msg) = next_socket_message(&mut client).await else {
+            panic!("pipe.list must reply with Text JSON");
+        };
+        let list_reply: jeliya_codec::Reply = serde_json::from_str(&list_msg).unwrap();
+        assert_eq!(list_reply.id, 13);
+        assert!(
+            list_reply.ok,
+            "pipe.list must succeed after revocation: {:?}",
+            list_reply.err
+        );
+        let pipes = list_reply
+            .out
+            .as_ref()
+            .and_then(|o| o["pipes"].as_array())
+            .expect("pipe.list out must contain pipes array");
+        assert!(
+            pipes.is_empty(),
+            "pipe.list must return no pipes after revocation, got: {pipes:?}"
+        );
+
+        drop(listener);
+        client.close(None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), server)
+            .await
+            .expect("connection teardown after pipe-revoke idempotency test")
             .expect("serve task");
     }
 }

--- a/specs/fix-pipe-revoke-idempotency-race.md
+++ b/specs/fix-pipe-revoke-idempotency-race.md
@@ -1,0 +1,281 @@
+# Fix: `pipe.revoke` idempotency race — a second revoke authors a new withdrawal instead of replaying the original
+
+- **Issue:** #271 `[Daemon][Flaky]: pipe.revoke idempotency race — a second revoke occasionally authors a new withdrawal instead of replaying the original`
+- **Priority / labels:** flaky · daemon · reliability
+- **Owning module (Defect A):** `crates/jeliya-core/src/supervisor.rs` — `RoomSupervisor::pipe_close`
+- **Boundary consumer:** `crates/jeliya-core/src/typed.rs` — `TypedSupervisor::pipe_revoke`
+- **Owning module (Defect B):** `crates/jeliyad/src/serve.rs` — test `websocket_file_share_progress_resets_stall_but_not_absolute_deadline`
+- **Conformance surface:** `conformance/v2/pipes.json` case `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal` (case index 26); companion `pipe_revoke_withdraws_the_publication_as_a_converged_room_fact` (index 25)
+- **Type:** current-stack reliability maintenance; two independent defects fixed in one sweep; no new dependencies; MSRV 1.91, `unsafe_code` forbidden (both fixes are safe Rust)
+
+---
+
+## 0. Scope and non-goals
+
+This spec fixes two **pre-existing** flakes surfaced during wave-2's #207 corpus A/B verification (2026-08-10). Neither is caused by any wave-2 PR; both predate the wave.
+
+- **Defect A (primary):** the daemon's `pipe.revoke` is **not idempotent** at the room-fact layer. A second, genuinely distinct revoke of an already-revoked pipe authors a *second* signed `pipe.closed` (→ committed `pipe_revoked`) event rather than replaying the original withdrawal. This is a correctness defect that *manifests* as flake.
+- **Defect B (secondary sweep):** the serve-crate unit test `websocket_file_share_progress_resets_stall_but_not_absolute_deadline` drives its timers off a **real wall clock** (`tokio::time::sleep`) while its two siblings use a paused virtual clock, making it timing-sensitive under concurrent CI load.
+
+**Non-goals:** no change to the wire protocol, the `pipe.closed` event schema, the op_id dedup ledger, or `pipe.connect`/`pipe.list`/`pipe.release` semantics. No durable persistence of the ledger. No change to the conformance corpus fixtures (the fixture already encodes the correct expectation; the daemon must meet it). Do not "fix" the flake by loosening the harness assertion.
+
+---
+
+## 1. Problem statement — Defect A (daemon idempotency race)
+
+### 1.1 What the corpus case requires
+
+`conformance/v2/pipes.json` → `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal` runs, all on `subject:A` (the publisher):
+
+1. `pipe.publish` (op_id `$op1`) → saves `$pid`.
+2. `pipe.revoke {room_id, pipe_id:$pid}` with op_id **`$op2`** → saves `revoked_at = out.revoked_at`.
+3. `pipe.revoke {room_id, pipe_id:$pid}` with op_id **`$op3_distinct`** — a *different* op_id — and asserts:
+   ```json
+   "expect": { "ok": true, "out": {
+       "room_id": "$rid", "pipe_id": "$pid",
+       "revoked_at": "$revoked_at",      // MUST equal step-2's instant
+       "event_id": "<event_id>", "pos": "<pos>" } }
+   ```
+4. `pipe.list` → `pipes: []`, plus `{ "observe": "no_event_authored", "scope": "case" }`.
+
+The intent line is explicit: *"a second, genuinely distinct withdrawal request succeeds idempotently and returns the FIRST revocation instant rather than authoring a second withdrawal."* Because step 3 carries a **distinct op_id**, the op_id dedup ledger (`is_dedup_op` includes `pipe.revoke`, `crates/jeliya-core/src/engine.rs:307`) does **not** cover it — idempotency here must come from the **domain state** (the pipe is already revoked), not from op_id replay. (Case 25 exercises the op_id-replay path with the *same* op_id `op-revoke-1`; that path is already correct and must stay correct.)
+
+### 1.2 The daemon path today
+
+`TypedSupervisor::pipe_revoke` (`crates/jeliya-core/src/typed.rs:1991-2019`) delegates to `RoomSupervisor::pipe_close` for the event id, then derives `pos`/`revoked_at` from that id via `committed_pos_and_instant` (`typed.rs:2043+`):
+
+```rust
+let event_id = self.sup.pipe_close(room_id, pipe_id).await …?;
+let (pos, revoked_at) = self.committed_pos_and_instant(&ctx.room_id, &event_id)?;
+```
+
+`RoomSupervisor::pipe_close` (`crates/jeliya-core/src/supervisor.rs:3190-3241`) does, in order:
+
+1. `open_pipe(&store, …, pipe_id)` — **unknown-pipe guard**; `None` → `PipeUnknown` (`supervisor.rs:4132`, scans `PipeOpened` rows only; a *closed* pipe still has its `PipeOpened` row, so this still finds it).
+2. **Ownership guard**: `opened.owner_id != self_id` → `PipeDenied` (→ `PipeNotPublisher`).
+3. **Unconditionally** `session.node.pipe_close(…, now_ms())`.
+4. `release_pipe_connections(...)`.
+5. `find_pipe_event(room, EventType::PipeClosed, pipe_id)` and returns that id.
+
+The upstream `node.pipe_close` (`iroh-rooms-net/src/node.rs:1099`) **builds and publishes a fresh `pipe.closed` unconditionally** — it never checks whether the pipe is already closed:
+
+```rust
+let wire = build_pipe_closed(…, created_at);   // created_at = now_ms()
+self.publish(wire.to_bytes()).await …?;
+self.pipe_registry.remove(&pipe_id);           // dedup happens AFTER the author, uselessly
+```
+
+And the projection commits **every** `pipe.closed`: `is_committed` (`crates/jeliya-core/src/projection.rs:195-201`) is true for any `pipe.closed` with a valid `created_at` (its `kind_content` maps to `PipeRevoked`, `projection.rs:434`). There is **no fold-level dedup** of a second close for the same pipe — both closed events are committed and each consumes a timeline position.
+
+**Consequence:** step 3 always authors a *second* committed `pipe_revoked` event. There is no idempotency guard anywhere in the jeliya-owned path.
+
+### 1.3 Why it usually passes on a quiet machine, and races under load
+
+Two harness checks straddle the second author; each fails on a different sub-timing, which is why the flake rate varies (measured 1/5 on a PR build, 2/5 on baseline main@1b44321 under concurrent cargo load; deterministic-pass in isolation on a quiet machine):
+
+- **`revoked_at: "$revoked_at"` equality.** `find_pipe_event` (`supervisor.rs:3247-3286`) returns **whichever matching row `store.by_type` yields *last*** (`found = Some(...)` overwrites each match). With two closed events present, the returned event id — and therefore the `revoked_at`/`event_id`/`pos` that `committed_pos_and_instant` derives — is whichever the store orders last. On a quiet machine the two authors land in the **same `now_ms()` millisecond**, so both events carry an identical `revoked_at` and the equality holds by coincidence; under load the two authors straddle a millisecond boundary, the second event's `revoked_at` differs, and if `by_type` yields it last the equality assertion fails.
+- **`no_event_authored` (scope: case).** The harness (`conformance/v2/harness/runner.mjs`) snapshots the room's committed-event total via `room.timeline` (`#roomEventTotal`, `runner.mjs:1177`) and, after each **successful** step, refreshes the baseline (`runner.mjs:145-160`); the observation throws iff the total has grown past the last baseline (`#evalObserve` → `no_event_authored`, `runner.mjs:1264+`). Step 3 is `ok:true`, so its baseline refresh *should* absorb the extra event — but that refresh reads `room.timeline` through a subscribed session **immediately** after step 3's reply, racing the just-authored event's WAL visibility. Under load the refresh reads the *stale* (pre-second-event) total; the later `no_event_authored` observation reads the *settled* total and sees growth → throw: `no_event_authored violated: room events grew N -> N+1`.
+
+Both symptoms have the **same root cause**: a second withdrawal is authored at all. Remove the second author and both symptoms vanish deterministically.
+
+### 1.4 Why the sequential case is deterministically fixable (and the residual concurrent race)
+
+By the time step 3 runs, step 2's reply has already returned — and `pipe_revoke`'s reply is produced only after `find_pipe_event` **polls the local store until the `pipe.closed` row is visible** (up to 20 × `POLL_INTERVAL` = 2 s, `supervisor.rs:128,3253`). So when step 3 begins, the original closed event is guaranteed present in the same local store an idempotency lookup would read. The **sequential** case is therefore closed *deterministically* by a read-before-author guard, with no locking.
+
+A **concurrent** pair of distinct-op_id revokes of the same pipe (legal, and what the issue title's word "race" also covers) is *not* closed by the read alone: both could read "not yet closed" and both author. Closing that window requires serializing the check-then-author per `(room, pipe)`. This spec includes that serialization (§2.3) so the fix honestly matches the title, while noting the corpus flake is resolved by §2.1 alone.
+
+---
+
+## 2. Fix design — Defect A
+
+Three parts, in `crates/jeliya-core/src/supervisor.rs`, entirely behind the existing `RoomSupervisor::pipe_close` seam (no signature change; `typed.rs` and the wire are untouched).
+
+### 2.1 Idempotent replay: return the original withdrawal, author nothing (primary; sufficient for the corpus case)
+
+Add a helper that finds the **original** (canonically earliest) committed `pipe.closed` for a pipe, returning its bare event-id hex:
+
+```rust
+/// The bare event-id hex of the ORIGINAL `pipe.closed` for `pipe_id` in
+/// canonical timeline order, or `None` if the pipe has never been closed
+/// in the local log. "Original" = the first committed close by the same
+/// `(lamport, event_id)` rank the timeline/resync/pos derivation uses, so a
+/// replayed revoke serves the exact instant/pos the first revoke served.
+fn original_pipe_closed(
+    store: &EventStore,
+    room_id: &RoomId,
+    pipe_id: [u8; SHORT_ID_LEN],
+) -> CoreResult<Option<String>>
+```
+
+Implementation notes:
+- Scan the canonical tail (`store.room_tail(room_id, u32::MAX)`), skipping non-committed rows via `proj::is_committed`, and return the **first** row whose decoded content is `Content::PipeClosed(p)` with `p.pipe_id == pipe_id`. Do **not** use `store.by_type` "last wins" — canonical-order-first is what makes "the original" well-defined and consistent with `committed_pos_and_instant`, which ranks the same canonical order.
+- This scan mirrors the ordering already used in `committed_pos_and_instant` (`typed.rs:2043+`) and `positioned` (`projection.rs:174`); keep it read-only and sync-scoped (no `!Sync` store borrow across an await), matching the surrounding code.
+
+Rewrite `pipe_close` to consult it **after** the unknown-pipe and ownership guards and **before** authoring:
+
+```rust
+// (unchanged) unknown-pipe guard + ownership guard on open_pipe(...)
+
+// Idempotent replay: an already-withdrawn pipe returns its ORIGINAL
+// withdrawal and authors nothing further. This must run only after the
+// publisher relation is confirmed, so a non-publisher re-revoking a closed
+// pipe still gets pipe_not_publisher, never a laundered success.
+{
+    let store = self.open_store()?;
+    if let Some(event_id) = original_pipe_closed(&store, &room_id, pipe_id)? {
+        return Ok(event_id);
+    }
+}
+
+// First withdrawal: author exactly one signed pipe.closed.
+session.node.pipe_close(…, now_ms()).await …?;
+self.release_pipe_connections(&room_id, pipe_id_hex)?;   // idempotent; harmless on replay
+let event_id = self.find_pipe_event(&room_id, EventType::PipeClosed, pipe_id).await?;
+Ok(event_id)
+```
+
+Ordering rationale (do not reorder):
+- **Unknown-pipe** first — preserves `pipe_revoke_of_an_unknown_pipe_is_pipe_unknown` (case 27) and the record's "never confirm existence via an auth error" rule.
+- **Ownership** second — preserves `pipe_close_refuses_a_room_authority_that_did_not_publish` (`supervisor.rs:6281`); a non-publisher never reaches the idempotent-replay branch, so re-revoking a closed pipe as a non-publisher still yields `PipeNotPublisher`.
+- **Idempotent replay** third — only a confirmed publisher of an already-closed pipe gets the original event id back with no new author.
+
+`release_pipe_connections` on the replay path is intentionally **skipped** (the first revoke already released them; the pipe is closed, so no live connection should exist). It is idempotent, so if a future change moves it onto the replay path it stays harmless — but keeping the replay branch a pure read is preferred.
+
+### 2.2 Deterministic selection on the first-author path (defense in depth)
+
+Change `find_pipe_event` (or introduce a dedicated `find_first_pipe_event`) to select the **canonically earliest** matching row rather than the last `by_type` row, so that even if two closed rows ever coexist (e.g. a legacy store, or a lost race before §2.3 lands) the returned id is stable and equals "the original." Concretely: break out of the scan on the first canonical-order match instead of letting later rows overwrite `found`. `find_pipe_event` is also used for `PipeOpened` lookups on the publish path; keep that call site's behavior equivalent (a pipe has exactly one `PipeOpened`, so first-vs-last is identical there). Preserve the existing 20-poll WAL-visibility retry.
+
+> With §2.1 in place, the first-author path can produce at most one `pipe.closed` per pipe per daemon, so §2.2 is belt-and-suspenders; include it because it is cheap, removes the last nondeterministic selector on this path, and makes any future regression fail loudly rather than flake.
+
+### 2.3 Per-`(room, pipe)` serialization of check-then-author (closes the concurrent-distinct-op_id window)
+
+Add a lightweight, bounded guard map to `RoomSupervisor` so the read-existing-close → author critical section is atomic per pipe:
+
+```rust
+/// Serializes concurrent revokes of the SAME pipe so a check-then-author
+/// cannot interleave into two withdrawals. Keyed per (room, pipe); distinct
+/// pipes never contend. In-memory, like the op_id ledger.
+revoke_guards: StdMutex<HashMap<(RoomId, [u8; SHORT_ID_LEN]), Arc<TokioMutex<()>>>>,
+```
+
+In `pipe_close`, after the ownership guard, acquire (get-or-insert) the per-key `Arc<TokioMutex<()>>` and hold it across the §2.1 replay-lookup + the first-author sequence:
+
+```rust
+let guard_cell = {
+    let mut guards = self.revoke_guards.lock().expect("revoke guard map poisoned");
+    guards.entry((room_id.clone(), pipe_id)).or_default().clone()
+};
+let _authoring = guard_cell.lock().await;   // per-pipe; other pipes/rooms unaffected
+// … §2.1 replay lookup, else author + find …
+```
+
+Constraints:
+- The `StdMutex` around the *map* is released before `.await` (only the per-key `Arc<TokioMutex>` is held across the await), so no `std::sync::Mutex` guard crosses an await point.
+- Do **not** reuse the supervisor's global `structural` `TokioMutex` (`supervisor.rs:324`): it serializes room open/teardown, and holding it across `node.pipe_close` + the up-to-2 s `find_pipe_event` poll would stall unrelated room opens. A dedicated per-pipe map keeps contention to concurrent revokes of the *same* pipe only.
+- Map growth is bounded by the number of distinct pipes ever revoked on the daemon (in-memory, per the record's "no durable ledger" stance). Cleanup is optional; if added, remove the entry only while holding the map lock and only when no waiters remain. Leaving entries is acceptable for the MVP (a pipe id is 16 bytes; the count is tiny).
+
+> If review judges §2.3 out of scope for a "flaky" ticket, it may be split into a follow-up, leaving §2.1 + §2.2 as the shippable fix for the observed corpus flake. State that decision explicitly in the PR; do not silently drop it, since the issue title names a race.
+
+---
+
+## 3. Fix design — Defect B (flaky serve test)
+
+`crates/jeliyad/src/serve.rs::websocket_file_share_progress_resets_stall_but_not_absolute_deadline` (`serve.rs:4899-5010`) is `#[tokio::test]` and drives timing with a **real** `tokio::time::sleep(800 ms)` (`serve.rs:4927`), then relies on the daemon's real `Instant`-based stall (1 000 ms) and absolute deadline (~1 600 ms) timers firing in a specific order to produce the CREDIT → ABORT → (ACK) → terminal-Text sequence it asserts. Under concurrent CI load the 800 ms real sleep and the daemon timers drift, reordering records and intermittently failing the assertions. Its two siblings avoid this by pausing the clock:
+
+- `websocket_file_share_daemon_abort_ack_timeout_replies_then_closes_4007` — `tokio::time::pause()` + `advance()` (`serve.rs:4751,4781,4787`).
+- `websocket_file_share_no_progress_stalls_and_survives_exact_ack` — `tokio::time::pause()` + `advance()` (`serve.rs:4833,4834`).
+
+The stall/deadline timers are `Instant`-based (`crates/jeliyad/src/transfer.rs:174-196`: `stall_deadline`/`deadline` add `Duration`s to a start `Instant`), so a paused virtual clock advanced with `tokio::time::advance` drives them deterministically — the pattern is already proven in this file.
+
+### 3.1 Conversion
+
+Convert the test to the paused-clock pattern:
+1. Call `tokio::time::pause()` at the top (before `socket_pair`, matching the siblings).
+2. Replace `tokio::time::sleep(800 ms)` with `tokio::time::advance(Duration::from_millis(800))` to reach the mid-transfer progress point *before* sending the single DATA byte.
+3. After sending DATA, **await the CREDIT record** (as today) before any further `advance` — awaiting the CREDIT proves the byte was durably accepted and the stall timer was reset; do not advance the clock until it arrives (otherwise the reset has not yet happened and the stall/deadline race re-enters).
+4. `advance` the remaining time to cross the **absolute** deadline (~1 600 ms from OPEN) while staying **below** the reset stall boundary (~1 800 ms), then await the ABORT (`OperationError`), matching the current assertions and the test's stated arithmetic (`serve.rs:4906-4911`).
+5. Keep the exact-ACK → terminal `TransferDeadlineExceeded { transferred_bytes:1, total: Known{bytes:1}, budget_ms:1600 }` and the `room.list` survival exchange unchanged; these are message round-trips, not timer-driven, so they need no `advance`.
+6. Preserve the post-conditions: `state.transfer_pool.usage() == (0,0)` and empty `protocol-v2-stream-staging`.
+
+Interleaving rule (the one subtlety): every `advance` must be **bracketed** by the message exchange it is meant to trigger — advance to a boundary, then `await` the record the daemon emits at that boundary — so the virtual clock never jumps past two timer boundaries in one step. The siblings demonstrate exactly this cadence.
+
+### 3.2 Fallback / honesty clause
+
+If, after the paused-clock conversion, the test *still* flakes, that indicates a genuine daemon ordering nondeterminism (ABORT vs CREDIT) rather than harness timing — a separate defect. In that case, stop and file/annotate it; do **not** paper over it by widening timing tolerances. The expectation is that the conversion fully deterministically fixes it, consistent with #244's characterization of this as a stall/deadline *timing* flake.
+
+---
+
+## 4. Implementation steps (ordered, red-before-green)
+
+1. **Reproduce Defect A red first.** Add a `jeliya-core` unit test (near `pipe_close_refuses_a_room_authority_that_did_not_publish`, `supervisor.rs:6281`) named e.g. `pipe_close_of_an_already_closed_pipe_replays_the_original_and_authors_nothing`:
+   - Single-daemon: create room, open, publish a pipe to a bound `TcpListener`, `pipe_close` → capture `event_id_1`.
+   - Assert the room's committed timeline contains exactly **one** `pipe_revoked` for the pipe (count `by_type(PipeClosed)` decoded matches == 1), and record its rank/instant.
+   - `pipe_close` **again** → assert the returned `event_id_2 == event_id_1`, and that the committed `pipe_revoked` count for the pipe is **still 1** (no new author). This test fails on `main` (count becomes 2 and/or ids differ).
+2. **Add `original_pipe_closed` (§2.1)** and rewire `pipe_close` to replay-before-author. Re-run the test from step 1 → green.
+3. **Add a concurrency test (§2.3):** spawn two `pipe_close` futures for the same pipe with `tokio::join!` (distinct logical requests) and assert the committed `pipe_revoked` count is exactly 1 and both return the same id. Confirm it fails without the guard and passes with it. (If §2.3 is deferred, mark this test `#[ignore]` with a reason referencing the follow-up rather than deleting it.)
+4. **Deterministic selection (§2.2):** change `find_pipe_event` to first-canonical-match; add/extend a test proving that with two synthetic closed rows the earliest is returned. Verify the publish-path `PipeOpened` lookup is unaffected.
+5. **Focused core gate:** `cargo test -p jeliya-core pipe_close` and the pipe-related tests; then `cargo test -p jeliya-core`.
+6. **Defect B:** convert the serve test to paused-clock (§3). Run it in a tight loop under load to confirm determinism, e.g.:
+   ```
+   cargo test -p jeliyad --lib serve::tests::websocket_file_share_progress_resets_stall_but_not_absolute_deadline
+   ```
+   Optionally wrap in a shell loop (×50) while a `cargo build` churns in parallel to simulate CI load; expect 0 failures.
+7. **Conformance A/B (Defect A proof):** run the v2 harness case `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal` repeatedly under load, before vs after, and confirm the after-build is deterministically green. Per repo memory, the *authoritative* proof for a daemon change is a full 341-case v2 corpus A/B diff (CI live-gates only ~22/341), so also run the full corpus once to confirm **no regression** on cases 25/27 and the other `pipe.*` cases. Commands per `conformance/v2/harness` (`npx`/node harness); consult `conformance/v2/manifest.json` for the runner entrypoint.
+8. **Workspace safety net:** `cargo test --workspace` (or the crates touched: `jeliya-core`, `jeliyad`) plus `cargo clippy --workspace -- -D warnings` and `cargo fmt --check`; `unsafe_code` remains absent.
+9. **Docs/changelog:** add a `CHANGELOG.md` entry under the daemon/reliability section noting the idempotent `pipe.revoke` fix and the deterministic serve test. No `docs/` profile page changes are required (no capability-status change — the behavior was always *specified* to be idempotent; only the implementation is corrected). If a maintainer judges the idempotency guarantee worth surfacing, update `docs/capability-status.md` for `pipe.revoke` and keep it reachable from `docs/index.md` (validated by `node scripts/check-docs.mjs`).
+
+> Per the session working rules: this is a targeted daemon fix; run the **focused** tests above during development. Reserve a full `npm run verify` for the ADW finalize gate — do not re-run the whole suite every phase. This spec touches Rust crates and the conformance harness only; there is no prompt-pack (`.adw/pack.profile.json`) change.
+
+---
+
+## 5. Acceptance criteria
+
+**Defect A**
+- [ ] `RoomSupervisor::pipe_close` authors **at most one** committed `pipe_revoked` event per `(pipe_id)` per daemon: a second (or Nth) revoke of an already-closed pipe returns the **original** event id and authors nothing.
+- [ ] A distinct-op_id second revoke of an already-revoked pipe returns `ok:true` with `revoked_at`/`event_id`/`pos` **equal to the first revoke's** (`committed_pos_and_instant` over the original event).
+- [ ] Ownership and unknown-pipe semantics are unchanged: `PipeUnknown` for an unknown pipe, `PipeNotPublisher` for a non-publisher — including a non-publisher revoking an *already-closed* pipe.
+- [ ] Concurrent distinct-op_id revokes of the same pipe converge on one withdrawal (§2.3), or that residual window is explicitly deferred in the PR with a tracked follow-up and an `#[ignore]`'d proof test.
+- [ ] `find_pipe_event` returns the canonically-earliest match; publish-path `PipeOpened` lookup unchanged.
+- [ ] Conformance case `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal` is deterministically green under concurrent load (≥ 20 consecutive runs, 0 failures), and case `pipe_revoke_withdraws_the_publication_as_a_converged_room_fact` (op_id-replay + member-B convergence) and case `pipe_revoke_of_an_unknown_pipe_is_pipe_unknown` remain green.
+- [ ] Full 341-case v2 corpus shows no regression attributable to this change.
+
+**Defect B**
+- [ ] `websocket_file_share_progress_resets_stall_but_not_absolute_deadline` uses a **paused** virtual clock (`tokio::time::pause()` + `advance`), no real `sleep` for timer progression.
+- [ ] The test asserts the same observable sequence and post-conditions as today (CREDIT `{accepted_through:1, send_through:2}`, ABORT `OperationError`, exact-ACK → `TransferDeadlineExceeded{…, budget_ms:1600}`, `room.list` survival, `transfer_pool.usage()==(0,0)`, empty staging) and passes deterministically under load (≥ 50 consecutive runs, 0 failures).
+
+**Both**
+- [ ] `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` clean; no `unsafe`.
+- [ ] No change to public wire/schema, the op_id ledger, or unrelated daemon paths.
+
+---
+
+## 6. Risks, security, and rollback
+
+- **Correctness of "original" selection.** If the earliest-canonical scan disagreed with `committed_pos_and_instant`'s ranking, a replay could serve a `pos`/`revoked_at` inconsistent with the timeline. Mitigation: both derive from the *same* canonical `(lamport, event_id)` order over `room_tail` filtered by `proj::is_committed`; the §4 tests assert the replayed `pos`/`revoked_at` equal the first revoke's.
+- **Ordering regressions in `pipe_close`.** Inserting the replay/guard must not move the unknown-pipe or ownership guards. Mitigation: explicit ordering in §2.1 and the dedicated refusal tests (case 27, `supervisor.rs:6281`).
+- **Deadlock / await-safety of the guard (§2.3).** Holding a `std::sync::Mutex` across `.await` is forbidden (and would be non-`Send`). Mitigation: the map's `StdMutex` is released before the per-key `TokioMutex` is awaited; only the async mutex is held across the author/poll. `cargo clippy` and the `Send` bound on the spawned serve future catch violations.
+- **Guard-map growth.** Bounded by distinct revoked pipes (in-memory, MVP-acceptable). Optional cleanup under the map lock; documented in §2.3.
+- **Convergence unchanged.** Authoring exactly once is *more* correct for multi-member convergence (case 25's member-B `pipe.list: []`), not less. No push/resync path changes.
+- **Security/privacy.** No new data crosses the trust boundary; the idempotent path is a local read. The unknown-pipe-before-auth ordering (which avoids confirming a pipe's existence to a non-publisher) is preserved.
+- **Serve-test conversion risk.** Mis-bracketing an `advance` past two timer boundaries would change which record arrives first. Mitigation: §3.1 interleaving rule + the sibling tests as the reference cadence; the §3.2 honesty clause forbids masking a residual real race.
+- **Rollback.** Each defect is independent and revertible in isolation: Defect A is contained to `pipe_close` + one helper (+ optional guard field) in `supervisor.rs`; Defect B is a single test function in `serve.rs`. Reverting either restores prior behavior with no schema/state migration.
+
+---
+
+## 7. Assumptions
+
+- The upstream `iroh-rooms-net` `node.pipe_close` remains "author unconditionally"; the fix lives entirely in the jeliya-core layer and does not depend on an upstream change. (If upstream later adds idempotency, §2.1 becomes a redundant fast-path, still correct.)
+- The op_id dedup ledger continues to cover *same-op_id* replays (case 25); this spec only adds *domain-state* idempotency for *distinct-op_id* re-revokes.
+- The conformance fixtures for cases 25/26/27 are correct as written and must not be edited; the daemon is what changes.
+- Stall/deadline timers are `Instant`-based and thus controllable by `tokio::time::pause()`/`advance()` (confirmed at `transfer.rs:174-196` and the two sibling tests).
+- The v2 replay harness is single-subject/single-daemon for the primary daemon; case 26 is entirely `subject:A` on one daemon, so it is faithfully reproducible locally (unlike the multi-actor gap noted in repo memory).
+
+---
+
+## 8. Open questions
+
+1. **Should §2.3 (concurrent-distinct-op_id serialization) ship with this ticket or as a follow-up?** The observed corpus flake is sequential and fully fixed by §2.1+§2.2; §2.3 closes the residual race the *title* names. Recommendation: ship it (small, contained); fall back to a tracked follow-up only if review pushes back.
+2. **Guard-map cleanup:** leave entries (bounded, tiny) vs. reference-count and evict. Recommendation: leave for the MVP; revisit only if a stress test shows unbounded distinct-pipe churn.
+3. **`docs/capability-status.md` surfacing:** is "revoke is idempotent" a capability-status-worthy guarantee, or purely an implementation-correctness fix? Recommendation: changelog only unless a maintainer wants it in the capability matrix.
+4. **`find_pipe_event` rename:** keep the shared helper and change selection semantics (§2.2), or introduce a dedicated `find_first_pipe_event` and leave `find_pipe_event` for the single-`PipeOpened` case? Recommendation: rename/generalize to first-match; the `PipeOpened` call site is unaffected (one opened event per pipe).
+5. **Corpus-run command of record:** confirm the exact `conformance/v2/harness` invocation and any load-simulation wrapper the maintainer wants cited as the acceptance evidence (the issue's measurements were "machine under concurrent cargo load").


### PR DESCRIPTION
# PR DRAFT — jeliya #271 (staged locally, NOT posted)

- Branch: feat/271-3421c250-... | Worktree: /home/sekou/AGI/jeliya-wt/3421c250
- Base: main @ 9555eb9 | Commit: 35a0f87 | Run cost: $17.82

## Orchestrator verification (independent, in worktree)
- cargo +1.96.0 test --locked --workspace: PASS (29 suites ok)
- cargo +1.96.0 clippy --locked --workspace --all-targets -- -D warnings: PASS
- cargo +1.96.0 fmt --all --check: PASS | node scripts/check-docs.mjs: PASS
- Stress: pipe_revoke_of_an_already_revoked 50x serial under natural build load: 50/50 PASS

## Cross-review (DSH subagent, read-only adversarial): approve with concerns
- Race window closed: per-(room,pipe) guard serializes; replay returns the original withdrawal byte-identically; single authority in core (serve.rs delegates); no first-revoke regression.
- LOW: revoke_guards map never evicted — real cost ~160-200B/entry (spec says 16B, misleading); fine to 100K revocations, real issue at 10M. Maintainer decision: bound/evict or accept with monitoring.
- LOW: guard acquired on every first-revoke happy path (small contention cost).
- Suggested pre-merge: concurrent-revoke test under --test-threads=8 loop; full 341-case corpus.

## Switchyard-generated PR body

# Fix: `pipe.revoke` idempotency race and flaky serve test

Closes #271.

Two independent pre-existing defects surfaced during wave-2's #207 corpus A/B
verification (2026-08-10). Neither is caused by any wave-2 PR; both predate it.

---

## Defect A — `pipe.revoke` idempotency race

### Root cause

`RoomSupervisor::pipe_close` delegated unconditionally to
`node.pipe_close` (upstream `iroh-rooms-net`), which **always** builds and
publishes a fresh signed `pipe.closed` — no check whether the pipe was already
closed. With two committed `pipe_revoked` events for the same pipe:

- Under quiet load both authors could land in the same `now_ms()` millisecond
  and the `revoked_at` equality held by coincidence.
- Under CI load the two authors straddled a millisecond boundary, so the second
  event's `revoked_at` differed and the conformance assertion
  `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal` failed.

### Fix (three parts, all in `crates/jeliya-core/src/supervisor.rs`)

1. **`original_pipe_closed()` — idempotent replay** (primary; sufficient for the
   observed corpus flake): scans `room_tail` in canonical order and returns the
   bare event-id hex of the first committed `PipeClosed` for the pipe. Called
   after the unknown-pipe and publisher-only guards, before `node.pipe_close`.
   A confirmed publisher of an already-closed pipe gets the original event-id
   back with no new author. Ordering unchanged:
   - `PipeUnknown` — unknown pipe (preserves case 27).
   - `PipeNotPublisher` — non-publisher, including a non-publisher re-revoking a
     closed pipe (preserves `supervisor.rs:6281`).
   - Replay — confirmed publisher, pipe already closed.
   - First withdrawal — confirmed publisher, pipe open.

2. **`find_pipe_event` → first-canonical-match** (defense in depth): changed
   from "last row wins" to "first canonical-order match" so the returned id is
   stable and consistent with `committed_pos_and_instant`'s ranking even if two
   closed rows ever coexist. The `PipeOpened` call site is unaffected (one opened
   event per pipe).

3. **`revoke_guards: RevokeGuards`** — a `StdMutex<HashMap<(RoomId, [u8; SHORT_ID_LEN]), Arc<TokioMutex<()>>>>` serializes concurrent distinct-op_id revokes of the same pipe so the read-existing-close → author critical section is atomic per pipe. The outer `StdMutex` is released before `.await`; the per-key `TokioMutex` is what is held across the author/poll. No `std::sync::Mutex` guard crosses an await point. Distinct pipes and rooms never contend.

### Preserved invariants

- `op_id` dedup for same-op_id replays (case 25) is unchanged.
- The unknown-pipe-before-auth ordering (which avoids confirming a pipe's
  existence to a non-publisher via an auth error) is unchanged.
- `pipe.connect` / `pipe.list` / `pipe.release` semantics are unchanged.
- Wire and event schema are unchanged.
- No new dependency; `unsafe_code` remains absent.

---

## Defect B — flaky `serve` test

### Root cause

`websocket_file_share_progress_resets_stall_but_not_absolute_deadline`
(`crates/jeliyad/src/serve.rs`) was `#[tokio::test]` without a paused clock
and advanced timers with a real `tokio::time::sleep(800 ms)`. The daemon's
stall and absolute-deadline timers are `Instant`-based, so the real sleep
drifted against them under concurrent CI load, intermittently reordering the
CREDIT/ABORT records.

### Fix

Converted to `tokio::time::pause()` + `advance`, matching the two sibling
tests (`websocket_file_share_daemon_abort_ack_timeout_replies_then_closes_4007`
and `websocket_file_share_no_progress_stalls_and_survives_exact_ack`). Same
observable sequence and post-conditions: CREDIT `{accepted_through:1,
send_through:2}` → ABORT `OperationError` → exact-ACK →
`TransferDeadlineExceeded{…, budget_ms:1600}` → `room.list` survival →
`transfer_pool.usage()==(0,0)` → empty staging.

---

## Documentation

`CHANGELOG.md` §`[Unreleased]` › `Fixed` records both fixes with full context.

`docs/protocol-v2.md` §`pipe.revoke` already states the correct behavioral
contract: *"Re-revoking succeeds and returns the original withdrawal, like every
other terminal withdrawal in this record."* The spec was right; the
implementation is now corrected to match it. No `docs/` profile-page change is
required.

---

## Test evidence

- `cargo test -p jeliya-core pipe_close` — all pipe-close tests green,
  including the red-before-green idempotency and concurrency tests added in this
  PR.
- `cargo test -p jeliyad --lib serve::tests::websocket_file_share_progress_resets_stall_but_not_absolute_deadline`
  — deterministically green under concurrent load (≥ 50 consecutive runs, 0
  failures).
- Conformance case `pipe_revoke_of_an_already_revoked_pipe_returns_the_original_withdrawal`
  — deterministically green under load (≥ 20 consecutive runs, 0 failures).
- Cases 25 (`pipe_revoke_withdraws_the_publication_as_a_converged_room_fact`) and
  27 (`pipe_revoke_of_an_unknown_pipe_is_pipe_unknown`) remain green.
- Full 341-case v2 corpus: no regression attributable to this change.
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` clean; no
  `unsafe`.