### PR TITLE
docs(diagnostics): document jeliyad log levels, locations, rotation, and safe collection

### DIFF
--- a/docs/diagnostics-logging.md
+++ b/docs/diagnostics-logging.md
@@ -1,0 +1,305 @@
+---
+type: "Guide"
+title: "Jeliya diagnostics and logging"
+description: "Enable, locate, follow, rotate, and safely share jeliyad diagnostic logs on the released daemon and packaged desktop."
+tags: ["diagnostics", "logging", "operations", "daemon", "desktop"]
+timestamp: "2026-08-16T00:00:00Z"
+status: "canonical"
+implementation_status: "partial"
+verification_status: "unverified"
+release_status: "partial"
+audience: ["operators", "contributors", "maintainers"]
+---
+
+# Jeliya diagnostics and logging
+
+This guide explains how to enable, locate, follow, rotate, and safely share the
+`jeliyad` daemon's diagnostic logs. It covers the released daemon on macOS,
+Linux, and Windows, and the daemon as it runs under a supervising desktop
+process. Everything here describes the current Dioxus/`jeliyad` stack; legacy
+client launchers are out of scope (see [Clean-slate scope](#clean-slate-scope)).
+
+Two very different things are called "logs" in Jeliya. This guide is about the
+first; read [Diagnostic logs versus signed room event logs](#diagnostic-logs-versus-signed-room-event-logs)
+before you share anything.
+
+- **Diagnostic (process) logs** — the `tracing` output described here. Meant for
+  troubleshooting, and safe to share **after redaction**.
+- **Signed room event logs** — the product's cryptographically signed room
+  state. Operational truth, **never** a troubleshooting artifact, and **never**
+  something to attach to an issue.
+
+## Status and scope of this guide
+
+- The daemon's stderr and rolling-file logging is implemented and ships in the
+  released daemon (`v0.6.0`).
+- The packaged desktop application is not built in this repository yet, so its
+  operating-system-specific way of setting environment variables and collecting
+  logs is owned by issue #189 and marked pending below. The daemon-level truth
+  in this guide holds regardless of how the daemon is launched.
+- The in-app "export diagnostics" affordance is owned by issue #180 and does not
+  exist yet; it is referenced as the intended push-button collection path.
+- The normative redaction contract and release-security evidence are owned by
+  issue #196; the safe-sharing checklist here defers to it.
+- The commands below are derived from the daemon source and have **not** yet been
+  exercised against a release candidate on every claimed operating system, so the
+  page's `verification_status` is `unverified`. Treat the macOS and Windows paths
+  as the documented intent until per-operating-system evidence is recorded.
+
+## What jeliyad logs, and where
+
+On startup the daemon installs two log sinks that receive the **same** filtered
+event stream:
+
+- **Standard error (stderr)** — human-readable lines for whoever launched the
+  process. Ephemeral: it is only whatever the launching terminal or service
+  captured.
+- **A daily-rolling file** under the data directory, at `logs/` with base name
+  `jeliyad.log`. This is the durable record.
+
+The default level is `info`. The file sink is plain text with no ANSI colour;
+both sinks suppress the event **target** column, so a line shows its level and
+message but not the module it came from. Filtering still matches on the target
+(see below), so targeted filters work even though the target is not printed.
+
+The daemon also prints its data directory to standard output on startup (a
+`ready` JSON line and a human-readable `data dir: …` line), so you can always see
+which directory a running daemon is using.
+
+## Diagnostic logs versus signed room event logs
+
+This distinction is the most important safety rule on this page.
+
+- **Diagnostic/process logs** are the `tracing` output: the dated files under the
+  data directory's `logs/` folder, plus stderr. These are what "share your logs"
+  means. They are safe to share **after** the redaction checklist below.
+- **Signed room event logs** are the product's cryptographically signed room
+  state, stored in the room store under the data directory (for example the room
+  database and blob files). They are the product's operational source of truth,
+  **not** a process log. They can contain message content and identities. Never
+  treat them as diagnostic logs, and **never attach them to an issue**.
+
+When someone asks you for "logs" to debug a problem, they mean the diagnostic
+files, never the room store.
+
+## Setting the log level and filters
+
+The filter is chosen once, from the first source that is set:
+
+1. `JELIYAD_LOG` (Jeliya-specific; wins if present),
+2. otherwise `RUST_LOG`,
+3. otherwise the built-in default `info`.
+
+So `JELIYAD_LOG` overrides `RUST_LOG`, and `RUST_LOG` is honoured only when
+`JELIYAD_LOG` is unset. Both variables use
+[`tracing_subscriber::EnvFilter`](https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/filter/struct.EnvFilter.html)
+syntax: a comma-separated list of directives, each `target[=level]`. A bare level
+(for example `debug`) sets the default for everything; a `target=level` directive
+raises or lowers one module. Module paths use `::`.
+
+The daemon process emits events under two targets today: `jeliyad` (the daemon
+binary) and `jeliya_core` (the protocol engine). At the default `info` level,
+dependency crates such as `iroh`, `hyper`, `tokio`, and `tungstenite` are
+effectively silent. A bare global level like `debug` raises **all** of them
+and can be very verbose; prefer the scoped form
+`info,jeliyad=debug,jeliya_core=debug` to stay focused on Jeliya code. Use
+a global `debug` only when you need to diagnose a problem in a dependency.
+
+A parse-invalid directive in `JELIYAD_LOG` (or the value `JELIYAD_LOG=`)
+causes the whole variable to be silently ignored; the daemon then falls through
+to `RUST_LOG` and finally to `info`. If the level you set appears to have no
+effect, check for a typo in the directive string first.
+
+Useful, safe examples:
+
+```sh
+# Whole daemon at debug — all crates including dependencies; can be verbose.
+JELIYAD_LOG=debug
+
+# Daemon and engine at debug, dependencies left at info.
+JELIYAD_LOG=info,jeliyad=debug,jeliya_core=debug
+
+# One module only.
+JELIYAD_LOG=info,jeliya_core::engine=debug
+
+# Quiet baseline, daemon only.
+JELIYAD_LOG=warn,jeliyad=debug
+```
+
+Setting the variable per shell:
+
+```sh
+# macOS / Linux (bash, zsh): one-shot for a single run.
+JELIYAD_LOG=debug jeliyad
+
+# Or persist it for the shell session.
+export JELIYAD_LOG=info,jeliyad=debug,jeliya_core=debug
+jeliyad
+```
+
+```powershell
+# Windows PowerShell.
+$env:JELIYAD_LOG = 'debug'
+jeliyad
+```
+
+**`trace` is a footgun.** The `trace` level can surface high-cardinality and
+potentially sensitive values. Do not enable it for logs you intend to share, and
+never paste a `trace` run into an issue without careful redaction.
+
+## Where the log files live
+
+Logs live in a `logs/` subdirectory of the daemon's data directory. The default
+data directory is a per-user platform location, so a launch from any working
+directory always lands in the same place:
+
+| Operating system | Default data directory | Log directory |
+|---|---|---|
+| macOS | `~/Library/Application Support/Jeliya` | `~/Library/Application Support/Jeliya/logs/` |
+| Linux | `$XDG_DATA_HOME/Jeliya` (by default `~/.local/share/Jeliya`) | `~/.local/share/Jeliya/logs/` |
+| Windows | `%APPDATA%\Jeliya` (`C:\Users\<user>\AppData\Roaming\Jeliya`) | `%APPDATA%\Jeliya\logs\` |
+
+If no platform data directory can be discovered, the daemon falls back to
+`./.jeliya-data` relative to its working directory, with logs at
+`./.jeliya-data/logs/`.
+
+You can move the whole root with `--data-dir DIR`; logs then live at `DIR/logs/`.
+The daemon canonicalizes the path (resolving symlinks and relative spelling), so
+the directory it reports on startup can differ textually from what you typed —
+trust the printed path.
+
+## Rotation, retention, and what survives restart
+
+- **Rotation is daily.** With the base name `jeliyad.log`, the appender writes
+  **dated** files named `jeliyad.log.YYYY-MM-DD` (for example
+  `jeliyad.log.2026-08-16`). The date boundary is **UTC**.
+- **There is no plain `jeliyad.log` file and no "current" symlink.** The newest
+  dated file is the active one. Any tool or instruction that expects a bare
+  `jeliyad.log` is wrong for this daemon.
+- **Nothing is pruned.** Every day's file is kept; old dated files are never
+  deleted automatically. Logs grow without bound across days, so cleanup of old
+  files is the operator's responsibility.
+- **Prior files survive restarts and crashes.** Restarting the daemon appends to
+  the current day's file (or opens the next day's file after a rollover); older
+  dated files are untouched.
+- The file writer is non-blocking, so on a hard crash a few of the most recent
+  buffered records can be lost. A clean shutdown flushes the buffer before exit.
+
+## Following the active log
+
+Follow the newest dated file:
+
+```sh
+# macOS / Linux — the current UTC day explicitly.
+tail -f "$HOME/.local/share/Jeliya/logs/jeliyad.log.$(date -u +%F)"
+
+# Or follow every dated file, so you always see the newest without computing
+# the date (handy around the UTC midnight rollover).
+tail -f "$HOME/.local/share/Jeliya"/logs/jeliyad.log.*
+```
+
+```powershell
+# Windows PowerShell — pick the most recently written dated file and follow it.
+$log = Get-ChildItem "$env:APPDATA\Jeliya\logs\jeliyad.log.*" |
+  Sort-Object LastWriteTime | Select-Object -Last 1
+if ($log) { Get-Content -Wait -Tail 50 $log.FullName }
+else { Write-Host "No log files found — has jeliyad been run?" }
+```
+
+Because the daily boundary is UTC, a follow command that computes a **local**
+date can point at the wrong file for a few hours around midnight; prefer the
+glob/newest-file forms to sidestep it. Adjust the path if you launched the daemon
+with `--data-dir`.
+
+## Foreground versus supervised and packaged launches
+
+### Foreground (you launched it)
+
+When you run the daemon yourself, stderr goes to your terminal and the dated file
+is written in parallel:
+
+```sh
+JELIYAD_LOG=debug jeliyad
+# Optionally capture stderr to a file too:
+JELIYAD_LOG=debug jeliyad 2> jeliyad.stderr.log
+```
+
+### Supervised or packaged (the app owns the daemon)
+
+When the desktop application owns the daemon, it launches it in **supervised**
+mode (`jeliyad --supervised --data-dir … --port 0`) and **drains and discards the
+daemon's stderr**. There is no console to read.
+
+> In a supervised or packaged launch, the dated file under the data directory's
+> `logs/` folder is the **only** place the daemon's logs appear. This is the
+> single most important operator fact on this page.
+
+To raise the level for a supervised daemon, set the environment variable in the
+environment of the process that launches the supervisor — the packaged app — and
+then restart it. The daemon reads its filter from its own process environment at
+startup, so the variable must already be present when the launcher starts. The
+exact per-operating-system mechanism (a macOS launchd plist, a Linux
+`.desktop`/systemd user environment, or the Windows application environment) is
+owned by issue #189 and will be documented and verified against the packaged
+build when it exists.
+
+The in-app diagnostics export (issue #180) is the intended push-button way to
+collect logs from a packaged launch. It does not exist yet; until it lands, read
+the dated file directly.
+
+## Runtime filter changes are unsupported
+
+The filter is read **exactly once at daemon startup**. There is no runtime
+reload, no signal, and no admin endpoint to change verbosity while the daemon is
+running. To change the level you set the environment variable and **restart** the
+daemon. Adding a runtime log-level flag is an explicit non-goal of this work.
+
+## Before you share logs: redaction and safe collection
+
+Diagnostic logs are safe to share only after redaction. The normative rules are
+owned by issue #196; this checklist defers to it and names the values you must
+never paste into an issue, a chat, or any external service:
+
+- **The daemon authentication / bearer token.** By design it lives in the 0600
+  `daemon.json` portfile, not in logs — but never paste `daemon.json` either. The
+  supervisor holds this token behind a redaction shield that prints `<redacted>`,
+  so a stray debug print cannot spill it; do not defeat that by pasting the
+  portfile.
+- **Single-use connect tickets** — the `?ct=` values minted by
+  `POST /api/session`.
+- **Invite tickets and room join material.**
+- **Message bodies and any room content.**
+- **Full private filesystem paths** that reveal a username or home directory.
+  Scrub any absolute path down to a placeholder. Note that the daemon prints its
+  data-directory path on startup and can mention paths in warnings, so this value
+  routinely appears even at `info`.
+- **Any secret or key material.**
+
+Also:
+
+- Prefer `info` or `debug` for logs you intend to share. Avoid `trace` unless
+  asked, and redact it heavily if you must share it.
+- Share the smallest useful slice — the lines around the failure, not an entire
+  multi-day file.
+- When the diagnostics export (issue #180) ships, prefer it: it is the intended
+  redaction-aware collection path.
+
+## How this fits release and security evidence
+
+- Daemon supervision behaviour — including the drain-and-discard of a supervised
+  daemon's stderr — is owned by issue #170.
+- Packaged-desktop environment and log-collection evidence is owned by issue
+  #189; treat the packaged specifics above as pending until that evidence exists.
+- The in-app diagnostics export is owned by issue #180.
+- Redaction rules and release-security evidence are owned by issue #196; see also
+  the [security and threat model](security-threat-model.md) and
+  [signing and notarization](signing-notarization.md) records, and the
+  [platform matrix](platform-matrix.md) for per-operating-system release status.
+
+## Clean-slate scope
+
+This guide documents only the current Dioxus/`jeliyad` stack. Legacy client
+launchers (the React web UI and the Flutter desktop and Android apps) are out of
+scope and are being retired under issues #200–#203; when their owners remove
+them, no launch instructions for them belong here. If you are looking for how a
+legacy client surfaced logs, that path is not supported by this guide.

--- a/docs/diagnostics-logging.md
+++ b/docs/diagnostics-logging.md
@@ -84,10 +84,11 @@ files, never the room store.
 
 ## Setting the log level and filters
 
-The filter is chosen once, from the first source that is set:
+The filter is chosen once, from the first source that **parses successfully**:
 
-1. `JELIYAD_LOG` (Jeliya-specific; wins if present),
-2. otherwise `RUST_LOG`,
+1. `JELIYAD_LOG` (Jeliya-specific; wins when set to a valid filter — a value
+   that fails to parse falls through to the next source),
+2. otherwise `RUST_LOG` (same parse rule),
 3. otherwise the built-in default `info`.
 
 So `JELIYAD_LOG` overrides `RUST_LOG`, and `RUST_LOG` is honoured only when
@@ -261,10 +262,13 @@ owned by issue #196; this checklist defers to it and names the values you must
 never paste into an issue, a chat, or any external service:
 
 - **The daemon authentication / bearer token.** By design it lives in the 0600
-  `daemon.json` portfile, not in logs — but never paste `daemon.json` either. The
-  supervisor holds this token behind a redaction shield that prints `<redacted>`,
-  so a stray debug print cannot spill it; do not defeat that by pasting the
-  portfile.
+  `daemon.json` portfile, and `jeliyad` never writes it to its logs — but
+  `jeliyad` performs **no redaction of its own log output**: if you raise the
+  filter to `trace`, values passed through debug paths can appear verbatim.
+  The `<redacted>` shield lives in the `jeliya-supervisor` crate and applies
+  only to supervisor logs and RPC errors, not to `jeliyad`'s trace output. So
+  treat every daemon log above `info` as unredacted, never paste `daemon.json`,
+  and do not assume a stray debug print elsewhere is shielded.
 - **Single-use connect tickets** — the `?ct=` values minted by
   `POST /api/session`.
 - **Invite tickets and room join material.**

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ retained as a valid, dated evidence record about the revision it examined.
 
 ## Operations and release evidence
 
+- [Diagnostics and logging](diagnostics-logging.md) - Enable, locate, follow, rotate, and safely share `jeliyad` diagnostic logs on the released daemon and packaged desktop, and the boundary that keeps signed room event logs out of troubleshooting.
 - [Accessibility release checklist](accessibility-checklist.md) - The screen-reader and keyboard behaviours automated checks cannot prove, verified by hand before a release.
 - [Real-network NAT runbook](realnet-runbook.md) - Procedure for proving direct or relayed connectivity across two networks.
 - [v0.6.1 evidence boundary](evidence/v0.6.1/index.md) - Empty qualification boundary reserved for fresh, signed v0.6.1 manifests after candidate designation.

--- a/scripts/check-docs.test.mjs
+++ b/scripts/check-docs.test.mjs
@@ -714,3 +714,209 @@ test('developer documentation matches the MSRV and complete CI job matrix', () =
   for (const job of jobs) assert.match(contributing, new RegExp('`' + job + '`'));
   assert.match(contributing, /manually without publishing a release/);
 });
+
+// ── Issue #42: diagnostics-logging.md contract tests ──────────────────────────
+
+test('diagnostics-logging.md passes the OKF docs gate with no findings', () => {
+  const repoRoot = new URL('..', import.meta.url).pathname;
+  const allFindings = validateDocumentation({ repoRoot });
+  const docFindings = allFindings.filter(
+    (entry) => entry.file === 'docs/diagnostics-logging.md',
+  );
+  assert.deepEqual(
+    docFindings.map((entry) => `[${entry.code}] ${entry.message}`),
+    [],
+  );
+});
+
+test('diagnostics-logging.md states JELIYAD_LOG precedence, RUST_LOG fallback, and info default', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  const jeliyaLogPos = source.indexOf('JELIYAD_LOG');
+  const rustLogPos = source.indexOf('RUST_LOG');
+  assert.ok(jeliyaLogPos !== -1, 'JELIYAD_LOG must be documented');
+  assert.ok(rustLogPos !== -1, 'RUST_LOG must be documented');
+  assert.ok(
+    jeliyaLogPos < rustLogPos,
+    'JELIYAD_LOG must appear before RUST_LOG in the document (precedence order)',
+  );
+  assert.match(source, /built-in default `info`/, 'info default must be documented');
+  assert.match(source, /`trace` is a footgun/, 'trace footgun warning must be present');
+});
+
+test('diagnostics-logging.md states YYYY-MM-DD rotation, UTC boundary, no plain jeliyad.log, and no pruning', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /YYYY-MM-DD/, 'rotation date format must be documented');
+  assert.match(source, /The date boundary is \*\*UTC\*\*/, 'UTC boundary must be explicitly stated');
+  assert.match(
+    source,
+    /no plain `jeliyad\.log` file/,
+    'absence of a plain jeliyad.log file must be explicitly stated',
+  );
+  assert.match(source, /Nothing is pruned/, 'no-pruning fact must be stated');
+});
+
+test('diagnostics-logging.md states that supervised launches drain and discard stderr', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /drains and discards the\s+daemon's stderr/s,
+    'supervised stderr drain-and-discard must be documented',
+  );
+  assert.match(
+    source,
+    /\*\*only\*\* place the daemon's logs appear/,
+    'dated file as the only log location in supervised mode must be prominently stated',
+  );
+});
+
+test('diagnostics-logging.md states the filter is read once at startup with no runtime reload', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /filter is read \*\*exactly once at daemon startup\*\*/,
+    'once-at-startup semantics must be documented',
+  );
+  assert.match(
+    source,
+    /no runtime\s+reload/s,
+    'absence of runtime reload must be explicitly stated',
+  );
+  assert.match(
+    source,
+    /restart.*the\s+daemon|daemon.*restart/s,
+    'restart requirement must be documented',
+  );
+});
+
+test('diagnostics-logging.md distinguishes diagnostic logs from signed room event logs', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /Signed room event logs/,
+    'signed room event logs must be explicitly named',
+  );
+  assert.match(
+    source,
+    /never.*something to attach to an issue/s,
+    'prohibition on attaching event logs to issues must be stated',
+  );
+  assert.match(
+    source,
+    /Diagnostic.*process.*log|Diagnostic \(process\) log/s,
+    'diagnostic/process logs must be named distinctly from room event logs',
+  );
+});
+
+test('diagnostics-logging.md redaction checklist names all required prohibited values', () => {
+  const source = readFileSync(
+    new URL('../docs/diagnostics-logging.md', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /bearer token/, 'bearer token must be in the redaction checklist');
+  assert.match(
+    source,
+    /Single-use connect tickets.*\?ct=/s,
+    'connect tickets must be identified by the ?ct= parameter',
+  );
+  assert.match(
+    source,
+    /[Ii]nvite tickets/,
+    'invite tickets must be in the redaction checklist',
+  );
+  assert.match(
+    source,
+    /[Mm]essage bodies/,
+    'message bodies must be in the redaction checklist',
+  );
+  assert.match(
+    source,
+    /Full private filesystem paths/,
+    'private filesystem paths must be named in the redaction checklist',
+  );
+});
+
+// ── Issue #42: source-alignment e2e tests ────────────────────────────────────
+// These tests cross the docs↔code boundary: they verify the implementation
+// sources still match the specific claims the guide makes, catching silent
+// drift before it misleads operators.
+
+test('lifecycle.rs uses JELIYAD_LOG env var and jeliyad.log rolling-appender base name', () => {
+  const lifecycle = readFileSync(
+    new URL('../crates/jeliyad/src/lifecycle.rs', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    lifecycle,
+    /try_from_env\("JELIYAD_LOG"\)/,
+    'lifecycle.rs must read the JELIYAD_LOG env var as documented',
+  );
+  assert.match(
+    lifecycle,
+    /rolling::daily\([^,]+,\s*"jeliyad\.log"\)/,
+    'lifecycle.rs must pass "jeliyad.log" as the rolling-appender base name',
+  );
+  assert.match(
+    lifecycle,
+    /data_dir\.join\("logs"\)/,
+    'lifecycle.rs must place log files in a "logs" subdirectory of the data dir',
+  );
+});
+
+test('main.rs default_data_dir uses dirs::data_dir with "Jeliya" and .jeliya-data fallback', () => {
+  const main = readFileSync(
+    new URL('../crates/jeliyad/src/main.rs', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    main,
+    /dirs::data_dir\(\)/,
+    'main.rs must use dirs::data_dir() for the platform data directory',
+  );
+  assert.match(
+    main,
+    /\.join\("Jeliya"\)/,
+    'main.rs must append "Jeliya" to the platform data directory',
+  );
+  assert.match(
+    main,
+    /\.jeliya-data/,
+    'main.rs must fall back to .jeliya-data when no platform dir is found',
+  );
+});
+
+test('supervisor.rs drains and discards daemon stderr in a background task', () => {
+  const supervisor = readFileSync(
+    new URL('../crates/jeliya-supervisor/src/supervisor.rs', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    supervisor,
+    /stderr\(Stdio::piped\(\)\)/,
+    'supervisor.rs must pipe the daemon stderr (so it can be drained)',
+  );
+  assert.match(
+    supervisor,
+    /[Dd]rain.*stderr|stderr.*[Dd]rain/s,
+    'supervisor.rs must drain the daemon stderr',
+  );
+  assert.match(
+    supervisor,
+    /[Bb]ytes are discarded|discard/,
+    'supervisor.rs must discard the drained stderr bytes',
+  );
+});

--- a/specs/docs-jeliyad-diagnostics-logging.md
+++ b/specs/docs-jeliyad-diagnostics-logging.md
@@ -1,0 +1,333 @@
+# Spec: Document jeliyad log levels, locations, rotation, and safe collection (issue #42)
+
+Status: proposal / planning spec. This document tells an engineer or agent
+exactly what operator-facing documentation to author, where, and with what
+verified facts. It does **not** change production code and does **not** add a
+new runtime log flag (issue non-goal). The deliverable is one new page in the
+`docs/` wiki plus its index wiring.
+
+## 1. Outcome
+
+Publish an accurate user/operator guide for enabling, locating, filtering,
+following, and safely sharing `jeliyad` diagnostic logs across the released
+daemon and the packaged desktop surface. The guide must be true against the
+current Dioxus/`jeliyad` stack and pass the documentation gate
+(`node scripts/check-docs.mjs`).
+
+## 2. Owning surfaces and sources of truth (verified against code)
+
+Everything the guide states about behavior must trace to one of these. Cite
+them in the PR body when the doc is authored; re-verify each before publication
+because line numbers drift.
+
+| Fact | Source of truth (this tree) |
+|---|---|
+| Filter precedence `JELIYAD_LOG` → `RUST_LOG` → `info`; `EnvFilter` syntax | `crates/jeliyad/src/lifecycle.rs` `init_tracing` (`EnvFilter::try_from_env("JELIYAD_LOG").or_else(try_from_default_env).unwrap_or(EnvFilter::new("info"))`) |
+| Two sinks: stderr + daily-rolling file under `<data-dir>/logs/`, base `jeliyad.log` | `crates/jeliyad/src/lifecycle.rs` `init_tracing` (`tracing_appender::rolling::daily(&logs_dir, "jeliyad.log")`, `logs_dir = data_dir.join("logs")`) |
+| File layer is plain text (`with_ansi(false)`); both layers set `with_target(false)` | `crates/jeliyad/src/lifecycle.rs` `init_tracing` |
+| Filter is read once at startup; there is **no** `reload` handle | `crates/jeliyad/src/lifecycle.rs` (no `tracing_subscriber::reload` anywhere) |
+| Log worker is non-blocking; the guard must be dropped to flush at exit | `crates/jeliyad/src/lifecycle.rs` (`tracing_appender::non_blocking`) + `crates/jeliyad/src/main.rs` (`drop(log_guard)` before `std::process::exit`) |
+| Default data-dir per OS; `--data-dir` override; canonicalized | `crates/jeliyad/src/main.rs` `default_data_dir` (`dirs::data_dir().map(|d| d.join("Jeliya")).unwrap_or("./.jeliya-data")`) and `Args.data_dir` |
+| Supervised launch discards stderr; rolling file is the only durable copy | `crates/jeliya-supervisor/src/supervisor.rs` (spawns `jeliyad --supervised --data-dir … --port 0`, `stderr(Stdio::piped())`, then a background task drains stderr in raw chunks and discards the bytes) |
+| Secret shield used for the daemon auth token | `crates/jeliya-supervisor/src/redact.rs` `Redacted<T>` (Debug/Display print `<redacted>`; mirrors `jeliya_client::kernel::diag::Redacted`) |
+| Released daemon targets (claimed OSes) | `packaging/README.md` (five archives: `aarch64`/`x86_64-apple-darwin`, `x86_64`/`aarch64-unknown-linux-musl`, `x86_64-pc-windows-msvc`) |
+| Install locations per OS | `packaging/install.sh` (`/usr/local/bin` or `~/.local/bin`), `packaging/install.ps1` (`%LOCALAPPDATA%\Programs\Jeliya`, added to user PATH) |
+| Signed room event log is the product's operational truth, not a process log | `docs/PROFILE.md` Non-goals ("Jeliya's signed room event log remains the product's source of operational truth") |
+| Docs contract (frontmatter, single H1, reachability, no raw HTML) | `docs/PROFILE.md`, enforced by `scripts/check-docs.mjs` |
+
+### 2.1 Downstream owners referenced by the issue
+
+The guide must **reference** these but must not invent their behavior. Where a
+surface is not yet built in this tree, say so plainly and use the least
+favorable truthful status.
+
+- **#170 — daemon supervision.** Implemented as `crates/jeliya-supervisor`.
+  This is the authority for how an owned/adopted daemon is launched and how its
+  stderr is handled (drained and discarded). Cite it for supervised collection.
+- **#189 — packaged desktop evidence.** Owns the per-OS packaged-launch
+  environment and log-collection evidence. At authoring time the packaged
+  desktop app is **not** built in this tree (see `docs/platform-matrix.md`).
+  Document the daemon-level truth and mark packaged-desktop specifics as owned
+  by #189, to be verified against the packaged build when it exists.
+- **#180 — diagnostics UI integration / diagnostics export.** Owns the in-app
+  "export diagnostics" affordance. Reference it as the intended integration
+  point; do not describe an export bundle format that does not yet exist.
+- **#196 — redaction and release/security evidence.** Owns the authoritative
+  redaction rules and the release-security evidence. The guide's safe-sharing
+  section must align with #196 and defer the normative redaction contract to it.
+
+## 3. Ground-truth behavior the guide must state (and must not contradict)
+
+### 3.1 Levels and filtering
+- Precedence: `JELIYAD_LOG` wins; else `RUST_LOG`; else the default `info`.
+- Syntax is `tracing_subscriber::EnvFilter` (directives are
+  `target[=level]`, comma-separated; a bare level sets the default, e.g.
+  `debug`; module paths use `::`).
+- The same filter applies to **both** the stderr sink and the file sink.
+- Event **targets are suppressed in the printed output** (`with_target(false)`),
+  but `EnvFilter` still matches on target — so targeted directives work even
+  though the target column is not shown.
+- Emitting targets inside the daemon process today are `jeliyad` (from
+  `main.rs`, `lifecycle.rs`) and `jeliya_core` (from `engine.rs`,
+  `protocol_upload.rs`); dependency crates (for example `iroh`, `hyper`,
+  `tokio`, `tungstenite`) emit only when their targets are enabled. The author
+  MUST re-derive this list from the code at authoring time (grep `tracing::`
+  macros in the daemon's dependency graph) rather than copying it blindly.
+- Useful, safe examples to include (verify each runs):
+  - Whole-daemon debug, still quiet-ish: `JELIYAD_LOG=debug`
+  - Daemon + core at debug, deps quiet: `JELIYAD_LOG=info,jeliyad=debug,jeliya_core=debug`
+  - One module: `JELIYAD_LOG=info,jeliya_core::engine=debug`
+  - Quiet baseline, daemon only: `JELIYAD_LOG=warn,jeliyad=debug`
+- **`trace` is a footgun**: state that `trace` can surface high-cardinality,
+  potentially sensitive values and must not be pasted into an issue unredacted.
+
+### 3.2 Locations and rotation
+- Logs live at `<data-dir>/logs/`. Default `<data-dir>` per OS:
+  - macOS: `~/Library/Application Support/Jeliya`
+  - Linux: `$XDG_DATA_HOME/Jeliya`, i.e. `~/.local/share/Jeliya` by default
+  - Windows: `%APPDATA%\Jeliya`, i.e. `C:\Users\<user>\AppData\Roaming\Jeliya`
+  - Fallback when no platform dir is discoverable: `./.jeliya-data` (relative to
+    the working directory)
+- `--data-dir DIR` moves the whole root; logs then live at `DIR/logs/`. The
+  daemon canonicalizes the path, so the printed path may differ from the spelled
+  one.
+- Rotation is **daily**. With base name `jeliyad.log`, `tracing-appender` writes
+  **dated** files named `jeliyad.log.YYYY-MM-DD`. State explicitly that there is
+  **no** plain `jeliyad.log` file and **no** "current" symlink — the newest
+  dated file is the active one.
+- The daily boundary is a wall-clock **date** as `tracing-appender` computes it.
+  The author MUST verify empirically whether that date is UTC or local before
+  claiming a timezone (0.2.5 rolls on UTC date; confirm on the RC).
+- **No pruning**: the daily appender keeps every dated file; nothing deletes old
+  days. State that operators are responsible for cleanup and that logs grow
+  unbounded across days.
+
+### 3.3 What survives restart
+- Restarting appends to the same day's file (or opens the next day's file at the
+  rollover). Prior dated files are untouched and survive restarts and crashes.
+- stderr output is ephemeral (it is whatever the launching terminal/service
+  captured); the dated files are the durable record.
+- On a hard crash a few buffered records can be lost because the file writer is
+  non-blocking; a clean shutdown drops the guard and flushes.
+
+### 3.4 Following the active file
+- Provide copy-paste follow commands per OS, targeting the newest dated file:
+  - macOS/Linux: `tail -f "<data-dir>/logs/jeliyad.log.$(date -u +%F)"` (note the
+    UTC-vs-local caveat; also show a glob form
+    `tail -f "<data-dir>"/logs/jeliyad.log.*` for "whatever is newest").
+  - Windows PowerShell: `Get-Content -Wait -Tail 50 (Get-ChildItem "$env:APPDATA\Jeliya\logs\jeliyad.log.*" | Sort-Object LastWriteTime | Select-Object -Last 1)`
+- All angle-bracket placeholders such as `<data-dir>` and `<user>` MUST be inside
+  inline code or a fenced block (see §6 authoring hazard).
+
+### 3.5 Foreground vs supervised/packaged collection
+- **Foreground / manual run**: `JELIYAD_LOG=debug jeliyad …` prints to stderr
+  (redirect with `2> jeliyad.stderr.log` if desired) and also writes the dated
+  file. Show setting the env var per OS shell (`VAR=… cmd`, `export`, and
+  PowerShell `$env:JELIYAD_LOG='debug'`).
+- **Supervised / packaged**: when the desktop app owns the daemon through
+  `jeliya-supervisor`, the child is spawned `--supervised` and its **stderr is
+  drained and discarded**. There is no console to read. The **dated file in
+  `<data-dir>/logs/` is the only place logs appear** — this is the single most
+  important operator fact and must be stated prominently.
+  - To raise the level for a supervised daemon, the environment must be set for
+    the process that launches the supervisor (the packaged app), then restart.
+    The exact per-OS mechanism (launchd plist, `.desktop`/systemd user env,
+    Windows app env) is **owned by #189**; document the daemon-level requirement
+    (env must be present in the launcher's environment before start) and defer
+    the packaged specifics to #189, to be filled in and verified against the
+    packaged build.
+- Cross-link the in-app diagnostics export (#180) as the intended
+  push-button collection path once it exists.
+
+### 3.6 Runtime filter changes are unsupported
+- State clearly: the filter is read exactly once at daemon startup; there is no
+  runtime reload, no signal, and no admin endpoint to change verbosity live.
+  Changing the level requires setting the env var and **restarting** the daemon.
+- Note the non-goal: this issue does not add a runtime log-level flag.
+
+### 3.7 Diagnostic logs vs signed room event logs (must be clearly distinguished)
+- **Diagnostic/process logs** = the `tracing` output described here
+  (`<data-dir>/logs/jeliyad.log.*` and stderr). Safe-to-share after redaction;
+  intended for troubleshooting.
+- **Signed room event logs** = the product's cryptographically signed room
+  state (in the room store under `<data-dir>`, e.g. `rooms.db`/blobs), which is
+  the product's operational source of truth per `docs/PROFILE.md`. These are
+  **not** diagnostic logs, are **not** what "share your logs" means, and must
+  **never** be attached to an issue (they can contain message content and
+  identities). Make this boundary explicit and unambiguous.
+
+## 4. Safe-sharing and redaction guidance (name the prohibited values)
+
+The guide must include an explicit "before you paste logs into an issue"
+checklist. Align with #196 (owns the normative rules) and state that the guide
+defers to it. At minimum, name these as **never paste**:
+
+- The daemon auth token / bearer token (held redacted as `Redacted<T>` in the
+  supervisor; it lives in the `daemon.json` portfile, **not** in logs by design —
+  but never paste `daemon.json`).
+- Single-use connect tickets (the `?ct=` values minted by `POST /api/session`).
+- Invite tickets / room join material.
+- Message bodies and any room content.
+- Full private filesystem paths that reveal a username or home directory
+  (redact `<data-dir>` and any absolute path down to a placeholder).
+- Any secret/key material.
+
+Also state:
+- Prefer `info`/`debug` for shared logs; avoid `trace` unless asked, and redact.
+- The daemon already prints its data-dir path on startup (stdout and info logs);
+  tell operators to scrub that path before sharing.
+- Point to the diagnostics export (#180) as the preferred, redaction-aware
+  collection path when available.
+
+## 5. Target document and index wiring
+
+- **Path**: `docs/diagnostics-logging.md` (kebab-case; author may choose
+  `daemon-logging.md` if preferred, but keep title/H1 in sync).
+- **Type**: `Guide` (task-oriented operator instructions).
+- **Frontmatter** (exactly the ten required fields; use the least favorable
+  truthful status axes because packaged-desktop specifics are unbuilt and the
+  commands are unverified until §7 runs):
+
+```yaml
+---
+type: "Guide"
+title: "Jeliya diagnostics and logging"
+description: "Enable, locate, follow, rotate, and safely share jeliyad diagnostic logs on the released daemon and packaged desktop."
+tags: ["diagnostics", "logging", "operations", "daemon", "desktop"]
+timestamp: "<authoring-UTC-instant>"
+status: "canonical"
+implementation_status: "partial"
+verification_status: "unverified"
+release_status: "partial"
+audience: ["operators", "contributors", "maintainers"]
+---
+```
+
+  Rationale for the axes (adjust only with evidence):
+  - `implementation_status: partial` — daemon file/stderr logging is implemented;
+    packaged-desktop diagnostics and in-app export are not in this tree.
+  - `verification_status: unverified` until §7 evidence is recorded against a
+    release candidate; upgrade to `partial`/`verified` with a Status Report or an
+    evidence link when the per-OS runs are done.
+  - `release_status: partial` — the daemon (and its file logging) ships in
+    `v0.6.0`; packaged-desktop diagnostics do not.
+- **Title/H1**: the single `#` heading must read exactly `Jeliya diagnostics and
+  logging` (must equal `title`).
+- **Index wiring** (`docs/index.md`): add one bullet under
+  **Operations and release evidence** (or a new **Diagnostics** subsection if the
+  author prefers) linking `diagnostics-logging.md` with a one-line description.
+  Reachability from `docs/index.md` is required or CI fails.
+- **Inbound cross-links to add** so the page is well-connected: from
+  `docs/security-threat-model.md` (redaction/evidence) and optionally
+  `docs/known-gaps-roadmap.md`. Keep links file-relative, no leading slash.
+
+## 6. Authoring hazards (docs gate) — read before writing
+
+`scripts/check-docs.mjs` will reject the page for any of these; the doc is
+angle-bracket-heavy, so the first one is the likely failure:
+
+1. **Raw-HTML from angle-bracket placeholders.** The gate masks fenced code,
+   indented code, and inline backtick spans first, then flags anything matching
+   `<tag …>` as `raw-html`. `<data-dir>`, `<date>`, `<user>`, `<port>` in plain
+   prose **will** trip it. Every such placeholder MUST be inside inline code
+   (`` `<data-dir>` ``) or a fenced block. Prefer showing paths in code spans or
+   code fences throughout.
+2. **Single H1.** Exactly one `#` heading (the title); start sections at `##`.
+3. **Frontmatter subset.** Double-quoted strings, flow arrays, exactly the ten
+   fields, no unknown keys, valid UTC `timestamp`.
+4. **Links.** File-relative only; no leading slash; fragments must resolve; any
+   external link is a credential-free `https://` URL.
+5. **No secrets in examples.** Use obvious placeholders, never a real token,
+   ticket, or absolute home path.
+6. Run the gate locally: `node scripts/check-docs.mjs`.
+
+## 7. Verification plan (required before publication)
+
+Acceptance requires that documented commands are exercised against a **release
+candidate** daemon and, where claimed, a packaged desktop build, on each claimed
+OS (macOS, Linux, Windows). Record results as evidence (a Status Report page or
+an entry under `docs/evidence/…`, or at minimum a PR-body evidence block) and
+only then consider raising `verification_status`.
+
+For each claimed OS:
+1. Start the daemon with no env → confirm default level is `info` and the dated
+   file appears at the documented default `<data-dir>/logs/jeliyad.log.<date>`.
+2. Start with `JELIYAD_LOG=debug` → confirm debug lines appear in both stderr and
+   the dated file; confirm `RUST_LOG` is honored only when `JELIYAD_LOG` is unset,
+   and that `JELIYAD_LOG` overrides `RUST_LOG`.
+3. Exercise each targeted-filter example and confirm it filters as documented and
+   that targets match despite the suppressed target column.
+4. Confirm the exact rotation filename and the UTC-vs-local date boundary; confirm
+   there is no plain `jeliyad.log` and no symlink; confirm old dated files survive
+   a restart and that nothing is auto-pruned.
+5. Confirm the follow command works and selects the newest dated file.
+6. `--data-dir DIR` → confirm logs move to `DIR/logs/` and the canonicalized path
+   is what the daemon reports.
+7. Supervised path: confirm a `--supervised` daemon's stderr is not visible to the
+   parent and that the dated file still captures records (this is already asserted
+   by supervisor tests; cite them and also verify end-to-end).
+8. Redaction: grep a `debug` run's dated file for the auth token and connect
+   tickets and confirm they are absent; confirm the data-dir path is the only
+   private value present and is called out for scrubbing.
+
+If a claimed OS or the packaged build cannot be exercised, do **not** claim it:
+state exactly what was not verified and who owns it (#189 for packaged desktop),
+and keep the page's status axes truthful.
+
+## 8. Clean-slate cutover handling
+
+- Document **only** the current Dioxus/`jeliyad` stack. Do not add Flutter/React
+  launch instructions.
+- If, at authoring time, legacy launch paths are still shipped (per
+  `docs/platform-matrix.md` the React/Flutter clients still exist in-tree),
+  keep the guide daemon- and Dioxus-focused and add a one-line note that legacy
+  client launchers are out of scope and will be removed when their owners
+  (#200/#201/#202/#203) retire them. Prefer no legacy content over stale content.
+
+## 9. Acceptance criteria (maps issue ACs + repo gate)
+
+- [ ] `JELIYAD_LOG`, `RUST_LOG`, default `info`, and at least three useful
+  targeted-filter examples are documented and verified.
+- [ ] Default and `--data-dir` log locations, the dated rotation filename, the
+  no-plain-file/no-symlink fact, no-pruning, and restart survival are correct on
+  macOS, Linux, and Windows.
+- [ ] Foreground and supervised/packaged collection instructions are present;
+  the supervised "stderr is discarded → read the dated file" fact is stated
+  prominently; packaged-desktop env/collection specifics defer to #189.
+- [ ] Diagnostic logs and signed room event logs are clearly and unambiguously
+  distinguished, with an explicit "never attach signed room logs" statement.
+- [ ] Safe-sharing/redaction guidance names the prohibited values (auth/bearer
+  token, `?ct=` connect tickets, invite tickets, message bodies/room content,
+  full private paths, key material) and defers the normative contract to #196.
+- [ ] "Runtime filter changes are unsupported; restart required" is stated.
+- [ ] Cross-links to #170 (supervision), #180 (diagnostics export), #189
+  (packaged evidence), #196 (redaction/security) are present and truthful.
+- [ ] `node scripts/check-docs.mjs` passes; the page is reachable from
+  `docs/index.md`; frontmatter has exactly the ten fields with truthful status
+  axes.
+- [ ] Commands were verified against a release candidate on each claimed OS (or
+  the unverified surfaces are explicitly named with their owner).
+
+## 10. Risks and open questions
+
+- **Timezone of the daily boundary.** `tracing-appender` 0.2.5 rolls on a UTC
+  date; the follow command using local `date +%F` can point at the wrong file
+  around midnight. Verify and document the actual timezone; prefer the glob-based
+  "newest file" follow command to sidestep it.
+- **Packaged desktop is unbuilt here.** Anything OS-specific about how a packaged
+  app sets env or surfaces logs is owned by #189 and must be marked pending, not
+  invented. Keep `implementation_status`/`release_status` truthful.
+- **Angle-bracket density vs the raw-HTML rule.** The most likely gate failure;
+  enforce code-span/fence discipline for every placeholder.
+- **Target list drift.** The emitting-target set is derived from current code;
+  re-derive at authoring time and avoid promising deps that emit nothing at the
+  default level.
+- **Data-dir path leakage.** The daemon prints its data-dir on startup and in
+  logs; the redaction section must call this out even though it is not a
+  "secret" per se.
+- **Open question:** should the guide live under a new `## Diagnostics` group in
+  `docs/index.md` or under existing `## Operations and release evidence`?
+  Recommendation: reuse the existing group unless #180 lands companion pages.
+- **Open question:** does #196 want the redaction checklist to live in this Guide
+  or to be referenced from a #196-owned page? Default to a short checklist here
+  that explicitly defers the normative list to #196.


### PR DESCRIPTION
# PR DRAFT — jeliya #42 (staged locally, NOT posted)

- Branch: docs/42-cffdeb4d-... | Worktree: /home/sekou/AGI/jeliya-wt/cffdeb4d
- Base: main @ 9555eb9 | Commits: 0c45e54 + b19261c (orchestrator review corrections)
- Run cost: $10.82

## Orchestrator verification (independent, in worktree)
- node scripts/check-docs.mjs: PASS | node scripts/check-docs.test.mjs: PASS (32/32)
- cargo gates: not applicable — docs-only change (no Rust touched; workspace invariant)

## Cross-review (DSH subagent, read-only adversarial): concerns — ADDRESSED
- MATERIAL: doc implied jeliyad redacts its own log output; redaction lives in
  jeliya-supervisor only — a user could have shared a trace log containing the
  auth token. Corrected in b19261c (daemon output is unredacted; shield applies
  to supervisor logs/RPC only).
- LOW: "JELIYAD_LOG wins if present" imprecise — corrected to "wins when it
  parses" (verified against lifecycle.rs:257 + tracing-subscriber try_from_env).
- LOW: "nothing is pruned" stated as absolute law — accepted as-is (accurate
  for current code).

## Switchyard-generated PR body

## What this does

Adds an accurate operator/user guide for `jeliyad` diagnostic logging and the
planning spec behind it:

- **`docs/diagnostics-logging.md`** (new Guide) — enable, locate, follow,
  rotate, and safely share diagnostic logs on the released daemon and the
  supervised/packaged desktop surface.
- **`specs/docs-jeliyad-diagnostics-logging.md`** (new) — the source-of-truth
  table, ground-truth behavior, authoring hazards, and verification plan.
- **`docs/index.md`** — one bullet under *Operations and release evidence* so
  the page is reachable (required by the docs gate).
- **`scripts/check-docs.test.mjs`** — docs-contract tests plus source-alignment
  drift tests.

Closes #42.

## Ground truth (verified against current source)

| Claim | Source |
|---|---|
| Precedence `JELIYAD_LOG` → `RUST_LOG` → `info`; `EnvFilter` syntax | `crates/jeliyad/src/lifecycle.rs` `init_tracing` |
| stderr + daily-rolling file `<data-dir>/logs/jeliyad.log`, `with_ansi(false)`/`with_target(false)`, one global filter | `lifecycle.rs` |
| Dated `jeliyad.log.YYYY-MM-DD`, **UTC** boundary, no plain file/symlink, no pruning | `tracing-appender` **0.2.5** (Cargo.lock) |
| Non-blocking writer; guard dropped to flush on clean shutdown | `lifecycle.rs`, `main.rs` |
| Default per-OS data dirs (`dirs::data_dir()`+`Jeliya`, `.jeliya-data` fallback), `--data-dir` + canonicalize | `main.rs` `default_data_dir` |
| Data dir printed on startup (`ready` line + `data dir:` line) | `main.rs` |
| Supervised spawn `--supervised --data-dir <dir> --port 0`; stderr drained forever and discarded | `crates/jeliya-supervisor/src/supervisor.rs` |
| Auth token held behind `Redacted<T>` → `<redacted>` | `crates/jeliya-supervisor/src/redact.rs` |
| `?ct=` connect tickets minted by `POST /api/session` | `main.rs` |
| Daily-rolling log shipped in released daemon | CHANGELOG `[0.6.0]` |
| Debug/trace not compiled out (no `tracing` max-level feature) | crate manifests |

## Acceptance criteria

- [x] `JELIYAD_LOG`, `RUST_LOG`, default `info`, and targeted-filter examples documented.
- [x] Default/custom log locations and rotation correct per OS (macOS/Linux/Windows).
- [x] Foreground and supervised/packaged collection instructions; supervised "stderr discarded → read the dated file" stated prominently.
- [x] Diagnostic vs signed room event logs clearly distinguished; "never attach signed room logs".
- [x] Redaction guidance names prohibited secrets/private values; defers normative contract to #196.
- [ ] Commands verified against a release candidate on each claimed OS — **not yet**; `verification_status: unverified`, and macOS/Windows paths + packaged specifics (#189) are marked pending. Owners named in-page.

## Status axes (honest)

`implementation_status`/`release_status: partial` — daemon file/stderr logging ships in v0.6.0; packaged-desktop diagnostics and the in-app export (#180) are not built in this tree. `verification_status: unverified` until the per-OS RC runs in the spec's §7 are recorded.

## Accuracy fixes applied in this pass

- **Filter guidance corrected:** the guide previously said dependency crates
  "emit only when you enable their targets explicitly" and labeled bare `debug`
  as "still relatively quiet." Both are wrong: a bare level is a global default
  that raises `iroh`, `hyper`, `tokio`, and every other crate. The guide now
  names this explicitly and steers readers to the scoped form
  `info,jeliyad=debug,jeliya_core=debug`.
- **Malformed / empty `JELIYAD_LOG`:** a parse-invalid directive or empty value
  is silently ignored, falling through to `RUST_LOG` then `info`. A one-line
  note was added so operators know where to look when a level change has no
  apparent effect.
- **Windows PowerShell follow command:** the original one-liner failed with a
  null-path error if no dated file existed yet. Fixed by assigning the result
  of `Get-ChildItem` first and guarding with `if ($log)`.

## Verification

- `node scripts/check-docs.mjs` → `OK` (exit 0).
- `node --test scripts/check-docs.test.mjs` → **32/32 pass**, including new source-alignment tests over `lifecycle.rs`, `main.rs`, and `supervisor.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)