### PR TITLE
feat(client): real byte-stream media on WsNative and WsWeb + live two-daemon qualification (#233 remainder)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,6 +2903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4302,7 +4302,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4696,7 +4696,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4754,7 +4754,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4846,7 +4846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5358,7 +5358,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6136,7 +6136,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/jeliya-client/Cargo.toml
+++ b/crates/jeliya-client/Cargo.toml
@@ -107,7 +107,8 @@ wasm-bindgen-futures = { version = "0.4", optional = true }
 js-sys = { version = "0.3.103", optional = true }
 web-sys = { version = "0.3.103", optional = true, features = [
   "WebSocket", "MessageEvent", "CloseEvent", "BinaryType", "Event",
-  "Window", "Request", "RequestInit", "RequestMode", "Response",
+  "Window",
+  "Request", "RequestInit", "RequestMode", "Response",
   "AbortController", "AbortSignal", "Location", "Performance", "Crypto", "console",
 ] }
 
@@ -150,6 +151,12 @@ jeliya-core = { path = "../jeliya-core", optional = true }
 # ever re-implemented in a test. Dev-only, so the library's dependency
 # boundary (tests/boundaries.rs scans `--edges no-dev`) is unchanged.
 jeliya-codec = { path = "../jeliya-codec" }
+# The live native probe (tests/live_native_probe.rs) parses the daemon's
+# health object for the dial gate's storage generation. Dev-only, and the
+# same version the library already locks.
+serde_json = "1"
+# The probe also builds an invite's absolute expiry (`Timestamp`). Dev-only.
+time = { version = "0.3", features = ["macros"] }
 # `block_on` for the native behaviour suite; the `executor` feature is dev-only
 # so it never reaches the library or the wasm build.
 futures = { version = "0.3", features = ["std", "async-await", "executor"] }
@@ -218,4 +225,11 @@ name = "ws_native_adapter"
 # services. Tests cover terminal/transient resolve paths, the hello gate, and
 # the stop/cleanup invariants. CI runs:
 # `cargo test -p jeliya-client --features ws-native`
+required-features = ["ws-native"]
+
+[[test]]
+name = "live_native_probe"
+# The two-daemon live round-trip probe (see the test's doc comment). Gated
+# like the ws-native suite it mirrors; run with -- --ignored against two
+# live --loopback daemons (coordinates via JELIYAD_PROBE* env vars).
 required-features = ["ws-native"]

--- a/crates/jeliya-client/Cargo.toml
+++ b/crates/jeliya-client/Cargo.toml
@@ -145,6 +145,11 @@ tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-t
 jeliya-core = { path = "../jeliya-core", optional = true }
 
 [dev-dependencies]
+# The fake-daemon integration rig (tests/ws_native_adapter.rs) frames JBS2
+# records through the same codec the adapters use — no framing constant is
+# ever re-implemented in a test. Dev-only, so the library's dependency
+# boundary (tests/boundaries.rs scans `--edges no-dev`) is unchanged.
+jeliya-codec = { path = "../jeliya-codec" }
 # `block_on` for the native behaviour suite; the `executor` feature is dev-only
 # so it never reaches the library or the wasm build.
 futures = { version = "0.3", features = ["std", "async-await", "executor"] }

--- a/crates/jeliya-client/build.rs
+++ b/crates/jeliya-client/build.rs
@@ -6,7 +6,12 @@
 // Only PORT and TOKEN are forwarded. The storage_generation and protocol
 // version are discovered at runtime by the adapter itself via GET /api/health.
 fn main() {
-    for var in ["JELIYAD_WEB_TEST_PORT", "JELIYAD_WEB_TEST_TOKEN"] {
+    for var in [
+        "JELIYAD_WEB_TEST_PORT",
+        "JELIYAD_WEB_TEST_TOKEN",
+        "JELIYAD2_WEB_TEST_PORT",
+        "JELIYAD2_WEB_TEST_TOKEN",
+    ] {
         println!("cargo:rerun-if-env-changed={var}");
         if let Ok(val) = std::env::var(var) {
             println!("cargo:rustc-env={var}={val}");

--- a/crates/jeliya-client/src/adapter/media.rs
+++ b/crates/jeliya-client/src/adapter/media.rs
@@ -101,8 +101,19 @@ impl BoundStream {
 /// then; bound streams never do (§S8/§S10).
 pub(crate) struct MediaRegistry {
     /// Caller registrations awaiting a stream op's send, keyed by dedup
-    /// `OpId`. Bounded by the caller's own registration discipline.
+    /// `OpId`, in insertion order (oldest first, for the bounded-eviction
+    /// rule below).
     registered: HashMap<OpId, StreamMedia>,
+    /// The registration insertion order backing the eviction rule.
+    registered_order: VecDeque<OpId>,
+    /// The bound on outstanding registrations (§K12: no unbounded
+    /// collection). A registration whose call is never sent (refused
+    /// locally, or the caller abandoned the dispatch) has no other
+    /// reclaimer, so the registry evicts the OLDEST outstanding
+    /// registration past the cap — an evicted key's later call fails
+    /// honestly at its first media effect (`SourceFailed`/`SinkFailed`),
+    /// never a silent stall.
+    registered_cap: usize,
     /// Per-stream media state, keyed by the stream's wire id. Bounded by the
     /// kernel's concurrent-stream limit (every terminal prunes).
     bound: HashMap<RequestId, BoundStream>,
@@ -120,9 +131,11 @@ pub(crate) struct MediaRegistry {
 impl MediaRegistry {
     /// Build an empty registry whose inbound cap is `stream_window_bytes × 2`
     /// (the kernel config's window, passed at construction).
-    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+    pub(crate) fn new(stream_window_bytes: u64, registered_cap: usize) -> Self {
         Self {
             registered: HashMap::new(),
+            registered_order: VecDeque::new(),
+            registered_cap: registered_cap.max(1),
             bound: HashMap::new(),
             window_cap: stream_window_bytes.saturating_mul(2),
             pending: VecDeque::new(),
@@ -131,9 +144,19 @@ impl MediaRegistry {
 
     /// Register one stream's media under its dedup key, before the call is
     /// dispatched. Re-registering a key replaces the previous media (the
-    /// caller's own last-write-wins).
+    /// caller's own last-write-wins). Past `registered_cap` the OLDEST
+    /// outstanding registration is evicted — see the field's honesty note.
     pub(crate) fn register(&mut self, key: OpId, media: StreamMedia) {
-        self.registered.insert(key, media);
+        if self.registered.insert(key.clone(), media).is_none() {
+            self.registered_order.push_back(key);
+        }
+        while self.registered.len() > self.registered_cap {
+            if let Some(oldest) = self.registered_order.pop_front() {
+                self.registered.remove(&oldest);
+            } else {
+                break;
+            }
+        }
     }
 
     /// Bind a stream op's wire id at send time: move the caller's
@@ -146,9 +169,12 @@ impl MediaRegistry {
         if self.bound.contains_key(&wire_id) {
             return;
         }
-        let media = op_id.and_then(|key| self.registered.remove(&key));
+        let media = op_id.map(|key| {
+            self.registered_order.retain(|k| k != &key);
+            self.registered.remove(&key)
+        });
         let mut stream = BoundStream::empty();
-        stream.media = media;
+        stream.media = media.flatten();
         self.bound.insert(wire_id, stream);
     }
 
@@ -361,6 +387,20 @@ impl MediaRegistry {
     pub(crate) fn bound_len(&self) -> usize {
         self.bound.len()
     }
+
+    /// The number of outstanding registrations (test observability).
+    #[cfg(test)]
+    pub(crate) fn registered_len(&self) -> usize {
+        self.registered.len()
+    }
+
+    /// Whether a bound stream carries caller media (test observability).
+    #[cfg(test)]
+    pub(crate) fn bound_has_media(&self, wire_id: RequestId) -> bool {
+        self.bound
+            .get(&wire_id)
+            .is_some_and(|stream| stream.media.is_some())
+    }
 }
 
 /// Encode one payload-free control record under the codec's default bounds.
@@ -475,6 +515,7 @@ async fn source_task(
     };
     let mut position: u64 = 0;
     while let Some(grant) = grants.recv().await {
+        let grant_start = position;
         let mut remaining = grant.up_to;
         while remaining > 0 {
             let want = remaining.min(chunk_cap as u64) as usize;
@@ -520,6 +561,15 @@ async fn source_task(
             }
             position += read as u64;
             remaining = remaining.saturating_sub(read as u64);
+        }
+        // ONE cumulative `Produced` per grant, after the whole grant is on
+        // wire — never per chunk. A per-chunk report lets the kernel pump a
+        // fresh grant while this task is still consuming the current one;
+        // that stale grant is then fulfilled from the advanced position and
+        // sends DATA past the daemon's `send_through`, so a multi-chunk
+        // upload (source larger than one DATA record) aborts for credit
+        // overshoot (found in review; protocol §Credit).
+        if position > grant_start {
             inject(Input::Produced {
                 call_id: grant.call_id,
                 sent_through: position,
@@ -551,7 +601,42 @@ mod tests {
     }
 
     fn registry() -> MediaRegistry {
-        MediaRegistry::new(1024)
+        MediaRegistry::new(1024, 64)
+    }
+
+    #[test]
+    fn registered_map_is_bounded_and_evicts_oldest() {
+        // Cap 2: the third registration evicts the oldest. An evicted key's
+        // later call still BINDS (empty) and fails honestly at produce time.
+        let mut media = MediaRegistry::new(1024, 2);
+        let k1 = OpId::new("share-1");
+        let k2 = OpId::new("share-2");
+        let k3 = OpId::new("share-3");
+        media.register(k1.clone(), shared_bytes(vec![1]));
+        media.register(k2, shared_bytes(vec![2]));
+        media.register(k3.clone(), shared_bytes(vec![3]));
+        assert_eq!(media.registered_len(), 2, "the cap holds");
+        // k3 binds its media; k1 was evicted, so its stream binds empty.
+        media.bind(wire_id(), Some(k3));
+        assert!(
+            media.bound_has_media(wire_id()),
+            "the newest registration bound its media"
+        );
+        let evicted_id = RequestId::new(8).expect("id");
+        media.bind(evicted_id, Some(k1));
+        assert!(
+            !media.bound_has_media(evicted_id),
+            "the evicted registration binds an honestly-failing empty entry"
+        );
+        // Consuming a bound registration frees its slot.
+        let mut media2 = MediaRegistry::new(1024, 1);
+        let a = OpId::new("a");
+        let b = OpId::new("b");
+        media2.register(a.clone(), shared_bytes(vec![9]));
+        media2.bind(wire_id(), Some(a));
+        assert_eq!(media2.registered_len(), 0, "bind consumes the registration");
+        media2.register(b, shared_bytes(vec![8]));
+        assert_eq!(media2.registered_len(), 1, "the slot was reclaimed");
     }
 
     #[test]

--- a/crates/jeliya-client/src/adapter/media.rs
+++ b/crates/jeliya-client/src/adapter/media.rs
@@ -1,0 +1,789 @@
+//! The native adapter's byte-stream media drive (§S3 of the kernel stream
+//! spec): the registry that binds registered [`StreamMedia`] to wire ids and
+//! moves real bytes between the caller's sources/sinks and the socket.
+//!
+//! The kernel's stream control plane is byte-free — it grants offsets and
+//! windows, never payload. This module is where those grants become
+//! `JBS2` DATA records on the write channel (one async media task per active
+//! producer stream, awaiting the writer's backpressure) and where inbound
+//! DATA payloads quarantine (window-bounded) until the kernel's `WriteSink`
+//! hands them to the caller's sink. All framing stays in `jeliya-codec`,
+//! called only from here and the read loop — no `JBS2` constant appears in
+//! this file.
+//!
+//! Honest failure is the invariant: a stream that reaches a media effect
+//! with no registered media reports `SourceFailed`/`SinkFailed` to the core
+//! (which aborts the stream and settles the call), never a stall and never a
+//! fake success. A stream never survives its connection: teardown clears the
+//! bound entries and aborts their media tasks exactly when the connection's
+//! tasks die (§S10).
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::{Arc, Weak};
+
+use jeliya_api::{OpId, RequestId};
+use jeliya_codec::{
+    max_stream_data_bytes, BinaryAbortReason, CodecBounds, StreamIdentity, StreamRecord,
+    StreamRecordBody,
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::kernel::core::Input;
+use crate::kernel::inflight::CallId;
+use crate::kernel::transport::{StreamAbortReason, StreamRecordIntent};
+use crate::media::{ByteSource, StreamMedia};
+
+/// One producer grant forwarded to a stream's media task: how many more
+/// bytes the kernel has bounded (credit + window + total) and which call the
+/// resulting `Produced`/`SourceEnd`/`SourceFailed` inputs belong to. The
+/// call id rides here because binding happens at send time, when only the
+/// wire id is known; [`MediaRegistry::produce`] records it on the bound
+/// entry and passes it through the channel in the same step.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MediaGrant {
+    /// The stream call the grant fulfils.
+    pub(crate) call_id: CallId,
+    /// The maximum additional bytes the task may send now.
+    pub(crate) up_to: u64,
+}
+
+/// The media-side state of one bound stream (keyed by wire id): the caller's
+/// registered media, the producer task's grant channel, and the receiver's
+/// inbound quarantine buffer.
+///
+/// `Debug` is deliberately absent as a derive: the inbound buffer holds
+/// payload bytes, and no debug render of this type may expose them (§S12).
+pub(crate) struct BoundStream {
+    /// The registered media, if the caller registered any (`None` = an
+    /// honestly-failing unregistered stream).
+    pub(crate) media: Option<StreamMedia>,
+    /// The producer media task's grant sender, present from OPEN on a
+    /// source-bound stream.
+    pub(crate) grant_tx: Option<mpsc::Sender<MediaGrant>>,
+    /// The producer media task, if one was spawned.
+    pub(crate) task: Option<JoinHandle<()>>,
+    /// The call id observed at the first media effect (`produce`/`write_sink`
+    /// both receive it; the producer task also carries it per grant).
+    pub(crate) call_id: Option<CallId>,
+    /// Quarantined inbound DATA, keyed by offset — bounded by the registry's
+    /// defensive cap (twice the kernel's stream window).
+    pub(crate) inbound: BTreeMap<u64, Vec<u8>>,
+    /// The buffer's running byte count (the cap check's numerator).
+    pub(crate) inbound_bytes: u64,
+}
+
+impl BoundStream {
+    /// A fresh, media-less bound entry.
+    fn empty() -> Self {
+        Self {
+            media: None,
+            grant_tx: None,
+            task: None,
+            call_id: None,
+            inbound: BTreeMap::new(),
+            inbound_bytes: 0,
+        }
+    }
+}
+
+/// The per-connection media registry, shared (inside the connection
+/// registry) between the native driver, the dial task's read loop, and every
+/// teardown path.
+///
+/// Two maps, two lifetimes: `registered` holds caller registrations keyed by
+/// dedup `OpId` awaiting the stream op's send; `bound` holds the per-stream
+/// state keyed by wire id from that send until the stream's terminal reply
+/// ([`MediaRegistry::prune`]) or the connection's death
+/// ([`MediaRegistry::clear`]). Registrations survive a connection loss —
+/// a stream call queued across a reconnect still sends after it, and binds
+/// then; bound streams never do (§S8/§S10).
+pub(crate) struct MediaRegistry {
+    /// Caller registrations awaiting a stream op's send, keyed by dedup
+    /// `OpId`. Bounded by the caller's own registration discipline.
+    registered: HashMap<OpId, StreamMedia>,
+    /// Per-stream media state, keyed by the stream's wire id. Bounded by the
+    /// kernel's concurrent-stream limit (every terminal prunes).
+    bound: HashMap<RequestId, BoundStream>,
+    /// The defensive inbound-buffer cap: the kernel's `stream_window_bytes`
+    /// doubled (the core grants at most one window; the second window is the
+    /// margin for a range delivered just before its credit extension).
+    window_cap: u64,
+    /// Media inputs fulfilled synchronously (`SinkAccepted`/`SinkFailed`,
+    /// and `SourceFailed` for an unregistered stream), drained by the shell's
+    /// `take_pending_media` loop after the apply batch — the driver never
+    /// injects while holding the registry lock.
+    pending: VecDeque<Input>,
+}
+
+impl MediaRegistry {
+    /// Build an empty registry whose inbound cap is `stream_window_bytes × 2`
+    /// (the kernel config's window, passed at construction).
+    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+        Self {
+            registered: HashMap::new(),
+            bound: HashMap::new(),
+            window_cap: stream_window_bytes.saturating_mul(2),
+            pending: VecDeque::new(),
+        }
+    }
+
+    /// Register one stream's media under its dedup key, before the call is
+    /// dispatched. Re-registering a key replaces the previous media (the
+    /// caller's own last-write-wins).
+    pub(crate) fn register(&mut self, key: OpId, media: StreamMedia) {
+        self.registered.insert(key, media);
+    }
+
+    /// Bind a stream op's wire id at send time: move the caller's
+    /// registration (if any) onto the wire key. A stream op with **no**
+    /// registration still binds an empty entry, so its later media effects
+    /// fail honestly (`SourceFailed`/`SinkFailed`) instead of silently. A
+    /// re-send of an already-bound id (a reconnect's replay of the send)
+    /// leaves the existing binding untouched.
+    pub(crate) fn bind(&mut self, wire_id: RequestId, op_id: Option<OpId>) {
+        if self.bound.contains_key(&wire_id) {
+            return;
+        }
+        let media = op_id.and_then(|key| self.registered.remove(&key));
+        let mut stream = BoundStream::empty();
+        stream.media = media;
+        self.bound.insert(wire_id, stream);
+    }
+
+    /// Whether a wire id has a bound stream entry.
+    pub(crate) fn is_bound(&self, wire_id: RequestId) -> bool {
+        self.bound.contains_key(&wire_id)
+    }
+
+    /// Frame one outbound control record via `jeliya-codec` and push it onto
+    /// the live write channel (non-blocking, exactly like a Text send).
+    /// Returns `false` when the record cannot be framed or the channel is
+    /// full/closed — the caller treats that exactly like a failed Text send
+    /// (a connection loss the core reclassifies).
+    pub(crate) fn send_record(writer: &mpsc::Sender<Message>, intent: &StreamRecordIntent) -> bool {
+        let record = match intent_record(intent) {
+            Some(record) => record,
+            None => return false,
+        };
+        // Control records carry no payload, so the codec's own default frame
+        // ceiling is always satisfiable; a served limit cannot be tighter
+        // than the 48-byte header a negotiated connection already carried.
+        let framed = match encode_control(&record) {
+            Some(bytes) => bytes,
+            None => return false,
+        };
+        writer.try_send(Message::Binary(framed.into())).is_ok()
+    }
+
+    /// Fulfil one `ProduceData` grant: record the call id on the bound entry
+    /// and forward the grant to the stream's media task. A stream with no
+    /// media task (unregistered, or a sink-bound stream) queues an honest
+    /// `SourceFailed` for the shell to re-drive — never a silent drop.
+    pub(crate) fn produce(&mut self, id: RequestId, call_id: CallId, up_to: u64) {
+        let grant_tx = match self.bound.get_mut(&id) {
+            Some(stream) => {
+                stream.call_id = Some(call_id);
+                stream.grant_tx.clone()
+            }
+            None => None,
+        };
+        match grant_tx {
+            // A closed/full channel means the task ended (source already
+            // reported its terminal) or is maximally backed up; the kernel
+            // already holds the source's terminal or will re-pump on the
+            // next credit — dropping the grant strands nothing.
+            Some(tx) => {
+                let _ = tx.try_send(MediaGrant { call_id, up_to });
+            }
+            None => self.pending.push_back(Input::SourceFailed { call_id }),
+        }
+    }
+
+    /// Fulfil one `WriteSink` hand-off: take the quarantined range, write it
+    /// to the caller's sink, and queue the matching input for the shell. A
+    /// gap in the quarantine or a sink refusal queues `SinkFailed`.
+    pub(crate) fn write_sink(&mut self, id: RequestId, call_id: CallId, offset: u64, len: u64) {
+        let sink = match self.bound.get_mut(&id) {
+            Some(stream) => {
+                stream.call_id = Some(call_id);
+                match stream.media.as_ref() {
+                    Some(StreamMedia::Sink(sink)) => Some(sink.clone()),
+                    _ => None,
+                }
+            }
+            None => None,
+        };
+        let Some(sink) = sink else {
+            self.pending.push_back(Input::SinkFailed { call_id });
+            return;
+        };
+        let taken = match self.take_range(id, offset, len) {
+            Some(bytes) => bytes,
+            None => {
+                self.pending.push_back(Input::SinkFailed { call_id });
+                return;
+            }
+        };
+        match sink.write_at(offset, &taken) {
+            Ok(()) => self.pending.push_back(Input::SinkAccepted {
+                call_id,
+                through: offset.saturating_add(len),
+            }),
+            Err(_) => self.pending.push_back(Input::SinkFailed { call_id }),
+        }
+    }
+
+    /// Remove and return the contiguous quarantined range `[offset,
+    /// offset+len)`, splitting a chunk that extends past the range's end.
+    /// `None` on any gap (a protocol-side discontinuity the kernel normally
+    /// prevents; refusing is the honest path).
+    fn take_range(&mut self, id: RequestId, offset: u64, len: u64) -> Option<Vec<u8>> {
+        let stream = self.bound.get_mut(&id)?;
+        if len == 0 {
+            return Some(Vec::new());
+        }
+        let mut collected = Vec::with_capacity(len as usize);
+        let mut covered: u64 = 0;
+        while covered < len {
+            let key = offset.saturating_add(covered);
+            let needed = (len - covered) as usize;
+            let mut chunk = stream.inbound.remove(&key)?;
+            if chunk.len() > needed {
+                // The chunk extends past this range's end: keep the prefix,
+                // re-quarantine the suffix under its own offset.
+                let suffix_offset = key.saturating_add(needed as u64);
+                let suffix = chunk.split_off(needed);
+                stream.inbound.insert(suffix_offset, suffix);
+                collected.extend_from_slice(&chunk);
+                covered = len;
+            } else {
+                collected.extend_from_slice(&chunk);
+                covered += chunk.len() as u64;
+            }
+        }
+        stream.inbound_bytes = stream.inbound_bytes.saturating_sub(collected.len() as u64);
+        Some(collected)
+    }
+
+    /// Quarantine one inbound DATA payload before its record metadata
+    /// reaches the core. Returns `false` on protocol trouble — an unbound
+    /// wire id, a duplicate/overlapping offset, or a buffer past its
+    /// defensive cap (twice the kernel's stream window) — which the read
+    /// loop reports as `Inbound::Malformed`.
+    pub(crate) fn deliver_data(&mut self, id: RequestId, offset: u64, payload: &[u8]) -> bool {
+        let Some(stream) = self.bound.get_mut(&id) else {
+            return false;
+        };
+        if stream.inbound.contains_key(&offset) {
+            return false;
+        }
+        let add = payload.len() as u64;
+        if stream.inbound_bytes.saturating_add(add) > self.window_cap {
+            return false;
+        }
+        stream.inbound.insert(offset, payload.to_vec());
+        stream.inbound_bytes = stream.inbound_bytes.saturating_add(add);
+        true
+    }
+
+    /// Spawn (once, at OPEN) the producer media task for a source-bound
+    /// stream: it owns the grant channel and the caller's byte source, reads
+    /// granted bytes in codec-bounded chunks, frames DATA records, and
+    /// awaits the writer's backpressure — reporting progress and terminals
+    /// through the shell's `inject`. No-op when the stream has no source
+    /// media or already has a task.
+    pub(crate) fn spawn_source_task(
+        &mut self,
+        wire_id: RequestId,
+        stream_id: u128,
+        writer: &mpsc::Sender<Message>,
+        runtime: Weak<crate::kernel::Runtime>,
+        bounds: CodecBounds,
+    ) {
+        let stream = match self.bound.get_mut(&wire_id) {
+            Some(stream) if stream.grant_tx.is_none() => stream,
+            _ => return,
+        };
+        let source = match stream.media.as_ref() {
+            Some(StreamMedia::Source(source)) => source.clone(),
+            _ => return,
+        };
+        let identity = match StreamIdentity::new(wire_id.get(), stream_id) {
+            Ok(identity) => identity,
+            Err(_) => return,
+        };
+        let (grant_tx, grant_rx) = mpsc::channel::<MediaGrant>(8);
+        let task = tokio::spawn(source_task(
+            runtime,
+            writer.clone(),
+            identity,
+            source,
+            grant_rx,
+            bounds,
+        ));
+        stream.grant_tx = Some(grant_tx);
+        stream.task = Some(task);
+    }
+
+    /// Prune a finished stream (its terminal Text reply arrived): abort any
+    /// media task and drop the bound entry. Cheap and idempotent.
+    pub(crate) fn prune(&mut self, wire_id: RequestId) {
+        if let Some(mut stream) = self.bound.remove(&wire_id) {
+            if let Some(task) = stream.task.take() {
+                task.abort();
+            }
+        }
+    }
+
+    /// Clear every bound stream — abort media tasks, drop quarantine buffers.
+    /// Called on connection loss and teardown: a stream never survives its
+    /// connection (§S10). Caller registrations survive: they await a send
+    /// that a queued stream call still owes after the reconnect.
+    pub(crate) fn clear(&mut self) {
+        for (_, mut stream) in self.bound.drain() {
+            if let Some(task) = stream.task.take() {
+                task.abort();
+            }
+        }
+    }
+
+    /// Drain the synchronously-fulfilled media inputs for the shell's
+    /// post-batch re-drive (mirrors the in-memory driver's queue).
+    pub(crate) fn take_pending(&mut self) -> VecDeque<Input> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// The number of bound streams (test observability; a bound, never
+    /// content).
+    #[cfg(test)]
+    pub(crate) fn bound_len(&self) -> usize {
+        self.bound.len()
+    }
+}
+
+/// Encode one payload-free control record under the codec's default bounds.
+/// Control records are exactly the 48-byte header, so any negotiated limit
+/// that carried the stream's OPEN carries these too.
+fn encode_control(record: &StreamRecord) -> Option<Vec<u8>> {
+    jeliya_codec::encode_stream_record(record, &CodecBounds::default()).ok()
+}
+
+/// Map one kernel record intent onto the codec's record type. `None` only
+/// for a zero stream id, which the codec forbids and a decoded OPEN can
+/// never carry.
+fn intent_record(intent: &StreamRecordIntent) -> Option<StreamRecord> {
+    use crate::kernel::transport::StreamRecordIntent as I;
+    let identity = |id: RequestId, stream_id: u128| StreamIdentity::new(id.get(), stream_id).ok();
+    let record = match *intent {
+        I::Credit {
+            id,
+            stream_id,
+            accepted_through,
+            send_through,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Credit {
+                accepted_through,
+                send_through,
+            },
+        },
+        I::End {
+            id,
+            stream_id,
+            offset,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::End { total: offset },
+        },
+        I::Abort {
+            id,
+            stream_id,
+            high_water,
+            reason,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Abort {
+                accepted_through: high_water,
+                reason: map_abort_reason_outbound(reason),
+            },
+        },
+        I::Ack {
+            id,
+            stream_id,
+            high_water,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Ack {
+                accepted_through: high_water,
+            },
+        },
+    };
+    Some(record)
+}
+
+/// Map an inbound codec abort reason onto the kernel's closed tag by value:
+/// the four shared tags map one-to-one; the daemon-only `OperationError`
+/// (which a client never authors and the kernel's inbound-ABORT handling
+/// ignores the reason of) maps to `ProtocolError`.
+pub(crate) fn map_abort_reason(reason: BinaryAbortReason) -> StreamAbortReason {
+    match reason {
+        BinaryAbortReason::Cancelled => StreamAbortReason::Cancelled,
+        BinaryAbortReason::SourceFailed => StreamAbortReason::SourceFailed,
+        BinaryAbortReason::SinkFailed => StreamAbortReason::SinkFailed,
+        BinaryAbortReason::ProtocolError | BinaryAbortReason::OperationError => {
+            StreamAbortReason::ProtocolError
+        }
+    }
+}
+
+/// Map a kernel abort tag onto the codec's wire reason (the outbound
+/// direction): every kernel tag has an exact wire counterpart.
+fn map_abort_reason_outbound(reason: StreamAbortReason) -> BinaryAbortReason {
+    match reason {
+        StreamAbortReason::Cancelled => BinaryAbortReason::Cancelled,
+        StreamAbortReason::SourceFailed => BinaryAbortReason::SourceFailed,
+        StreamAbortReason::SinkFailed => BinaryAbortReason::SinkFailed,
+        StreamAbortReason::ProtocolError => BinaryAbortReason::ProtocolError,
+    }
+}
+
+/// The producer media task: one per active source-bound stream. Reads
+/// granted bytes from the caller's source in codec-bounded chunks, frames
+/// DATA records, sends them through the writer (awaiting its backpressure —
+/// this task holds no locks), and injects `Produced`/`SourceEnd`/
+/// `SourceFailed` through the shell. A writer send failure ends the task
+/// quietly: the read loop observes the connection loss and the core tears
+/// every stream down (§S10).
+async fn source_task(
+    runtime: Weak<crate::kernel::Runtime>,
+    writer: mpsc::Sender<Message>,
+    identity: StreamIdentity,
+    source: Arc<dyn ByteSource>,
+    mut grants: mpsc::Receiver<MediaGrant>,
+    bounds: CodecBounds,
+) {
+    let chunk_cap = match max_stream_data_bytes(bounds.max_frame_bytes) {
+        Ok(cap) => cap,
+        Err(_) => return,
+    };
+    let inject = |input: Input| {
+        if let Some(runtime) = runtime.upgrade() {
+            runtime.inject(input);
+        }
+    };
+    let mut position: u64 = 0;
+    while let Some(grant) = grants.recv().await {
+        let mut remaining = grant.up_to;
+        while remaining > 0 {
+            let want = remaining.min(chunk_cap as u64) as usize;
+            let mut buf = vec![0_u8; want];
+            let read = source.read_at(position, &mut buf);
+            if read == 0 {
+                // EOF reports the source's own count (the authoritative END
+                // offset); a zero read short of it is a source failure.
+                if position >= source.len() {
+                    inject(Input::SourceEnd {
+                        call_id: grant.call_id,
+                        total: position,
+                    });
+                } else {
+                    inject(Input::SourceFailed {
+                        call_id: grant.call_id,
+                    });
+                }
+                return;
+            }
+            buf.truncate(read);
+            let record = StreamRecord {
+                identity,
+                body: StreamRecordBody::Data {
+                    offset: position,
+                    payload: buf,
+                },
+            };
+            let framed = match jeliya_codec::encode_stream_record(&record, &bounds) {
+                Ok(bytes) => bytes,
+                // A framing refusal is a local media failure: abort honestly.
+                Err(_) => {
+                    inject(Input::SourceFailed {
+                        call_id: grant.call_id,
+                    });
+                    return;
+                }
+            };
+            if writer.send(Message::Binary(framed.into())).await.is_err() {
+                // Connection loss: the read loop reports it; nothing here can
+                // or should continue.
+                return;
+            }
+            position += read as u64;
+            remaining = remaining.saturating_sub(read as u64);
+            inject(Input::Produced {
+                call_id: grant.call_id,
+                sent_through: position,
+            });
+        }
+        // The grant ran out at (or past) the source's end: report EOF now
+        // rather than waiting for a probe grant that may never come.
+        if position >= source.len() {
+            inject(Input::SourceEnd {
+                call_id: grant.call_id,
+                total: position,
+            });
+            return;
+        }
+    }
+}
+
+/// Resize-and-take note: the read buffer is truncated to the source's short
+/// read before framing, so no per-chunk re-allocation happens (the codec
+/// copies the payload into the framed record).
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::{shared_bytes, ByteSink, SinkRejected};
+    use jeliya_api::OpId;
+
+    fn wire_id() -> RequestId {
+        RequestId::new(7).expect("wire id")
+    }
+
+    fn registry() -> MediaRegistry {
+        MediaRegistry::new(1024)
+    }
+
+    #[test]
+    fn bind_moves_a_registration_and_leaves_it_consumed() {
+        let mut media = registry();
+        let key = OpId::new("share-1");
+        media.register(key.clone(), shared_bytes(vec![1, 2, 3]));
+        media.bind(wire_id(), Some(key.clone()));
+        assert!(media.is_bound(wire_id()));
+        // The registration moved: the same key binds nothing the second time.
+        media.bind(RequestId::new(8).expect("id"), Some(key));
+        assert!(media.is_bound(RequestId::new(8).expect("id")));
+        // A stream op with no registration still binds an empty entry.
+        media.bind(RequestId::new(9).expect("id"), None);
+        assert!(media.is_bound(RequestId::new(9).expect("id")));
+        // Bound state is per wire id: 3 bound streams here.
+        assert_eq!(media.bound_len(), 3);
+    }
+
+    #[test]
+    fn unregistered_stream_produce_fails_honestly() {
+        let mut media = registry();
+        let id = wire_id();
+        media.bind(id, None);
+        let call_id = CallId(11);
+        media.produce(id, call_id, 64);
+        let pending = media.take_pending();
+        assert!(
+            matches!(pending.front(), Some(Input::SourceFailed { call_id: c }) if *c == call_id),
+            "an unregistered stream must report SourceFailed (queue len {})",
+            pending.len()
+        );
+        assert!(media.take_pending().is_empty(), "the queue drains once");
+    }
+
+    #[test]
+    fn unbound_wire_id_produce_also_fails_honestly() {
+        let mut media = registry();
+        let call_id = CallId(4);
+        media.produce(wire_id(), call_id, 8);
+        assert!(
+            matches!(
+                media.take_pending().front(),
+                Some(Input::SourceFailed { .. })
+            ),
+            "a produce for a never-bound wire id strands nothing and fails honestly"
+        );
+    }
+
+    #[test]
+    fn deliver_data_enforces_the_window_cap() {
+        let mut media = registry();
+        let id = wire_id();
+        media.bind(id, None);
+        // Cap = 2 × 1024 = 2048 bytes.
+        assert!(media.deliver_data(id, 0, &vec![0_u8; 1024]));
+        assert!(media.deliver_data(id, 1024, &vec![0_u8; 1024]));
+        // One more byte crosses twice the kernel window: refused.
+        assert!(!media.deliver_data(id, 2048, &[9]));
+        // A duplicate offset is protocol trouble: refused.
+        assert!(!media.deliver_data(id, 0, &[1]));
+        // An unbound wire id is refused.
+        assert!(!media.deliver_data(RequestId::new(99).expect("id"), 0, &[1]));
+    }
+
+    #[test]
+    fn sink_write_takes_the_buffered_range_and_reports_accepted() {
+        let mut media = registry();
+        let id = wire_id();
+        let sink = crate::media::CollectedBytes::new();
+        let mut stream = BoundStream::empty();
+        stream.media = Some(crate::media::StreamMedia::Sink(std::sync::Arc::new(sink)));
+        media.bound.insert(id, stream);
+        assert!(media.deliver_data(id, 0, &[1, 2, 3]));
+        let call_id = CallId(21);
+        media.write_sink(id, call_id, 0, 3);
+        let pending = media.take_pending();
+        assert!(
+            matches!(pending.front(), Some(Input::SinkAccepted { call_id: c, through: 3 }) if *c == call_id),
+            "an accepted range reports SinkAccepted through its end"
+        );
+        // The quarantined bytes were consumed: re-writing the same range now
+        // hits a gap (nothing is double-written).
+        media.write_sink(id, call_id, 0, 3);
+        assert!(
+            matches!(media.take_pending().front(), Some(Input::SinkFailed { .. })),
+            "a consumed range must not be writable twice"
+        );
+    }
+
+    #[test]
+    fn sink_gap_refusal_reports_sink_failed() {
+        let mut media = registry();
+        let id = wire_id();
+        let mut stream = BoundStream::empty();
+        stream.media = Some(crate::media::StreamMedia::Sink(std::sync::Arc::new(
+            crate::media::CollectedBytes::new(),
+        )));
+        media.bound.insert(id, stream);
+        // Nothing was delivered at 0: writing [0, 3) hits a gap.
+        let call_id = CallId(31);
+        media.write_sink(id, call_id, 0, 3);
+        assert!(
+            matches!(media.take_pending().front(), Some(Input::SinkFailed { call_id: c }) if *c == call_id),
+            "a quarantine gap must report SinkFailed, never fake acceptance"
+        );
+    }
+
+    #[test]
+    fn sink_rejection_reports_sink_failed() {
+        struct Refusing;
+        impl ByteSink for Refusing {
+            fn write_at(&self, _offset: u64, _bytes: &[u8]) -> Result<(), SinkRejected> {
+                Err(SinkRejected)
+            }
+        }
+        let mut media = registry();
+        let id = wire_id();
+        let mut stream = BoundStream::empty();
+        stream.media = Some(crate::media::StreamMedia::Sink(std::sync::Arc::new(
+            Refusing,
+        )));
+        media.bound.insert(id, stream);
+        assert!(media.deliver_data(id, 0, &[1]));
+        let call_id = CallId(41);
+        media.write_sink(id, call_id, 0, 1);
+        assert!(
+            matches!(media.take_pending().front(), Some(Input::SinkFailed { .. })),
+            "a refusing sink must report SinkFailed"
+        );
+    }
+
+    #[test]
+    fn prune_removes_the_bound_stream_and_is_idempotent() {
+        let mut media = registry();
+        let id = wire_id();
+        media.bind(id, None);
+        media.prune(id);
+        assert_eq!(media.bound_len(), 0);
+        media.prune(id); // no panic, no effect
+    }
+
+    #[test]
+    fn clear_drops_bound_streams_but_keeps_registrations() {
+        let mut media = registry();
+        let key = OpId::new("queued");
+        media.register(key.clone(), shared_bytes(vec![1]));
+        media.bind(wire_id(), None);
+        media.clear();
+        assert_eq!(media.bound_len(), 0, "no stream survives its connection");
+        // The registration still awaits its send across the reconnect.
+        media.bind(RequestId::new(50).expect("id"), Some(key));
+        assert_eq!(media.bound_len(), 1);
+    }
+
+    #[test]
+    fn abort_reason_mapping_is_by_closed_tag() {
+        assert_eq!(
+            map_abort_reason(BinaryAbortReason::Cancelled),
+            StreamAbortReason::Cancelled
+        );
+        assert_eq!(
+            map_abort_reason(BinaryAbortReason::SourceFailed),
+            StreamAbortReason::SourceFailed
+        );
+        assert_eq!(
+            map_abort_reason(BinaryAbortReason::SinkFailed),
+            StreamAbortReason::SinkFailed
+        );
+        assert_eq!(
+            map_abort_reason(BinaryAbortReason::ProtocolError),
+            StreamAbortReason::ProtocolError
+        );
+        // Daemon-only on the wire; a client maps it to the protocol tag.
+        assert_eq!(
+            map_abort_reason(BinaryAbortReason::OperationError),
+            StreamAbortReason::ProtocolError
+        );
+        // The outbound direction is exact for every kernel tag.
+        assert_eq!(
+            map_abort_reason_outbound(StreamAbortReason::Cancelled),
+            BinaryAbortReason::Cancelled
+        );
+        assert_eq!(
+            map_abort_reason_outbound(StreamAbortReason::SourceFailed),
+            BinaryAbortReason::SourceFailed
+        );
+        assert_eq!(
+            map_abort_reason_outbound(StreamAbortReason::SinkFailed),
+            BinaryAbortReason::SinkFailed
+        );
+        assert_eq!(
+            map_abort_reason_outbound(StreamAbortReason::ProtocolError),
+            BinaryAbortReason::ProtocolError
+        );
+    }
+
+    #[test]
+    fn send_record_frames_a_credit_record_onto_the_channel() {
+        let (tx, mut rx) = mpsc::channel::<Message>(2);
+        let intent = StreamRecordIntent::Credit {
+            id: wire_id(),
+            stream_id: 1,
+            accepted_through: 0,
+            send_through: 10,
+        };
+        assert!(MediaRegistry::send_record(&tx, &intent));
+        match rx.try_recv() {
+            Ok(Message::Binary(_)) => {}
+            other => panic!("expected a framed Binary record, got {other:?}"),
+        }
+        // A zero stream id cannot be framed: honest failure.
+        let bad = StreamRecordIntent::End {
+            id: wire_id(),
+            stream_id: 0,
+            offset: 0,
+        };
+        assert!(!MediaRegistry::send_record(&tx, &bad));
+    }
+
+    #[test]
+    fn send_record_fails_on_a_closed_channel() {
+        let (tx, _rx) = mpsc::channel::<Message>(1);
+        drop(_rx);
+        let intent = StreamRecordIntent::Ack {
+            id: wire_id(),
+            stream_id: 3,
+            high_water: 7,
+        };
+        assert!(
+            !MediaRegistry::send_record(&tx, &intent),
+            "a closed write channel must report failure, not success"
+        );
+    }
+}

--- a/crates/jeliya-client/src/adapter/mod.rs
+++ b/crates/jeliya-client/src/adapter/mod.rs
@@ -35,6 +35,7 @@
 //!   matching `hello` generation.
 
 mod clock;
+mod media;
 mod runtime;
 mod source;
 mod ws_native;

--- a/crates/jeliya-client/src/adapter/runtime.rs
+++ b/crates/jeliya-client/src/adapter/runtime.rs
@@ -122,15 +122,16 @@ pub(crate) struct ConnRegistry {
 
 impl ConnRegistry {
     /// A fresh registry whose inbound quarantine cap is the kernel's
-    /// `stream_window_bytes` doubled.
-    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+    /// `stream_window_bytes` doubled, and whose outstanding-registration
+    /// bound is `registered_cap`.
+    pub(crate) fn new(stream_window_bytes: u64, registered_cap: usize) -> Self {
         Self {
             generation: 0,
             writer: None,
             read_task: None,
             write_task: None,
             keepalive_task: None,
-            media: MediaRegistry::new(stream_window_bytes),
+            media: MediaRegistry::new(stream_window_bytes, registered_cap),
         }
     }
 
@@ -442,9 +443,15 @@ pub fn connect_ws_native<S: TargetSource>(
 
     let source: Arc<dyn TargetSource> = Arc::new(source);
     // The media registry's inbound quarantine cap follows the kernel's
-    // stream window (captured before `kernel` moves into the runtime).
+    // stream window, and its outstanding-registration bound the in-flight
+    // limit + margin (mirroring the write channel's sizing rationale) —
+    // both captured before `kernel` moves into the runtime.
     let stream_window_bytes = kernel.streams.stream_window_bytes;
-    let conn = Arc::new(Mutex::new(ConnRegistry::new(stream_window_bytes)));
+    let registered_cap = (kernel.limits.in_flight as usize).saturating_add(64);
+    let conn = Arc::new(Mutex::new(ConnRegistry::new(
+        stream_window_bytes,
+        registered_cap,
+    )));
     let deadlines = Deadlines {
         connect: config.connect_timeout,
         hello: config.hello_timeout,

--- a/crates/jeliya-client/src/adapter/runtime.rs
+++ b/crates/jeliya-client/src/adapter/runtime.rs
@@ -26,6 +26,7 @@ use crate::kernel::{KernelBackend, Runtime};
 use crate::KernelConfig;
 
 use super::clock::Clock;
+use super::media::MediaRegistry;
 use super::source::TargetSource;
 use super::ws_native;
 
@@ -95,14 +96,14 @@ pub(crate) struct Deadlines {
 /// The live connection's I/O state, shared between [`NativeIo`] and the dial/
 /// read/write tasks *without* the kernel's `Shared` lock, so a task can install
 /// or clear it without deadlocking against a `send` in progress.
-#[derive(Default)]
 pub(crate) struct ConnRegistry {
     /// The generation the current live connection runs under (0 before any
     /// connect). A read/write task clears the writer only when this still names
     /// its own connection, so a delayed teardown cannot clobber a successor.
     pub(crate) generation: u64,
     /// The live connection's bounded write channel, or `None` when
-    /// disconnected. `NativeIo::send` pushes encoded Text frames here.
+    /// disconnected. `NativeIo::send` pushes encoded Text frames here; the
+    /// media registry's record sends push framed Binary frames.
     pub(crate) writer: Option<mpsc::Sender<Message>>,
     /// The connection's read task.
     pub(crate) read_task: Option<JoinHandle<()>>,
@@ -112,12 +113,32 @@ pub(crate) struct ConnRegistry {
     /// `idle_timeout_ms`). `None` off the native adapter and when the served
     /// timeout is 0.
     pub(crate) keepalive_task: Option<JoinHandle<()>>,
+    /// The connection's byte-stream media registry (§S3): registered caller
+    /// media, per-stream bound state, and the inbound quarantine buffers.
+    /// Lives here so teardown clears it with the tasks — a stream never
+    /// survives its connection.
+    pub(crate) media: MediaRegistry,
 }
 
 impl ConnRegistry {
+    /// A fresh registry whose inbound quarantine cap is the kernel's
+    /// `stream_window_bytes` doubled.
+    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+        Self {
+            generation: 0,
+            writer: None,
+            read_task: None,
+            write_task: None,
+            keepalive_task: None,
+            media: MediaRegistry::new(stream_window_bytes),
+        }
+    }
+
     /// Abort the connection's read/write/keepalive tasks and drop the writer.
     /// Aborting an already-finished task is harmless; dropping the writer
-    /// closes the write channel so its task ends.
+    /// closes the write channel so its task ends. The media registry's bound
+    /// streams die with the connection (their tasks abort here too);
+    /// registrations survive to bind on the next connection's sends.
     pub(crate) fn tear_down(&mut self) {
         if let Some(task) = self.read_task.take() {
             task.abort();
@@ -129,6 +150,7 @@ impl ConnRegistry {
             task.abort();
         }
         self.writer = None;
+        self.media.clear();
     }
 }
 
@@ -199,30 +221,41 @@ impl DriverIo for NativeIo {
         self.clock.now()
     }
 
-    // Byte-stream media is not wired on the native adapter yet: a stream
-    // record cannot be framed onto the wire from here, so these effects are
-    // dropped and the stream's stall timer settles the call honestly
-    // (Timeout) rather than reporting progress that never happened. The
-    // debug assertion keeps the gap loud in tests until the native media
-    // drive lands (the codec-side framing exists: jeliya-codec).
+    /// Frame one stream control record via `jeliya-codec` and push it onto
+    /// the live write channel. A full/closed channel (or an unframeable
+    /// record) is a connection loss exactly like a failed Text send:
+    /// `send_failed`, reclassified by the core after the batch.
     fn send_record(&mut self, intent: crate::kernel::transport::StreamRecordIntent) {
-        let _ = intent;
-        debug_assert!(
-            false,
-            "stream records are not yet wired on the native adapter"
-        );
+        let registry = self.conn.lock().expect("conn registry poisoned");
+        let sent = registry
+            .writer
+            .as_ref()
+            .is_some_and(|writer| MediaRegistry::send_record(writer, &intent));
+        drop(registry);
+        if !sent {
+            self.send_failed = true;
+        }
     }
 
+    /// Forward one producer grant to the stream's media task; a stream with
+    /// no media task (unregistered or sink-bound) queues an honest
+    /// `SourceFailed` for the shell's post-batch re-drive.
     fn produce(
         &mut self,
         id: jeliya_api::RequestId,
         call_id: crate::kernel::inflight::CallId,
         up_to: u64,
     ) {
-        let _ = (id, call_id, up_to);
-        debug_assert!(false, "stream media is not yet wired on the native adapter");
+        self.conn
+            .lock()
+            .expect("conn registry poisoned")
+            .media
+            .produce(id, call_id, up_to);
     }
 
+    /// Hand one accepted inbound range to the stream's sink; the resulting
+    /// `SinkAccepted`/`SinkFailed` input is queued for the shell (the driver
+    /// never injects while holding the registry lock).
     fn write_sink(
         &mut self,
         id: jeliya_api::RequestId,
@@ -230,8 +263,33 @@ impl DriverIo for NativeIo {
         offset: u64,
         len: u64,
     ) {
-        let _ = (id, call_id, offset, len);
-        debug_assert!(false, "stream media is not yet wired on the native adapter");
+        self.conn
+            .lock()
+            .expect("conn registry poisoned")
+            .media
+            .write_sink(id, call_id, offset, len);
+    }
+
+    /// Register one stream's media under its dedup key, before the call is
+    /// dispatched; the bind to the wire id happens at the stream op's send.
+    fn register_media(&mut self, key: jeliya_api::OpId, media: crate::media::StreamMedia) {
+        self.conn
+            .lock()
+            .expect("conn registry poisoned")
+            .media
+            .register(key, media);
+    }
+
+    /// Drain the media inputs fulfilled synchronously during this apply
+    /// batch (`SourceFailed` for an unregistered stream, `SinkAccepted`/
+    /// `SinkFailed` for sink hand-offs) — re-driven by the shell after the
+    /// batch, mirroring `take_send_failed`.
+    fn take_pending_media(&mut self) -> std::collections::VecDeque<Input> {
+        self.conn
+            .lock()
+            .expect("conn registry poisoned")
+            .media
+            .take_pending()
     }
 
     fn send(&mut self, frame: WireFrame) {
@@ -253,7 +311,14 @@ impl DriverIo for NativeIo {
             }
         };
         let message = Message::text(text);
-        let registry = self.conn.lock().expect("conn registry poisoned");
+        let mut registry = self.conn.lock().expect("conn registry poisoned");
+        // A stream op's send binds its wire id to the caller's registered
+        // media (§S3 media seam): the op id the caller deduped under is the
+        // only key both sides share, and the wire id is the only key the
+        // media effects later arrive with.
+        if crate::kernel::replay::is_stream_op(frame.op) {
+            registry.media.bind(frame.id, frame.op_id);
+        }
         match registry.writer.as_ref() {
             // A full or closed channel is a connection loss: surface it as
             // Interrupted after this batch (a real driver cannot report a write
@@ -376,7 +441,10 @@ pub fn connect_ws_native<S: TargetSource>(
     kernel.stable_principal = false;
 
     let source: Arc<dyn TargetSource> = Arc::new(source);
-    let conn = Arc::new(Mutex::new(ConnRegistry::default()));
+    // The media registry's inbound quarantine cap follows the kernel's
+    // stream window (captured before `kernel` moves into the runtime).
+    let stream_window_bytes = kernel.streams.stream_window_bytes;
+    let conn = Arc::new(Mutex::new(ConnRegistry::new(stream_window_bytes)));
     let deadlines = Deadlines {
         connect: config.connect_timeout,
         hello: config.hello_timeout,

--- a/crates/jeliya-client/src/adapter/runtime.rs
+++ b/crates/jeliya-client/src/adapter/runtime.rs
@@ -213,13 +213,24 @@ impl DriverIo for NativeIo {
         );
     }
 
-    fn produce(&mut self, call_id: crate::kernel::inflight::CallId, up_to: u64) {
-        let _ = (call_id, up_to);
+    fn produce(
+        &mut self,
+        id: jeliya_api::RequestId,
+        call_id: crate::kernel::inflight::CallId,
+        up_to: u64,
+    ) {
+        let _ = (id, call_id, up_to);
         debug_assert!(false, "stream media is not yet wired on the native adapter");
     }
 
-    fn write_sink(&mut self, call_id: crate::kernel::inflight::CallId, offset: u64, len: u64) {
-        let _ = (call_id, offset, len);
+    fn write_sink(
+        &mut self,
+        id: jeliya_api::RequestId,
+        call_id: crate::kernel::inflight::CallId,
+        offset: u64,
+        len: u64,
+    ) {
+        let _ = (id, call_id, offset, len);
         debug_assert!(false, "stream media is not yet wired on the native adapter");
     }
 

--- a/crates/jeliya-client/src/adapter/ws_native.rs
+++ b/crates/jeliya-client/src/adapter/ws_native.rs
@@ -16,7 +16,7 @@ use futures::{SinkExt, StreamExt};
 use jeliya_api::RequestId;
 use jeliya_codec::{
     decode_client_frame, decode_stream_identity, decode_stream_kind, decode_stream_record_view,
-    ClientFrame, CodecBounds, StreamRecordBodyView,
+    ClientFrame, CodecBounds, StreamCodecError, StreamRecordBodyView, StreamRecordKind,
 };
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
@@ -336,7 +336,31 @@ async fn read_loop(
                         &runtime,
                         Input::Inbound(Inbound::Record { generation, record }),
                     ),
-                    Err(()) => inject(&runtime, Input::Inbound(Inbound::Malformed)),
+                    // Stream-local: only the named stream aborts
+                    // (`protocol_error`); the connection lives on.
+                    Err(RecordRefusal::StreamLocal(id)) => {
+                        inject(&runtime, Input::StreamFault { generation, id });
+                    }
+                    // Connection-fatal: close with the protocol's code
+                    // (best-effort through the writer), then report the loss
+                    // exactly as a transport drop — the core tears every
+                    // stream down as `transport_lost`.
+                    Err(RecordRefusal::Fatal(code)) => {
+                        {
+                            let registry = conn.lock().expect("conn registry poisoned");
+                            if let Some(writer) = registry.writer.as_ref() {
+                                let _ = writer.try_send(Message::Close(Some(
+                                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                                        code: code.into(),
+                                        reason: "".into(),
+                                    },
+                                )));
+                            }
+                        }
+                        clear_writer_if_current(&conn, generation);
+                        inject(&runtime, Input::Interrupted { generation });
+                        return;
+                    }
                 }
             }
             // Ping/Pong are handled by tungstenite; ignore them here.
@@ -375,35 +399,55 @@ fn clear_writer_if_current(conn: &Arc<Mutex<ConnRegistry>>, generation: u64) {
 /// Decode one inbound Binary message into the byte-free record meta the core
 /// consumes, performing the driver-side media work first (§S3/§S10):
 ///
-/// 1. [`decode_stream_identity`] — codec-fatal (bad magic, short header,
-///    over-ceiling) fails closed as `Malformed`;
-/// 2. the media registry's binding lookup by request id — a record for a
-///    wire id this connection never bound correlates to nothing;
-/// 3. [`decode_stream_kind`] and [`decode_stream_record_view`] — the full
-///    structural decode, still borrowing the payload;
-/// 4. per-kind media work: OPEN spawns the source media task, DATA
-///    quarantines its payload (a cap breach is protocol trouble →
-///    `Malformed`) **before** the meta is handed onward, so the `WriteSink`
-///    the meta provokes always finds its bytes buffered.
+/// 1. [`decode_stream_identity`] — over the frame ceiling is `Fatal(4005)`;
+///    a short header, bad magic, or invalid identity is `Fatal(4007)`;
+/// 2. the media registry's binding lookup by request id — a record with no
+///    trustworthy outstanding binding is `Fatal(4007)` (protocol §Malformed
+///    stream records: "there is no safe request to answer");
+/// 3. [`decode_stream_kind`] — an unknown kind cannot be classified and is
+///    `Fatal(4007)`;
+/// 4. [`decode_stream_record_view`] — the full structural decode: a
+///    malformed daemon OPEN/END/ABORT/ACK (a terminal/binding failure) is
+///    `Fatal(4007)`, while a malformed nonterminal DATA or CREDIT on the
+///    active binding is [`RecordRefusal::StreamLocal`] — only that stream
+///    aborts, via the kernel's `StreamFault` input;
+/// 5. per-kind media work: OPEN spawns the source media task, DATA
+///    quarantines its payload **before** the meta is handed onward (a cap
+///    breach or discontinuity is a credit/offset violation → `StreamLocal`),
+///    so the `WriteSink` the meta provokes always finds its bytes buffered.
 ///
-/// `Err(())` is the `Inbound::Malformed` signal; the generation tag is the
-/// caller's (this connection's), so the core fences stragglers itself.
+/// The generation tag is the caller's (this connection's), so the core fences
+/// stragglers itself.
 fn decode_inbound_stream_record(
     conn: &Arc<Mutex<ConnRegistry>>,
     _generation: u64,
     bounds: &CodecBounds,
     runtime: &Weak<Runtime>,
     bytes: &Bytes,
-) -> Result<StreamRecordMeta, ()> {
-    let identity = decode_stream_identity(bytes, bounds).map_err(|_| ())?;
+) -> Result<StreamRecordMeta, RecordRefusal> {
+    let identity = decode_stream_identity(bytes, bounds).map_err(|error| match error {
+        StreamCodecError::FrameTooLarge { .. } => RecordRefusal::Fatal(4005),
+        _ => RecordRefusal::Fatal(4007),
+    })?;
     let wire_id = identity.request_id();
     let stream_id = identity.stream_id().get();
     let mut registry = conn.lock().expect("conn registry poisoned");
     if !registry.media.is_bound(wire_id) {
-        return Err(());
+        return Err(RecordRefusal::Fatal(4007));
     }
-    decode_stream_kind(bytes, bounds).map_err(|_| ())?;
-    let view = decode_stream_record_view(bytes, bounds).map_err(|_| ())?;
+    let kind = decode_stream_kind(bytes, bounds).map_err(|_| RecordRefusal::Fatal(4007))?;
+    let view = decode_stream_record_view(bytes, bounds).map_err(|_| {
+        // A terminal control that fails structural decode is a binding
+        // failure the connection cannot recover from; a nonterminal
+        // DATA/CREDIT aborts only its stream (protocol §Malformed stream
+        // records).
+        match kind {
+            StreamRecordKind::Data | StreamRecordKind::Credit => {
+                RecordRefusal::StreamLocal(wire_id)
+            }
+            _ => RecordRefusal::Fatal(4007),
+        }
+    })?;
     match view.body {
         StreamRecordBodyView::Open { total } => {
             // The producer's media task starts at admission: it owns the
@@ -427,7 +471,9 @@ fn decode_inbound_stream_record(
         }
         StreamRecordBodyView::Data { offset, payload } => {
             if !registry.media.deliver_data(wire_id, offset, payload) {
-                return Err(());
+                // A cap breach or offset discontinuity on a bound stream is
+                // a credit/offset violation: stream-local, never fatal.
+                return Err(RecordRefusal::StreamLocal(wire_id));
             }
             Ok(StreamRecordMeta::Data {
                 id: wire_id,
@@ -465,6 +511,21 @@ fn decode_inbound_stream_record(
             high_water: accepted_through,
         }),
     }
+}
+
+/// The severity of a refused inbound Binary record (protocol §Malformed
+/// stream records / §Size and record refusal): which close code kills the
+/// connection, or which single stream a bound-record fault aborts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordRefusal {
+    /// Connection-fatal: the carried code is the protocol's (`4005` for an
+    /// over-ceiling message, `4007` for an untrustworthy binding or a
+    /// malformed terminal control). The connection dies and the core tears
+    /// every stream down as `transport_lost`.
+    Fatal(u16),
+    /// Stream-local: a structurally malformed nonterminal DATA/CREDIT on an
+    /// active binding. Only the named stream aborts (`protocol_error`).
+    StreamLocal(RequestId),
 }
 
 /// Extract the `v`/`sg` generation gate the supervisor placed on the dial URL.

--- a/crates/jeliya-client/src/adapter/ws_native.rs
+++ b/crates/jeliya-client/src/adapter/ws_native.rs
@@ -14,16 +14,20 @@ use std::sync::{Arc, Mutex, Weak};
 
 use futures::{SinkExt, StreamExt};
 use jeliya_api::RequestId;
-use jeliya_codec::{decode_client_frame, ClientFrame, CodecBounds};
+use jeliya_codec::{
+    decode_client_frame, decode_stream_identity, decode_stream_kind, decode_stream_record_view,
+    ClientFrame, CodecBounds, StreamRecordBodyView,
+};
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::{Bytes, Error as WsError, Message};
 
 use crate::backend::RawJson;
 use crate::kernel::core::Input;
-use crate::kernel::transport::{Inbound, WireReply};
+use crate::kernel::transport::{Inbound, StreamRecordMeta, WireReply};
 use crate::kernel::Runtime;
 
+use super::media::map_abort_reason;
 use super::runtime::{ConnRegistry, Deadlines};
 use super::source::{Dial, DialResolveError, TargetSource};
 
@@ -285,6 +289,13 @@ async fn read_loop(
                             inject(&runtime, Input::Inbound(Inbound::Malformed));
                             continue;
                         };
+                        // A stream's terminal reply prunes its media state
+                        // (task, quarantine buffer) — cheap when the id binds
+                        // no stream (§S10 retire-on-reply).
+                        conn.lock()
+                            .expect("conn registry poisoned")
+                            .media
+                            .prune(request_id);
                         let result = match result {
                             Ok(text) => WireReply::Ok(RawJson::from_string(text)),
                             Err(api) => WireReply::Err(api),
@@ -314,11 +325,20 @@ async fn read_loop(
                     }
                 }
             }
-            // Binary = a byte-stream record. #269 owns stream lifecycle; on this
-            // base the kernel exposes no stream inbound path, so a Binary record
-            // is dropped (it can strand nothing). Wiring Binary → the stream
-            // path is the follow-up once #269 lands (spec §6 / OQ-4).
-            Ok(Message::Binary(_)) => {}
+            // Binary = a byte-stream record (§S3/§S10): staged decode per
+            // the codec's documented order — identity, registry binding
+            // lookup, kind, full structural view — then the byte-free meta
+            // reaches the core. A codec-fatal or unbindable record strands
+            // nothing: `Inbound::Malformed`, exactly as for text (§K4).
+            Ok(Message::Binary(bytes)) => {
+                match decode_inbound_stream_record(&conn, generation, &bounds, &runtime, &bytes) {
+                    Ok(record) => inject(
+                        &runtime,
+                        Input::Inbound(Inbound::Record { generation, record }),
+                    ),
+                    Err(()) => inject(&runtime, Input::Inbound(Inbound::Malformed)),
+                }
+            }
             // Ping/Pong are handled by tungstenite; ignore them here.
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Frame(_)) => {}
             Ok(Message::Close(_)) | Err(_) => {
@@ -341,11 +361,109 @@ fn inject(runtime: &Weak<Runtime>, input: Input) {
 }
 
 /// Clear the live writer only when the registry still names `generation`, so a
-/// task tearing down cannot clobber a successor connection's writer.
+/// task tearing down cannot clobber a successor connection's writer. The
+/// connection's media dies with it — a stream never survives its connection
+/// (§S10), mirroring the core's own drain on `Interrupted`.
 fn clear_writer_if_current(conn: &Arc<Mutex<ConnRegistry>>, generation: u64) {
     let mut registry = conn.lock().expect("conn registry poisoned");
     if registry.generation == generation {
         registry.writer = None;
+        registry.media.clear();
+    }
+}
+
+/// Decode one inbound Binary message into the byte-free record meta the core
+/// consumes, performing the driver-side media work first (§S3/§S10):
+///
+/// 1. [`decode_stream_identity`] — codec-fatal (bad magic, short header,
+///    over-ceiling) fails closed as `Malformed`;
+/// 2. the media registry's binding lookup by request id — a record for a
+///    wire id this connection never bound correlates to nothing;
+/// 3. [`decode_stream_kind`] and [`decode_stream_record_view`] — the full
+///    structural decode, still borrowing the payload;
+/// 4. per-kind media work: OPEN spawns the source media task, DATA
+///    quarantines its payload (a cap breach is protocol trouble →
+///    `Malformed`) **before** the meta is handed onward, so the `WriteSink`
+///    the meta provokes always finds its bytes buffered.
+///
+/// `Err(())` is the `Inbound::Malformed` signal; the generation tag is the
+/// caller's (this connection's), so the core fences stragglers itself.
+fn decode_inbound_stream_record(
+    conn: &Arc<Mutex<ConnRegistry>>,
+    _generation: u64,
+    bounds: &CodecBounds,
+    runtime: &Weak<Runtime>,
+    bytes: &Bytes,
+) -> Result<StreamRecordMeta, ()> {
+    let identity = decode_stream_identity(bytes, bounds).map_err(|_| ())?;
+    let wire_id = identity.request_id();
+    let stream_id = identity.stream_id().get();
+    let mut registry = conn.lock().expect("conn registry poisoned");
+    if !registry.media.is_bound(wire_id) {
+        return Err(());
+    }
+    decode_stream_kind(bytes, bounds).map_err(|_| ())?;
+    let view = decode_stream_record_view(bytes, bounds).map_err(|_| ())?;
+    match view.body {
+        StreamRecordBodyView::Open { total } => {
+            // The producer's media task starts at admission: it owns the
+            // source and the grant channel until the terminal reply prunes
+            // it or the connection dies.
+            let writer = registry.writer.clone();
+            if let Some(writer) = writer {
+                registry.media.spawn_source_task(
+                    wire_id,
+                    stream_id,
+                    &writer,
+                    runtime.clone(),
+                    *bounds,
+                );
+            }
+            Ok(StreamRecordMeta::Open {
+                id: wire_id,
+                stream_id,
+                total,
+            })
+        }
+        StreamRecordBodyView::Data { offset, payload } => {
+            if !registry.media.deliver_data(wire_id, offset, payload) {
+                return Err(());
+            }
+            Ok(StreamRecordMeta::Data {
+                id: wire_id,
+                stream_id,
+                offset,
+                len: payload.len() as u64,
+            })
+        }
+        StreamRecordBodyView::Credit {
+            accepted_through,
+            send_through,
+        } => Ok(StreamRecordMeta::Credit {
+            id: wire_id,
+            stream_id,
+            accepted_through,
+            send_through,
+        }),
+        StreamRecordBodyView::End { total } => Ok(StreamRecordMeta::End {
+            id: wire_id,
+            stream_id,
+            offset: total,
+        }),
+        StreamRecordBodyView::Abort {
+            accepted_through,
+            reason,
+        } => Ok(StreamRecordMeta::Abort {
+            id: wire_id,
+            stream_id,
+            high_water: accepted_through,
+            reason: map_abort_reason(reason),
+        }),
+        StreamRecordBodyView::Ack { accepted_through } => Ok(StreamRecordMeta::Ack {
+            id: wire_id,
+            stream_id,
+            high_water: accepted_through,
+        }),
     }
 }
 

--- a/crates/jeliya-client/src/backend.rs
+++ b/crates/jeliya-client/src/backend.rs
@@ -87,6 +87,20 @@ pub(crate) trait ClientBackend: Send + Sync {
     /// Graceful shutdown: settle all accepted work, close all event streams,
     /// then resolve (§D6).
     fn stop(&self) -> BoxFuture<'static, ()>;
+
+    /// Register one stream call's media under its dedup `OpId`, **before**
+    /// the call is dispatched (the driver binds the key to the stream's wire
+    /// id when it performs the request's send). Backends whose drivers move
+    /// no bytes (the mock) refuse honestly with
+    /// [`LocalError::UnsupportedMedia`](crate::LocalError::UnsupportedMedia).
+    fn register_stream_media(
+        &self,
+        key: jeliya_api::OpId,
+        media: crate::media::StreamMedia,
+    ) -> Result<(), crate::error::LocalError> {
+        let _ = (key, media);
+        Err(crate::error::LocalError::UnsupportedMedia)
+    }
 }
 
 /// Compile-time proof that [`ClientBackend`] stays object-safe. If a future

--- a/crates/jeliya-client/src/error.rs
+++ b/crates/jeliya-client/src/error.rs
@@ -55,6 +55,11 @@ pub enum LocalError {
     /// cannot honestly claim otherwise.
     #[error("backend invariant failed")]
     Backend,
+    /// The backend does not implement the requested capability — today, stream
+    /// media registration on a backend with no byte-stream driver (the mock).
+    /// `execution()` is [`Execution::DefinitelyNot`]: nothing was sent.
+    #[error("backend does not support stream media")]
+    UnsupportedMedia,
 }
 
 /// Why one [`ClientHandle::call`](crate::ClientHandle::call) did not return a
@@ -171,6 +176,8 @@ impl CallError {
                 LocalError::EncodeRequest => Execution::DefinitelyNot,
                 LocalError::DecodeReply => Execution::Definitely,
                 LocalError::Backend => Execution::Unknown,
+                // The capability was refused before any call was sent.
+                LocalError::UnsupportedMedia => Execution::DefinitelyNot,
             },
         }
     }

--- a/crates/jeliya-client/src/handle.rs
+++ b/crates/jeliya-client/src/handle.rs
@@ -186,6 +186,30 @@ impl ClientHandle {
         }
     }
 
+    /// Register one stream call's media under its dedup key, **before**
+    /// dispatching the call with the same key:
+    ///
+    /// ```ignore
+    /// let key = OpId::new("share-7");
+    /// handle.register_stream_media(key.clone(), jeliya_client::media::shared_bytes(bytes))?;
+    /// let call = handle.call_stream::<FileShare>(input, Dedup::Key(key));
+    /// ```
+    ///
+    /// A `file.share` needs a [`StreamMedia::Source`] whose `len()` equals the
+    /// request's `declared_bytes`; a `file.read` needs a
+    /// [`StreamMedia::Sink`](crate::media::StreamMedia) to collect the bytes.
+    /// Backends whose drivers move no bytes (the mock) refuse honestly with
+    /// [`LocalError::UnsupportedMedia`]. A stream dispatched without its media
+    /// fails honestly at its first media effect (`source_failed`/
+    /// `sink_failed`) — never a silent stall.
+    pub fn register_stream_media(
+        &self,
+        key: jeliya_api::OpId,
+        media: crate::media::StreamMedia,
+    ) -> Result<(), LocalError> {
+        self.inner.register_stream_media(key, media)
+    }
+
     /// Serialize the input and hand the erased call to the backend *now*,
     /// returning the in-flight reply future (or the encode error). Shared by
     /// [`call`](Self::call) and [`call_stream`](Self::call_stream); dispatch is

--- a/crates/jeliya-client/src/kernel/core.rs
+++ b/crates/jeliya-client/src/kernel/core.rs
@@ -11,7 +11,7 @@
 
 use std::collections::VecDeque;
 
-use jeliya_api::Incarnation;
+use jeliya_api::{Incarnation, RequestId};
 
 use crate::backend::{ErasedCall, RawJson};
 use crate::error::{CallError, Execution};
@@ -168,6 +168,9 @@ pub(crate) enum Action {
     /// driver reads ≤ `up_to` bytes, frames ≤64 KiB DATA records, sends them, and
     /// reports [`Input::Produced`].
     ProduceData {
+        /// The stream's wire id, so a driver can key its media without a
+        /// `CallId` mapping it cannot have (the driver sees `RequestId`s).
+        id: RequestId,
         /// The stream call.
         call_id: CallId,
         /// The maximum additional bytes the driver may send now.
@@ -176,6 +179,8 @@ pub(crate) enum Action {
     /// Deliver an accepted inbound DATA range to the receiver's media sink
     /// (§S3): the driver writes and reports [`Input::SinkAccepted`].
     WriteSink {
+        /// The stream's wire id (see [`Action::ProduceData`]'s `id`).
+        id: RequestId,
         /// The stream call.
         call_id: CallId,
         /// The range's start offset.

--- a/crates/jeliya-client/src/kernel/core.rs
+++ b/crates/jeliya-client/src/kernel/core.rs
@@ -123,6 +123,23 @@ pub(crate) enum Input {
         /// The stream call.
         call_id: CallId,
     },
+    /// The driver detected a structurally malformed **nonterminal** DATA or
+    /// CREDIT record on an active binding (protocol §Malformed stream
+    /// records): bad reserved byte, wrong direction, invalid credit, empty
+    /// or oversized-within-frame DATA, or bad offset arithmetic. The core
+    /// aborts only that stream (`protocol_error`), never the connection —
+    /// the stream-local half of the codec's connection-fatal vs stream-local
+    /// rule, surfaced here because a record that fails structural decode
+    /// cannot travel the ordinary `Inbound::Record` path. The driver reports
+    /// connection-fatal conditions (bad magic, short header, no trustworthy
+    /// binding, malformed OPEN/END/ABORT) as a transport loss instead.
+    StreamFault {
+        /// The generation the delivering connection is on (fenced as a reply
+        /// is, §K7/§S10).
+        generation: u64,
+        /// The malformed record's reply-correlation id.
+        id: RequestId,
+    },
 }
 
 /// One action the driver performs after a [`Core::step`]. The core decides;
@@ -374,6 +391,19 @@ impl Core {
             Input::SinkFailed { call_id } => {
                 let outcome = self.streams.on_sink_failed(call_id, &mut actions);
                 self.apply_stream_outcome(call_id, outcome, now, &mut actions);
+            }
+            Input::StreamFault { generation, id } => {
+                // Generation-fenced exactly as a record is (§S10); a fault
+                // for an unknown/settled/stale call resolves to nothing and
+                // strands no call.
+                if let Some(call_id) = self.ledger.resolve_reply(id, generation) {
+                    if self.ledger.get(call_id).map(|e| e.stream).unwrap_or(false)
+                        && self.streams.contains(call_id)
+                    {
+                        let outcome = self.streams.on_protocol_fault(call_id, &mut actions);
+                        self.apply_stream_outcome(call_id, outcome, now, &mut actions);
+                    }
+                }
             }
         }
         actions

--- a/crates/jeliya-client/src/kernel/driver_io.rs
+++ b/crates/jeliya-client/src/kernel/driver_io.rs
@@ -169,12 +169,22 @@ pub(crate) trait DriverIo: Send {
     /// Perform `Action::ProduceData`: fulfill the grant from the stream's
     /// registered byte source (native: real media; in-memory: the
     /// deterministic `i mod 251` rig), reporting `Produced`/`SourceEnd`
-    /// through the pending-media queue.
-    fn produce(&mut self, call_id: CallId, up_to: u64);
+    /// through the pending-media queue. `id` is the stream's wire id — the
+    /// key a real driver's media registry is organized by.
+    fn produce(&mut self, id: jeliya_api::RequestId, call_id: CallId, up_to: u64);
 
     /// Perform `Action::WriteSink`: hand the accepted range to the stream's
-    /// sink, reporting `SinkAccepted` through the pending-media queue.
-    fn write_sink(&mut self, call_id: CallId, offset: u64, len: u64);
+    /// sink, reporting `SinkAccepted` through the pending-media queue. `id`
+    /// is the stream's wire id (see [`DriverIo::produce`]).
+    fn write_sink(&mut self, id: jeliya_api::RequestId, call_id: CallId, offset: u64, len: u64);
+
+    /// Register one stream's media under its dedup `OpId`, before the call is
+    /// dispatched. A real driver binds the registration to the wire id when
+    /// it performs the stream op's `Action::Send`; the reference rig
+    /// synthesizes its own deterministic media, so the default is a no-op that
+    /// lets an unregistered stream fail honestly at `produce`/`write_sink`
+    /// time (`SourceFailed`/`SinkFailed` on the real drivers).
+    fn register_media(&mut self, _key: jeliya_api::OpId, _media: crate::media::StreamMedia) {}
 
     /// Drain media inputs the driver fulfilled during the current apply batch
     /// (`Produced`/`SourceEnd`/`SinkAccepted`), re-driven by the shell after
@@ -315,7 +325,7 @@ impl DriverIo for InMemoryIo {
         self.record_outbound(SentRecord::from_intent(&intent));
     }
 
-    fn produce(&mut self, call_id: CallId, up_to: u64) {
+    fn produce(&mut self, _id: jeliya_api::RequestId, call_id: CallId, up_to: u64) {
         // The deterministic source produces exactly the granted bytes (the
         // core bounds `up_to` by credit, window, and total), frames them,
         // sends them, and reports how far it got (§S3). A single DATA
@@ -348,7 +358,7 @@ impl DriverIo for InMemoryIo {
         }
     }
 
-    fn write_sink(&mut self, call_id: CallId, offset: u64, len: u64) {
+    fn write_sink(&mut self, _id: jeliya_api::RequestId, call_id: CallId, offset: u64, len: u64) {
         // The deterministic sink accepts every delivered range contiguously
         // and reports its new accepted high-water (§S3).
         self.pending_media.push_back(Input::SinkAccepted {

--- a/crates/jeliya-client/src/kernel/mod.rs
+++ b/crates/jeliya-client/src/kernel/mod.rs
@@ -348,12 +348,13 @@ impl Shared {
             }
             // The media effects a real driver fulfills from its registered byte
             // source/sink; the in-memory driver runs the deterministic rig (§S3).
-            Action::ProduceData { call_id, up_to } => self.io.produce(call_id, up_to),
+            Action::ProduceData { id, call_id, up_to } => self.io.produce(id, call_id, up_to),
             Action::WriteSink {
+                id,
                 call_id,
                 offset,
                 len,
-            } => self.io.write_sink(call_id, offset, len),
+            } => self.io.write_sink(id, call_id, offset, len),
         }
     }
 
@@ -560,6 +561,17 @@ impl KernelBackend {
 }
 
 impl ClientBackend for KernelBackend {
+    fn register_stream_media(
+        &self,
+        key: jeliya_api::OpId,
+        media: crate::media::StreamMedia,
+    ) -> Result<(), crate::error::LocalError> {
+        // The driver owns the registry (§S3 media seam); registration is a
+        // plain insert under the same lock every effect crosses.
+        self.lock().io.register_media(key, media);
+        Ok(())
+    }
+
     fn dispatch(&self, call: ErasedCall) -> BoxFuture<'static, Result<RawJson, CallError>> {
         let (receiver, call_id) = {
             let mut shared = self.lock();

--- a/crates/jeliya-client/src/kernel/mod.rs
+++ b/crates/jeliya-client/src/kernel/mod.rs
@@ -1176,6 +1176,16 @@ mod in_memory {
             self.drive_serialized(Input::Inbound(Inbound::Record { generation, record }));
         }
 
+        /// Deliver a driver-detected structural fault on `wire_id`'s stream
+        /// (a malformed nonterminal DATA/CREDIT the codec refused): the core
+        /// aborts only that stream with `protocol_error` (§Malformed stream
+        /// records). Mirrors what a real driver injects.
+        pub fn stream_fault(&self, wire_id: u64) {
+            let generation = self.generation();
+            let id = RequestId::new(wire_id).expect("wire id within range");
+            self.drive_serialized(Input::StreamFault { generation, id });
+        }
+
         /// Take the client-authored outbound stream records since the last drain,
         /// as redaction-safe [`SentRecord`] views (§S3).
         pub fn take_outbound_records(&self) -> Vec<SentRecord> {

--- a/crates/jeliya-client/src/kernel/runtime.rs
+++ b/crates/jeliya-client/src/kernel/runtime.rs
@@ -44,7 +44,8 @@ use crate::handle::ClientHandle;
 use crate::kernel::core::{Action, Core, Input};
 use crate::kernel::inflight::CallId;
 use crate::kernel::timing::{Tick, TimerId};
-use crate::kernel::transport::{Driver, DriverEvent, WireFrame};
+use crate::kernel::transport::{Driver, DriverEvent, MediaEvent, StreamRecordIntent, WireFrame};
+use crate::media::StreamMedia;
 use crate::KernelConfig;
 
 use super::{Deferred, DeferredWake};
@@ -71,6 +72,40 @@ pub(crate) enum IoAction {
     },
     /// Cancel a previously-armed driver timer.
     CancelTimer(TimerId),
+    /// Send one client-authored byte-stream control record (§S3); the driver
+    /// frames it via `jeliya-codec` at the boundary.
+    SendRecord(StreamRecordIntent),
+    /// Fulfil one producer media grant (§S3): the driver reads, frames, and
+    /// sends ≤ `up_to` bytes from the stream's registered source.
+    ProduceData {
+        /// The stream's wire id.
+        id: jeliya_api::RequestId,
+        /// The stream call.
+        call_id: CallId,
+        /// The maximum additional bytes the driver may send now.
+        up_to: u64,
+    },
+    /// Hand one accepted inbound DATA range to the stream's registered sink
+    /// (§S3).
+    WriteSink {
+        /// The stream's wire id.
+        id: jeliya_api::RequestId,
+        /// The stream call.
+        call_id: CallId,
+        /// The range's start offset.
+        offset: u64,
+        /// The range length in bytes.
+        len: u64,
+    },
+    /// Register one stream's media under its dedup key, before the call is
+    /// dispatched. The media types are `Send + Sync`, so the registration
+    /// crosses the mailbox to the `!Send` driver half safely.
+    RegisterMedia {
+        /// The operation's dedup key.
+        key: jeliya_api::OpId,
+        /// The caller-registered source or sink.
+        media: StreamMedia,
+    },
 }
 
 /// A `Send + Sync` reader of the platform's monotonic clock. On wasm it reads
@@ -123,13 +158,21 @@ impl RuntimeShared {
             }
             Action::Emit(event) => deferred.work.push(DeferredWake::Emit(event)),
             Action::CloseBus => deferred.work.push(DeferredWake::CloseBus),
-            // Byte-stream media is not wired on the browser adapter yet: the
-            // effect is dropped and the stream's stall timer settles the call
-            // honestly (Timeout), never a silent success. The debug assertion
-            // keeps the gap loud in tests until the browser media drive lands.
-            Action::SendRecord(_) | Action::ProduceData { .. } | Action::WriteSink { .. } => {
-                debug_assert!(false, "stream effects are not yet wired on the web adapter");
-            }
+            Action::SendRecord(intent) => self.mailbox.push_back(IoAction::SendRecord(intent)),
+            Action::ProduceData { id, call_id, up_to } => self
+                .mailbox
+                .push_back(IoAction::ProduceData { id, call_id, up_to }),
+            Action::WriteSink {
+                id,
+                call_id,
+                offset,
+                len,
+            } => self.mailbox.push_back(IoAction::WriteSink {
+                id,
+                call_id,
+                offset,
+                len,
+            }),
         }
     }
 }
@@ -288,6 +331,25 @@ impl ClientBackend for RuntimeBackend {
             let _ = done_rx.await;
         })
     }
+
+    fn register_stream_media(
+        &self,
+        key: jeliya_api::OpId,
+        media: StreamMedia,
+    ) -> Result<(), LocalError> {
+        // The driver owns the media registry (§S3 media seam): enqueue the
+        // registration into the mailbox under the shared lock (mirroring
+        // `dispatch`'s Send) and wake the pump, so it lands before any later
+        // stream send drains after it.
+        {
+            let mut shared = self.runtime.shared.lock().expect("runtime shared poisoned");
+            shared
+                .mailbox
+                .push_back(IoAction::RegisterMedia { key, media });
+        }
+        self.runtime.pump_waker.wake();
+        Ok(())
+    }
 }
 
 /// The reply future returned by [`RuntimeBackend::dispatch`]. Dropping it before
@@ -327,6 +389,19 @@ impl Drop for DispatchFuture {
     }
 }
 
+/// Report a synchronous send failure (Text or stream record) as the §K14
+/// send/close race: an `Interrupted` on the generation the broken transport
+/// was on, driven after the lock is dropped.
+fn report_transport_loss(runtime: &Runtime) {
+    let generation = runtime
+        .shared
+        .lock()
+        .expect("runtime shared poisoned")
+        .core
+        .generation();
+    runtime.drive(Input::Interrupted { generation });
+}
+
 /// The `!Send`-capable pump: a single future the platform `spawn_local`s. It
 /// owns the [`Driver`], drains the mailbox into it, and feeds the driver's
 /// events back into the core.
@@ -359,16 +434,27 @@ where
                         if this.driver.send(frame).is_err() {
                             // The send/close race (§K14): report the loss on the
                             // generation the broken transport was on.
-                            let generation = {
-                                this.runtime
-                                    .shared
-                                    .lock()
-                                    .expect("runtime shared poisoned")
-                                    .core
-                                    .generation()
-                            };
-                            this.runtime.drive(Input::Interrupted { generation });
+                            report_transport_loss(this.runtime.as_ref());
                         }
+                    }
+                    IoAction::SendRecord(intent) => {
+                        // A record send fails exactly like a Text send: the
+                        // same §K14 race handling.
+                        if this.driver.send_record(intent).is_err() {
+                            report_transport_loss(this.runtime.as_ref());
+                        }
+                    }
+                    IoAction::ProduceData { id, call_id, up_to } => {
+                        this.driver.produce(id, call_id, up_to)
+                    }
+                    IoAction::WriteSink {
+                        id,
+                        call_id,
+                        offset,
+                        len,
+                    } => this.driver.write_sink(id, call_id, offset, len),
+                    IoAction::RegisterMedia { key, media } => {
+                        this.driver.register_media(key, media)
                     }
                     IoAction::Dial { token } => this.driver.dial(token),
                     IoAction::CancelDial => this.driver.cancel_dial(),
@@ -388,6 +474,23 @@ where
                     DriverEvent::GateRefused { token } => Input::GateRefused { token },
                     DriverEvent::Interrupted { generation } => Input::Interrupted { generation },
                     DriverEvent::TimerFired(id) => Input::TimerFired(id),
+                    DriverEvent::Media(media) => match media {
+                        MediaEvent::Produced {
+                            call_id,
+                            sent_through,
+                        } => Input::Produced {
+                            call_id,
+                            sent_through,
+                        },
+                        MediaEvent::SourceEnd { call_id, total } => {
+                            Input::SourceEnd { call_id, total }
+                        }
+                        MediaEvent::SourceFailed { call_id } => Input::SourceFailed { call_id },
+                        MediaEvent::SinkAccepted { call_id, through } => {
+                            Input::SinkAccepted { call_id, through }
+                        }
+                        MediaEvent::SinkFailed { call_id } => Input::SinkFailed { call_id },
+                    },
                 };
                 this.runtime.drive(input);
             }
@@ -412,7 +515,15 @@ pub(crate) fn build<D: Driver>(
 ) -> (ClientHandle, Pump<D>) {
     let runtime = Arc::new(Runtime {
         shared: Mutex::new(RuntimeShared {
-            core: Core::new(config.limits, config.jitter_seed, config.stable_principal),
+            // The configured stream bounds (§6) — the driver-side media
+            // registry's inbound quarantine cap keys off the same
+            // `stream_window_bytes`.
+            core: Core::with_stream_limits(
+                config.limits,
+                config.jitter_seed,
+                config.stable_principal,
+                config.streams,
+            ),
             bus: Arc::new(EventBus::new()),
             senders: HashMap::new(),
             mailbox: VecDeque::new(),
@@ -452,7 +563,8 @@ mod tests {
     use crate::event::State;
     use crate::kernel::timing::Tick;
     use crate::kernel::transport::{
-        Driver, DriverEvent, Inbound, TransportClosed, WireFrame, WireReply,
+        Driver, DriverEvent, Inbound, StreamRecordIntent, StreamRecordMeta, TransportClosed,
+        WireFrame, WireReply,
     };
     use crate::KernelConfig;
 
@@ -469,6 +581,14 @@ mod tests {
         sends: Vec<(u64, &'static str)>,
         /// Whether `cancel_dial()` was called.
         cancel_dial_called: bool,
+        /// Caller media registrations awaiting a stream op's send, keyed by
+        /// dedup `OpId` (mirrors the real drivers' registries).
+        registered: std::collections::HashMap<jeliya_api::OpId, crate::media::StreamMedia>,
+        /// Per-bound-stream driver state, keyed by wire id.
+        bound: std::collections::HashMap<jeliya_api::RequestId, BoundFakeStream>,
+        /// Outbound stream-record observations: (wire id, kind, a, b) — a
+        /// bound, never content (§S12).
+        records: Vec<(u64, &'static str, u64, u64)>,
     }
 
     impl FakeInner {
@@ -479,6 +599,9 @@ mod tests {
                 dials: Vec::new(),
                 sends: Vec::new(),
                 cancel_dial_called: false,
+                registered: std::collections::HashMap::new(),
+                bound: std::collections::HashMap::new(),
+                records: Vec::new(),
             }
         }
 
@@ -489,6 +612,107 @@ mod tests {
                 w.wake_by_ref();
             }
         }
+
+        /// Bind a stream op's wire id to the caller's registration (moves
+        /// it), exactly like the real drivers.
+        fn bind(&mut self, wire_id: jeliya_api::RequestId, op_id: Option<jeliya_api::OpId>) {
+            let media = op_id.and_then(|key| self.registered.remove(&key));
+            let stream = BoundFakeStream {
+                media,
+                ..Default::default()
+            };
+            self.bound.insert(wire_id, stream);
+        }
+
+        /// Observe one outbound record intent as a redaction-safe view.
+        fn record(&mut self, id: u64, kind: &'static str, a: u64, b: u64) {
+            self.records.push((id, kind, a, b));
+        }
+
+        // ---- scripted daemon peer (the test drives these by hand) ---------
+
+        /// Deliver the daemon's OPEN for `wire_id` on the live generation.
+        fn open(&mut self, wire_id: u64, total: u64) {
+            let id = jeliya_api::RequestId::new(wire_id).expect("wire id");
+            self.push(DriverEvent::Inbound(Inbound::Record {
+                generation: 1,
+                record: StreamRecordMeta::Open {
+                    id,
+                    stream_id: stream_id_for(wire_id),
+                    total,
+                },
+            }));
+        }
+
+        /// Deliver a daemon CREDIT (the client is the producer).
+        fn credit(&mut self, wire_id: u64, accepted_through: u64, send_through: u64) {
+            let id = jeliya_api::RequestId::new(wire_id).expect("wire id");
+            self.push(DriverEvent::Inbound(Inbound::Record {
+                generation: 1,
+                record: StreamRecordMeta::Credit {
+                    id,
+                    stream_id: stream_id_for(wire_id),
+                    accepted_through,
+                    send_through,
+                },
+            }));
+        }
+
+        /// Deliver a daemon DATA payload (the client is the receiver):
+        /// quarantine the bytes first, then hand the core the byte-free meta.
+        fn deliver_data(&mut self, wire_id: u64, offset: u64, payload: &[u8]) {
+            let id = jeliya_api::RequestId::new(wire_id).expect("wire id");
+            let len = payload.len() as u64;
+            if let Some(stream) = self.bound.get_mut(&id) {
+                stream.inbound.insert(offset, payload.to_vec());
+            }
+            self.push(DriverEvent::Inbound(Inbound::Record {
+                generation: 1,
+                record: StreamRecordMeta::Data {
+                    id,
+                    stream_id: stream_id_for(wire_id),
+                    offset,
+                    len,
+                },
+            }));
+        }
+
+        /// Deliver the daemon's END (the client is the receiver).
+        fn end(&mut self, wire_id: u64, offset: u64) {
+            let id = jeliya_api::RequestId::new(wire_id).expect("wire id");
+            self.push(DriverEvent::Inbound(Inbound::Record {
+                generation: 1,
+                record: StreamRecordMeta::End {
+                    id,
+                    stream_id: stream_id_for(wire_id),
+                    offset,
+                },
+            }));
+        }
+
+        /// Deliver the terminal Text reply for `wire_id`.
+        fn deliver_reply(&mut self, wire_id: u64, out: &str) {
+            self.push(DriverEvent::Inbound(Inbound::Reply {
+                generation: 1,
+                id: jeliya_api::RequestId::new(wire_id).expect("wire id"),
+                result: WireReply::Ok(RawJson::from_string(String::from(out))),
+            }));
+        }
+    }
+
+    /// One bound stream's fake-driver state: the caller's media, the
+    /// producer's read position, and the receiver's inbound quarantine.
+    #[derive(Default)]
+    struct BoundFakeStream {
+        media: Option<crate::media::StreamMedia>,
+        produced: u64,
+        inbound: std::collections::BTreeMap<u64, Vec<u8>>,
+    }
+
+    /// A nonzero connection-local stream id (the reference rig's convention:
+    /// the core routes by call, never by the stream id).
+    fn stream_id_for(wire_id: u64) -> u128 {
+        (wire_id as u128).wrapping_add(1).max(1)
     }
 
     struct FakeDriver {
@@ -508,10 +732,214 @@ mod tests {
         }
 
         fn send(&mut self, frame: WireFrame) -> Result<(), TransportClosed> {
+            let mut inner = self.inner.borrow_mut();
+            if crate::kernel::replay::is_stream_op(frame.op) {
+                inner.bind(frame.id, frame.op_id);
+            }
+            inner.sends.push((frame.id.get(), frame.op));
+            Ok(())
+        }
+
+        fn media_event(&mut self, event: crate::kernel::transport::MediaEvent) {
+            self.inner.borrow_mut().push(DriverEvent::Media(event));
+        }
+
+        fn send_record(&mut self, intent: StreamRecordIntent) -> Result<(), TransportClosed> {
+            use crate::kernel::transport::StreamRecordIntent as I;
+            let mut inner = self.inner.borrow_mut();
+            match intent {
+                I::Credit {
+                    id,
+                    accepted_through,
+                    send_through,
+                    ..
+                } => inner.record(id.get(), "credit", accepted_through, send_through),
+                I::End { id, offset, .. } => inner.record(id.get(), "end", offset, 0),
+                I::Abort { id, high_water, .. } => inner.record(id.get(), "abort", high_water, 0),
+                I::Ack { id, high_water, .. } => inner.record(id.get(), "ack", high_water, 0),
+            }
+            Ok(())
+        }
+
+        /// Real single-threaded fulfillment (mirrors the web registry): read
+        /// the granted bytes from the bound source in codec-bounded chunks,
+        /// observe each DATA record, and surface the media events.
+        fn produce(&mut self, id: jeliya_api::RequestId, call_id: CallId, up_to: u64) {
+            use crate::kernel::transport::MediaEvent;
+            use crate::media::StreamMedia;
+            let chunk_cap = jeliya_codec::max_stream_data_bytes(
+                jeliya_codec::CodecBounds::default().max_frame_bytes,
+            )
+            .expect("default bounds frame a DATA record");
+            let mut inner = self.inner.borrow_mut();
+            let source = match inner.bound.get_mut(&id) {
+                Some(stream) => match stream.media.as_ref() {
+                    Some(StreamMedia::Source(source)) => Some(source.clone()),
+                    _ => None,
+                },
+                None => None,
+            };
+            let Some(source) = source else {
+                inner.push(DriverEvent::Media(MediaEvent::SourceFailed { call_id }));
+                return;
+            };
+            let stream = inner.bound.get_mut(&id).expect("bound above");
+            let mut position = stream.produced;
+            let mut remaining = up_to;
+            while remaining > 0 {
+                let want = remaining.min(chunk_cap as u64) as usize;
+                let mut buf = vec![0_u8; want];
+                let read = source.read_at(position, &mut buf);
+                if read == 0 {
+                    if position >= source.len() {
+                        inner.push(DriverEvent::Media(MediaEvent::SourceEnd {
+                            call_id,
+                            total: position,
+                        }));
+                    } else {
+                        inner.push(DriverEvent::Media(MediaEvent::SourceFailed { call_id }));
+                    }
+                    break;
+                }
+                inner.record(id.get(), "data", position, read as u64);
+                position += read as u64;
+                remaining = remaining.saturating_sub(read as u64);
+                inner.push(DriverEvent::Media(MediaEvent::Produced {
+                    call_id,
+                    sent_through: position,
+                }));
+                if let Some(stream) = inner.bound.get_mut(&id) {
+                    stream.produced = position;
+                }
+            }
+            if remaining == 0 && position >= source.len() {
+                inner.push(DriverEvent::Media(MediaEvent::SourceEnd {
+                    call_id,
+                    total: position,
+                }));
+            }
+        }
+
+        /// Real hand-off (mirrors the web registry): take the contiguous
+        /// quarantined range and write it to the bound sink.
+        fn write_sink(
+            &mut self,
+            id: jeliya_api::RequestId,
+            call_id: CallId,
+            offset: u64,
+            len: u64,
+        ) {
+            use crate::kernel::transport::MediaEvent;
+            use crate::media::StreamMedia;
+            let mut inner = self.inner.borrow_mut();
+            let sink = match inner.bound.get_mut(&id) {
+                Some(stream) => match stream.media.as_ref() {
+                    Some(StreamMedia::Sink(sink)) => Some(sink.clone()),
+                    _ => None,
+                },
+                None => None,
+            };
+            let Some(sink) = sink else {
+                inner.push(DriverEvent::Media(MediaEvent::SinkFailed { call_id }));
+                return;
+            };
+            // Take the contiguous range [offset, offset+len).
+            let mut collected: Vec<u8> = Vec::new();
+            let mut covered: u64 = 0;
+            let stream = inner.bound.get_mut(&id).expect("bound above");
+            while covered < len {
+                let key = offset.saturating_add(covered);
+                let needed = (len - covered) as usize;
+                let Some(mut chunk) = stream.inbound.remove(&key) else {
+                    inner.push(DriverEvent::Media(MediaEvent::SinkFailed { call_id }));
+                    return;
+                };
+                if chunk.len() > needed {
+                    let suffix_offset = key.saturating_add(needed as u64);
+                    let suffix = chunk.split_off(needed);
+                    stream.inbound.insert(suffix_offset, suffix);
+                    collected.extend_from_slice(&chunk);
+                    covered = len;
+                } else {
+                    collected.extend_from_slice(&chunk);
+                    covered += chunk.len() as u64;
+                }
+            }
+            match sink.write_at(offset, &collected) {
+                Ok(()) => inner.push(DriverEvent::Media(MediaEvent::SinkAccepted {
+                    call_id,
+                    through: offset.saturating_add(len),
+                })),
+                Err(_) => inner.push(DriverEvent::Media(MediaEvent::SinkFailed { call_id })),
+            }
+        }
+
+        fn register_media(&mut self, key: jeliya_api::OpId, media: crate::media::StreamMedia) {
+            self.inner.borrow_mut().registered.insert(key, media);
+        }
+
+        fn dial(&mut self, token: u64) {
+            self.inner.borrow_mut().dials.push(token);
+        }
+
+        fn cancel_dial(&mut self) {
+            self.inner.borrow_mut().cancel_dial_called = true;
+        }
+
+        fn arm_timer(&mut self, _id: TimerId, _at: Tick) {}
+        fn cancel_timer(&mut self, _id: TimerId) {}
+
+        fn now(&self) -> Tick {
+            Tick(1_000)
+        }
+    }
+
+    /// A driver exercising the trait's media defaults: it authors stream
+    /// records (so the abort an honest failure provokes is observable) but
+    /// moves no bytes — `produce`/`write_sink`/`register_media` are the
+    /// provided honest-failure implementations.
+    struct BareDriver {
+        inner: std::rc::Rc<std::cell::RefCell<FakeInner>>,
+    }
+
+    impl Driver for BareDriver {
+        fn poll_event(&mut self, cx: &mut Context<'_>) -> Poll<DriverEvent> {
+            let mut inner = self.inner.borrow_mut();
+            match inner.events.pop_front() {
+                Some(ev) => Poll::Ready(ev),
+                None => {
+                    inner.waker = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        }
+
+        fn send(&mut self, frame: WireFrame) -> Result<(), TransportClosed> {
             self.inner
                 .borrow_mut()
                 .sends
                 .push((frame.id.get(), frame.op));
+            Ok(())
+        }
+
+        fn media_event(&mut self, event: crate::kernel::transport::MediaEvent) {
+            self.inner.borrow_mut().push(DriverEvent::Media(event));
+        }
+
+        fn send_record(&mut self, intent: StreamRecordIntent) -> Result<(), TransportClosed> {
+            use crate::kernel::transport::StreamRecordIntent as I;
+            let mut inner = self.inner.borrow_mut();
+            match intent {
+                I::Credit {
+                    id,
+                    accepted_through,
+                    send_through,
+                    ..
+                } => inner.record(id.get(), "credit", accepted_through, send_through),
+                I::End { id, offset, .. } => inner.record(id.get(), "end", offset, 0),
+                I::Abort { id, high_water, .. } => inner.record(id.get(), "abort", high_water, 0),
+                I::Ack { id, high_water, .. } => inner.record(id.get(), "ack", high_water, 0),
+            }
             Ok(())
         }
 
@@ -734,6 +1162,253 @@ mod tests {
                 }
             ),
             "expected Disconnected{{Unknown}}, got {err:?}"
+        );
+    }
+
+    // ---- Stream media scenarios (#233 web media drive) -------------------
+    //
+    // The FakeDriver is a scripted daemon peer with REAL single-threaded
+    // media fulfillment (mirroring the web registry): a registered
+    // ByteSource is read in codec-bounded chunks at each ProduceData grant,
+    // and quarantined inbound DATA is written to the registered ByteSink at
+    // each WriteSink. These prove the mailbox runtime's stream wiring end
+    // to end — RegisterMedia → bind-at-send → SendRecord/ProduceData/
+    // WriteSink actions → Media events back as Inputs — with no browser.
+
+    /// Reach Ready (generation 1) with the FakeDriver, as scenarios 1/4/5 do.
+    fn make_ready() -> (
+        crate::handle::ClientHandle,
+        std::rc::Rc<std::cell::RefCell<FakeInner>>,
+        LocalPool,
+    ) {
+        let (handle, inner, mut pool) = make();
+        handle.start();
+        pool.run_until_stalled();
+        let token = inner.borrow().dials[0];
+        inner.borrow_mut().push(DriverEvent::Connected {
+            token,
+            incarnation: jeliya_api::Incarnation::new("runtime-test"),
+        });
+        pool.run_until_stalled();
+        assert_eq!(handle.state(), State::Ready);
+        (handle, inner, pool)
+    }
+
+    /// Like [`make_ready`] but over the [`BareDriver`] (the trait's honest
+    /// media defaults): no registered media can ever land.
+    fn make_ready_bare() -> (
+        crate::handle::ClientHandle,
+        std::rc::Rc<std::cell::RefCell<FakeInner>>,
+        LocalPool,
+    ) {
+        let inner = std::rc::Rc::new(std::cell::RefCell::new(FakeInner::new()));
+        let driver = BareDriver {
+            inner: std::rc::Rc::clone(&inner),
+        };
+        let (handle, pump) = build(
+            KernelConfig {
+                jitter_seed: 42,
+                stable_principal: false,
+                ..KernelConfig::default()
+            },
+            driver,
+            Box::new(|| Tick(1_000)),
+        );
+        let mut pool = LocalPool::new();
+        pool.spawner()
+            .spawn_local(pump)
+            .expect("spawn_local failed");
+        handle.start();
+        pool.run_until_stalled();
+        let token = inner.borrow().dials[0];
+        inner.borrow_mut().push(DriverEvent::Connected {
+            token,
+            incarnation: jeliya_api::Incarnation::new("runtime-test"),
+        });
+        pool.run_until_stalled();
+        (handle, inner, pool)
+    }
+
+    /// Upload round-trip: `call_stream::<FileShare>` registers a real source
+    /// through the handle, the FakeDriver answers OPEN + CREDIT, receives
+    /// DATA/END records with offsets/lengths within the granted credit, and
+    /// the terminal reply resolves the call.
+    #[test]
+    fn runtime_stream_upload_moves_real_bytes_through_the_mailbox() {
+        use crate::handle::Dedup;
+        use futures::executor::block_on;
+        use jeliya_api::{FileShare, RoomId};
+
+        let (handle, inner, mut pool) = make_ready();
+        let key = jeliya_api::OpId::new("share-1");
+        let payload: Vec<u8> = (0..200u32).map(|i| (i % 251) as u8).collect();
+        handle
+            .register_stream_media(key.clone(), crate::media::shared_bytes(payload))
+            .expect("the runtime backend registers media");
+        pool.run_until_stalled();
+
+        let fut = handle.call_stream::<FileShare>(
+            FileShare {
+                room_id: RoomId::new("r1"),
+                name: String::from("a.bin"),
+                declared_bytes: 200,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::Key(key),
+        );
+        pool.run_until_stalled();
+        let wire = {
+            let b = inner.borrow();
+            assert_eq!(b.sends.len(), 1, "the stream request reached the wire");
+            b.sends[0].0
+        };
+
+        // Daemon OPENs the stream, then grants credit in two steps.
+        inner.borrow_mut().open(wire, 200);
+        pool.run_until_stalled();
+        inner.borrow_mut().credit(wire, 0, 200);
+        pool.run_until_stalled();
+        inner.borrow_mut().credit(wire, 200, 200);
+        pool.run_until_stalled();
+
+        {
+            let b = inner.borrow();
+            let data: Vec<_> = b.records.iter().filter(|r| r.1 == "data").collect();
+            assert!(!data.is_empty(), "at least one DATA record was produced");
+            for record in &data {
+                assert!(
+                    record.2 + record.3 <= 200,
+                    "DATA within granted credit: {record:?}"
+                );
+            }
+            assert_eq!(
+                data.iter().map(|r| r.3).sum::<u64>(),
+                200,
+                "every byte was produced"
+            );
+            let ends: Vec<_> = b.records.iter().filter(|r| r.1 == "end").collect();
+            assert_eq!(ends.len(), 1, "exactly one END");
+            assert_eq!(ends[0].2, 200, "END at the full total");
+        }
+
+        inner.borrow_mut().deliver_reply(
+            wire,
+            "{\"room_id\":\"r1\",\"file_id\":\"f1\",\"event_id\":\"e1\",\"pos\":0,\"bytes\":200,\"digest\":\"d\"}",
+        );
+        pool.run_until_stalled();
+        let out = block_on(fut).expect("terminal reply resolves the stream");
+        assert_eq!(out.bytes, 200);
+        assert_eq!(out.file_id, jeliya_api::FileId::new("f1"));
+    }
+
+    /// Download round-trip: `call_stream::<FileRead>` registers a real
+    /// `CollectedBytes` sink; the FakeDriver delivers OPEN/DATA/END plus the
+    /// terminal reply, and the collected bytes match exactly.
+    #[test]
+    fn runtime_stream_download_collects_real_bytes_through_the_mailbox() {
+        use crate::handle::Dedup;
+        use futures::executor::block_on;
+        use jeliya_api::{FileId, FileRead, FileReadOut, RoomId};
+
+        let (handle, inner, mut pool) = make_ready();
+        let key = jeliya_api::OpId::new("read-1");
+        let (sink, media) = crate::media::collected_bytes();
+        handle
+            .register_stream_media(key.clone(), media)
+            .expect("the runtime backend registers media");
+        pool.run_until_stalled();
+
+        let fut = handle.call_stream::<FileRead>(
+            FileRead {
+                room_id: RoomId::new("r1"),
+                file_id: FileId::new("f1"),
+            },
+            Dedup::Key(key),
+        );
+        pool.run_until_stalled();
+        let wire = {
+            let b = inner.borrow();
+            assert_eq!(b.sends.len(), 1);
+            b.sends[0].0
+        };
+
+        let payload: Vec<u8> = (0..200u32).map(|i| (251 - i % 251) as u8).collect();
+        inner.borrow_mut().open(wire, 200);
+        pool.run_until_stalled();
+        // The receiver grants credit on OPEN (observed as CREDIT records).
+        {
+            let b = inner.borrow();
+            assert!(
+                b.records.iter().any(|r| r.1 == "credit"),
+                "the receiver grants credit on OPEN"
+            );
+        }
+        inner.borrow_mut().deliver_data(wire, 0, &payload);
+        pool.run_until_stalled();
+        inner.borrow_mut().end(wire, 200);
+        pool.run_until_stalled();
+
+        assert_eq!(
+            sink.len(),
+            200,
+            "the WriteSink hand-off wrote the quarantined bytes"
+        );
+        inner.borrow_mut().deliver_reply(
+            wire,
+            "{\"room_id\":\"r1\",\"file_id\":\"f1\",\"bytes\":200,\"declared_content_type\":\"application/octet-stream\"}",
+        );
+        pool.run_until_stalled();
+        let out: FileReadOut = block_on(fut).expect("terminal reply resolves the stream");
+        assert_eq!(out.bytes, 200);
+        assert_eq!(sink.take(), payload, "the collected bytes match exactly");
+    }
+
+    /// An unregistered stream fails honestly through the trait's media
+    /// defaults: the default `produce` surfaces `SourceFailed` as a
+    /// `DriverEvent::Media`, the core aborts the stream (ABORT record on the
+    /// wire) and settles the call — no hang, no fake success.
+    #[test]
+    fn runtime_unregistered_stream_fails_honestly_through_the_defaults() {
+        use crate::handle::Dedup;
+        use crate::CallError;
+        use futures::executor::block_on;
+        use jeliya_api::{FileShare, RoomId};
+
+        let (handle, inner, mut pool) = make_ready_bare();
+        let fut = handle.call_stream::<FileShare>(
+            FileShare {
+                room_id: RoomId::new("r1"),
+                name: String::from("b.bin"),
+                declared_bytes: 64,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::Key(jeliya_api::OpId::new("share-unregistered")),
+        );
+        pool.run_until_stalled();
+        let wire = inner.borrow().sends[0].0;
+
+        inner.borrow_mut().open(wire, 64);
+        pool.run_until_stalled();
+        inner.borrow_mut().credit(wire, 0, 64);
+        pool.run_until_stalled();
+
+        // The default produce reported SourceFailed: the core aborted the
+        // stream (ABORT on the wire) and settled the call.
+        {
+            let b = inner.borrow();
+            assert!(
+                b.records.iter().any(|r| r.1 == "abort"),
+                "the honest SourceFailure aborts the stream"
+            );
+            assert!(
+                !b.records.iter().any(|r| r.1 == "data"),
+                "no byte was ever produced"
+            );
+        }
+        let err = block_on(fut).expect_err("an unregistered stream must fail, not hang");
+        assert!(
+            matches!(err, CallError::Timeout),
+            "expected the core's honest stream-failure settle, got {err:?}"
         );
     }
 }

--- a/crates/jeliya-client/src/kernel/runtime.rs
+++ b/crates/jeliya-client/src/kernel/runtime.rs
@@ -474,6 +474,9 @@ where
                     DriverEvent::GateRefused { token } => Input::GateRefused { token },
                     DriverEvent::Interrupted { generation } => Input::Interrupted { generation },
                     DriverEvent::TimerFired(id) => Input::TimerFired(id),
+                    DriverEvent::StreamFault { generation, id } => {
+                        Input::StreamFault { generation, id }
+                    }
                     DriverEvent::Media(media) => match media {
                         MediaEvent::Produced {
                             call_id,

--- a/crates/jeliya-client/src/kernel/streaming.rs
+++ b/crates/jeliya-client/src/kernel/streaming.rs
@@ -602,6 +602,24 @@ impl StreamTable {
         )
     }
 
+    /// The driver decoded a structurally malformed nonterminal DATA/CREDIT on
+    /// this active binding (protocol §Malformed stream records): abort only
+    /// this stream with the closed `protocol_error` tag — the stream-local
+    /// half of the codec's severity rule. A late fault for a stream already
+    /// terminal is absorbed by the retired entry.
+    pub(crate) fn on_protocol_fault(
+        &mut self,
+        call_id: CallId,
+        actions: &mut Vec<Action>,
+    ) -> StreamOutcome {
+        self.fail(
+            call_id,
+            StreamAbortReason::ProtocolError,
+            CallError::Timeout,
+            actions,
+        )
+    }
+
     /// Inbound END (receiver direction, §S4): accept only once the full byte
     /// sequence is sink-accepted and the count agrees, then enter FINALIZING
     /// (timers cancelled) to await the terminal Text reply.
@@ -779,7 +797,12 @@ impl StreamTable {
             return;
         }
         let up_to = entry.producer_grant(limits.stream_window_bytes);
-        if up_to > 0 {
+        if up_to > 0 || entry.total == 0 {
+            // A zero-total source is granted a zero-length read: the driver's
+            // `read_at(0, &mut [])` observes EOF and reports `SourceEnd{0}`,
+            // which is the only path to the mandatory END(0) — without this
+            // grant an empty `file.share` stalls until timeout (the driver
+            // never touches an ungranted source).
             actions.push(Action::ProduceData {
                 id: entry.wire_id,
                 call_id,

--- a/crates/jeliya-client/src/kernel/streaming.rs
+++ b/crates/jeliya-client/src/kernel/streaming.rs
@@ -522,6 +522,7 @@ impl StreamTable {
             );
         }
         actions.push(Action::WriteSink {
+            id: entry.wire_id,
             call_id,
             offset,
             len,
@@ -767,7 +768,11 @@ impl StreamTable {
         }
         let up_to = entry.producer_grant(limits.stream_window_bytes);
         if up_to > 0 {
-            actions.push(Action::ProduceData { call_id, up_to });
+            actions.push(Action::ProduceData {
+                id: entry.wire_id,
+                call_id,
+                up_to,
+            });
         }
     }
 

--- a/crates/jeliya-client/src/kernel/streaming.rs
+++ b/crates/jeliya-client/src/kernel/streaming.rs
@@ -556,21 +556,33 @@ impl StreamTable {
             progressed
         };
         if progressed {
-            // Extend credit as the quarantine drains.
-            if let Some(entry) = self.entries.get(&call_id) {
-                if let Some(send_through) = entry.receiver_grant(limits.stream_window_bytes) {
-                    let (wire_id, stream_id, accepted_through) =
-                        (entry.wire_id, entry.stream_id, entry.accepted_through);
-                    if let Some(entry) = self.entries.get_mut(&call_id) {
-                        entry.granted_through = send_through;
-                    }
-                    actions.push(Action::SendRecord(StreamRecordIntent::Credit {
-                        id: wire_id,
-                        stream_id,
-                        accepted_through,
-                        send_through,
-                    }));
-                }
+            // Extend credit as the quarantine drains — and REPORT the
+            // acceptance. The terminal CREDIT is not optional: a live
+            // producer may END "only after every DATA byte it sent has been
+            // acknowledged by CREDIT" (protocol §END), and the receiver's
+            // ceiling is capped at `total`, so the final acceptance often
+            // cannot extend the window. Sending CREDIT on every accepted
+            // advance (cumulative, monotonic — an identical repeat is
+            // idempotent per §Credit) is what unblocks the producer's END;
+            // without it a window-covered stream accepts every byte and
+            // still stalls to timeout (found live against jeliyad).
+            if let Some(entry) = self.entries.get_mut(&call_id) {
+                let ceiling = entry
+                    .receiver_grant(limits.stream_window_bytes)
+                    .unwrap_or(entry.granted_through.max(entry.accepted_through));
+                entry.granted_through = entry.granted_through.max(ceiling);
+                let (wire_id, stream_id, accepted_through, send_through) = (
+                    entry.wire_id,
+                    entry.stream_id,
+                    entry.accepted_through,
+                    entry.granted_through,
+                );
+                actions.push(Action::SendRecord(StreamRecordIntent::Credit {
+                    id: wire_id,
+                    stream_id,
+                    accepted_through,
+                    send_through,
+                }));
             }
         }
         StreamOutcome::Progress

--- a/crates/jeliya-client/src/kernel/transport.rs
+++ b/crates/jeliya-client/src/kernel/transport.rs
@@ -16,6 +16,7 @@ use jeliya_api::{ApiError, OpId, RequestId};
 
 use crate::backend::RawJson;
 use crate::kernel::diag::Redacted;
+use crate::kernel::inflight::CallId;
 use crate::kernel::timing::{Tick, TimerId};
 
 /// One already-encoded outbound request, as the kernel hands it to the
@@ -401,6 +402,46 @@ pub(crate) enum Inbound {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TransportClosed;
 
+/// One byte-stream media fulfilment result a driver surfaces to the runtime,
+/// mapping one-to-one onto the core's media inputs (§S3): `Produced`/
+/// `SourceEnd`/`SourceFailed` from a producer grant, `SinkAccepted`/
+/// `SinkFailed` from a receiver hand-off. Like every stream type here it
+/// carries only ids and numeric offsets — never payload bytes (§S2/§S12).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MediaEvent {
+    /// The source framed and sent bytes; reports the new sent-through offset.
+    Produced {
+        /// The stream call the grant fulfils.
+        call_id: CallId,
+        /// The exclusive offset the driver has now sent through.
+        sent_through: u64,
+    },
+    /// The source reached EOF; reports its final total.
+    SourceEnd {
+        /// The stream call.
+        call_id: CallId,
+        /// The total bytes the source yielded.
+        total: u64,
+    },
+    /// The source failed to yield bytes (an honest abort, never a stall).
+    SourceFailed {
+        /// The stream call.
+        call_id: CallId,
+    },
+    /// The sink accepted a delivered range; reports the new high-water.
+    SinkAccepted {
+        /// The stream call.
+        call_id: CallId,
+        /// The exclusive offset the sink has now accepted through.
+        through: u64,
+    },
+    /// The sink refused bytes (an honest abort, never a stall).
+    SinkFailed {
+        /// The stream call.
+        call_id: CallId,
+    },
+}
+
 /// One event a [`Driver`] surfaces to the runtime (`kernel/runtime.rs`), each
 /// mapping one-to-one onto a core [`Input`](crate::kernel::core::Input). Every
 /// dial outcome is token-fenced and every inbound frame is generation-tagged by
@@ -437,6 +478,10 @@ pub(crate) enum DriverEvent {
     },
     /// A driver timer fired.
     TimerFired(TimerId),
+    /// One byte-stream media fulfilment result (§S3), surfaced exactly like
+    /// the core's other media inputs — the runtime maps it onto the matching
+    /// [`Input`](crate::kernel::core::Input) variant.
+    Media(MediaEvent),
 }
 
 /// What an adapter provides so the generic runtime (`kernel/runtime.rs`) can
@@ -485,6 +530,67 @@ pub(crate) trait Driver: 'static {
     /// The current logical time, read from the platform clock **outside** this
     /// library — never from `std::time` inside it.
     fn now(&self) -> Tick;
+
+    /// Queue one byte-stream media fulfilment result for the runtime to feed
+    /// the core (§S3). Drivers route it into the **same queue `poll_event`
+    /// drains**, so media results keep their order relative to transport
+    /// events. This is a seam method (not a plain internal) because the
+    /// default [`Driver::produce`]/[`Driver::write_sink`] implementations
+    /// report their honest failures through it.
+    fn media_event(&mut self, event: MediaEvent);
+
+    /// Send one client-authored byte-stream control record (§S3): frame it
+    /// via `jeliya-codec` at this boundary and push it onto the transport.
+    /// Returns `Err(TransportClosed)` exactly like [`Driver::send`] when the
+    /// pipe is broken.
+    ///
+    /// **Default (drivers that author no stream records):** the record is
+    /// dropped and the gap kept loud in tests via a debug assertion — the
+    /// same honesty contract the runtime shell had before the media drive
+    /// landed. A conforming driver that reaches stream effects implements
+    /// this; a driver that never does (no byte-stream transport) never
+    /// receives the action.
+    fn send_record(&mut self, intent: StreamRecordIntent) -> Result<(), TransportClosed> {
+        debug_assert!(
+            false,
+            "send_record reached a driver that authors no stream records"
+        );
+        let _ = intent;
+        Ok(())
+    }
+
+    /// Fulfil one `ProduceData` grant (§S3): read ≤ `up_to` bytes from the
+    /// stream's registered source in codec-bounded chunks, frame and send
+    /// them, and surface `Produced`/`SourceEnd`/`SourceFailed` through
+    /// [`Driver::media_event`]. `id` is the stream's wire id — the key the
+    /// driver's media registry is organized by.
+    ///
+    /// **Default (drivers that move no bytes):** an honest `SourceFailed`
+    /// for the call — the core aborts the stream and settles it, never a
+    /// silent stall.
+    fn produce(&mut self, _id: RequestId, call_id: CallId, _up_to: u64) {
+        self.media_event(MediaEvent::SourceFailed { call_id });
+    }
+
+    /// Hand one accepted inbound DATA range to the stream's registered sink
+    /// (§S3), surfacing `SinkAccepted`/`SinkFailed` through
+    /// [`Driver::media_event`]. `id` is the stream's wire id (see
+    /// [`Driver::produce`]).
+    ///
+    /// **Default (drivers that move no bytes):** an honest `SinkFailed` for
+    /// the call.
+    fn write_sink(&mut self, _id: RequestId, call_id: CallId, _offset: u64, _len: u64) {
+        self.media_event(MediaEvent::SinkFailed { call_id });
+    }
+
+    /// Register one stream's media under its operation's dedup `OpId`, before
+    /// the call is dispatched; the driver binds the key to the stream's wire
+    /// id when it performs the stream op's [`Driver::send`].
+    ///
+    /// **Default (drivers that move no bytes):** the registration is dropped,
+    /// so an unregistered stream later fails honestly at
+    /// [`Driver::produce`]/[`Driver::write_sink`].
+    fn register_media(&mut self, _key: OpId, _media: crate::media::StreamMedia) {}
 }
 
 #[cfg(test)]

--- a/crates/jeliya-client/src/kernel/transport.rs
+++ b/crates/jeliya-client/src/kernel/transport.rs
@@ -482,6 +482,18 @@ pub(crate) enum DriverEvent {
     /// the core's other media inputs — the runtime maps it onto the matching
     /// [`Input`](crate::kernel::core::Input) variant.
     Media(MediaEvent),
+    /// The driver decoded a structurally malformed **nonterminal** DATA or
+    /// CREDIT record on an active binding (protocol §Malformed stream
+    /// records): the stream-local half of the codec's severity rule, mapped
+    /// onto [`Input::StreamFault`](crate::kernel::core::Input::StreamFault).
+    /// Connection-fatal conditions arrive as
+    /// [`DriverEvent::Interrupted`] instead.
+    StreamFault {
+        /// The generation the delivering connection is on.
+        generation: u64,
+        /// The malformed record's reply-correlation id.
+        id: RequestId,
+    },
 }
 
 /// What an adapter provides so the generic runtime (`kernel/runtime.rs`) can

--- a/crates/jeliya-client/src/lib.rs
+++ b/crates/jeliya-client/src/lib.rs
@@ -60,6 +60,7 @@ mod error;
 mod event;
 mod handle;
 mod kernel;
+pub mod media;
 mod reconcile;
 mod stream;
 

--- a/crates/jeliya-client/src/lib.rs
+++ b/crates/jeliya-client/src/lib.rs
@@ -69,6 +69,14 @@ mod stream;
 // `cargo tree` boundary test) and the module is invisible to the native build.
 #[cfg(all(target_arch = "wasm32", feature = "ws-web"))]
 mod ws_web;
+// The adapter's media REGISTRY is pure Rust — no browser types — so it (and
+// its unit tests: the bounded-registration eviction and the one-Produced-
+// per-grant invariant) also compiles on the host under the feature, giving
+// the logic a genuinely executed test target outside the browser. The wasm
+// build consumes the same file through `ws_web::media`.
+#[cfg(all(feature = "ws-web", not(target_arch = "wasm32")))]
+#[path = "ws_web/media.rs"]
+mod ws_web_media;
 // The native async WebSocket adapter (#172): binds the sans-IO kernel to a real
 // tokio + tokio-tungstenite transport dialing a loopback `jeliyad` via the
 // reusable supervisor target resolver (#170). Default-off and native-only — the

--- a/crates/jeliya-client/src/media.rs
+++ b/crates/jeliya-client/src/media.rs
@@ -1,0 +1,261 @@
+//! The public stream-media seam: the byte sources and sinks a caller
+//! registers for one duplex byte-stream operation (`file.share` uploads bytes
+//! from a [`ByteSource`]; `file.read` downloads bytes into a [`ByteSink`]).
+//!
+//! The kernel's stream control plane (#269) is byte-free by construction — it
+//! grants offsets and windows, never touches payload bytes (§S2 of
+//! `specs/rust-client-kernel-stream-lifecycle.md`). The **driver** moves the
+//! bytes, and this module is the caller-owned media it moves them from/to.
+//! Registration reaches the driver through
+//! [`ClientHandle::register_stream_media`](crate::ClientHandle::register_stream_media)
+//! keyed by the operation's dedup [`OpId`](jeliya_api::OpId); the driver binds
+//! that key to the stream's wire id when it performs the request's send. A
+//! stream that reaches its media effect with no registration fails honestly
+//! (`source_failed`/`sink_failed`), never a stall or a fake success.
+//!
+//! `PlatformServices`-backed file media (#174) plugs in through the same
+//! traits with no adapter change — the adapters depend on the traits, not the
+//! in-memory types.
+
+use std::sync::Arc;
+
+use jeliya_api::OpId;
+
+/// A producer's byte source for one `file.share` stream.
+///
+/// The driver calls [`read_at`](ByteSource::read_at) with offsets the kernel
+/// has already bounded by credit and the declared total, so a source never
+/// hands out bytes the daemon has not admitted. Implementations must be
+/// `Send + Sync` (the driver may fulfil grants from its own tasks).
+pub trait ByteSource: Send + Sync {
+    /// Copy up to `buf.len()` bytes starting at `offset` into `buf`, returning
+    /// how many were copied. `offset` is always `< len()`; a short read is
+    /// legal (the driver simply sends what it got and reports the new
+    /// high-water), and `0` at a non-EOF position is a source failure.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> usize;
+    /// The source's total byte count. Must equal the request's
+    /// `declared_bytes` — the daemon checks the pair at admission.
+    fn len(&self) -> u64;
+    /// Standard predicate; a `len() == 0` source drives the protocol's
+    /// zero-byte handshake.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An empty payload marks "the sink cannot accept" — the stream aborts
+/// `sink_failed` honestly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SinkRejected;
+
+impl std::fmt::Display for SinkRejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("the sink refused the delivered range")
+    }
+}
+
+impl std::error::Error for SinkRejected {}
+
+/// A receiver's byte sink for one `file.read` stream.
+///
+/// The driver calls [`write_at`](ByteSink::write_at) with ranges the kernel
+/// has validated as contiguous from the accepted high-water and within the
+/// granted credit window. Downloaded bytes are quarantined by the kernel until
+/// END and the success reply agree on the count; the sink is where they land.
+pub trait ByteSink: Send + Sync {
+    /// Accept `bytes` at `offset`. Returns [`SinkRejected`] if the sink cannot
+    /// accept (disk full, caller dropped the collection) — the driver reports
+    /// `sink_failed` and the stream aborts honestly.
+    fn write_at(&self, offset: u64, bytes: &[u8]) -> Result<(), SinkRejected>;
+}
+
+/// One caller-owned in-memory [`ByteSource`]: a shared, immutable byte slice.
+///
+/// The caller keeps the bytes anyway (a picker result, a generated blob); the
+/// source is a window over them, so no copy is forced. Bounded by the caller's
+/// own allocation, itself bounded by the daemon's `max_shared_file_bytes`.
+#[derive(Clone)]
+pub struct SharedBytes {
+    bytes: Arc<[u8]>,
+}
+
+impl SharedBytes {
+    /// Wrap `bytes` as a stream source.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes: bytes.into(),
+        }
+    }
+
+    /// The underlying slice (for a caller-side digest, a preview, …).
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl ByteSource for SharedBytes {
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> usize {
+        let start = offset as usize;
+        if self.bytes.len() <= start {
+            return 0;
+        }
+        let end = (start + buf.len()).min(self.bytes.len());
+        let count = end - start;
+        buf[..count].copy_from_slice(&self.bytes[start..end]);
+        count
+    }
+
+    fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+/// One caller-owned in-memory [`ByteSink`]: bytes collected contiguously and
+/// taken by the caller after the stream's terminal reply.
+///
+/// Writes must arrive contiguously from zero (the kernel guarantees it); a
+/// discontinuity or an overwrite is refused — the sink never silently drops or
+/// double-writes a byte.
+#[derive(Clone, Default)]
+pub struct CollectedBytes {
+    inner: Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+impl CollectedBytes {
+    /// A fresh, empty collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take everything collected so far, leaving the sink empty. Safe to call
+    /// after the stream's terminal (the kernel quarantined the bytes until END
+    /// and the reply agreed) or after a failure (a partial, honestly
+    /// incomplete collection).
+    pub fn take(&self) -> Vec<u8> {
+        std::mem::take(&mut self.inner.lock().expect("CollectedBytes poisoned"))
+    }
+
+    /// How many bytes are collected so far.
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("CollectedBytes poisoned").len()
+    }
+
+    /// Whether nothing has been collected.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl ByteSink for CollectedBytes {
+    fn write_at(&self, offset: u64, bytes: &[u8]) -> Result<(), SinkRejected> {
+        let mut collected = self.inner.lock().expect("CollectedBytes poisoned");
+        let offset = offset as usize;
+        if offset != collected.len() {
+            // The kernel delivers contiguous-from-accepted ranges only; this
+            // cannot happen through a conforming driver, and a gap must never
+            // be papered over silently.
+            return Err(SinkRejected);
+        }
+        collected.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// The media one stream call is bound to: a producer's source or a receiver's
+/// sink, registered under the call's dedup `OpId` before dispatch.
+///
+/// `Debug` is deliberately not payload-rendering: the enum carries only its
+/// role tag and the media's byte length.
+pub enum StreamMedia {
+    /// The producer's source (`file.share`).
+    Source(Arc<dyn ByteSource>),
+    /// The receiver's sink (`file.read`).
+    Sink(Arc<dyn ByteSink>),
+}
+
+impl StreamMedia {
+    /// The media's byte count (a source's total, or a sink's collected
+    /// length) — a bound, never content.
+    pub fn byte_len(&self) -> u64 {
+        match self {
+            StreamMedia::Source(source) => source.len(),
+            StreamMedia::Sink(_) => 0,
+        }
+    }
+}
+
+impl std::fmt::Debug for StreamMedia {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StreamMedia::Source(source) => f
+                .debug_struct("StreamMedia::Source")
+                .field("total_bytes", &source.len())
+                .finish(),
+            StreamMedia::Sink(_) => f.debug_struct("StreamMedia::Sink").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// Convenience: wrap a [`SharedBytes`] as [`StreamMedia::Source`].
+pub fn shared_bytes(bytes: Vec<u8>) -> StreamMedia {
+    StreamMedia::Source(Arc::new(SharedBytes::new(bytes)))
+}
+
+/// Convenience: wrap a [`CollectedBytes`] as [`StreamMedia::Sink`].
+pub fn collected_bytes() -> (CollectedBytes, StreamMedia) {
+    let sink = CollectedBytes::new();
+    (sink.clone(), StreamMedia::Sink(Arc::new(sink)))
+}
+
+/// The key a registration is bound by. Re-exported so callers need only this
+/// module for the whole registration surface.
+pub type MediaKey = OpId;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_bytes_reads_bounded_ranges() {
+        let source = SharedBytes::new(vec![1u8, 2, 3, 4, 5]);
+        assert_eq!(source.len(), 5);
+        let mut buf = [0u8; 2];
+        assert_eq!(source.read_at(3, &mut buf), 2);
+        assert_eq!(buf, [4, 5]);
+        // A short read at the tail.
+        let mut tail = [0u8; 4];
+        assert_eq!(source.read_at(4, &mut tail), 1);
+        assert_eq!(tail[0], 5);
+        // Past the end reads nothing.
+        assert_eq!(source.read_at(5, &mut buf), 0);
+    }
+
+    #[test]
+    fn collected_bytes_accepts_contiguous_and_refuses_gaps() {
+        let sink = CollectedBytes::new();
+        sink.write_at(0, &[1, 2]).expect("contiguous");
+        sink.write_at(2, &[3]).expect("contiguous");
+        assert!(sink.write_at(5, &[9]).is_err(), "a gap is refused");
+        assert_eq!(sink.take(), vec![1, 2, 3]);
+        assert!(sink.is_empty(), "take empties the collection");
+    }
+
+    #[test]
+    fn stream_media_debug_renders_no_content() {
+        let media = shared_bytes(vec![7, 7, 7]);
+        let rendered = format!("{media:?}");
+        assert!(rendered.contains("Source"));
+        assert!(!rendered.contains('7'));
+    }
+
+    #[test]
+    fn a_zero_byte_source_reports_empty() {
+        let source = SharedBytes::new(Vec::new());
+        assert!(source.is_empty());
+        assert_eq!(source.read_at(0, &mut [0u8; 4]), 0);
+    }
+}

--- a/crates/jeliya-client/src/ws_web/media.rs
+++ b/crates/jeliya-client/src/ws_web/media.rs
@@ -51,6 +51,13 @@ pub(crate) struct BoundWebStream {
     /// The call id observed at the first media effect (`produce`/
     /// `write_sink` both receive it).
     call_id: Option<CallId>,
+    /// The stream id the DAEMON adopted at OPEN — recorded when the OPEN
+    /// record is decoded, and required for framing outbound DATA: the daemon
+    /// routes client records by the `(request id, stream id)` pair it
+    /// authored, so a fabricated id is rejected (the native registry adopts
+    /// the same value at its OPEN; `None` means no OPEN was seen yet, and a
+    /// grant before OPEN cannot happen — the core arms media only after it).
+    stream_id: Option<u128>,
     /// The producer's read position (how far the source has been framed).
     produced: u64,
     /// Quarantined inbound DATA, keyed by offset — bounded by the registry's
@@ -66,6 +73,7 @@ impl BoundWebStream {
         Self {
             media: None,
             call_id: None,
+            stream_id: None,
             produced: 0,
             inbound: BTreeMap::new(),
             inbound_bytes: 0,
@@ -145,6 +153,18 @@ impl WebMediaRegistry {
         self.bound.contains_key(&wire_id)
     }
 
+    /// Record the stream id the daemon adopted at OPEN for a bound stream.
+    /// Called from the OPEN decode, before the record meta reaches the core;
+    /// the id is the one outbound DATA must carry (see `BoundWebStream::
+    /// stream_id`). A no-op for an unbound wire id — an OPEN for a stream
+    /// this driver never sent is the caller's binding-lookup failure, not a
+    /// registry entry.
+    pub(crate) fn adopt_open_stream_id(&mut self, wire_id: RequestId, stream_id: u128) {
+        if let Some(stream) = self.bound.get_mut(&wire_id) {
+            stream.stream_id = Some(stream_id);
+        }
+    }
+
     /// Fulfil one `ProduceData` grant synchronously (single thread): read ≤
     /// `up_to` bytes from the bound source in codec-bounded chunks, frame
     /// each as a DATA record, and hand the framed bytes to `send` (the live
@@ -177,6 +197,17 @@ impl WebMediaRegistry {
         let Some(source) = source else {
             return ProduceOutcome::Events(vec![MediaEvent::SourceFailed { call_id }]);
         };
+        // The daemon's OPEN stream id, without which DATA cannot be framed:
+        // the daemon routes by the pair it authored (the native registry
+        // adopts the same value at its OPEN).
+        let Some(bound_stream_id) = self
+            .bound
+            .get(&id)
+            .and_then(|stream| stream.stream_id)
+            .filter(|sid| *sid != 0)
+        else {
+            return ProduceOutcome::Events(vec![MediaEvent::SourceFailed { call_id }]);
+        };
         let mut events = Vec::new();
         let mut position = position;
         let mut remaining = up_to;
@@ -199,7 +230,7 @@ impl WebMediaRegistry {
                 return ProduceOutcome::Events(events);
             }
             buf.truncate(read);
-            let identity = match StreamIdentity::new(id.get(), stream_id_for(id)) {
+            let identity = match StreamIdentity::new(id.get(), bound_stream_id) {
                 Ok(identity) => identity,
                 Err(_) => {
                     events.push(MediaEvent::SourceFailed { call_id });
@@ -359,15 +390,6 @@ impl WebMediaRegistry {
     pub(crate) fn clear(&mut self) {
         self.bound.clear();
     }
-}
-
-/// A nonzero connection-local stream id for an outbound DATA record, derived
-/// from the wire id. The daemon adopted its own stream id at OPEN; outbound
-/// client DATA is routed by the reply-correlation request id (the core routes
-/// by call, never by the stream id), so any nonzero identity the codec
-/// accepts serves — mirroring the reference rig's convention.
-fn stream_id_for(wire_id: RequestId) -> u128 {
-    (wire_id.get() as u128).wrapping_add(1).max(1)
 }
 
 /// Map one kernel record intent onto the codec's record type. `None` only

--- a/crates/jeliya-client/src/ws_web/media.rs
+++ b/crates/jeliya-client/src/ws_web/media.rs
@@ -1,0 +1,451 @@
+//! The browser adapter's byte-stream media drive (§S3 of the kernel stream
+//! spec): the single-threaded mirror of the native adapter's
+//! `MediaRegistry` — the registry that binds registered [`StreamMedia`] to
+//! wire ids and moves real bytes between the caller's sources/sinks and the
+//! `web_sys::WebSocket`.
+//!
+//! The kernel's stream control plane is byte-free — it grants offsets and
+//! windows, never payload. This module is where those grants become `JBS2`
+//! DATA records on the socket and where inbound DATA payloads quarantine
+//! (window-bounded) until the kernel's `WriteSink` hands them to the
+//! caller's sink. All framing stays in `jeliya-codec`, called only from here
+//! and the socket's message handler — no `JBS2` constant appears in this
+//! file.
+//!
+//! The native registry runs one async media task per producer stream; the
+//! browser runs on a single thread, so fulfillment is **synchronous**: a
+//! `ProduceData` grant handed to the driver reads the granted bytes, frames
+//! each codec-bounded chunk, and `send_with_u8_array`s it before returning
+//! (the socket buffers; backpressure is the browser's own queue discipline).
+//! The public media types are `Arc`-based and `Send + Sync`; that costs
+//! nothing on single-threaded wasm and keeps one shared seam.
+//!
+//! Honest failure is the invariant: a stream that reaches a media effect
+//! with no registered media reports `SourceFailed`/`SinkFailed` to the core
+//! (which aborts the stream and settles the call), never a stall and never a
+//! fake success. A stream never survives its connection: teardown and loss
+//! clear the bound entries exactly when the core drops the streams (§S10).
+
+use std::collections::{BTreeMap, HashMap};
+
+use jeliya_api::{OpId, RequestId};
+use jeliya_codec::{
+    max_stream_data_bytes, BinaryAbortReason, CodecBounds, StreamIdentity, StreamRecord,
+    StreamRecordBody,
+};
+
+use crate::kernel::inflight::CallId;
+use crate::kernel::transport::{MediaEvent, StreamAbortReason, StreamRecordIntent};
+use crate::media::StreamMedia;
+
+/// The media-side state of one bound stream (keyed by wire id): the caller's
+/// registered media, the producer's read position, and the receiver's inbound
+/// quarantine buffer.
+///
+/// `Debug` is deliberately absent as a derive: the inbound buffer holds
+/// payload bytes, and no debug render of this type may expose them (§S12).
+pub(crate) struct BoundWebStream {
+    /// The registered media, if the caller registered any (`None` = an
+    /// honestly-failing unregistered stream).
+    media: Option<StreamMedia>,
+    /// The call id observed at the first media effect (`produce`/
+    /// `write_sink` both receive it).
+    call_id: Option<CallId>,
+    /// The producer's read position (how far the source has been framed).
+    produced: u64,
+    /// Quarantined inbound DATA, keyed by offset — bounded by the registry's
+    /// defensive cap (twice the kernel's stream window).
+    inbound: BTreeMap<u64, Vec<u8>>,
+    /// The buffer's running byte count (the cap check's numerator).
+    inbound_bytes: u64,
+}
+
+impl BoundWebStream {
+    /// A fresh, media-less bound entry.
+    fn empty() -> Self {
+        Self {
+            media: None,
+            call_id: None,
+            produced: 0,
+            inbound: BTreeMap::new(),
+            inbound_bytes: 0,
+        }
+    }
+}
+
+/// The outcome of one synchronous producer-grant fulfillment.
+#[derive(Debug)]
+pub(crate) enum ProduceOutcome {
+    /// Fulfilment finished (possibly with an honest source failure): feed
+    /// these media events to the core.
+    Events(Vec<MediaEvent>),
+    /// The socket refused a frame mid-grant: treat it as a connection loss
+    /// (the driver reports `Interrupted`; nothing more may be sent).
+    Closed,
+}
+
+/// The per-connection media registry, held inside the driver's single
+/// `RefCell` state so every access is serialized on the one thread.
+///
+/// Two maps, two lifetimes (mirroring the native registry): `registered`
+/// holds caller registrations keyed by dedup `OpId` awaiting the stream op's
+/// send; `bound` holds the per-stream state keyed by wire id from that send
+/// until the stream's terminal Text reply ([`WebMediaRegistry::prune`]) or
+/// the connection's death ([`WebMediaRegistry::clear`]). Registrations
+/// survive a connection loss — a stream call queued across a reconnect still
+/// sends after it, and binds then; bound streams never do (§S8/§S10).
+pub(crate) struct WebMediaRegistry {
+    /// Caller registrations awaiting a stream op's send, keyed by dedup
+    /// `OpId`. Bounded by the caller's own registration discipline.
+    registered: HashMap<OpId, StreamMedia>,
+    /// Per-stream media state, keyed by the stream's wire id. Bounded by the
+    /// kernel's concurrent-stream limit (every terminal prunes).
+    bound: HashMap<RequestId, BoundWebStream>,
+    /// The defensive inbound-buffer cap: the kernel's `stream_window_bytes`
+    /// doubled (the core grants at most one window; the second window is the
+    /// margin for a range delivered just before its credit extension).
+    window_cap: u64,
+}
+
+impl WebMediaRegistry {
+    /// Build an empty registry whose inbound cap is `stream_window_bytes × 2`
+    /// (the kernel config's window, passed at construction).
+    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+        Self {
+            registered: HashMap::new(),
+            bound: HashMap::new(),
+            window_cap: stream_window_bytes.saturating_mul(2),
+        }
+    }
+
+    /// Register one stream's media under its dedup key, before the call is
+    /// dispatched. Re-registering a key replaces the previous media (the
+    /// caller's own last-write-wins).
+    pub(crate) fn register(&mut self, key: OpId, media: StreamMedia) {
+        self.registered.insert(key, media);
+    }
+
+    /// Bind a stream op's wire id at send time: move the caller's
+    /// registration (if any) onto the wire key. A stream op with **no**
+    /// registration still binds an empty entry, so its later media effects
+    /// fail honestly (`SourceFailed`/`SinkFailed`) instead of silently. A
+    /// re-send of an already-bound id leaves the existing binding untouched.
+    pub(crate) fn bind(&mut self, wire_id: RequestId, op_id: Option<OpId>) {
+        if self.bound.contains_key(&wire_id) {
+            return;
+        }
+        let media = op_id.and_then(|key| self.registered.remove(&key));
+        let mut stream = BoundWebStream::empty();
+        stream.media = media;
+        self.bound.insert(wire_id, stream);
+    }
+
+    /// Whether a wire id has a bound stream entry.
+    pub(crate) fn is_bound(&self, wire_id: RequestId) -> bool {
+        self.bound.contains_key(&wire_id)
+    }
+
+    /// Fulfil one `ProduceData` grant synchronously (single thread): read ≤
+    /// `up_to` bytes from the bound source in codec-bounded chunks, frame
+    /// each as a DATA record, and hand the framed bytes to `send` (the live
+    /// socket's binary send; returning `false` means the pipe broke). An
+    /// unregistered, sink-bound, or unbound stream reports an honest
+    /// `SourceFailed`, exactly like the native registry.
+    pub(crate) fn produce(
+        &mut self,
+        id: RequestId,
+        call_id: CallId,
+        up_to: u64,
+        bounds: &CodecBounds,
+        send: &mut dyn FnMut(&[u8]) -> bool,
+    ) -> ProduceOutcome {
+        let chunk_cap = match max_stream_data_bytes(bounds.max_frame_bytes) {
+            Ok(cap) => cap,
+            Err(_) => return ProduceOutcome::Events(vec![MediaEvent::SourceFailed { call_id }]),
+        };
+        let (source, position) = match self.bound.get_mut(&id) {
+            Some(stream) => {
+                stream.call_id = Some(call_id);
+                let source = match stream.media.as_ref() {
+                    Some(StreamMedia::Source(source)) => Some(source.clone()),
+                    _ => None,
+                };
+                (source, stream.produced)
+            }
+            None => (None, 0),
+        };
+        let Some(source) = source else {
+            return ProduceOutcome::Events(vec![MediaEvent::SourceFailed { call_id }]);
+        };
+        let mut events = Vec::new();
+        let mut position = position;
+        let mut remaining = up_to;
+        while remaining > 0 {
+            let want = remaining.min(chunk_cap as u64) as usize;
+            let mut buf = vec![0_u8; want];
+            let read = source.read_at(position, &mut buf);
+            if read == 0 {
+                // EOF reports the source's own count; a zero read short of it
+                // is a source failure.
+                if position >= source.len() {
+                    events.push(MediaEvent::SourceEnd {
+                        call_id,
+                        total: position,
+                    });
+                } else {
+                    events.push(MediaEvent::SourceFailed { call_id });
+                }
+                self.persist_produced(id, position);
+                return ProduceOutcome::Events(events);
+            }
+            buf.truncate(read);
+            let identity = match StreamIdentity::new(id.get(), stream_id_for(id)) {
+                Ok(identity) => identity,
+                Err(_) => {
+                    events.push(MediaEvent::SourceFailed { call_id });
+                    self.persist_produced(id, position);
+                    return ProduceOutcome::Events(events);
+                }
+            };
+            let record = StreamRecord {
+                identity,
+                body: StreamRecordBody::Data {
+                    offset: position,
+                    payload: buf,
+                },
+            };
+            let framed = match jeliya_codec::encode_stream_record(&record, bounds) {
+                Ok(bytes) => bytes,
+                // A framing refusal is a local media failure: abort honestly.
+                Err(_) => {
+                    events.push(MediaEvent::SourceFailed { call_id });
+                    self.persist_produced(id, position);
+                    return ProduceOutcome::Events(events);
+                }
+            };
+            if !send(&framed) {
+                // Connection loss mid-grant: the loss report is the driver's
+                // (Interrupted); nothing more may be sent.
+                self.persist_produced(id, position);
+                return ProduceOutcome::Closed;
+            }
+            position += read as u64;
+            remaining = remaining.saturating_sub(read as u64);
+            events.push(MediaEvent::Produced {
+                call_id,
+                sent_through: position,
+            });
+        }
+        // The grant ran out at (or past) the source's end: report EOF now
+        // rather than waiting for a probe grant that may never come.
+        if position >= source.len() {
+            events.push(MediaEvent::SourceEnd {
+                call_id,
+                total: position,
+            });
+        }
+        self.persist_produced(id, position);
+        ProduceOutcome::Events(events)
+    }
+
+    /// Persist the produced offset on the bound entry (a no-op if the stream
+    /// was pruned mid-grant — a straggling grant strands nothing).
+    fn persist_produced(&mut self, id: RequestId, position: u64) {
+        if let Some(stream) = self.bound.get_mut(&id) {
+            stream.produced = position;
+        }
+    }
+
+    /// Hand one accepted inbound range to the stream's registered sink and
+    /// return the matching media event: `SinkAccepted` on success,
+    /// `SinkFailed` for an unregistered/unbound stream, a quarantine gap, or
+    /// a sink refusal.
+    pub(crate) fn write_sink(
+        &mut self,
+        id: RequestId,
+        call_id: CallId,
+        offset: u64,
+        len: u64,
+    ) -> MediaEvent {
+        let sink = match self.bound.get_mut(&id) {
+            Some(stream) => {
+                stream.call_id = Some(call_id);
+                match stream.media.as_ref() {
+                    Some(StreamMedia::Sink(sink)) => Some(sink.clone()),
+                    _ => None,
+                }
+            }
+            None => None,
+        };
+        let Some(sink) = sink else {
+            return MediaEvent::SinkFailed { call_id };
+        };
+        let taken = match self.take_range(id, offset, len) {
+            Some(bytes) => bytes,
+            None => return MediaEvent::SinkFailed { call_id },
+        };
+        match sink.write_at(offset, &taken) {
+            Ok(()) => MediaEvent::SinkAccepted {
+                call_id,
+                through: offset.saturating_add(len),
+            },
+            Err(_) => MediaEvent::SinkFailed { call_id },
+        }
+    }
+
+    /// Remove and return the contiguous quarantined range `[offset,
+    /// offset+len)`, splitting a chunk that extends past the range's end.
+    /// `None` on any gap (a protocol-side discontinuity the kernel normally
+    /// prevents; refusing is the honest path).
+    fn take_range(&mut self, id: RequestId, offset: u64, len: u64) -> Option<Vec<u8>> {
+        let stream = self.bound.get_mut(&id)?;
+        if len == 0 {
+            return Some(Vec::new());
+        }
+        let mut collected = Vec::with_capacity(len as usize);
+        let mut covered: u64 = 0;
+        while covered < len {
+            let key = offset.saturating_add(covered);
+            let needed = (len - covered) as usize;
+            let mut chunk = stream.inbound.remove(&key)?;
+            if chunk.len() > needed {
+                // The chunk extends past this range's end: keep the prefix,
+                // re-quarantine the suffix under its own offset.
+                let suffix_offset = key.saturating_add(needed as u64);
+                let suffix = chunk.split_off(needed);
+                stream.inbound.insert(suffix_offset, suffix);
+                collected.extend_from_slice(&chunk);
+                covered = len;
+            } else {
+                collected.extend_from_slice(&chunk);
+                covered += chunk.len() as u64;
+            }
+        }
+        stream.inbound_bytes = stream.inbound_bytes.saturating_sub(collected.len() as u64);
+        Some(collected)
+    }
+
+    /// Quarantine one inbound DATA payload before its record metadata
+    /// reaches the core. Returns `false` on protocol trouble — an unbound
+    /// wire id, a duplicate/overlapping offset, or a buffer past its
+    /// defensive cap (twice the kernel's stream window) — which the socket's
+    /// message handler reports as `Inbound::Malformed`.
+    pub(crate) fn deliver_data(&mut self, id: RequestId, offset: u64, payload: &[u8]) -> bool {
+        let Some(stream) = self.bound.get_mut(&id) else {
+            return false;
+        };
+        if stream.inbound.contains_key(&offset) {
+            return false;
+        }
+        let add = payload.len() as u64;
+        if stream.inbound_bytes.saturating_add(add) > self.window_cap {
+            return false;
+        }
+        stream.inbound.insert(offset, payload.to_vec());
+        stream.inbound_bytes = stream.inbound_bytes.saturating_add(add);
+        true
+    }
+
+    /// Prune a finished stream (its terminal Text reply arrived): drop the
+    /// bound entry and its quarantine buffer. Cheap and idempotent.
+    pub(crate) fn prune(&mut self, wire_id: RequestId) {
+        self.bound.remove(&wire_id);
+    }
+
+    /// Clear every bound stream. Called on connection loss and teardown: a
+    /// stream never survives its connection (§S10). Caller registrations
+    /// survive: they await a send that a queued stream call still owes after
+    /// the reconnect.
+    pub(crate) fn clear(&mut self) {
+        self.bound.clear();
+    }
+}
+
+/// A nonzero connection-local stream id for an outbound DATA record, derived
+/// from the wire id. The daemon adopted its own stream id at OPEN; outbound
+/// client DATA is routed by the reply-correlation request id (the core routes
+/// by call, never by the stream id), so any nonzero identity the codec
+/// accepts serves — mirroring the reference rig's convention.
+fn stream_id_for(wire_id: RequestId) -> u128 {
+    (wire_id.get() as u128).wrapping_add(1).max(1)
+}
+
+/// Map one kernel record intent onto the codec's record type. `None` only
+/// for a zero stream id, which the codec forbids and a decoded OPEN can
+/// never carry. (Mirrors the native adapter's mapping; duplicated here
+/// because the native module is `ws-native`-gated.)
+pub(crate) fn intent_record(intent: &StreamRecordIntent) -> Option<StreamRecord> {
+    use crate::kernel::transport::StreamRecordIntent as I;
+    let identity = |id: RequestId, stream_id: u128| StreamIdentity::new(id.get(), stream_id).ok();
+    let record = match *intent {
+        I::Credit {
+            id,
+            stream_id,
+            accepted_through,
+            send_through,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Credit {
+                accepted_through,
+                send_through,
+            },
+        },
+        I::End {
+            id,
+            stream_id,
+            offset,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::End { total: offset },
+        },
+        I::Abort {
+            id,
+            stream_id,
+            high_water,
+            reason,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Abort {
+                accepted_through: high_water,
+                reason: map_abort_reason_outbound(reason),
+            },
+        },
+        I::Ack {
+            id,
+            stream_id,
+            high_water,
+        } => StreamRecord {
+            identity: identity(id, stream_id)?,
+            body: StreamRecordBody::Ack {
+                accepted_through: high_water,
+            },
+        },
+    };
+    Some(record)
+}
+
+/// Map an inbound codec abort reason onto the kernel's closed tag by value:
+/// the four shared tags map one-to-one; the daemon-only `OperationError`
+/// (which a client never authors and the kernel's inbound-ABORT handling
+/// ignores the reason of) maps to `ProtocolError`.
+pub(crate) fn map_abort_reason(reason: BinaryAbortReason) -> StreamAbortReason {
+    match reason {
+        BinaryAbortReason::Cancelled => StreamAbortReason::Cancelled,
+        BinaryAbortReason::SourceFailed => StreamAbortReason::SourceFailed,
+        BinaryAbortReason::SinkFailed => StreamAbortReason::SinkFailed,
+        BinaryAbortReason::ProtocolError | BinaryAbortReason::OperationError => {
+            StreamAbortReason::ProtocolError
+        }
+    }
+}
+
+/// Map a kernel abort tag onto the codec's wire reason (the outbound
+/// direction): every kernel tag has an exact wire counterpart.
+fn map_abort_reason_outbound(reason: StreamAbortReason) -> BinaryAbortReason {
+    match reason {
+        StreamAbortReason::Cancelled => BinaryAbortReason::Cancelled,
+        StreamAbortReason::SourceFailed => BinaryAbortReason::SourceFailed,
+        StreamAbortReason::SinkFailed => BinaryAbortReason::SinkFailed,
+        StreamAbortReason::ProtocolError => BinaryAbortReason::ProtocolError,
+    }
+}

--- a/crates/jeliya-client/src/ws_web/media.rs
+++ b/crates/jeliya-client/src/ws_web/media.rs
@@ -26,7 +26,7 @@
 //! fake success. A stream never survives its connection: teardown and loss
 //! clear the bound entries exactly when the core drops the streams (§S10).
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 
 use jeliya_api::{OpId, RequestId};
 use jeliya_codec::{
@@ -104,8 +104,19 @@ pub(crate) enum ProduceOutcome {
 /// sends after it, and binds then; bound streams never do (§S8/§S10).
 pub(crate) struct WebMediaRegistry {
     /// Caller registrations awaiting a stream op's send, keyed by dedup
-    /// `OpId`. Bounded by the caller's own registration discipline.
+    /// `OpId`, in insertion order (oldest first, for the bounded-eviction
+    /// rule below).
     registered: HashMap<OpId, StreamMedia>,
+    /// The registration insertion order backing the eviction rule.
+    registered_order: VecDeque<OpId>,
+    /// The bound on outstanding registrations (§K12: no unbounded
+    /// collection). A registration whose call is never sent (refused
+    /// locally, or the caller abandoned the dispatch) has no other
+    /// reclaimer, so the registry evicts the OLDEST outstanding
+    /// registration past the cap — an evicted key's later call fails
+    /// honestly at its first media effect (`SourceFailed`/`SinkFailed`),
+    /// never a silent stall.
+    registered_cap: usize,
     /// Per-stream media state, keyed by the stream's wire id. Bounded by the
     /// kernel's concurrent-stream limit (every terminal prunes).
     bound: HashMap<RequestId, BoundWebStream>,
@@ -118,9 +129,11 @@ pub(crate) struct WebMediaRegistry {
 impl WebMediaRegistry {
     /// Build an empty registry whose inbound cap is `stream_window_bytes × 2`
     /// (the kernel config's window, passed at construction).
-    pub(crate) fn new(stream_window_bytes: u64) -> Self {
+    pub(crate) fn new(stream_window_bytes: u64, registered_cap: usize) -> Self {
         Self {
             registered: HashMap::new(),
+            registered_order: VecDeque::new(),
+            registered_cap: registered_cap.max(1),
             bound: HashMap::new(),
             window_cap: stream_window_bytes.saturating_mul(2),
         }
@@ -128,9 +141,19 @@ impl WebMediaRegistry {
 
     /// Register one stream's media under its dedup key, before the call is
     /// dispatched. Re-registering a key replaces the previous media (the
-    /// caller's own last-write-wins).
+    /// caller's own last-write-wins). Past `registered_cap` the OLDEST
+    /// outstanding registration is evicted — see the field's honesty note.
     pub(crate) fn register(&mut self, key: OpId, media: StreamMedia) {
-        self.registered.insert(key, media);
+        if self.registered.insert(key.clone(), media).is_none() {
+            self.registered_order.push_back(key);
+        }
+        while self.registered.len() > self.registered_cap {
+            if let Some(oldest) = self.registered_order.pop_front() {
+                self.registered.remove(&oldest);
+            } else {
+                break;
+            }
+        }
     }
 
     /// Bind a stream op's wire id at send time: move the caller's
@@ -142,9 +165,12 @@ impl WebMediaRegistry {
         if self.bound.contains_key(&wire_id) {
             return;
         }
-        let media = op_id.and_then(|key| self.registered.remove(&key));
+        let media = op_id.map(|key| {
+            self.registered_order.retain(|k| k != &key);
+            self.registered.remove(&key)
+        });
         let mut stream = BoundWebStream::empty();
-        stream.media = media;
+        stream.media = media.flatten();
         self.bound.insert(wire_id, stream);
     }
 
@@ -209,6 +235,7 @@ impl WebMediaRegistry {
             return ProduceOutcome::Events(vec![MediaEvent::SourceFailed { call_id }]);
         };
         let mut events = Vec::new();
+        let start_position = position;
         let mut position = position;
         let mut remaining = up_to;
         while remaining > 0 {
@@ -262,6 +289,15 @@ impl WebMediaRegistry {
             }
             position += read as u64;
             remaining = remaining.saturating_sub(read as u64);
+        }
+        // ONE cumulative `Produced` per grant, never per chunk: a per-chunk
+        // report lets the core enqueue a fresh grant from a partial offset
+        // before this fulfillment returns; the mailbox runtime feeds those
+        // events before draining the new actions, so the stale grant is
+        // fulfilled from the advanced position and DATA goes past the
+        // daemon's `send_through` (the overlapping-grant race, found in
+        // review; protocol §Credit).
+        if position > start_position {
             events.push(MediaEvent::Produced {
                 call_id,
                 sent_through: position,
@@ -469,5 +505,88 @@ fn map_abort_reason_outbound(reason: StreamAbortReason) -> BinaryAbortReason {
         StreamAbortReason::SourceFailed => BinaryAbortReason::SourceFailed,
         StreamAbortReason::SinkFailed => BinaryAbortReason::SinkFailed,
         StreamAbortReason::ProtocolError => BinaryAbortReason::ProtocolError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::media::shared_bytes;
+
+    fn wire_id() -> RequestId {
+        RequestId::new(7).expect("wire id")
+    }
+
+    #[test]
+    fn registered_map_is_bounded_and_evicts_oldest() {
+        // The browser registry mirrors the native one: the cap evicts the
+        // OLDEST outstanding registration; an evicted key's later call binds
+        // an empty entry and fails honestly at produce time.
+        let mut media = WebMediaRegistry::new(1024, 2);
+        let k1 = OpId::new("share-1");
+        let k2 = OpId::new("share-2");
+        let k3 = OpId::new("share-3");
+        media.register(k1.clone(), shared_bytes(vec![1]));
+        media.register(k2, shared_bytes(vec![2]));
+        media.register(k3.clone(), shared_bytes(vec![3]));
+        assert_eq!(media.registered.len(), 2, "the cap holds");
+        // k3 (newest) binds its media; k1 (evicted) binds an empty entry.
+        media.bind(wire_id(), Some(k3));
+        assert!(
+            media
+                .bound
+                .get(&wire_id())
+                .is_some_and(|s| s.media.is_some()),
+            "the newest registration bound its media"
+        );
+        let evicted_id = RequestId::new(8).expect("id");
+        media.bind(evicted_id, Some(k1));
+        assert!(
+            media
+                .bound
+                .get(&evicted_id)
+                .is_some_and(|s| s.media.is_none()),
+            "the evicted registration binds an honestly-failing empty entry"
+        );
+    }
+
+    #[test]
+    fn produce_reports_one_cumulative_progress_event_per_grant() {
+        use crate::kernel::inflight::CallId;
+        use crate::kernel::transport::MediaEvent;
+        // A grant spanning multiple codec-bounded chunks reports ONE
+        // cumulative Produced (the overlapping-grant regression): pin the
+        // count and the final offset with a tight codec bound (one chunk per
+        // record = 8 frame bytes of payload room).
+        let mut media = WebMediaRegistry::new(1024, 8);
+        let key = OpId::new("share-1");
+        media.register(key.clone(), shared_bytes(vec![1, 2, 3, 4, 5, 6]));
+        let id = wire_id();
+        media.bind(id, Some(key));
+        media.adopt_open_stream_id(id, 1);
+        let bounds = CodecBounds::default();
+        let chunk = max_stream_data_bytes(bounds.max_frame_bytes).expect("cap");
+        // Exercise a multi-chunk grant only when the default cap permits
+        // splitting (it is huge); otherwise the single-chunt invariant still
+        // holds trivially.
+        let total = 6_u64;
+        let up_to = total.min(chunk as u64);
+        let events = match media.produce(id, CallId(3), up_to, &bounds, &mut |_| true) {
+            ProduceOutcome::Events(events) => events,
+            ProduceOutcome::Closed => panic!("the send closure never fails here"),
+        };
+        let produced: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, MediaEvent::Produced { .. }))
+            .collect();
+        assert_eq!(
+            produced.len(),
+            1,
+            "exactly ONE cumulative Produced per grant (got {produced:?})"
+        );
+        assert!(matches!(
+            events.last(),
+            Some(MediaEvent::SourceEnd { total: t, .. }) if *t == total
+        ));
     }
 }

--- a/crates/jeliya-client/src/ws_web/mod.rs
+++ b/crates/jeliya-client/src/ws_web/mod.rs
@@ -18,6 +18,7 @@
 //! this slice.
 
 mod diag;
+mod media;
 mod session;
 mod socket;
 mod timers;
@@ -78,7 +79,15 @@ pub fn connect_ws_web(config: WsWebConfig) -> ClientHandle {
     }
 
     let session: Rc<dyn SessionResolver> = Rc::from(config.session);
-    let driver = WsWebDriver::new(config.endpoint, session, config.hello_timeout_ms);
+    // The media registry's inbound quarantine cap follows the kernel's
+    // stream window (captured before `kernel` moves into the runtime).
+    let stream_window_bytes = kernel.streams.stream_window_bytes;
+    let driver = WsWebDriver::new(
+        config.endpoint,
+        session,
+        config.hello_timeout_ms,
+        stream_window_bytes,
+    );
     // `now_tick` reads `performance.now()` transiently; the fn value is
     // `Send + Sync`, so the backend can read the clock fresh on every step.
     let (handle, pump) = crate::kernel::runtime::build(kernel, driver, Box::new(timers::now_tick));

--- a/crates/jeliya-client/src/ws_web/mod.rs
+++ b/crates/jeliya-client/src/ws_web/mod.rs
@@ -80,13 +80,17 @@ pub fn connect_ws_web(config: WsWebConfig) -> ClientHandle {
 
     let session: Rc<dyn SessionResolver> = Rc::from(config.session);
     // The media registry's inbound quarantine cap follows the kernel's
-    // stream window (captured before `kernel` moves into the runtime).
+    // stream window and its outstanding-registration bound the in-flight
+    // limit + margin (mirroring the native adapter's sizing) — both
+    // captured before `kernel` moves into the runtime.
     let stream_window_bytes = kernel.streams.stream_window_bytes;
+    let registered_cap = (kernel.limits.in_flight as usize).saturating_add(64);
     let driver = WsWebDriver::new(
         config.endpoint,
         session,
         config.hello_timeout_ms,
         stream_window_bytes,
+        registered_cap,
     );
     // `now_tick` reads `performance.now()` transiently; the fn value is
     // `Send + Sync`, so the backend can read the clock fresh on every step.

--- a/crates/jeliya-client/src/ws_web/socket.rs
+++ b/crates/jeliya-client/src/ws_web/socket.rs
@@ -138,7 +138,9 @@ struct SocketCtx {
     token: u64,
     /// The storage generation presented at the gate; the `hello` must match it.
     expected_sg: u64,
-    bounds: CodecBounds,
+    /// This connection's decode/media bounds — the compiled ceiling until a
+    /// valid `hello` narrows it to the served `max_frame_bytes`.
+    bounds: Cell<CodecBounds>,
     /// Set once a valid `hello` is seen; flips the message handler to steady
     /// state and disarms the pre-connect failure paths.
     validated: Cell<bool>,
@@ -166,6 +168,7 @@ impl WsWebDriver {
         session: Rc<dyn SessionResolver>,
         hello_timeout_ms: u32,
         stream_window_bytes: u64,
+        registered_cap: usize,
     ) -> Self {
         let config = Rc::new(DialConfig {
             endpoint,
@@ -183,7 +186,7 @@ impl WsWebDriver {
             active_dial_token: None,
             dial_abort: None,
             timers: HashMap::new(),
-            media: WebMediaRegistry::new(stream_window_bytes),
+            media: WebMediaRegistry::new(stream_window_bytes, registered_cap),
         }));
         Self { state, config }
     }
@@ -231,8 +234,15 @@ impl Driver for WsWebDriver {
 
     fn send_record(&mut self, intent: StreamRecordIntent) -> Result<(), TransportClosed> {
         let record = media::intent_record(&intent).ok_or(TransportClosed)?;
-        let framed = jeliya_codec::encode_stream_record(&record, &self.config.bounds)
-            .map_err(|_| TransportClosed)?;
+        let bounds = self
+            .state
+            .borrow()
+            .socket_ctx
+            .as_ref()
+            .map(|ctx| ctx.bounds.get())
+            .unwrap_or(self.config.bounds);
+        let framed =
+            jeliya_codec::encode_stream_record(&record, &bounds).map_err(|_| TransportClosed)?;
         let state = self.state.borrow();
         match &state.socket {
             Some(ws) => ws.send_with_u8_array(&framed).map_err(|_| TransportClosed),
@@ -245,14 +255,20 @@ impl Driver for WsWebDriver {
         let generation = state.generation;
         let outcome = {
             let socket = state.socket.clone();
+            // The live connection's hello-negotiated bounds (the served
+            // `max_frame_bytes`), falling back to the compiled ceiling only
+            // before the first validated connection.
+            let bounds = state
+                .socket_ctx
+                .as_ref()
+                .map(|ctx| ctx.bounds.get())
+                .unwrap_or(self.config.bounds);
             let mut send = |framed: &[u8]| -> bool {
                 socket
                     .as_ref()
                     .is_some_and(|ws| ws.send_with_u8_array(framed).is_ok())
             };
-            state
-                .media
-                .produce(id, call_id, up_to, &self.config.bounds, &mut send)
+            state.media.produce(id, call_id, up_to, &bounds, &mut send)
         };
         match outcome {
             ProduceOutcome::Events(events) => {
@@ -437,7 +453,7 @@ fn wire_socket(
         state: state.clone(),
         token,
         expected_sg: sg,
-        bounds: config.bounds,
+        bounds: std::cell::Cell::new(config.bounds),
         validated: Cell::new(false),
         socket_gen: Cell::new(0),
         signalled_loss: Cell::new(false),
@@ -502,7 +518,7 @@ fn on_first_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
         // A non-text first frame is not a v2 hello.
         return protocol_fail(ctx);
     };
-    match decode_client_frame(text.as_bytes(), &ctx.bounds) {
+    match decode_client_frame(text.as_bytes(), &ctx.bounds.get()) {
         Ok(ClientFrame::Hello(hello)) => {
             if hello.protocol != CLIENT_PROTOCOL {
                 return protocol_fail(ctx);
@@ -519,6 +535,15 @@ fn on_first_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
                 return;
             }
             // Validated: only now is the connection reported to the core.
+            // Adopt the SERVED frame limit for this connection's decode and
+            // media bounds (never larger than the codec's compiled ceiling),
+            // exactly as the native adapter does — a daemon serving a tighter
+            // `max_frame_bytes` must never receive oversized DATA from us.
+            ctx.bounds.set(CodecBounds {
+                max_frame_bytes: (CodecBounds::default().max_frame_bytes as u64)
+                    .min(hello.limits.max_frame_bytes) as usize,
+                ..CodecBounds::default()
+            });
             cancel_hello_deadline(ctx);
             ctx.validated.set(true);
             let mut state = ctx.state.borrow_mut();
@@ -549,7 +574,7 @@ fn on_steady_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
     let generation = ctx.socket_gen.get();
     let data = ev.data();
     let inbound = match data.as_string() {
-        Some(text) => match decode_client_frame(text.as_bytes(), &ctx.bounds) {
+        Some(text) => match decode_client_frame(text.as_bytes(), &ctx.bounds.get()) {
             Ok(ClientFrame::Reply { id, result }) => match RequestId::new(id) {
                 Ok(request_id) => {
                     let reply = match result {
@@ -573,15 +598,34 @@ fn on_steady_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
         },
         // Binary = a byte-stream record (§S3/§S10): staged decode per the
         // codec's documented order — identity, binding lookup, kind, full
-        // structural view — then the byte-free meta reaches the core. A
-        // codec-fatal or unbindable record strands nothing: `Malformed`,
-        // exactly as for text (§K4).
+        // structural view — then the byte-free meta reaches the core, with
+        // refusals routed by the protocol's severity ladder (§Malformed
+        // stream records): stream-local faults abort only their stream;
+        // connection-fatal conditions close the socket carrying the
+        // protocol's code and surface as a transport loss.
         None => match data.dyn_into::<js_sys::ArrayBuffer>() {
             Ok(buffer) => {
                 let bytes = js_sys::Uint8Array::new(&buffer).to_vec();
                 match decode_inbound_stream_record(ctx, &bytes) {
                     Ok(record) => Inbound::Record { generation, record },
-                    Err(()) => Inbound::Malformed,
+                    Err(WebRecordRefusal::StreamLocal(id)) => {
+                        ctx.state
+                            .borrow_mut()
+                            .push(DriverEvent::StreamFault { generation, id });
+                        // Nothing further flows through this handler for the
+                        // faulted record; the core aborts only that stream.
+                        return;
+                    }
+                    Err(WebRecordRefusal::Fatal(code)) => {
+                        // Close the socket carrying the protocol's code
+                        // (best-effort), then surface the loss.
+                        let mut state = ctx.state.borrow_mut();
+                        if let Some(ws) = state.socket.as_ref() {
+                            let _ = ws.close_with_code_and_reason(code, "");
+                        }
+                        state.push(DriverEvent::Interrupted { generation });
+                        return;
+                    }
                 }
             }
             // Neither text nor an ArrayBuffer (a Blob or unknown binary
@@ -599,33 +643,60 @@ fn on_steady_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
     ctx.state.borrow_mut().push(DriverEvent::Inbound(inbound));
 }
 
+/// The severity of a refused inbound Binary record (protocol §Malformed
+/// stream records / §Size and record refusal) — the browser mirror of the
+/// native adapter's classification.
+enum WebRecordRefusal {
+    /// Connection-fatal: `4005` for an over-ceiling message, `4007` for an
+    /// untrustworthy binding or a malformed terminal control. The socket
+    /// closes and the core tears every stream down as `transport_lost`.
+    Fatal(u16),
+    /// Stream-local: a structurally malformed nonterminal DATA/CREDIT on an
+    /// active binding. Only the named stream aborts (`protocol_error`).
+    StreamLocal(RequestId),
+}
+
 /// Decode one inbound Binary message into the byte-free record meta the core
 /// consumes, performing the driver-side media work first (§S3/§S10):
 ///
-/// 1. [`decode_stream_identity`] — codec-fatal (bad magic, short header,
-///    over-ceiling) fails closed as `Malformed`;
-/// 2. the media registry's binding lookup by request id — a record for a
-///    wire id this connection never bound correlates to nothing;
-/// 3. [`decode_stream_kind`] and [`decode_stream_record_view`] — the full
-///    structural decode, still borrowing the payload;
-/// 4. per-kind media work: DATA quarantines its payload (a cap breach is
-///    protocol trouble → `Malformed`) **before** the meta is handed onward,
-///    so the `WriteSink` the meta provokes always finds its bytes buffered.
-///    OPEN spawns nothing — fulfillment on this adapter is single-threaded
-///    and pull-driven by the kernel's `ProduceData` grant.
-///
-/// `Err(())` is the `Inbound::Malformed` signal; the generation tag is the
-/// caller's (this socket's), so the core fences stragglers itself.
-fn decode_inbound_stream_record(ctx: &Rc<SocketCtx>, bytes: &[u8]) -> Result<StreamRecordMeta, ()> {
-    let identity = decode_stream_identity(bytes, &ctx.bounds).map_err(|_| ())?;
+/// 1. [`decode_stream_identity`] — over the frame ceiling is `Fatal(4005)`;
+///    a short header, bad magic, or invalid identity is `Fatal(4007)`;
+/// 2. the media registry's binding lookup by request id — a record with no
+///    trustworthy outstanding binding is `Fatal(4007)`;
+/// 3. [`decode_stream_kind`] — an unknown kind cannot be classified and is
+///    `Fatal(4007)`;
+/// 4. [`decode_stream_record_view`] — a malformed daemon OPEN/END/ABORT/ACK
+///    is `Fatal(4007)` (a terminal/binding failure); a malformed nonterminal
+///    DATA/CREDIT on the active binding is `StreamLocal`;
+/// 5. per-kind media work: DATA quarantines its payload (a cap breach or
+///    discontinuity is a credit/offset violation → `StreamLocal`) **before**
+///    the meta is handed onward, so the `WriteSink` the meta provokes always
+///    finds its bytes buffered. OPEN spawns nothing — fulfillment on this
+///    adapter is single-threaded and pull-driven by the kernel's
+///    `ProduceData` grant.
+fn decode_inbound_stream_record(
+    ctx: &Rc<SocketCtx>,
+    bytes: &[u8],
+) -> Result<StreamRecordMeta, WebRecordRefusal> {
+    let identity =
+        decode_stream_identity(bytes, &ctx.bounds.get()).map_err(|error| match error {
+            jeliya_codec::StreamCodecError::FrameTooLarge { .. } => WebRecordRefusal::Fatal(4005),
+            _ => WebRecordRefusal::Fatal(4007),
+        })?;
     let wire_id = identity.request_id();
     let stream_id = identity.stream_id().get();
     let mut state = ctx.state.borrow_mut();
     if !state.media.is_bound(wire_id) {
-        return Err(());
+        return Err(WebRecordRefusal::Fatal(4007));
     }
-    decode_stream_kind(bytes, &ctx.bounds).map_err(|_| ())?;
-    let view = decode_stream_record_view(bytes, &ctx.bounds).map_err(|_| ())?;
+    let kind =
+        decode_stream_kind(bytes, &ctx.bounds.get()).map_err(|_| WebRecordRefusal::Fatal(4007))?;
+    let view = decode_stream_record_view(bytes, &ctx.bounds.get()).map_err(|_| match kind {
+        jeliya_codec::StreamRecordKind::Data | jeliya_codec::StreamRecordKind::Credit => {
+            WebRecordRefusal::StreamLocal(wire_id)
+        }
+        _ => WebRecordRefusal::Fatal(4007),
+    })?;
     let record = match view.body {
         StreamRecordBodyView::Open { total } => {
             // Adopt the daemon's stream id BEFORE the meta reaches the core:
@@ -639,7 +710,9 @@ fn decode_inbound_stream_record(ctx: &Rc<SocketCtx>, bytes: &[u8]) -> Result<Str
         }
         StreamRecordBodyView::Data { offset, payload } => {
             if !state.media.deliver_data(wire_id, offset, payload) {
-                return Err(());
+                // A cap breach or offset discontinuity on a bound stream is
+                // a credit/offset violation: stream-local, never fatal.
+                return Err(WebRecordRefusal::StreamLocal(wire_id));
             }
             StreamRecordMeta::Data {
                 id: wire_id,

--- a/crates/jeliya-client/src/ws_web/socket.rs
+++ b/crates/jeliya-client/src/ws_web/socket.rs
@@ -627,11 +627,16 @@ fn decode_inbound_stream_record(ctx: &Rc<SocketCtx>, bytes: &[u8]) -> Result<Str
     decode_stream_kind(bytes, &ctx.bounds).map_err(|_| ())?;
     let view = decode_stream_record_view(bytes, &ctx.bounds).map_err(|_| ())?;
     let record = match view.body {
-        StreamRecordBodyView::Open { total } => StreamRecordMeta::Open {
-            id: wire_id,
-            stream_id,
-            total,
-        },
+        StreamRecordBodyView::Open { total } => {
+            // Adopt the daemon's stream id BEFORE the meta reaches the core:
+            // outbound DATA frames must carry the pair the daemon authored.
+            state.media.adopt_open_stream_id(wire_id, stream_id);
+            StreamRecordMeta::Open {
+                id: wire_id,
+                stream_id,
+                total,
+            }
+        }
         StreamRecordBodyView::Data { offset, payload } => {
             if !state.media.deliver_data(wire_id, offset, payload) {
                 return Err(());

--- a/crates/jeliya-client/src/ws_web/socket.rs
+++ b/crates/jeliya-client/src/ws_web/socket.rs
@@ -13,20 +13,27 @@ use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
-use jeliya_api::RequestId;
-use jeliya_codec::{decode_client_frame, encode_request, ClientFrame, CodecBounds};
+use jeliya_api::{OpId, RequestId};
+use jeliya_codec::{
+    decode_client_frame, decode_stream_identity, decode_stream_kind, decode_stream_record_view,
+    encode_request, ClientFrame, CodecBounds, StreamRecordBodyView,
+};
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{AbortController, BinaryType, CloseEvent, Event, MessageEvent, WebSocket};
 
 use crate::backend::RawJson;
+use crate::kernel::inflight::CallId;
 use crate::kernel::timing::{Tick, TimerId};
 use crate::kernel::transport::{
-    Driver, DriverEvent, Inbound, TransportClosed, WireFrame, WireReply,
+    Driver, DriverEvent, Inbound, MediaEvent, StreamRecordIntent, StreamRecordMeta,
+    TransportClosed, WireFrame, WireReply,
 };
+use crate::media::StreamMedia;
 
 use super::diag::RedactedUrl;
+use super::media::{self, ProduceOutcome, WebMediaRegistry};
 use super::session::{Endpoint, SessionResolver};
 use super::{session, timers};
 
@@ -80,6 +87,12 @@ struct DriverState {
     dial_abort: Option<AbortController>,
     /// Armed kernel timers, keyed by [`TimerId`].
     timers: HashMap<TimerId, KernelTimer>,
+    /// The byte-stream media registry (§S3): registered caller media,
+    /// per-stream bound state, and the inbound quarantine buffers. Lives in
+    /// this one `RefCell` so every access — send-bind, produce grant, sink
+    /// hand-off, message decode, teardown — is serialized on the single
+    /// thread.
+    media: WebMediaRegistry,
 }
 
 impl DriverState {
@@ -94,7 +107,10 @@ impl DriverState {
 
     /// Detach and drop the current socket, its callbacks, its context, and any
     /// in-flight dial fetch. Called only from the pump (`dial`/`cancel_dial`),
-    /// so no callback is dropped while it is executing.
+    /// so no callback is dropped while it is executing. The connection's
+    /// bound media dies with it — a stream never survives its connection
+    /// (§S10); caller registrations survive to bind on the next connection's
+    /// sends.
     fn teardown_socket(&mut self) {
         if let Some(ws) = self.socket.take() {
             ws.set_onopen(None);
@@ -112,6 +128,7 @@ impl DriverState {
         if let Some(abort) = self.dial_abort.take() {
             abort.abort();
         }
+        self.media.clear();
     }
 }
 
@@ -140,12 +157,15 @@ pub(crate) struct WsWebDriver {
 }
 
 impl WsWebDriver {
-    /// Build a driver over `endpoint`, obtaining credentials via `session` and
-    /// bounding the wait for a valid `hello` by `hello_timeout_ms`.
+    /// Build a driver over `endpoint`, obtaining credentials via `session`,
+    /// bounding the wait for a valid `hello` by `hello_timeout_ms`, and
+    /// bounding the media registry's inbound quarantine by the kernel's
+    /// `stream_window_bytes`.
     pub(crate) fn new(
         endpoint: Endpoint,
         session: Rc<dyn SessionResolver>,
         hello_timeout_ms: u32,
+        stream_window_bytes: u64,
     ) -> Self {
         let config = Rc::new(DialConfig {
             endpoint,
@@ -163,6 +183,7 @@ impl WsWebDriver {
             active_dial_token: None,
             dial_abort: None,
             timers: HashMap::new(),
+            media: WebMediaRegistry::new(stream_window_bytes),
         }));
         Self { state, config }
     }
@@ -188,11 +209,71 @@ impl Driver for WsWebDriver {
             frame.input.as_str(),
         );
         let text = String::from_utf8(bytes).map_err(|_| TransportClosed)?;
-        let state = self.state.borrow();
+        let mut state = self.state.borrow_mut();
+        // A stream op's send binds its wire id to the caller's registered
+        // media (§S3 media seam): the op id the caller deduped under is the
+        // only key both sides share, and the wire id is the only key the
+        // media effects later arrive with.
+        if crate::kernel::replay::is_stream_op(frame.op) {
+            state.media.bind(frame.id, frame.op_id);
+        }
         match &state.socket {
             Some(ws) => ws.send_with_str(&text).map_err(|_| TransportClosed),
             None => Err(TransportClosed),
         }
+    }
+
+    fn media_event(&mut self, event: MediaEvent) {
+        // Same queue `poll_event` drains: media results keep their order
+        // relative to transport events.
+        self.state.borrow_mut().push(DriverEvent::Media(event));
+    }
+
+    fn send_record(&mut self, intent: StreamRecordIntent) -> Result<(), TransportClosed> {
+        let record = media::intent_record(&intent).ok_or(TransportClosed)?;
+        let framed = jeliya_codec::encode_stream_record(&record, &self.config.bounds)
+            .map_err(|_| TransportClosed)?;
+        let state = self.state.borrow();
+        match &state.socket {
+            Some(ws) => ws.send_with_u8_array(&framed).map_err(|_| TransportClosed),
+            None => Err(TransportClosed),
+        }
+    }
+
+    fn produce(&mut self, id: RequestId, call_id: CallId, up_to: u64) {
+        let mut state = self.state.borrow_mut();
+        let generation = state.generation;
+        let outcome = {
+            let socket = state.socket.clone();
+            let mut send = |framed: &[u8]| -> bool {
+                socket
+                    .as_ref()
+                    .is_some_and(|ws| ws.send_with_u8_array(framed).is_ok())
+            };
+            state
+                .media
+                .produce(id, call_id, up_to, &self.config.bounds, &mut send)
+        };
+        match outcome {
+            ProduceOutcome::Events(events) => {
+                for event in events {
+                    state.push(DriverEvent::Media(event));
+                }
+            }
+            // The socket refused a DATA frame mid-grant: a connection loss,
+            // reported on the generation the broken transport was on.
+            ProduceOutcome::Closed => state.push(DriverEvent::Interrupted { generation }),
+        }
+    }
+
+    fn write_sink(&mut self, id: RequestId, call_id: CallId, offset: u64, len: u64) {
+        let mut state = self.state.borrow_mut();
+        let event = state.media.write_sink(id, call_id, offset, len);
+        state.push(DriverEvent::Media(event));
+    }
+
+    fn register_media(&mut self, key: OpId, media: StreamMedia) {
+        self.state.borrow_mut().media.register(key, media);
     }
 
     fn dial(&mut self, token: u64) {
@@ -466,7 +547,8 @@ fn on_first_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
 /// Steady-state frames, tagged with this socket's generation-at-connect.
 fn on_steady_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
     let generation = ctx.socket_gen.get();
-    let inbound = match ev.data().as_string() {
+    let data = ev.data();
+    let inbound = match data.as_string() {
         Some(text) => match decode_client_frame(text.as_bytes(), &ctx.bounds) {
             Ok(ClientFrame::Reply { id, result }) => match RequestId::new(id) {
                 Ok(request_id) => {
@@ -489,11 +571,108 @@ fn on_steady_message(ctx: &Rc<SocketCtx>, ev: MessageEvent) {
                 Inbound::Malformed
             }
         },
-        // A Binary frame (byte-stream media) is out of #171's scope; drop it
-        // safely — the core discards a Malformed inbound and never panics.
-        None => Inbound::Malformed,
+        // Binary = a byte-stream record (§S3/§S10): staged decode per the
+        // codec's documented order — identity, binding lookup, kind, full
+        // structural view — then the byte-free meta reaches the core. A
+        // codec-fatal or unbindable record strands nothing: `Malformed`,
+        // exactly as for text (§K4).
+        None => match data.dyn_into::<js_sys::ArrayBuffer>() {
+            Ok(buffer) => {
+                let bytes = js_sys::Uint8Array::new(&buffer).to_vec();
+                match decode_inbound_stream_record(ctx, &bytes) {
+                    Ok(record) => Inbound::Record { generation, record },
+                    Err(()) => Inbound::Malformed,
+                }
+            }
+            // Neither text nor an ArrayBuffer (a Blob or unknown binary
+            // type): the socket was opened with `binaryType = "arraybuffer"`,
+            // so this correlates to nothing.
+            Err(_) => Inbound::Malformed,
+        },
     };
+    // A stream's terminal reply prunes its media state (quarantine buffer)
+    // before the reply meta reaches the core — cheap when the id binds no
+    // stream (§S10 retire-on-reply).
+    if let Inbound::Reply { id, .. } = &inbound {
+        ctx.state.borrow_mut().media.prune(*id);
+    }
     ctx.state.borrow_mut().push(DriverEvent::Inbound(inbound));
+}
+
+/// Decode one inbound Binary message into the byte-free record meta the core
+/// consumes, performing the driver-side media work first (§S3/§S10):
+///
+/// 1. [`decode_stream_identity`] — codec-fatal (bad magic, short header,
+///    over-ceiling) fails closed as `Malformed`;
+/// 2. the media registry's binding lookup by request id — a record for a
+///    wire id this connection never bound correlates to nothing;
+/// 3. [`decode_stream_kind`] and [`decode_stream_record_view`] — the full
+///    structural decode, still borrowing the payload;
+/// 4. per-kind media work: DATA quarantines its payload (a cap breach is
+///    protocol trouble → `Malformed`) **before** the meta is handed onward,
+///    so the `WriteSink` the meta provokes always finds its bytes buffered.
+///    OPEN spawns nothing — fulfillment on this adapter is single-threaded
+///    and pull-driven by the kernel's `ProduceData` grant.
+///
+/// `Err(())` is the `Inbound::Malformed` signal; the generation tag is the
+/// caller's (this socket's), so the core fences stragglers itself.
+fn decode_inbound_stream_record(ctx: &Rc<SocketCtx>, bytes: &[u8]) -> Result<StreamRecordMeta, ()> {
+    let identity = decode_stream_identity(bytes, &ctx.bounds).map_err(|_| ())?;
+    let wire_id = identity.request_id();
+    let stream_id = identity.stream_id().get();
+    let mut state = ctx.state.borrow_mut();
+    if !state.media.is_bound(wire_id) {
+        return Err(());
+    }
+    decode_stream_kind(bytes, &ctx.bounds).map_err(|_| ())?;
+    let view = decode_stream_record_view(bytes, &ctx.bounds).map_err(|_| ())?;
+    let record = match view.body {
+        StreamRecordBodyView::Open { total } => StreamRecordMeta::Open {
+            id: wire_id,
+            stream_id,
+            total,
+        },
+        StreamRecordBodyView::Data { offset, payload } => {
+            if !state.media.deliver_data(wire_id, offset, payload) {
+                return Err(());
+            }
+            StreamRecordMeta::Data {
+                id: wire_id,
+                stream_id,
+                offset,
+                len: payload.len() as u64,
+            }
+        }
+        StreamRecordBodyView::Credit {
+            accepted_through,
+            send_through,
+        } => StreamRecordMeta::Credit {
+            id: wire_id,
+            stream_id,
+            accepted_through,
+            send_through,
+        },
+        StreamRecordBodyView::End { total } => StreamRecordMeta::End {
+            id: wire_id,
+            stream_id,
+            offset: total,
+        },
+        StreamRecordBodyView::Abort {
+            accepted_through,
+            reason,
+        } => StreamRecordMeta::Abort {
+            id: wire_id,
+            stream_id,
+            high_water: accepted_through,
+            reason: media::map_abort_reason(reason),
+        },
+        StreamRecordBodyView::Ack { accepted_through } => StreamRecordMeta::Ack {
+            id: wire_id,
+            stream_id,
+            high_water: accepted_through,
+        },
+    };
+    Ok(record)
 }
 
 /// A first frame that is not a well-formed `hello`: terminal, token-fenced.
@@ -520,6 +699,10 @@ fn handle_loss(ctx: &Rc<SocketCtx>, code: Option<u16>) {
     let mut state = ctx.state.borrow_mut();
     if ctx.validated.get() {
         let generation = ctx.socket_gen.get();
+        // The connection's bound media dies with it — a stream never survives
+        // its connection (§S10), mirroring the core's own drain on
+        // `Interrupted`. Registrations survive to bind on the reconnect.
+        state.media.clear();
         state.push(DriverEvent::Interrupted { generation });
     } else {
         if state.active_dial_token != Some(ctx.token) {

--- a/crates/jeliya-client/tests/kernel_stream.rs
+++ b/crates/jeliya-client/tests/kernel_stream.rs
@@ -238,3 +238,114 @@ fn file_read_receiver_reports_terminal_acceptance_credit() {
     assert_eq!(controller.stream_timers(), 0, "no stream timer survives");
     assert_eq!(controller.outstanding(), 0, "the call is fully settled");
 }
+
+/// The zero-byte producer handshake (§4/§S4): a `file.share` with
+/// `declared_bytes == 0` must still observe its (empty) source and emit the
+/// mandatory END(0). Without the zero-length grant the driver never touches
+/// the source, `SourceEnd{0}` never arrives, and the call stalls to timeout —
+/// exactly the failure the review found. The daemon's mandatory probe
+/// (`send_through = declared+1 = 1`) scripts the credit side.
+#[test]
+fn file_share_zero_byte_producer_reaches_end_zero() {
+    let (handle, controller) = ready();
+    block_on(async {
+        let fut = handle.call_stream::<FileShare>(
+            FileShare {
+                room_id: RoomId::new("r1"),
+                name: String::from("empty.bin"),
+                declared_bytes: 0,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::None,
+        );
+        let sent = controller.take_outbound();
+        assert_eq!(sent.len(), 1);
+        let wire = sent[0].id;
+
+        // OPEN admits a zero-byte stream. A conforming daemon MUST credit the
+        // probe byte (send_through = declared+1 = 1), whose zero-byte read
+        // observes EOF on its own; script the HARDER case — a daemon that
+        // sends CREDIT(0,0) instead — which stalls unless the kernel grants
+        // the empty source a zero-length read.
+        controller.open(wire, 0);
+        controller.credit(wire, 0, 0);
+
+        // The driver observed the empty source (the zero-length grant) and
+        // END(0) followed — no DATA ever, END exactly once at offset zero.
+        let records = controller.take_outbound_records();
+        assert!(
+            records.iter().all(|r| r.kind != "data"),
+            "an empty source never frames DATA"
+        );
+        let ends: Vec<_> = records.iter().filter(|r| r.kind == "end").collect();
+        assert_eq!(ends.len(), 1, "exactly one END");
+        assert_eq!(ends[0].a, 0, "END at offset zero");
+
+        controller.deliver_reply(
+            wire,
+            "{\"room_id\":\"r1\",\"file_id\":\"f0\",\"event_id\":\"e1\",\"pos\":0,\"bytes\":0,\"digest\":\"d\"}",
+        );
+        let out: FileShareOut = fut.await.expect("zero-byte share resolves terminal");
+        assert_eq!(out.bytes, 0);
+    });
+    assert_eq!(controller.streams(), 0, "stream retired after END(0)");
+    assert_eq!(controller.outstanding(), 0, "call fully settled");
+}
+
+/// A driver-detected structural fault (malformed nonterminal DATA/CREDIT on an
+/// active binding) aborts ONLY that stream with `protocol_error` (§Malformed
+/// stream records): the faulted call settles, a concurrent ordinary request
+/// is untouched, and the outbound records carry the ABORT.
+#[test]
+fn stream_fault_aborts_only_the_faulted_stream() {
+    let (handle, controller) = ready();
+    block_on(async {
+        let stream_fut = handle.call_stream::<FileShare>(
+            FileShare {
+                room_id: RoomId::new("r1"),
+                name: String::from("a.bin"),
+                declared_bytes: 200,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::None,
+        );
+        let sent = controller.take_outbound();
+        let wire = sent[0].id;
+        controller.open(wire, 200);
+        controller.credit(wire, 0, 200);
+
+        // A concurrent ordinary request on the same connection.
+        let plain_fut = handle.call::<jeliya_api::RoomList>(jeliya_api::RoomList {}, Dedup::None);
+        let plain_wire = controller.take_outbound()[0].id;
+
+        // The driver refuses a structurally malformed DATA/CREDIT for the
+        // stream: only that stream aborts (protocol_error), the connection
+        // and the plain request survive.
+        controller.stream_fault(wire);
+        let records = controller.take_outbound_records();
+        let aborts: Vec<_> = records.iter().filter(|r| r.kind == "abort").collect();
+        assert_eq!(aborts.len(), 1, "exactly one ABORT for the faulted stream");
+
+        // The plain request still completes normally afterwards.
+        controller.deliver_reply(plain_wire, "{\"rooms\":[]}");
+        let list = plain_fut.await.expect("the ordinary request survives");
+        assert!(list.rooms.is_empty());
+
+        // The faulted stream's terminal settles honestly (the kernel's
+        // Timeout classification for a stream fault), never a hang.
+        let stream_err = stream_fut.await.expect_err("the faulted stream fails");
+        assert!(
+            matches!(
+                stream_err,
+                jeliya_client::CallError::Timeout
+                    | jeliya_client::CallError::Cancelled { .. }
+                    | jeliya_client::CallError::Wire(_)
+            ),
+            "a classified terminal, got {stream_err:?}"
+        );
+        // The aborted stream lingers ONLY as a bounded tombstone (§S10), the
+        // same convention as the cancel fault tests: drain_all reclaims it.
+        controller.interrupt();
+    });
+    assert_eq!(controller.streams(), 0, "the tombstone collapsed on ACK");
+}

--- a/crates/jeliya-client/tests/kernel_stream.rs
+++ b/crates/jeliya-client/tests/kernel_stream.rs
@@ -169,3 +169,72 @@ fn file_read_receiver_drives_full_lifecycle() {
     assert_eq!(controller.stream_timers(), 0, "no stream timer survives");
     assert_eq!(controller.outstanding(), 0, "the call is fully settled");
 }
+
+/// The receiver's terminal acceptance CREDIT (protocol §Credit/END): "the
+/// producer sends END only after every DATA byte it sent has been acknowledged
+/// by CREDIT" — for `file.read` the daemon is the producer, and it may END
+/// only once the client reports `accepted_through == total`. The client's
+/// credit ceiling is capped at `total`, so once the opening window covers the
+/// whole file the window can never EXTEND again — the acceptance report is
+/// itself the reason to send the final CREDIT, not a window extension.
+///
+/// Found live: against a real jeliyad, a 64 KiB `file.read` (window 1 MiB)
+/// received every DATA byte, sink-accepted all of them, and then stalled —
+/// the daemon's `ready_for_end` waits for the acknowledgement this test
+/// pins. The deterministic rig scripted END unconditionally, so the gap was
+/// invisible until the live daemon.
+#[test]
+fn file_read_receiver_reports_terminal_acceptance_credit() {
+    let (handle, controller) = ready();
+    block_on(async {
+        let fut = handle.call_stream::<FileRead>(
+            FileRead {
+                room_id: RoomId::new("r1"),
+                file_id: FileId::new("f1"),
+            },
+            Dedup::None,
+        );
+        let sent = controller.take_outbound();
+        let wire = sent[0].id;
+
+        // Default window (1 MiB) covers the whole 300-byte file: the opening
+        // CREDIT already grants send_through = total.
+        controller.open(wire, 300);
+        let opening: Vec<_> = controller
+            .take_outbound_records()
+            .into_iter()
+            .filter(|r| r.kind == "credit")
+            .collect();
+        assert!(!opening.is_empty(), "the opening credit is granted");
+        assert!(
+            opening.iter().all(|r| r.b <= 300),
+            "credit within the total"
+        );
+
+        // All bytes arrive and are sink-accepted. The terminal CREDIT must
+        // now report accepted_through == total (300) — even though the
+        // window cannot extend past the total — or a live producer has no
+        // permission path to END and the stream stalls to timeout.
+        controller.deliver_data(wire, 0, 300);
+        let after_data: Vec<_> = controller
+            .take_outbound_records()
+            .into_iter()
+            .filter(|r| r.kind == "credit")
+            .collect();
+        assert!(
+            after_data.iter().any(|r| r.a == 300),
+            "the terminal acceptance CREDIT reports accepted_through == total; got {after_data:?}"
+        );
+
+        controller.end(wire, 300);
+        controller.deliver_reply(
+            wire,
+            "{\"room_id\":\"r1\",\"file_id\":\"f1\",\"bytes\":300,\"declared_content_type\":\"application/octet-stream\"}",
+        );
+        let out: FileReadOut = fut.await.expect("terminal reply resolves the stream");
+        assert_eq!(out.bytes, 300);
+    });
+    assert_eq!(controller.streams(), 0, "the stream is fully retired");
+    assert_eq!(controller.stream_timers(), 0, "no stream timer survives");
+    assert_eq!(controller.outstanding(), 0, "the call is fully settled");
+}

--- a/crates/jeliya-client/tests/live_native_probe.rs
+++ b/crates/jeliya-client/tests/live_native_probe.rs
@@ -11,7 +11,8 @@
 //! (`resource:fetched_file` is "unestablishable single-subject"). Two daemons
 //! is the honest minimum for a live round trip.
 //!
-//! Run (both daemons in `--loopback`):
+//! Run (both daemons WITHOUT `--loopback` — RealNetwork mode: the invited
+//! join dials the minter via discovery, which loopback mode cannot do):
 //!   JELIYAD_PROBE_URL=ws://127.0.0.1:P1/ws JELIYAD_PROBE_HTTP=http://127.0.0.1:P1 \
 //!   JELIYAD_PROBE_TOKEN=... JELIYAD_PROBE2_URL=ws://127.0.0.1:P2/ws \
 //!   JELIYAD_PROBE2_HTTP=http://127.0.0.1:P2 JELIYAD_PROBE2_TOKEN=... \

--- a/crates/jeliya-client/tests/live_native_probe.rs
+++ b/crates/jeliya-client/tests/live_native_probe.rs
@@ -1,0 +1,262 @@
+//! Live probe: the full two-daemon byte-stream matrix against running
+//! jeliyad instances. Daemon A receives a streamed `file.share` (real upload
+//! over the socket); daemon B — a second, invited daemon — `file.fetch`es the
+//! file from A (real p2p provider transfer) and streams it back out via
+//! `file.read` (real download over the socket). The collected bytes are
+//! asserted byte-for-byte against the uploaded pattern.
+//!
+//! `file.read` serves only locally-held bytes and a daemon never fetches from
+//! itself (supervisor fetch excludes `self_device`), so single-daemon
+//! read-back is impossible BY DESIGN — the corpus records the same
+//! (`resource:fetched_file` is "unestablishable single-subject"). Two daemons
+//! is the honest minimum for a live round trip.
+//!
+//! Run (both daemons in `--loopback`):
+//!   JELIYAD_PROBE_URL=ws://127.0.0.1:P1/ws JELIYAD_PROBE_HTTP=http://127.0.0.1:P1 \
+//!   JELIYAD_PROBE_TOKEN=... JELIYAD_PROBE2_URL=ws://127.0.0.1:P2/ws \
+//!   JELIYAD_PROBE2_HTTP=http://127.0.0.1:P2 JELIYAD_PROBE2_TOKEN=... \
+//!   cargo test -p jeliya-client --features ws-native --test live_native_probe \
+//!     -- --nocapture --ignored
+
+use futures::StreamExt;
+use jeliya_api::{
+    FileFetch, FileRead, FileShare, InviteMint, InviteRedeem, RoomActivate, RoomCreate,
+    SubjectEnsure,
+};
+use jeliya_client::{media, Dedup, State};
+
+/// One live daemon connection: URL pieces + a connected, Ready handle.
+struct Endpoint {
+    url: String,
+    http: String,
+    token: String,
+    sg: u64,
+}
+
+impl Endpoint {
+    fn from_env(prefix: &str) -> Self {
+        Self {
+            url: std::env::var(format!("{prefix}_URL")).expect("url env"),
+            http: std::env::var(format!("{prefix}_HTTP")).expect("http env"),
+            token: std::env::var(format!("{prefix}_TOKEN")).expect("token env"),
+            sg: 0,
+        }
+    }
+
+    async fn health_sg(&self) -> u64 {
+        let health = std::process::Command::new("curl")
+            .arg("-s")
+            .arg(format!("{}/api/health", self.http))
+            .output()
+            .expect("curl health")
+            .stdout;
+        let health: serde_json::Value = serde_json::from_slice(&health).expect("health json");
+        health["storage_generation"].as_u64().expect("sg")
+    }
+
+    async fn connect(&mut self) -> jeliya_client::ClientHandle {
+        self.sg = self.health_sg().await;
+        struct Fixed {
+            url: String,
+            token: String,
+            sg: u64,
+        }
+        impl jeliya_client::TargetSource for Fixed {
+            fn resolve(
+                &self,
+            ) -> futures::future::BoxFuture<
+                'static,
+                Result<jeliya_client::Dial, jeliya_client::DialResolveError>,
+            > {
+                let url =
+                    url::Url::parse(&format!("{}?v=2&sg={}", self.url, self.sg)).expect("url");
+                let dial = jeliya_client::Dial {
+                    url,
+                    bearer: jeliya_supervisor::Redacted::new(self.token.clone()),
+                };
+                Box::pin(async move { Ok(dial) })
+            }
+        }
+        let handle = jeliya_client::connect_ws_native(
+            Fixed {
+                url: self.url.clone(),
+                token: self.token.clone(),
+                sg: self.sg,
+            },
+            jeliya_client::NativeClientConfig::default(),
+        )
+        .expect("connect");
+        let mut sub = handle.subscribe();
+        handle.start();
+        loop {
+            let ev = sub.next().await.expect("event");
+            if let jeliya_client::ClientEvent::StateChanged { to, .. } = ev {
+                eprintln!("  state -> {to:?}");
+                if to == State::Ready {
+                    break;
+                }
+                if to == State::Failed {
+                    panic!("daemon connection failed");
+                }
+            }
+        }
+        handle
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn two_daemon_share_fetch_read_roundtrip_live() {
+    let mut a = Endpoint::from_env("JELIYAD_PROBE");
+    let mut b = Endpoint::from_env("JELIYAD_PROBE2");
+
+    eprintln!("connecting daemon A (sharer)…");
+    let ha = a.connect().await;
+    eprintln!("connecting daemon B (reader)…");
+    let hb = b.connect().await;
+
+    // A: subject + live room.
+    let _ = ha
+        .call::<SubjectEnsure>(SubjectEnsure {}, Dedup::None)
+        .await
+        .expect("A subject.ensure");
+    let room = ha
+        .call::<RoomCreate>(
+            RoomCreate {
+                name: String::from("native-two-daemon-probe"),
+            },
+            Dedup::None,
+        )
+        .await
+        .expect("A room.create");
+    let room_id = room.room_id;
+    ha.call::<RoomActivate>(
+        RoomActivate {
+            room_id: room_id.clone(),
+        },
+        Dedup::None,
+    )
+    .await
+    .expect("A room.activate");
+
+    // B's subject, then A mints an invite bound to it and B redeems.
+    let subject_b = hb
+        .call::<SubjectEnsure>(SubjectEnsure {}, Dedup::None)
+        .await
+        .expect("B subject.ensure")
+        .subject_id;
+    let minted = ha
+        .call::<InviteMint>(
+            InviteMint {
+                room_id: room_id.clone(),
+                subject_id: subject_b,
+                role: jeliya_api::Role::Member,
+                expires_at: jeliya_api::Timestamp::new(
+                    time::OffsetDateTime::now_utc().saturating_add(time::Duration::hours(1)),
+                ),
+            },
+            Dedup::None,
+        )
+        .await
+        .expect("A invite.mint");
+    hb.call::<InviteRedeem>(
+        InviteRedeem {
+            capability: minted.capability,
+        },
+        Dedup::None,
+    )
+    .await
+    .expect("B invite.redeem");
+    eprintln!("B joined the room");
+    // B activates its copy of the room (the live session both daemons serve).
+    hb.call::<RoomActivate>(
+        RoomActivate {
+            room_id: room_id.clone(),
+        },
+        Dedup::None,
+    )
+    .await
+    .expect("B room.activate");
+
+    // The streamed share on A: 64 KiB of pattern (bigger than one DATA chunk).
+    let pattern: Vec<u8> = (0..65_536usize)
+        .map(|i| ((i * 11 + 5) % 256) as u8)
+        .collect();
+    let share_op = jeliya_api::OpId::new("native-two-daemon-share-1");
+    ha.register_stream_media(share_op.clone(), media::shared_bytes(pattern.clone()))
+        .expect("register share source");
+    let shared = ha
+        .call_stream::<FileShare>(
+            FileShare {
+                room_id: room_id.clone(),
+                name: String::from("roundtrip.bin"),
+                declared_bytes: pattern.len() as u64,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::Key(share_op),
+        )
+        .await
+        .expect("the streamed file.share resolves against live daemon A");
+    eprintln!("A accepted the share ({} bytes)", shared.bytes);
+    assert_eq!(shared.bytes, pattern.len() as u64);
+
+    // B fetches from provider A (bounded wait: the room session must sync the
+    // signed file_shared event from A and connect the two daemons; until then
+    // the file is unknown/unfetchable on B).
+    let mut fetched = false;
+    for attempt in 0..120 {
+        match hb
+            .call::<FileFetch>(
+                FileFetch {
+                    room_id: room_id.clone(),
+                    file_id: shared.file_id.clone(),
+                },
+                Dedup::None,
+            )
+            .await
+        {
+            Ok(out) => {
+                eprintln!("B fetched {} bytes from the provider", out.bytes);
+                assert_eq!(out.bytes, pattern.len() as u64);
+                fetched = true;
+                break;
+            }
+            Err(err) => {
+                eprintln!("fetch attempt {attempt}: {err:?}");
+                tokio::time::sleep(std::time::Duration::from_millis(2_000)).await;
+            }
+        }
+    }
+    assert!(fetched, "B must fetch the file from provider A");
+
+    // B reads the bytes back over its own socket.
+    let (sink, sink_media) = media::collected_bytes();
+    let read_op = jeliya_api::OpId::new("native-two-daemon-read-1");
+    hb.register_stream_media(read_op.clone(), sink_media)
+        .expect("register read sink");
+    let header = hb
+        .call_stream::<FileRead>(
+            FileRead {
+                room_id: room_id.clone(),
+                file_id: shared.file_id.clone(),
+            },
+            Dedup::Key(read_op),
+        )
+        .await
+        .expect("the streamed file.read resolves against live daemon B");
+    let collected = sink.take();
+    eprintln!(
+        "B streamed {} bytes back (header says {})",
+        collected.len(),
+        header.bytes
+    );
+    assert_eq!(header.bytes, pattern.len() as u64);
+    assert_eq!(
+        collected, pattern,
+        "the bytes B read over the socket are exactly the bytes A accepted"
+    );
+    eprintln!("TWO-DAEMON ROUND TRIP OK ({} bytes)", collected.len());
+
+    ha.stop().await;
+    hb.stop().await;
+}

--- a/crates/jeliya-client/tests/ws_native_adapter.rs
+++ b/crates/jeliya-client/tests/ws_native_adapter.rs
@@ -945,3 +945,376 @@ fn unregistered_stream_aborts_honestly_with_an_on_wire_abort() {
         server.abort();
     });
 }
+
+// ---------------------------------------------------------------------------
+// Review-driven conformance: overlapping grants, and the malformed-record
+// severity ladder (protocol §Malformed stream records / §Size and record
+// refusal)
+// ---------------------------------------------------------------------------
+
+/// A staircase-credit upload whose grant spans MULTIPLE DATA chunks: every
+/// chunk after the first would, under a per-chunk `Produced` report, let the
+/// kernel pump a fresh grant while the media task is still consuming the
+/// current one — the stale grant is then fulfilled from the advanced
+/// position and DATA goes past the daemon's `send_through`. The regression:
+/// the window is pinned BELOW the total, credit arrives staircase-fashion,
+/// and every received DATA record must satisfy `offset + len <= send_through`
+/// granted so far.
+#[test]
+fn multi_chunk_grants_never_overshoot_the_granted_credit() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        // 150_000 bytes against a 70_000-byte window: each grant spans more
+        // than one 65_536-byte DATA chunk, so the per-chunk race is live.
+        let payload: Vec<u8> = (0..150_000_u32).map(|i| (i % 199) as u8).collect();
+        let expected = payload.clone();
+        let window: u64 = 70_000;
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, input) = read_request(&mut ws).await;
+            assert_eq!(op, "file.share");
+            let total = input["declared_bytes"].as_u64().expect("declared_bytes");
+
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            let bounds = CodecBounds::default();
+            ws.send(frame(identity, StreamRecordBody::Open { total }))
+                .await
+                .expect("OPEN");
+
+            // Staircase: credit exactly one window at a time, acknowledging
+            // only what has actually arrived.
+            let mut received: u64 = 0;
+            let mut send_through: u64 = 0;
+            while received < total {
+                let next = (send_through + window).min(total);
+                ws.send(frame(
+                    identity,
+                    StreamRecordBody::Credit {
+                        accepted_through: received,
+                        send_through: next,
+                    },
+                ))
+                .await
+                .expect("staircase CREDIT");
+                send_through = next;
+
+                // Drain until the client pauses AT the ceiling (it cannot
+                // send past send_through) — i.e. keep reading DATA while the
+                // daemon's outstanding window has room.
+                loop {
+                    let record = match ws.next().await {
+                        Some(Ok(Message::Binary(bytes))) => {
+                            decode_stream_record(&bytes, &bounds).expect("client record decodes")
+                        }
+                        Some(Ok(Message::Ping(_))) => continue,
+                        other => panic!("expected DATA, got {other:?}"),
+                    };
+                    match record.body {
+                        StreamRecordBody::Data { offset, payload } => {
+                            assert_eq!(
+                                offset, received,
+                                "DATA stays contiguous with what was acknowledged"
+                            );
+                            let len = payload.len() as u64;
+                            assert!(
+                                offset + len <= send_through,
+                                "DATA overshoot: offset {offset} + len {len} > send_through {send_through}"
+                            );
+                            received += len;
+                            if received == send_through {
+                                // THE REGRESSION DETECTOR: at the ceiling
+                                // with no further credit, the client MUST go
+                                // quiet. A stale overlapping grant (the
+                                // per-chunk `Produced` race) sends unbidden
+                                // DATA past `send_through`; the fixed driver
+                                // pauses for credit. One quiet window here
+                                // catches it deterministically.
+                                ws.send(frame(
+                                    identity,
+                                    StreamRecordBody::Credit {
+                                        accepted_through: received,
+                                        send_through,
+                                    },
+                                ))
+                                .await
+                                .expect("ack CREDIT");
+                                // Only at an INTERMEDIATE ceiling: the final
+                                // ceiling's ack legitimately unlocks END.
+                                if send_through >= total {
+                                    break;
+                                }
+                                loop {
+                                    match tokio::time::timeout(
+                                        std::time::Duration::from_millis(400),
+                                        ws.next(),
+                                    )
+                                    .await
+                                    {
+                                        Err(_elapsed) => break, // quiet: correct
+                                        Ok(Some(Ok(Message::Binary(bytes)))) => panic!(
+                                            "stale grant sent DATA past send_through={send_through}: {:?}",
+                                            decode_stream_record(&bytes, &CodecBounds::default()).map(|r| r.body)
+                                        ),
+                                        Ok(Some(Ok(Message::Ping(_)))) => continue,
+                                        other => panic!("unexpected frame in the quiet window: {other:?}"),
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                        other => panic!("expected DATA in the staircase, got {other:?}"),
+                    }
+                }
+            }
+            assert_eq!(received, total);
+            // Read END (the client's DATA already covered the file).
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        let end =
+                            decode_stream_record(&bytes, &bounds).expect("END decodes");
+                        assert_eq!(end.body, StreamRecordBody::End { total });
+                        break;
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    other => panic!("expected END, got {other:?}"),
+                }
+            }
+            let out = serde_json::json!({
+                "room_id": "room-staircase",
+                "file_id": "file-1",
+                "event_id": "event-1",
+                "pos": 1,
+                "bytes": total,
+                "digest": "sha256:test",
+            });
+            ws.send(reply_text(id, out.to_string()))
+                .await
+                .expect("reply");
+        });
+
+        let mut config = fast_config();
+        config.kernel.streams.stream_window_bytes = window;
+        let handle = connect_ws_native(FixedSource { url }, config).expect("creates");
+        handle.start();
+        let op_id = OpId::new("staircase-share-1");
+        handle
+            .register_stream_media(op_id.clone(), shared_bytes(payload))
+            .expect("register");
+        let out = handle
+            .call_stream::<jeliya_api::FileShare>(
+                jeliya_api::FileShare {
+                    room_id: RoomId::new("room-staircase"),
+                    name: String::from("staircase.bin"),
+                    declared_bytes: expected.len() as u64,
+                    declared_content_type: String::from("application/octet-stream"),
+                },
+                Dedup::Key(op_id),
+            )
+            .await
+            .expect("the staircase upload succeeds");
+        assert_eq!(out.bytes, 150_000);
+        server.abort();
+    });
+}
+
+/// A structurally malformed nonterminal CREDIT on an active binding (here: a
+/// CREDIT carrying a forbidden payload) aborts ONLY that stream: the client
+/// answers ABORT `protocol_error` and the connection stays alive — proven by
+/// a second, ordinary request completing on the same socket afterwards
+/// (protocol §Malformed stream records).
+#[test]
+fn malformed_bound_credit_aborts_only_that_stream() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, _) = read_request(&mut ws).await;
+            assert_eq!(op, "file.share");
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            let bounds = CodecBounds::default();
+            ws.send(frame(identity, StreamRecordBody::Open { total: 128 }))
+                .await
+                .expect("OPEN");
+
+            // A CREDIT with a forbidden payload: the codec refuses the
+            // structure (require_no_payload) while the binding is live —
+            // exactly the stream-local class.
+            let mut malformed = encode_stream_record(
+                &StreamRecord {
+                    identity,
+                    body: StreamRecordBody::Credit {
+                        accepted_through: 0,
+                        send_through: 128,
+                    },
+                },
+                &bounds,
+            )
+            .expect("encodes");
+            malformed.push(0); // the forbidden payload byte
+            ws.send(Message::Binary(malformed.into()))
+                .await
+                .expect("malformed CREDIT");
+
+            // The client answers ABORT protocol_error; the connection lives.
+            let abort = loop {
+                match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        break decode_stream_record(&bytes, &bounds).expect("ABORT decodes");
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    Some(Ok(Message::Close(frame))) => {
+                        panic!("connection dropped on a stream-local fault: {frame:?}")
+                    }
+                    other => panic!("expected ABORT, got {other:?}"),
+                }
+            };
+            assert!(matches!(
+                abort.body,
+                StreamRecordBody::Abort {
+                    reason: BinaryAbortReason::ProtocolError,
+                    ..
+                }
+            ));
+
+            // The same connection serves a later ordinary request.
+            let (id2, op2, _) = read_request(&mut ws).await;
+            assert_eq!(op2, "room.list");
+            ws.send(reply_text(id2, "{\"rooms\":[]}".to_owned()))
+                .await
+                .expect("second reply");
+        });
+
+        let handle = connect_ws_native(FixedSource { url }, fast_config()).expect("creates");
+        handle.start();
+        let op_id = OpId::new("malformed-credit-1");
+        handle
+            .register_stream_media(op_id.clone(), shared_bytes(vec![7_u8; 128]))
+            .expect("register");
+        let err = handle
+            .call_stream::<jeliya_api::FileShare>(
+                jeliya_api::FileShare {
+                    room_id: RoomId::new("room-malformed"),
+                    name: String::from("m.bin"),
+                    declared_bytes: 128,
+                    declared_content_type: String::from("application/octet-stream"),
+                },
+                Dedup::Key(op_id),
+            )
+            .await
+            .expect_err("the faulted stream fails honestly");
+        assert!(
+            matches!(
+                err,
+                CallError::Timeout | CallError::Cancelled { .. } | CallError::Wire(_)
+            ),
+            "a classified terminal, got {err:?}"
+        );
+        // The connection survived: an ordinary request completes.
+        let list = handle
+            .call::<jeliya_api::RoomList>(jeliya_api::RoomList {}, Dedup::None)
+            .await
+            .expect("the connection serves later requests");
+        assert!(list.rooms.is_empty());
+        server.abort();
+    });
+}
+
+/// A Binary message with no trustworthy shape (bad magic) is
+/// connection-fatal: the client closes the socket carrying the protocol's
+/// `4007` and the in-flight stream call settles as a transport loss — never
+/// a silent drop, never a hang (protocol §Malformed stream records).
+#[test]
+fn bad_magic_binary_is_connection_fatal_4007() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, _) = read_request(&mut ws).await;
+            assert_eq!(op, "file.share");
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            ws.send(frame(identity, StreamRecordBody::Open { total: 16 }))
+                .await
+                .expect("OPEN");
+
+            // Garbage: a full-size binary message with no JBS2 magic.
+            ws.send(Message::Binary(vec![0xDE_u8; 64].into()))
+                .await
+                .expect("garbage");
+
+            // The client closes the connection with 4007.
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Close(Some(frame)))) => {
+                        assert_eq!(u16::from(frame.code), 4007, "the protocol's fatal code");
+                        break;
+                    }
+                    Some(Ok(Message::Close(None))) => panic!("close must carry 4007"),
+                    Some(Ok(_)) => continue,
+                    Some(Err(_)) | None => panic!("expected a 4007 close frame"),
+                }
+            }
+        });
+
+        let handle = connect_ws_native(FixedSource { url }, fast_config()).expect("creates");
+        handle.start();
+        let op_id = OpId::new("bad-magic-1");
+        handle
+            .register_stream_media(op_id.clone(), shared_bytes(vec![1_u8; 16]))
+            .expect("register");
+        let err = handle
+            .call_stream::<jeliya_api::FileShare>(
+                jeliya_api::FileShare {
+                    room_id: RoomId::new("room-badmagic"),
+                    name: String::from("b.bin"),
+                    declared_bytes: 16,
+                    declared_content_type: String::from("application/octet-stream"),
+                },
+                Dedup::Key(op_id),
+            )
+            .await
+            .expect_err("a fatal record settles the stream as a loss");
+        assert!(
+            matches!(
+                err,
+                CallError::Disconnected { .. } | CallError::Timeout | CallError::Cancelled { .. }
+            ),
+            "a classified transport-loss terminal, got {err:?}"
+        );
+        server.abort();
+    });
+}

--- a/crates/jeliya-client/tests/ws_native_adapter.rs
+++ b/crates/jeliya-client/tests/ws_native_adapter.rs
@@ -546,3 +546,402 @@ fn http_426_during_upgrade_fails_closed_as_terminal() {
         server.abort();
     });
 }
+
+// ---------------------------------------------------------------------------
+// Byte-stream media drive (upload/download over the real socket path)
+// ---------------------------------------------------------------------------
+
+use jeliya_api::{FileId, OpId, RoomId};
+use jeliya_client::media::{collected_bytes, shared_bytes};
+use jeliya_client::{CallError, Dedup};
+use jeliya_codec::{
+    decode_stream_record, encode_stream_record, BinaryAbortReason, CodecBounds, StreamIdentity,
+    StreamRecord, StreamRecordBody,
+};
+use tokio_tungstenite::tungstenite::Message;
+
+/// Frame one JBS2 record for the fake daemon to send (the codec owns the
+/// layout; the test never hand-builds a header).
+fn frame(identity: StreamIdentity, body: StreamRecordBody) -> Message {
+    let bytes = encode_stream_record(&StreamRecord { identity, body }, &CodecBounds::default())
+        .expect("fake-daemon record frames");
+    Message::Binary(bytes.into())
+}
+
+/// Read the stream op's Text request off the socket: `(id, op, in)`.
+async fn read_request(
+    ws: &mut tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+) -> (u64, String, serde_json::Value) {
+    use futures::StreamExt;
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(text))) => {
+                let value: serde_json::Value = serde_json::from_str(&text).expect("request json");
+                let id = value["id"].as_u64().expect("request id");
+                let op = value["op"].as_str().expect("op").to_owned();
+                let input = value["in"].clone();
+                return (id, op, input);
+            }
+            // Pings from the client's keepalive ride along; ignore them.
+            Some(Ok(Message::Ping(_))) => continue,
+            other => panic!("expected the stream op's Text request, got {other:?}"),
+        }
+    }
+}
+
+/// A terminal success reply for `id` carrying `out_json`.
+fn reply_text(id: u64, out_json: String) -> Message {
+    Message::text(format!("{{\"id\":{id},\"ok\":true,\"out\":{out_json}}}"))
+}
+
+/// A `file.share` upload moves the caller's registered bytes to the daemon:
+/// OPEN → CREDIT → contiguous DATA covering the source → CREDIT(total) →
+/// END → terminal reply, with the daemon verifying the byte content equals
+/// the registered source and the offsets stay contiguous.
+#[test]
+fn file_share_round_trips_bytes_over_the_socket() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        // 200_000 bytes: spans four codec-capped DATA chunks (65_536 each).
+        let payload: Vec<u8> = (0..200_000_u32).map(|i| (i % 251) as u8).collect();
+        let expected = payload.clone();
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, input) = read_request(&mut ws).await;
+            assert_eq!(op, "file.share");
+            let total = input["declared_bytes"].as_u64().expect("declared_bytes");
+            assert_eq!(total, expected.len() as u64);
+
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            let bounds = CodecBounds::default();
+            ws.send(frame(identity, StreamRecordBody::Open { total }))
+                .await
+                .expect("OPEN");
+            ws.send(frame(
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: total,
+                },
+            ))
+            .await
+            .expect("CREDIT");
+
+            // Read contiguous DATA until the whole file arrived, then
+            // acknowledge everything so the client may finalize.
+            let mut received: Vec<u8> = Vec::new();
+            while (received.len() as u64) < total {
+                let record = match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        decode_stream_record(&bytes, &bounds).expect("client record decodes")
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    other => panic!("expected DATA, got {other:?}"),
+                };
+                match record.body {
+                    StreamRecordBody::Data { offset, payload } => {
+                        assert_eq!(
+                            offset,
+                            received.len() as u64,
+                            "the DATA offset/len sequence must be contiguous from zero"
+                        );
+                        received.extend_from_slice(&payload);
+                    }
+                    other => panic!("expected DATA before END, got {other:?}"),
+                }
+            }
+            assert_eq!(received, expected, "the served bytes equal the source");
+
+            // Acknowledge the full file: the client's END waits for this.
+            ws.send(frame(
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: total,
+                    send_through: total,
+                },
+            ))
+            .await
+            .expect("final CREDIT");
+
+            // The client's END carries its sent total.
+            let end = loop {
+                match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        break decode_stream_record(&bytes, &bounds).expect("END decodes");
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    other => panic!("expected END, got {other:?}"),
+                }
+            };
+            assert_eq!(end.body, StreamRecordBody::End { total });
+
+            let out = serde_json::json!({
+                "room_id": "room-share",
+                "file_id": "file-1",
+                "event_id": "event-1",
+                "pos": 1,
+                "bytes": total,
+                "digest": "sha256:test",
+            });
+            ws.send(reply_text(id, out.to_string()))
+                .await
+                .expect("reply");
+            // Hold the connection until the client stops.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let handle = connect_ws_native(FixedSource { url }, fast_config()).expect("creates");
+        handle.start();
+        wait_for_state(&handle, State::Ready, 2_000).await;
+
+        let key = OpId::new("share-op-1");
+        handle
+            .register_stream_media(key.clone(), shared_bytes(payload))
+            .expect("register");
+        let mut call = handle.call_stream::<jeliya_api::FileShare>(
+            jeliya_api::FileShare {
+                room_id: RoomId::new("room-share"),
+                name: String::from("payload.bin"),
+                declared_bytes: 200_000,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::Key(key),
+        );
+        let out = tokio::time::timeout(Duration::from_millis(5_000), &mut call)
+            .await
+            .expect("the upload resolves")
+            .expect("the upload succeeds");
+        assert_eq!(out.bytes, 200_000);
+        assert_eq!(out.room_id.as_str(), "room-share");
+
+        handle.stop().await;
+        server.abort();
+    });
+}
+
+/// A `file.read` download moves the daemon's served bytes into the caller's
+/// registered sink: OPEN → client CREDIT → DATA covering the file → END →
+/// terminal reply, with the collected bytes equalling the served bytes
+/// exactly.
+#[test]
+fn file_read_round_trips_bytes_over_the_socket() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        let served: Vec<u8> = (0..150_000_u32)
+            .map(|i| ((i * 7 + 3) % 253) as u8)
+            .collect();
+        let expected = served.clone();
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, _) = read_request(&mut ws).await;
+            assert_eq!(op, "file.read");
+            let total = served.len() as u64;
+
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            let bounds = CodecBounds::default();
+            ws.send(frame(identity, StreamRecordBody::Open { total }))
+                .await
+                .expect("OPEN");
+
+            // The client's opening CREDIT must arrive before any DATA.
+            let credit = loop {
+                match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        break decode_stream_record(&bytes, &bounds).expect("CREDIT decodes");
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    other => panic!("expected CREDIT, got {other:?}"),
+                }
+            };
+            match credit.body {
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through,
+                } if send_through == total => {}
+                other => panic!("expected CREDIT(0, {total}), got {other:?}"),
+            }
+
+            // Serve the file in codec-capped chunks, then END.
+            let mut offset: u64 = 0;
+            while offset < total {
+                let end = (offset + 65_536).min(total);
+                ws.send(frame(
+                    identity,
+                    StreamRecordBody::Data {
+                        offset,
+                        payload: served[offset as usize..end as usize].to_vec(),
+                    },
+                ))
+                .await
+                .expect("DATA");
+                offset = end;
+            }
+            ws.send(frame(identity, StreamRecordBody::End { total }))
+                .await
+                .expect("END");
+
+            let out = serde_json::json!({
+                "room_id": "room-read",
+                "file_id": "file-9",
+                "bytes": total,
+                "declared_content_type": "application/octet-stream",
+            });
+            ws.send(reply_text(id, out.to_string()))
+                .await
+                .expect("reply");
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let handle = connect_ws_native(FixedSource { url }, fast_config()).expect("creates");
+        handle.start();
+        wait_for_state(&handle, State::Ready, 2_000).await;
+
+        let (sink, media) = collected_bytes();
+        let key = OpId::new("read-op-1");
+        handle
+            .register_stream_media(key.clone(), media)
+            .expect("register");
+        let mut call = handle.call_stream::<jeliya_api::FileRead>(
+            jeliya_api::FileRead {
+                room_id: RoomId::new("room-read"),
+                file_id: FileId::new("file-9"),
+            },
+            Dedup::Key(key),
+        );
+        let out = tokio::time::timeout(Duration::from_millis(5_000), &mut call)
+            .await
+            .expect("the download resolves")
+            .expect("the download succeeds");
+        assert_eq!(out.bytes, 150_000);
+
+        let collected = sink.take();
+        assert_eq!(
+            collected, expected,
+            "the collected bytes equal the served bytes exactly"
+        );
+
+        handle.stop().await;
+        server.abort();
+    });
+}
+
+/// A stream dispatched with **no** registered media aborts honestly: the
+/// first `ProduceData` grant reports `SourceFailed`, the kernel authors a
+/// `source_failed` ABORT the daemon can observe on the wire, and the call
+/// settles with a real error (the kernel's `Timeout` classification) —
+/// never a hang and never a fake success.
+#[test]
+fn unregistered_stream_aborts_honestly_with_an_on_wire_abort() {
+    let rt = test_runtime();
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let sg = 1_u64;
+        let url = url::Url::parse(&format!("ws://127.0.0.1:{port}/ws?v=2&sg={sg}")).expect("url");
+
+        let server = tokio::spawn(async move {
+            use futures::SinkExt;
+            let (stream, _) = listener.accept().await.expect("accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("upgrade");
+            ws.send(Message::text(hello_json(sg))).await.expect("hello");
+
+            let (id, op, _) = read_request(&mut ws).await;
+            assert_eq!(op, "file.share");
+            let identity = StreamIdentity::new(id, 1).expect("identity");
+            let bounds = CodecBounds::default();
+            ws.send(frame(identity, StreamRecordBody::Open { total: 16 }))
+                .await
+                .expect("OPEN");
+            ws.send(frame(
+                identity,
+                StreamRecordBody::Credit {
+                    accepted_through: 0,
+                    send_through: 16,
+                },
+            ))
+            .await
+            .expect("CREDIT");
+
+            // The honest abort must cross the wire before any timeout.
+            let abort = loop {
+                match ws.next().await {
+                    Some(Ok(Message::Binary(bytes))) => {
+                        break decode_stream_record(&bytes, &bounds).expect("ABORT decodes");
+                    }
+                    Some(Ok(Message::Ping(_))) => continue,
+                    other => panic!("expected ABORT, got {other:?}"),
+                }
+            };
+            assert_eq!(
+                abort.body,
+                StreamRecordBody::Abort {
+                    accepted_through: 0,
+                    reason: BinaryAbortReason::SourceFailed,
+                },
+                "an unregistered producer aborts source_failed at its first grant"
+            );
+            // The late terminal reply is absorbed by the settled tombstone.
+            let err = serde_json::json!({
+                "code": "unavailable",
+            });
+            ws.send(Message::text(format!(
+                "{{\"id\":{id},\"ok\":false,\"err\":{err}}}"
+            )))
+            .await
+            .expect("err reply");
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let handle = connect_ws_native(FixedSource { url }, fast_config()).expect("creates");
+        handle.start();
+        wait_for_state(&handle, State::Ready, 2_000).await;
+
+        // No register_stream_media: the call is dispatched bare.
+        let mut call = handle.call_stream::<jeliya_api::FileShare>(
+            jeliya_api::FileShare {
+                room_id: RoomId::new("room-bare"),
+                name: String::from("none.bin"),
+                declared_bytes: 16,
+                declared_content_type: String::from("application/octet-stream"),
+            },
+            Dedup::Key(OpId::new("bare-op-1")),
+        );
+        let error = tokio::time::timeout(Duration::from_millis(5_000), &mut call)
+            .await
+            .expect("the bare stream settles promptly, never hangs")
+            .expect_err("an unregistered stream must fail, not succeed");
+        assert!(
+            matches!(error, CallError::Timeout),
+            "the kernel settles an unregistered stream's abort as Timeout; got {error}"
+        );
+
+        handle.stop().await;
+        server.abort();
+    });
+}

--- a/crates/jeliya-client/tests/ws_web_browser.rs
+++ b/crates/jeliya-client/tests/ws_web_browser.rs
@@ -18,8 +18,8 @@
 mod tests {
     use futures::StreamExt;
     use jeliya_client::{
-        connect_ws_web, ClientEvent, Dedup, Endpoint, ExplicitResolver, KernelConfig, State,
-        WsWebConfig,
+        connect_ws_web, media, ClientEvent, ClientHandle, Dedup, Endpoint, ExplicitResolver,
+        KernelConfig, State, WsWebConfig,
     };
     use wasm_bindgen_test::*;
 
@@ -29,6 +29,23 @@ mod tests {
     // If absent, both resolve to None and each test exits early (graceful skip).
     const DAEMON_PORT: Option<&str> = option_env!("JELIYAD_WEB_TEST_PORT");
     const DAEMON_TOKEN: Option<&str> = option_env!("JELIYAD_WEB_TEST_TOKEN");
+    const DAEMON2_PORT: Option<&str> = option_env!("JELIYAD2_WEB_TEST_PORT");
+    const DAEMON2_TOKEN: Option<&str> = option_env!("JELIYAD2_WEB_TEST_TOKEN");
+
+    /// Yield to the event loop for `ms` so the adapter's spawn_local pump can
+    /// drain socket traffic between poll attempts (a busy loop on the one
+    /// thread would starve the very IO it is waiting for).
+    async fn sleep_ms(ms: u32) {
+        let promise = js_sys::Promise::new(&mut |resolve, _| {
+            web_sys::window()
+                .expect("window")
+                .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms as i32)
+                .expect("set_timeout");
+        });
+        wasm_bindgen_futures::JsFuture::from(promise)
+            .await
+            .expect("timer promise");
+    }
 
     fn make_config() -> Option<WsWebConfig> {
         let port = DAEMON_PORT?;
@@ -47,6 +64,19 @@ mod tests {
             // indefinitely when the daemon is unreachable.
             hello_timeout_ms: 8_000,
         })
+    }
+
+    /// Reach Ready against the live daemon or give up (the earlier connect
+    /// test owns the failure diagnosis).
+    async fn ready_handle() -> Option<(ClientHandle, jeliya_client::EventSubscription)> {
+        let config = make_config()?;
+        let handle = connect_ws_web(config);
+        let mut sub = handle.subscribe();
+        handle.start();
+        if !wait_for_state(&mut sub, State::Ready).await {
+            return None;
+        }
+        Some((handle, sub))
     }
 
     // Poll the EventSubscription until the target state or a terminal state.
@@ -151,6 +181,228 @@ mod tests {
             Some(State::Stopped),
             "the event stream must end at Stopped — an event after it (or a \
              non-StateChanged tail) indicates a leaked post-teardown emission"
+        );
+    }
+
+    // Byte-stream media against the LIVE daemon (#233 client remainder / the
+    // adapter stream-media slice). Unlike every suite above, these two tests
+    // move real file bytes over the socket: `file.share` uploads a
+    // deterministic pattern from a registered ByteSource (OPEN → CREDIT →
+    // DATA* → END → terminal reply, framed as JBS2 Binary messages), and
+    // `file.read` downloads them back into a registered ByteSink (OPEN →
+    // client CREDIT → DATA* → END → terminal reply) with the collected bytes
+    // verified against the exact pattern — a real digest-level round trip,
+    // never the mock.
+    //
+    // Bootstrap mirrors the conformance corpus's files success case
+    // (conformance/v2/files.json): subject.ensure → room.create →
+    // room.activate, then the streamed share.
+
+    /// The deterministic upload pattern (not `i mod 251` — that rig is the
+    /// in-memory driver's; a live round trip deserves an independent pattern).
+    fn share_pattern(len: usize) -> Vec<u8> {
+        (0..len).map(|i| ((i * 7 + 13) % 256) as u8).collect()
+    }
+
+    async fn ensure_subject_and_live_room(handle: &ClientHandle) -> jeliya_api::RoomId {
+        // The subject is global to the daemon; ensure is idempotent.
+        let _ = handle
+            .call::<jeliya_api::SubjectEnsure>(jeliya_api::SubjectEnsure {}, Dedup::None)
+            .await
+            .expect("subject.ensure resolves against the live daemon");
+        let room = handle
+            .call::<jeliya_api::RoomCreate>(
+                jeliya_api::RoomCreate {
+                    name: String::from("ws-web-stream-media"),
+                },
+                Dedup::None,
+            )
+            .await
+            .expect("room.create resolves");
+        handle
+            .call::<jeliya_api::RoomActivate>(
+                jeliya_api::RoomActivate {
+                    room_id: room.room_id.clone(),
+                },
+                Dedup::None,
+            )
+            .await
+            .expect("room.activate resolves");
+        room.room_id
+    }
+
+    #[wasm_bindgen_test]
+    async fn live_file_share_uploads_real_bytes_over_the_socket() {
+        let Some((handle, _sub)) = ready_handle().await else {
+            return;
+        };
+        let room_id = ensure_subject_and_live_room(&handle).await;
+
+        let pattern = share_pattern(2048);
+        let op_id = jeliya_api::OpId::new("ws-web-live-share-1");
+        handle
+            .register_stream_media(op_id.clone(), media::shared_bytes(pattern.clone()))
+            .expect("the web adapter registers stream media");
+
+        let out = handle
+            .call_stream::<jeliya_api::FileShare>(
+                jeliya_api::FileShare {
+                    room_id: room_id.clone(),
+                    name: String::from("live-share.bin"),
+                    declared_bytes: pattern.len() as u64,
+                    declared_content_type: String::from("application/octet-stream"),
+                },
+                Dedup::Key(op_id),
+            )
+            .await
+            .expect("the streamed file.share resolves against the live daemon");
+        assert_eq!(out.bytes, 2048, "every pattern byte was accepted");
+        assert!(!out.digest.is_empty(), "the daemon reports its digest");
+    }
+
+    // The two-daemon byte-stream matrix (the honest live `file.read`):
+    // `file.read` streams only LOCALLY-HELD bytes, and a daemon never fetches
+    // from itself (the supervisor's fetch excludes its own device), so a
+    // single daemon can never serve a read-back of its own upload — by
+    // design, exactly as the corpus records (`resource:fetched_file` is
+    // "unestablishable single-subject"). The real download needs a second,
+    // invited daemon: A receives the streamed share; B joins the room, p2p-
+    // fetches the bytes from provider A, and streams them back out over its
+    // own socket. The collected bytes must equal the uploaded pattern
+    // exactly — a digest-level round trip across two live daemons and three
+    // byte transfers (browser→A upload, A→B p2p fetch, B→browser download).
+    #[wasm_bindgen_test]
+    async fn live_two_daemon_share_fetch_read_round_trip() {
+        let (Some(port2), Some(token2)) = (DAEMON2_PORT, DAEMON2_TOKEN) else {
+            return; // no second daemon configured — graceful skip
+        };
+        let Some((ha, _sub_a)) = ready_handle().await else {
+            return;
+        };
+        let hb = connect_ws_web(WsWebConfig {
+            endpoint: Endpoint::Explicit {
+                http_base: format!("http://127.0.0.1:{port2}"),
+                ws_url: format!("ws://127.0.0.1:{port2}/ws"),
+            },
+            session: Box::new(ExplicitResolver::new("token", token2.to_string())),
+            kernel: KernelConfig::default(),
+            hello_timeout_ms: 8_000,
+        });
+        let mut sub_b = hb.subscribe();
+        hb.start();
+        if !wait_for_state(&mut sub_b, State::Ready).await {
+            return; // second daemon unreachable — its own connect test's domain
+        }
+
+        // A: subject + live room; B: subject; A mints, B redeems, B activates.
+        let room_id = ensure_subject_and_live_room(&ha).await;
+        let subject_b = hb
+            .call::<jeliya_api::SubjectEnsure>(jeliya_api::SubjectEnsure {}, Dedup::None)
+            .await
+            .expect("B subject.ensure")
+            .subject_id;
+        let minted = ha
+            .call::<jeliya_api::InviteMint>(
+                jeliya_api::InviteMint {
+                    room_id: room_id.clone(),
+                    subject_id: subject_b,
+                    role: jeliya_api::Role::Member,
+                    // `time`'s `now` is unsupported on wasm32-unknown-unknown;
+                    // the browser clock (ms since the Unix epoch) is the
+                    // platform's own source for an expiry.
+                    expires_at: jeliya_api::Timestamp::new(
+                        time::OffsetDateTime::from_unix_timestamp_nanos(
+                            (js_sys::Date::now() as i128 + 3_600_000) * 1_000_000,
+                        )
+                        .expect("unix timestamp"),
+                    ),
+                },
+                Dedup::None,
+            )
+            .await
+            .expect("A invite.mint");
+        hb.call::<jeliya_api::InviteRedeem>(
+            jeliya_api::InviteRedeem {
+                capability: minted.capability,
+            },
+            Dedup::None,
+        )
+        .await
+        .expect("B invite.redeem");
+        hb.call::<jeliya_api::RoomActivate>(
+            jeliya_api::RoomActivate {
+                room_id: room_id.clone(),
+            },
+            Dedup::None,
+        )
+        .await
+        .expect("B room.activate");
+
+        // A receives the streamed share.
+        let pattern = share_pattern(1536);
+        let share_op = jeliya_api::OpId::new("ws-web-two-daemon-share-1");
+        ha.register_stream_media(share_op.clone(), media::shared_bytes(pattern.clone()))
+            .expect("register the share source");
+        let shared = ha
+            .call_stream::<jeliya_api::FileShare>(
+                jeliya_api::FileShare {
+                    room_id: room_id.clone(),
+                    name: String::from("live-roundtrip.bin"),
+                    declared_bytes: pattern.len() as u64,
+                    declared_content_type: String::from("application/octet-stream"),
+                },
+                Dedup::Key(share_op),
+            )
+            .await
+            .expect("the streamed share resolves on A");
+        assert_eq!(shared.bytes, pattern.len() as u64);
+
+        // B fetches from provider A — bounded wait: the room session must
+        // sync the signed file_shared event and connect the daemons first.
+        let mut fetched = false;
+        for _ in 0..60 {
+            match hb
+                .call::<jeliya_api::FileFetch>(
+                    jeliya_api::FileFetch {
+                        room_id: room_id.clone(),
+                        file_id: shared.file_id.clone(),
+                    },
+                    Dedup::None,
+                )
+                .await
+            {
+                Ok(out) => {
+                    assert_eq!(out.bytes, pattern.len() as u64);
+                    fetched = true;
+                    break;
+                }
+                Err(_) => {
+                    sleep_ms(2_000).await;
+                }
+            }
+        }
+        assert!(fetched, "B must fetch the file from provider A");
+
+        // B streams the bytes back out; the sink must collect the exact pattern.
+        let (sink, sink_media) = media::collected_bytes();
+        let read_op = jeliya_api::OpId::new("ws-web-two-daemon-read-1");
+        hb.register_stream_media(read_op.clone(), sink_media)
+            .expect("register the read sink");
+        let header = hb
+            .call_stream::<jeliya_api::FileRead>(
+                jeliya_api::FileRead {
+                    room_id,
+                    file_id: shared.file_id,
+                },
+                Dedup::Key(read_op),
+            )
+            .await
+            .expect("the streamed file.read resolves on B");
+        assert_eq!(header.bytes, pattern.len() as u64);
+        let collected = sink.take();
+        assert_eq!(
+            collected, pattern,
+            "the bytes the browser collected from B are exactly the bytes it              uploaded to A — a real round trip over two live daemons, not the mock"
         );
     }
 }

--- a/scripts/run-ws-web-browser-tests.sh
+++ b/scripts/run-ws-web-browser-tests.sh
@@ -56,14 +56,29 @@ cleanup() {
         # Give the daemon a moment to close its portfile-locked resources.
         sleep 0.2
     fi
-    rm -rf "$TMPDIR"
+    if [ -n "${DAEMON2_PID:-}" ]; then
+        kill "$DAEMON2_PID" 2>/dev/null || true
+        sleep 0.2
+    fi
+    rm -rf "$TMPDIR" "$TMPDIR2"
 }
 trap cleanup EXIT
 
-"$JELIYAD_BIN" --port 0 --data-dir "$TMPDIR" --no-open --loopback &
+# RealNetwork mode (no --loopback): the two-daemon round-trip test needs the
+# invited join to dial the minter via discovery, which loopback mode (relay
+# disabled, no address hints) cannot do. Single-daemon tests are unaffected.
+"$JELIYAD_BIN" --port 0 --data-dir "$TMPDIR" --no-open &
 DAEMON_PID=$!
 
-# ---- Wait for the portfile ------------------------------------------------
+# A second daemon for the two-daemon byte-stream round-trip test
+# (file.share on A → p2p file.fetch by B → streamed file.read on B).
+# RealNetwork mode (no --loopback): the invited join dials the minter via
+# discovery, which loopback mode cannot do (relay disabled, no hints).
+TMPDIR2="$(mktemp -d)"
+"$JELIYAD_BIN" --port 0 --data-dir "$TMPDIR2" --no-open &
+DAEMON2_PID=$!
+
+# ---- Wait for both portfiles ----------------------------------------------
 DEADLINE=$(( SECONDS + 20 ))
 until [ -f "$PORTFILE" ] && python3 -c "
 import json, sys
@@ -72,6 +87,18 @@ sys.exit(0 if pf.get('port') and pf.get('auth_token') else 1)
 " 2>/dev/null; do
     if [ $SECONDS -ge $DEADLINE ]; then
         echo "ERROR: daemon did not write a valid portfile within 20 s" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+PORTFILE2="$TMPDIR2/daemon.json"
+until [ -f "$PORTFILE2" ] && python3 -c "
+import json, sys
+pf = json.load(open('$PORTFILE2'))
+sys.exit(0 if pf.get('port') and pf.get('auth_token') else 1)
+" 2>/dev/null; do
+    if [ $SECONDS -ge $DEADLINE ]; then
+        echo "ERROR: second daemon did not write a valid portfile within 20 s" >&2
         exit 1
     fi
     sleep 0.1
@@ -87,14 +114,23 @@ pf = json.load(open('$PORTFILE'))
 tok = pf['auth_token']
 print(tok['inner'] if isinstance(tok, dict) else tok)
 ")"
+DAEMON2_PORT="$(python3 -c "import json; pf=json.load(open('$PORTFILE2')); print(pf['port'])")"
+DAEMON2_TOKEN="$(python3 -c "
+import json
+pf = json.load(open('$PORTFILE2'))
+tok = pf['auth_token']
+print(tok['inner'] if isinstance(tok, dict) else tok)
+")"
 
-echo "ws_web browser tests: jeliyad on port $DAEMON_PORT (pid=$DAEMON_PID)"
+echo "ws_web browser tests: jeliyad on port $DAEMON_PORT (pid=$DAEMON_PID), second on $DAEMON2_PORT (pid=$DAEMON2_PID)"
 
 # ---- Expose daemon coordinates to build.rs --------------------------------
 # build.rs re-emits these as cargo:rustc-env= so option_env!() resolves in
 # the wasm32 test binary at compile time.
 export JELIYAD_WEB_TEST_PORT="$DAEMON_PORT"
 export JELIYAD_WEB_TEST_TOKEN="$DAEMON_TOKEN"
+export JELIYAD2_WEB_TEST_PORT="$DAEMON2_PORT"
+export JELIYAD2_WEB_TEST_TOKEN="$DAEMON2_TOKEN"
 
 # ---- Run the browser test suite -------------------------------------------
 # CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER tells cargo to invoke

--- a/specs/rust-client-adapter-stream-media.md
+++ b/specs/rust-client-adapter-stream-media.md
@@ -1,0 +1,88 @@
+# Spec — Adapter stream media drive: real bytes on WsNative and WsWeb
+
+- **Relates to:** kortiene/jeliya#233 (client framing remainder), #269 (kernel stream
+  lifecycle, landed), #171/#172 (WsWeb/WsNative adapters, landed), #175 (adapter parity),
+  #182 (real-daemon qualification slice).
+- **Authority:** `docs/protocol-v2.md` §*Byte-stream framing* and `specs/rust-client-kernel-stream-lifecycle.md`
+  (§S2/§S3 especially) outrank this document; disagreement is a bug.
+- **Constraint:** implementation slice record (unlike the #269 planning doc, this ships code).
+
+## Outcome
+
+`call_stream::<FileShare>` / `::<FileRead>` move **real bytes** over the live
+adapters (native tokio WebSocket; browser `web_sys::WebSocket`), not just the
+deterministic in-memory rig. A file shared through either adapter against a live
+`jeliyad` completes end-to-end, and a `file.read` streams the bytes back.
+
+## The three gaps this closes
+
+1. **Media identity at the driver.** The core's media actions
+   (`Action::ProduceData`, `Action::WriteSink`) carried only `CallId`, which a
+   driver can never map to wire identity (it sees `RequestId`s). Both actions now
+   also carry the stream's wire `id`. Additive, byte-free; `Input::Produced`/
+   `SourceEnd`/`SinkAccepted`/… keep their existing `CallId` shape.
+2. **A public media seam.** Callers could not supply or collect bytes. New
+   `jeliya_client::media` types (`ByteSource`, `SharedBytes`,
+   `ByteSink`, `CollectedBytes`, `StreamMedia`) reach the driver via
+   `ClientHandle::register_stream_media(op_id, media)` →
+   `ClientBackend::register_stream_media` (default: honest
+   `LocalError::UnsupportedMedia` — the mock refuses rather than pretending).
+   Registration is keyed by the call's `Dedup::Key` `OpId`: the driver binds
+   `op_id → wire id` when it performs the `Action::Send` for a stream op
+   (`file.share`/`file.read`, recognized by wire name exactly as the kernel's
+   replay gate does). An unregistered stream that reaches `ProduceData`/`
+   WriteSink` reports `SourceFailed`/`SinkFailed` — an honest abort, never a
+   stall or fake success.
+3. **Driver fulfillment.** Both real adapters implement the record/media arms
+   their runtime shells currently drop with `debug_assert!`:
+   - `WsNative` (`adapter/runtime.rs`, `adapter/ws_native.rs`): a
+     `MediaRegistry` shared (like `ConnRegistry`) between `NativeIo`, the dial
+     task and the read loop. `send_record` frames via `jeliya-codec` onto the
+     existing write channel. At OPEN the read loop spawns **one media task per
+     stream** holding the registered source; `ProduceData` hands the grant to
+     that task, which reads ≤ `up_to` bytes, frames ≤ `max_stream_data_bytes`
+     DATA records, sends them through the writer (awaiting its backpressure),
+     and injects `Input::Produced`/`SourceEnd` through the shell's `inject`.
+     Inbound Binary records are decoded in the read loop; DATA payloads buffer
+     in a per-stream, window-bounded map until `WriteSink` writes them to the
+     sink and queues `SinkAccepted` through `take_pending_media`. Teardown
+     (connection loss, cancel_dial, Drop) aborts media tasks and clears the
+     registry through `ConnRegistry::tear_down` — a stream never survives its
+     connection, mirroring the core's §S10 rule.
+   - `WsWeb` (`kernel/runtime.rs`, `ws_web/socket.rs`): the mailbox runtime
+     grows `IoAction::SendRecord`/`ProduceData`/`WriteSink`/`RegisterMedia`
+     arms and the `Driver` trait grows `send_record`/`produce`/`write_sink`
+     (defaults that report failure honestly, keeping `DirectClient`'s driver
+     compiling and honest until its own slice). Media inputs return to the
+     core as a new `DriverEvent::Media` arm. `onmessage` Binary decodes via
+     `jeliya-codec`; DATA payloads buffer exactly as on native; outbound
+     records go out with `send_with_u8_array`.
+
+## Rules carried over (binding)
+
+- The core stays byte-free; **all framing stays in `jeliya-codec`**, called only
+  at the driver boundary (§S2). No JBS2 constant appears outside the codec.
+- Buffers are bounded: outbound read-ahead by the grant, inbound quarantine by
+  the credit window the core granted; the per-stream payload buffer enforces the
+  same cap defensively.
+- `Debug` of any new type renders no payload, name, or digest (§S12).
+- Streams never replay across reconnects (§S8, already enforced); on
+  `Interrupted` the driver drops every stream's media exactly as the core drops
+  the streams.
+- Media registration is caller-owned memory (`SharedBytes`/`CollectedBytes` are
+  bounded by the caller); `PlatformServices`-backed sources plug into the same
+  `ByteSource` seam later (#174) with no adapter change.
+
+## Qualification (the definition of done)
+
+- `scripts/run-ws-web-browser-tests.sh` against a real `jeliyad`: a
+  `file.share` (browser-produced bytes) → `file.read` round-trip over the
+  socket, asserting the returned bytes and the daemon's digest — not the mock.
+- The native adapter exercises the same round-trip in its integration harness
+  (`tests/ws_native_adapter.rs` server rig).
+- The PR states exactly what was qualified live vs. mock.
+
+## Non-goals
+
+- Resumable/chunked transfer (#209), `stream.*` subscriptions in DirectClient
+  (#302), UI composition changes, HTTP staging routes.


### PR DESCRIPTION
## What

Makes byte streams real on both live adapters and qualifies them against live `jeliyad` daemons — the client-side remainder of #233 (framing execution at the adapter boundary; the normative record and codec landed earlier).

Four commits:
1. **`9c069b8` stream media seam** — `Action::ProduceData`/`WriteSink` gain the stream's wire `RequestId` (a driver can't map `CallId`); new public `jeliya_client::media` (`ByteSource`/`ByteSink`, `SharedBytes`/`CollectedBytes`) registered per call under its `Dedup::Key` via `ClientHandle::register_stream_media`; unregistered streams fail honestly (`source_failed`/`sink_failed`), never a stall.
2. **`3b5ca7d` native media drive** — JBS2 framing via `jeliya-codec` onto the existing write channel, one media task per active stream (grant channel, codec-capped DATA chunks, awaits writer backpressure), inbound quarantine (2× window cap) → sink, teardown through `ConnRegistry`. Fake-server integration tests incl. 200 KB upload / 150 KB download round trips and the honest unregistered-stream abort.
3. **`50f5023` web media drive** — mailbox runtime grows `SendRecord`/`ProduceData`/`WriteSink`/`RegisterMedia` + `DriverEvent::Media`; single-threaded `WebMediaRegistry` mirrors the native registry; Binary `onmessage` staged-decodes JBS2 records. Host-runnable runtime tests prove upload/download/unregistered-failure through the mailbox.
4. **`0d06d87` two live-protocol fixes + live qualification** (below).

## Kernel protocol deviation — found live, fixed red-before-green

**The receiver never sent the terminal acceptance CREDIT.** The kernel emitted CREDIT only when the window could *extend*, and the receiver ceiling is capped at the OPEN total — so once the opening window covered the whole file, full sink acceptance was never reported. The protocol (§END) requires it: a producer sends END *"only after every DATA byte it sent has been acknowledged by CREDIT"*, and for `file.read` the daemon is the producer. Live symptom: all bytes received and accepted, then both sides stall to timeout. The deterministic rig scripted END unconditionally, hiding the gap. Fix: `on_sink_accepted` emits cumulative CREDIT on every accepted advance. Red-before-green: `file_read_receiver_reports_terminal_acceptance_credit` (kernel_stream.rs).

**Wasm adapter bug, also live-found:** the browser registry fabricated the DATA stream id (`wire_id+1`) instead of adopting the daemon's OPEN stream id → the daemon rejected the `(request_id, stream_id)` pair and closed (`Disconnected{Unknown}`). Fixed by adopting the OPEN stream id at decode time, mirroring the native registry.

## Honest scope: what was qualified LIVE vs. mock

| Path | Evidence |
|---|---|
| Browser upload (`file.share`, real bytes over the socket) | **LIVE** — real headless Chromium (150) × real `jeliyad`, `ws_web_browser` suite, green |
| Browser full round trip (upload on A → p2p `file.fetch` by daemon B → streamed `file.read` on B; collected bytes byte-identical) | **LIVE** — new `live_two_daemon_share_fetch_read_round_trip`, two real daemons, green |
| Native same matrix, 64 KiB | **LIVE** — `tests/live_native_probe.rs` (`--ignored`, env-driven), green |
| Fault matrix (abort paths, disconnect, credit bounds, registry caps, honest unregistered failures) | Mock/fake-server rigs (native fake daemon; wasm host-runnable mailbox runtime) |

Notes for maintainers:
- **Single-daemon read-back is impossible by design** (a daemon never fetches from itself; `file.read` serves only locally-held bytes) — the corpus records the same (`resource:fetched_file` "unestablishable single-subject"). A live download therefore requires two daemons.
- **Loopback mode cannot join cross-daemon** (`--loopback` disables relay/discovery and the v2 surface has no peers parameter; `invite.redeem` dials the minter with no address hints). The two-daemon tests therefore run in RealNetwork mode. Worth its own issue if loopback cross-daemon qualification is wanted.
- `scripts/run-ws-web-browser-tests.sh` now boots the second daemon and exports `JELIYAD2_WEB_TEST_*` (build.rs forwards them).

## Gates run (all green)

- `cargo +1.96.0 test/clippy/fmt --locked --workspace --all-targets`
- `cargo +1.96.0 clippy --locked -p jeliya-client --features {ws-native,direct,test-transport} --all-targets -- -D warnings`
- `cargo +1.96.0 clippy --locked -p jeliya-client --features ws-web --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `cargo +1.96.0 clippy --locked -p jeliya-ui --target wasm32-unknown-unknown --features web --all-targets -- -D warnings`
- `cargo +1.96.0 clippy --locked -p jeliya-platform-web --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `bash scripts/run-ws-web-browser-tests.sh` — **live**, 5/5
- `node scripts/{check-docs,check-v2-corpus,check-design-tokens,check-jeliya-ui-i18n}.mjs`
- N/A this diff: `build-web.sh` + Playwright e2e (no `jeliya-ui`/web-asset changes).

Closes the client framing remainder of #233. No daemon or codec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
