### PR TITLE
test(conformance): execute the raw_record stream fault in the v2 harness (#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,9 +455,10 @@ jobs:
           # gate pins the reliably-green slice so a regression in the
           # implemented surface goes red. The file cases exercise the binary
           # byte-stream executor (upload streaming, pre-OPEN refusals with
-          # bytes_streamed 0, and a declared-size-mismatch stream); the
-          # at-limit and over-limit cases stream the served 100 MiB bound and
-          # stay local-only.
+          # bytes_streamed 0, and a declared-size-mismatch stream) and both
+          # executed client-fault controls (producer cancel, stream-local
+          # malformed record); the at-limit and over-limit cases stream the
+          # served 100 MiB bound and stay local-only.
           node main.mjs ../../../target/debug/jeliyad \
             --case subject_ensure_creates_the_subject_on_a_fresh_daemon \
             --case subject_ensure_never_returns_secret_material \
@@ -478,6 +479,8 @@ jobs:
             --case share_size_refusal_is_never_reported_as_digest_mismatch \
             --case share_completed_result_replays_without_a_second_stream_and_authors_once \
             --case a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch \
+            --case share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled \
+            --case share_malformed_stream_record_aborts_that_stream_as_malformed_frame \
             --case list_of_a_room_that_is_not_available_answers_room_not_available \
             --case fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown \
             --case transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -32,7 +32,7 @@ claims:
 |---|---|---|
 | Structural validation | Implemented for all 342 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
 | Selected JSON-envelope/subject slice | Partial (22 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
-| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the one client-originated fault the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the raw-record, credit-pause, and transport-drop fault controls remain unimplemented, so malformed/backpressure stream cases are still declarative. |
+| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the two client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; and `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the credit-pause and transport-drop fault controls remain unimplemented, so backpressure and disconnect stream cases are still declarative. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
@@ -266,17 +266,26 @@ is invalid, because no other operation streams. The value is a `<uint>`, a
 limit" without compiling the number in.
 
 An upload may carry an optional **`fault`** beside `send_bytes` to make the
-*client* misbehave on purpose. The vocabulary is closed. The only value the
-single-subject harness executes today is `client_abort`: after the daemon admits
-the stream (OPEN) but before any DATA is sent, the client issues
-`ABORT(cancelled)`; the daemon must acknowledge the ABORT and then reply
-`stream_aborted{cancelled}` accounting for zero receiver-accepted bytes — the
-"client ABORT wins" leg of the race table. `fault` is legal only on `file.share`,
-because `file.read` has no executable download fixture at all (it needs a
-peer-fetched file the single-subject harness cannot stage). The record's other
-client faults — raw-record injection, credit-pause, and transport-drop — remain
-declarative until the executor drives them, and adding a value here without the
-executor to run it is not permitted.
+*client* misbehave on purpose. The vocabulary is closed. Two values are executed
+end-to-end by the single-subject harness today:
+
+- `client_abort`: after the daemon admits the stream (OPEN) but before any DATA
+  is sent, the client issues `ABORT(cancelled)`; the daemon must acknowledge the
+  ABORT and then reply `stream_aborted{cancelled}` accounting for zero
+  receiver-accepted bytes — the "client ABORT wins" leg of the race table.
+- `raw_record`: after admission the client sends one structurally malformed
+  record on the live binding (a nonzero reserved byte — a full, correlatable
+  48-byte header, so it is stream-local rather than the header-unparseable 4007
+  class). The daemon aborts only that stream with `ABORT(protocol_error)` at
+  accepted offset zero, the client ACKs (0x05), and the request resolves to the
+  correlated `malformed_frame` reply while the connection stays usable — the
+  "recoverable stream-local violation" leg of the framing record.
+
+`fault` is legal only on `file.share`, because `file.read` has no executable
+download fixture at all (it needs a peer-fetched file the single-subject harness
+cannot stage). The record's remaining client faults — credit-pause and
+transport-drop — remain declarative until the executor drives them, and adding a
+value here without the executor to run it is not permitted.
 
 A fresh admitted daemon `file.share` or `file.read` requires its matching stream.
 A terminal refusal before OPEN has no stream and records zero receiver-accepted

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -30,23 +30,23 @@ claims:
 
 | Slice | Status | What the claim means |
 |---|---|---|
-| Structural validation | Implemented for all 342 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
+| Structural validation | Implemented for all 346 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
 | Selected JSON-envelope/subject slice | Partial (22 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
 | Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the two client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; and `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the credit-pause and transport-drop fault controls remain unimplemented, so backpressure and disconnect stream cases are still declarative. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
 |---|---:|
-| Cases | 342 |
-| Attributed to an operation | 238 |
-| `operation: null` | 104 |
-| Untargeted / in-process-core / client-adapter targeted | 336 / 1 / 5 |
+| Cases | 346 |
+| Attributed to an operation | 239 |
+| `operation: null` | 107 |
+| Untargeted / in-process-core / client-adapter targeted | 340 / 1 / 5 |
 | Distinct step verbs in use | 7 |
 | Taxonomy codes / without a direct canonical operation case or verified transport representation | 64 / 8 (`forbidden_origin`, `pairing_code_invalid`, `protocol_unsupported`, `role_not_grantable`, `session_expired`, `storage_generation_mismatch`, `unauthenticated`, `unknown_operation`) |
-| Blocked on upstream | 14 (U1: 5, U2: 8, U3: 1) |
+| Blocked on upstream | 15 (U1: 5, U2: 8, U3: 1, U4: 1) |
 | Blocked on a settled record contradiction | 1 |
 
-Per-file case totals are: `files.json` 43, `handshake.json` 69,
+Per-file case totals are: `files.json` 45, `handshake.json` 72,
 `invites.json` 37, `pipes.json` 43, `rooms.json` 65,
 `subject-daemon.json` 24, and `timeline-streams.json` 60.
 

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -1,4381 +1,4381 @@
 {
- "domain": "files",
- "note": "Hand-authored from docs/protocol-v2.md. NOT generated from any implementation. See ../README.md.",
- "cases": [
-  {
-   "name": "handshake_serves_the_file_and_transfer_limits_as_integers",
-   "kind": "handshake",
-   "operation": null,
-   "intent": "Proves the shared-file maximum and the four transfer budget fields arrive in the hello limits object as JSON integers and that the served value is the policy value 104857600, so a daemon that stops serving a limit, serves it as a formatted string, or drifts from the ratified number is caught at the handshake before any file operation runs.",
-   "requires": [
-    "subject"
-   ],
-   "steps": [
+  "domain": "files",
+  "note": "Hand-authored from docs/protocol-v2.md. NOT generated from any implementation. See ../README.md.",
+  "cases": [
     {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes",
-      "max_transfers": "frame.limits.max_concurrent_transfers",
-      "max_inflight": "frame.limits.max_transfer_bytes_inflight",
-      "connect_ms": "frame.limits.transfer_connect_allowance_ms",
-      "floor_bps": "frame.limits.transfer_floor_bits_per_second",
-      "stall_ms": "frame.limits.transfer_stall_ms"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.t",
-       "op": "eq",
-       "value": "hello"
-      },
-      {
-       "path": "frame.protocol",
-       "op": "eq",
-       "value": 2
-      },
-      {
-       "path": "frame.limits.max_shared_file_bytes",
-       "op": "eq",
-       "value": "<uint>"
-      },
-      {
-       "path": "frame.limits.max_concurrent_transfers",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "frame.limits.max_transfer_bytes_inflight",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "frame.limits.transfer_connect_allowance_ms",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "frame.limits.transfer_floor_bits_per_second",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "frame.limits.transfer_stall_ms",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "$limit",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "$max_transfers",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "$max_inflight",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "$connect_ms",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "$floor_bps",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "$stall_ms",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "$limit",
-       "op": "type",
-       "value": "uint",
-       "note": "path recovered from context; exclusions: [\"string\", \"float\", \"null\", \"object\"]"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "$limit",
-       "op": "eq",
-       "value": 104857600
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "frame.pid",
-       "op": "absent"
-      },
-      {
-       "path": "frame.port",
-       "op": "absent"
-      },
-      {
-       "path": "frame.schema",
-       "op": "absent"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "client_reads_the_shared_file_limit_from_the_handshake",
-   "kind": "handshake",
-   "operation": "file.share",
-   "targets": [
-    "client_adapter"
-   ],
-   "intent": "Proves the client's share preflight threshold moves with a harness-reduced served max_shared_file_bytes rather than a compiled-in constant, catching any client that reintroduces one of the six hard-coded copies the size policy exists to delete.",
-   "requires": [],
-   "steps": [
-    {
-     "control": {
-      "do": "set_limit",
-      "limit": "max_shared_file_bytes",
-      "value": 1048576
-     }
-    },
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.limits.max_shared_file_bytes",
-       "op": "eq",
-       "value": 1048576
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "client_preflight",
-      "source_bytes": "$limit",
-      "source_reports_size": true
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "accepted"
-      },
-      {
-       "path": "frame.accepted",
-       "op": "eq",
-       "value": true
-      },
-      {
-       "path": "frame.source_bytes",
-       "op": "eq",
-       "value": "$limit"
-      },
-      {
-       "path": "frame.bytes_sent",
-       "op": "eq",
-       "value": "$limit"
-      },
-      {
-       "path": "frame.requests_emitted",
-       "op": "eq",
-       "value": 1
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "client_preflight",
-      "source_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      },
-      "source_reports_size": true
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "refused"
-      },
-      {
-       "path": "frame.refused",
-       "op": "eq",
-       "value": true
-      },
-      {
-       "path": "frame.bytes_sent",
-       "op": "eq",
-       "value": 0
-      },
-      {
-       "path": "frame.requests_emitted",
-       "op": "eq",
-       "value": 0
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "client_renders_the_limit_message_from_the_served_integer",
-   "kind": "handshake",
-   "operation": "file.share",
-   "targets": [
-    "client_adapter"
-   ],
-   "intent": "Proves the human-readable limit is rendered from the SERVED integer, so no catalog carries the number verbatim and a served change cannot make a translation lie. Asserted two ways: no locale catalog contains the number, and the rendered string moves when the harness overrides the limit.",
-   "requires": [],
-   "steps": [
-    {
-     "control": {
-      "do": "set_limit",
-      "limit": "max_shared_file_bytes",
-      "value": 1048576
-     }
-    },
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "control": {
-      "do": "client_render_limit",
-      "served_bytes": "$limit"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.source_bytes",
-       "op": "eq",
-       "value": "$limit"
-      },
-      {
-       "path": "frame.rendered",
-       "op": "type",
-       "value": "string"
-      },
-      {
-       "path": "frame.rendered",
-       "op": "byte_len",
-       "value": {
-        "op": "gt",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "share_below_the_served_limit_succeeds",
-   "kind": "success",
-   "operation": "file.share",
-   "intent": "Establishes the baseline success shape of the streamed share: a file identifier, the authored room fact, the daemon-computed digest and the accepted byte count, with no filesystem path in either direction, catching any regression to v1's path-taking RPC plus separate HTTP upload edge.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "Files"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-share-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "notes.txt",
-      "declared_bytes": 1024,
-      "declared_content_type": "text/plain"
-     },
-     "save": {
-      "fid": "out.file_id"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "<file_id>",
-       "event_id": "<event_id>",
-       "pos": "<uint>",
-       "bytes": 1024,
-       "digest": "<string>"
-      }
-     },
-     "op_id": "op-share-2",
-     "stream": {
-      "send_bytes": 1024
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.path",
-       "op": "absent"
-      },
-      {
-       "path": "out.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.file_url",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
+      "name": "handshake_serves_the_file_and_transfer_limits_as_integers",
+      "kind": "handshake",
+      "operation": null,
+      "intent": "Proves the shared-file maximum and the four transfer budget fields arrive in the hello limits object as JSON integers and that the served value is the policy value 104857600, so a daemon that stops serving a limit, serves it as a formatted string, or drifts from the ratified number is caught at the handshake before any file operation runs.",
+      "requires": [
+        "subject"
+      ],
+      "steps": [
         {
-         "file_id": "$fid",
-         "self_hosted": true,
-         "fetchable": true,
-         "bytes": 1024
-        }
-       ]
-      }
-     }
-    }
-   ]
-  },
-  {
-   "name": "share_at_exactly_the_served_limit_is_accepted",
-   "kind": "boundary",
-   "operation": "file.share",
-   "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes is accepted, catching an off-by-one that would silently refuse the largest legal file.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "AtLimit"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-atlimit-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "exactly-at-limit.bin",
-      "declared_bytes": "$limit",
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "<file_id>",
-       "event_id": "<event_id>",
-       "pos": "<uint>",
-       "bytes": "$limit",
-       "digest": "<string>"
-      }
-     },
-     "op_id": "op-atlimit-2",
-     "stream": {
-      "send_bytes": "$limit"
-     }
-    }
-   ]
-  },
-  {
-   "name": "share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled",
-   "kind": "error",
-   "operation": "file.share",
-   "intent": "Proves a client can cancel an admitted upload before sending any DATA by issuing ABORT(cancelled): the daemon acknowledges the ABORT and then replies stream_aborted{cancelled} accounting for zero receiver-accepted bytes -- the 'client ABORT wins' leg of the race table. Catches a daemon that ignores a producer ABORT, replies success, or sends its terminal reply without first acknowledging the ABORT, and a harness whose byte counter could pass without the daemon proving it accepted nothing.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "ClientCancel"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-clientcancel-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "cancelled.bin",
-      "declared_bytes": 1024,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "stream_aborted",
-       "transferred_bytes": 0,
-       "total": {
-        "state": "known",
-        "bytes": 1024
-       },
-       "reason": "cancelled"
-      }
-     },
-     "op_id": "op-clientcancel-2",
-     "stream": {
-      "send_bytes": 1024,
-      "fault": "client_abort"
-     }
-    }
-   ]
-  },
-  {
-   "name": "share_malformed_stream_record_aborts_that_stream_as_malformed_frame",
-   "kind": "error",
-   "operation": "file.share",
-   "intent": "Proves a client protocol violation mid-stream is stream-local, not connection-fatal: after admission the client sends one structurally malformed byte-stream record (a nonzero reserved byte) on the live (request id, stream id) binding, whose full 48-byte header the daemon can correlate. The daemon aborts only that stream with ABORT(protocol_error) at accepted offset zero, the client ACKs, and file.share resolves to the correlated malformed_frame reply while the connection stays usable. Catches a daemon that closes the connection (4005/4007) on a correlatable malformed record, replies success, or answers without first ABORTing, and a harness that cannot drive a raw malformed record.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "RawRecord"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-rawrecord-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "malformed.bin",
-      "declared_bytes": 1024,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "malformed_frame"
-      }
-     },
-     "op_id": "op-rawrecord-2",
-     "stream": {
-      "send_bytes": 1024,
-      "fault": "raw_record"
-     }
-    }
-   ]
-  },
-  {
-   "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
-   "kind": "boundary",
-   "operation": "file.share",
-   "intent": "Proves the earliest daemon-side enforcement point fires on a declaration one byte above the served limit before OPEN or any body byte, with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "OverByOne"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-over-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "one-past.bin",
-      "declared_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      },
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": {
-        "$add": [
-         "$limit",
-         1
-        ]
-       },
-       "limit_bytes": "$limit",
-       "enforced_at": "stage_declared"
-      }
-     },
-     "op_id": "op-over-2"
-    },
-    {
-     "assert": [
-      {
-       "path": "err.hint",
-       "op": "absent"
-      },
-      {
-       "path": "err.path",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "bytes_streamed",
-       "call": "step:5",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_push",
-       "room_id": "$rid",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_event_authored",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "err.declared_bytes",
-       "op": "type",
-       "value": "uint"
-      },
-      {
-       "path": "err.limit_bytes",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "$limit",
-       "op": "type",
-       "value": "uint",
-       "note": "path recovered from context; exclusions: [\"string\"]"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "share_declared_within_limit_but_stream_exceeds_it_aborts_at_stage_stream",
-   "kind": "boundary",
-   "operation": "file.share",
-   "intent": "Proves a declared length is treated as an assertion by an untrusted caller and not as fact: a caller declaring exactly $limit but streaming more is aborted mid-stream with enforced_at=stage_stream after consuming no more than limit_bytes, catching a daemon that enforces only on the declaration.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "LyingDeclaration"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-liar-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "understated.bin",
-      "declared_bytes": "$limit",
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": "$limit",
-       "limit_bytes": "$limit",
-       "enforced_at": "stage_stream"
-      }
-     },
-     "op_id": "op-liar-2",
-     "stream": {
-      "send_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "observe": "bytes_streamed",
-       "call": "step:5",
-       "value": {
-        "op": "eq",
-        "value": "$limit"
-       }
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_push",
-       "room_id": "$rid",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_event_authored",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_durable_mutation",
-       "scope": "case"
-      }
-     ],
-     "note": "an aborted stage leaves no stranded staged file"
-    }
-   ]
-  },
-  {
-   "name": "share_over_limit_in_process_core_is_refused_at_authoring",
-   "kind": "error",
-   "operation": "file.share",
-   "targets": [
-    "in_process_core"
-   ],
-   "intent": "Proves the core authoring layer enforces the limit on file metadata before hashing or blob import, which is the only enforcement point that exists for an in-process adapter with no daemon upload edge, catching an implementation that relies on the stage checks alone.",
-   "requires": [
-    "subject",
-    "room:live",
-    "control:limits"
-   ],
-   "steps": [
-    {
-     "control": {
-      "do": "set_limit",
-      "limit": "max_shared_file_bytes",
-      "value": 4096
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "InProcess"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-authoring-1"
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "too-big-in-process.bin",
-      "declared_bytes": 4097,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": 4097,
-       "limit_bytes": 4096,
-       "enforced_at": "authoring"
-      }
-     },
-     "op_id": "op-authoring-2"
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_durable_mutation",
-       "scope": "case"
-      }
-     ],
-     "note": "authoring refusal leaves nothing behind"
-    }
-   ]
-  },
-  {
-   "name": "client_preflight_refuses_over_limit_before_any_bytes_are_sent",
-   "kind": "boundary",
-   "operation": "file.share",
-   "targets": [
-    "client_adapter"
-   ],
-   "intent": "Proves the sixth enforcement point \u2014 the client preflight, which by definition never reaches the daemon \u2014 refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
-   "requires": [
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "control": {
-      "do": "client_preflight",
-      "source_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      },
-      "source_reports_size": true
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "refused"
-      },
-      {
-       "path": "frame.refused",
-       "op": "eq",
-       "value": true
-      },
-      {
-       "path": "frame.bytes_sent",
-       "op": "eq",
-       "value": 0
-      },
-      {
-       "path": "frame.requests_emitted",
-       "op": "eq",
-       "value": 0
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "client_unsized_source_streams_through_a_counting_bound",
-   "kind": "boundary",
-   "operation": "file.share",
-   "targets": [
-    "client_adapter"
-   ],
-   "intent": "Proves a client facing a source that reports no size neither rejects it for lacking a size nor copies it unbounded, but streams it through a byte-counting bound that stops at the served limit, catching the two failure modes the size policy names for the Android SAF path.",
-   "requires": [
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "control": {
-      "do": "client_preflight",
-      "source_bytes": 65536,
-      "source_reports_size": false
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "accepted"
-      },
-      {
-       "path": "frame.accepted",
-       "op": "eq",
-       "value": true
-      },
-      {
-       "path": "frame.bytes_sent",
-       "op": "eq",
-       "value": 65536
-      },
-      {
-       "path": "frame.requests_emitted",
-       "op": "eq",
-       "value": 1
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "client_preflight",
-      "source_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      },
-      "source_reports_size": false
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "refused"
-      },
-      {
-       "path": "frame.refused",
-       "op": "eq",
-       "value": true
-      },
-      {
-       "path": "frame.bytes_sent",
-       "op": "eq",
-       "value": 0
-      },
-      {
-       "path": "frame.requests_emitted",
-       "op": "eq",
-       "value": 0
-      },
-      {
-       "path": "frame.staged_bytes",
-       "op": "lte",
-       "value": "$limit"
-      },
-      {
-       "path": "frame.peak_buffered_bytes",
-       "op": "lte",
-       "value": "$limit"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "share_size_refusal_is_never_reported_as_digest_mismatch",
-   "kind": "error",
-   "operation": "file.share",
-   "intent": "First half of the paired direction rule: an over-limit share is reported as file_too_large and never as digest_mismatch, so a size refusal is never dressed up as a false accusation of content tampering against an honest caller.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "room.create",
-     "in": {
-      "name": "PairA"
-     },
-     "save": {
-      "rid": "out.room_id"
-     },
-     "op_id": "op-pairA-1"
-    },
-    {
-     "call": "room.activate",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "oversize.bin",
-      "declared_bytes": {
-       "$add": [
-        "$limit",
-        1
-       ]
-      },
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": {
-        "$add": [
-         "$limit",
-         1
-        ]
-       },
-       "limit_bytes": "$limit",
-       "enforced_at": "stage_declared"
-      }
-     },
-     "op_id": "op-pairA-2"
-    }
-   ]
-  },
-  {
-   "name": "fetch_of_corrupt_bytes_within_the_limit_is_digest_mismatch_never_file_too_large",
-   "kind": "error",
-   "operation": "file.fetch",
-   "intent": "Second half of the paired direction rule: a within-limit blob whose bytes do not verify against the signed digest is reported as digest_mismatch carrying expected and observed, never as file_too_large, so a content failure is never mislabelled a size failure and the two codes stay disjoint in both directions.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "digest_mismatch",
-       "expected": "<string>",
-       "observed": "<string>"
-      }
-     },
-     "op_id": "op-pairB-1"
-    }
-   ]
-  },
-  {
-   "name": "share_declared_size_as_a_formatted_string_is_malformed",
-   "kind": "malformed",
-   "operation": "file.share",
-   "intent": "Proves the size is carried as a typed integer and never as a formatted string, refusing both a unit-bearing string and a decimal string with invalid_argument rather than parsing either, catching a client that ships the human rendering onto the wire.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": "100 MiB",
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-malformed-1"
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": "1024",
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-malformed-2"
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_push",
-       "room_id": "$rid",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_event_authored",
-       "scope": "case"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "share_size_null_or_out_of_domain_is_malformed",
-   "kind": "malformed",
-   "operation": "file.share",
-   "intent": "Proves no JSON null carries meaning on the file path \u2014 a null size is not read as unknown \u2014 and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": null,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-null-1"
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": -1,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-null-3"
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": 1.5,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-null-4"
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "a.bin",
-      "declared_bytes": {
-       "state": "declared"
-      },
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "in.declared_bytes",
-       "reason": {
-        "state": "type",
-        "expected": "uint"
-       }
-      }
-     },
-     "op_id": "op-null-5"
-    }
-   ]
-  },
-  {
-   "name": "share_completed_result_replays_without_a_second_stream_and_authors_once",
-   "kind": "success",
-   "operation": "file.share",
-   "intent": "Proves a completed file.share result is op_id deduplicated across a same-principal reconnection: the replay returns the original out directly, opens no second stream, accepts zero bytes, and performs no second blob import or authored fact.",
-   "requires": [
-    "subject",
-    "room:live",
-    "control:reconnect"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {
-       "v": 2,
-       "sg": "$daemon.storage_generation"
-      },
-      "headers": {
-       "Authorization": "Bearer <bearer_from_portfile>"
-      }
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "once.bin",
-      "declared_bytes": 2048,
-      "declared_content_type": "application/octet-stream"
-     },
-     "on": "subject:self",
-     "save": {
-      "first": "out"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "<file_id>",
-       "event_id": "<event_id>",
-       "pos": "<uint>",
-       "bytes": 2048,
-       "digest": "<string>"
-      }
-     },
-     "op_id": "op-dedup-share",
-     "stream": {
-      "send_bytes": 2048
-     }
-    },
-    {
-     "control": {
-      "do": "disconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "control": {
-      "do": "reconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "once.bin",
-      "declared_bytes": 2048,
-      "declared_content_type": "application/octet-stream"
-     },
-     "on": "subject:self",
-     "op_id": "op-dedup-share",
-     "expect": {
-      "ok": true,
-      "out": "$first"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out",
-       "op": "eq",
-       "value": "$first"
-      },
-      {
-       "observe": "bytes_streamed",
-       "call": "step:5",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "on": "subject:self",
-     "note": "[bare-string assert 'exactly_one_entry_with' needs manual retranscription]"
-    },
-    {
-     "assert": [
-      {
-       "path": "$first.file_id",
-       "op": "present"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "list_names_provider_devices_with_fetchable_and_self_hosted_as_stated_facts",
-   "kind": "success",
-   "operation": "file.list",
-   "intent": "Proves file.list returns named provider devices carrying reachability evidence plus separate fetchable and self_hosted booleans, and carries none of v1's provider count, available boolean, or local path fields, catching any client forced back to inferring availability from a number.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "files": [
-        {
-         "file_id": "<file_id>",
-         "name": "design.pdf",
-         "digest": "<string>",
-         "providers": [
-          {
-           "device_id": "<device_id>",
-           "subject_id": "<subject_id>",
-           "link": {
-            "state": "direct",
-            "since": "<ts>"
-           }
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
           }
-         ],
-         "fetchable": "<bool>",
-         "self_hosted": "<bool>",
-         "bytes": "<uint>",
-         "declared_content_type": "application/pdf",
-         "shared_by": "<subject_id>",
-         "shared_at": "<ts>"
-        }
-       ]
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.files[*].available",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].providers_count",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].local_bytes",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].fetched",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].fetched_at_ms",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].mime",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].path",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].file_url",
-       "op": "absent"
-      },
-      {
-       "path": "out.path",
-       "op": "absent"
-      },
-      {
-       "path": "out.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.file_url",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "out.files[*].providers",
-       "op": "len",
-       "value": {
-        "op": "gte",
-        "value": 1
-       }
-      },
-      {
-       "path": "out.files[*].fetchable",
-       "op": "type",
-       "value": "bool"
-      },
-      {
-       "path": "out.files[*].self_hosted",
-       "op": "type",
-       "value": "bool"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "out",
-       "op": "no_nulls"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "list_reports_fetchable_false_with_a_stated_reason_when_no_provider_is_reachable",
-   "kind": "success",
-   "operation": "file.list",
-   "intent": "Proves fetchable is evidence-backed transport fact and not an inference from membership display state: a provider that room.members reports as an active member but that this daemon holds no link to yields fetchable false with a typed unreachable reason, which is the #50/#94 separation of membership from availability.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "note": "[control shape {\"provider_link\": \"down\"} needs review] [harness orchestration: provider_link]",
-     "control": {
-      "do": "idle",
-      "ms": 0
-     }
-    },
-    {
-     "call": "room.members",
-     "in": {
-      "room_id": "$rid"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "members": [
+        },
         {
-         "subject_id": "<string>",
-         "standing": "active"
-        }
-       ]
-      }
-     },
-     "save": {
-      "member": "out.members[0].subject_id"
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
-        {
-         "providers": [
-          {
-           "subject_id": "$member",
-           "device_id": "<string>",
-           "link": {
-            "state": "unreachable",
-            "reason": "no_route"
-           }
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes",
+            "max_transfers": "frame.limits.max_concurrent_transfers",
+            "max_inflight": "frame.limits.max_transfer_bytes_inflight",
+            "connect_ms": "frame.limits.transfer_connect_allowance_ms",
+            "floor_bps": "frame.limits.transfer_floor_bits_per_second",
+            "stall_ms": "frame.limits.transfer_stall_ms"
           }
-         ],
-         "fetchable": false,
-         "self_hosted": false
-        }
-       ]
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.room.members.standing",
-       "op": "present"
-      },
-      {
-       "path": "out.file.list.fetchable",
-       "op": "present"
-      },
-      {
-       "path": "out.file.list.providers[].reachability",
-       "op": "present"
-      }
-     ]
-    },
-    {
-     "note": "[control shape {\"provider_link\": \"up\"} needs review] [harness orchestration: provider_link]",
-     "control": {
-      "do": "idle",
-      "ms": 0
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
+        },
         {
-         "fetchable": true
-        }
-       ]
-      }
-     },
-     "note": "the fact tracks observed transport, not the member list"
-    }
-   ]
-  },
-  {
-   "name": "list_of_a_room_that_is_not_available_answers_room_not_available",
-   "kind": "error",
-   "operation": "file.list",
-   "intent": "Gives file.list its refusal case using the most specific code the v2 taxonomy defines for a room-scoped read, proving an unknown or non-member room never yields a generic argument error or an empty success that would leak that the room does not exist.",
-   "requires": [
-    "subject"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
-      }
-     }
-    }
-   ]
-  },
-  {
-   "name": "list_carries_a_hostile_peer_declared_name_as_an_opaque_display_string",
-   "kind": "malformed",
-   "operation": "file.list",
-   "intent": "Proves a peer-chosen file name containing path separators and traversal segments is carried verbatim in a display-only field and never appears in, or is used to construct, any path-typed field, catching a daemon that either silently rewrites peer-signed metadata or treats it as a location.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
-        {
-         "name": "../../../etc/passwd",
-         "declared_content_type": "text/plain"
-        }
-       ]
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.files[*].path",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.files[*].save_dir",
-       "op": "absent"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_from_a_reachable_provider_holds_the_bytes_locally",
-   "kind": "success",
-   "operation": "file.fetch",
-   "intent": "Establishes the baseline fetch success shape \u2014 the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response \u2014 catching any regression to v1's directory-taking, path-returning fetch.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "file_id": "$fid",
-       "room_id": "$rid",
-       "bytes": "<uint>",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     },
-     "op_id": "op-fetch-1"
-    },
-    {
-     "assert": [
-      {
-       "path": "out.path",
-       "op": "absent"
-      },
-      {
-       "path": "out.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.file_url",
-       "op": "absent"
-      },
-      {
-       "path": "out.verified",
-       "op": "absent"
-      },
-      {
-       "path": "out.local",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
-        {
-         "file_id": "$fid",
-         "self_hosted": true
-        }
-       ]
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.files[0].local",
-       "op": "absent"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_preflight_refuses_an_oversized_signed_size_before_contacting_a_provider",
-   "kind": "boundary",
-   "operation": "file.fetch",
-   "intent": "Proves the receive side preflights the signed size_bytes against the served limit and refuses with enforced_at=fetch_preflight before opening any connection, which is the enforcement point that does not exist today and the one that prevents an oversized remote blob from ever being reported as an integrity failure.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "limit": "frame.limits.max_shared_file_bytes"
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
-        {
-         "fetchable": "<bool>",
-         "bytes": {
-          "$add": [
-           "$limit",
-           1
+          "assert": [
+            {
+              "path": "frame.t",
+              "op": "eq",
+              "value": "hello"
+            },
+            {
+              "path": "frame.protocol",
+              "op": "eq",
+              "value": 2
+            },
+            {
+              "path": "frame.limits.max_shared_file_bytes",
+              "op": "eq",
+              "value": "<uint>"
+            },
+            {
+              "path": "frame.limits.max_concurrent_transfers",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "frame.limits.max_transfer_bytes_inflight",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "frame.limits.transfer_connect_allowance_ms",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "frame.limits.transfer_floor_bits_per_second",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "frame.limits.transfer_stall_ms",
+              "op": "type",
+              "value": "uint"
+            }
           ]
-         }
-        }
-       ]
-      }
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": {
-        "$add": [
-         "$limit",
-         1
-        ]
-       },
-       "limit_bytes": "$limit",
-       "enforced_at": "fetch_preflight"
-      }
-     },
-     "op_id": "op-preflight-1"
-    },
-    {
-     "assert": [
-      {
-       "observe": "bytes_streamed",
-       "call": "step:4",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_stream_refuses_a_peer_serving_more_than_it_declared",
-   "kind": "boundary",
-   "operation": "file.fetch",
-   "intent": "Proves the mid-stream fetch bound reports a provider response exceeding the signed declaration as file_too_large at fetch_stream after accepting exactly the declared bytes; it remains blocked until U3 supplies a size-distinguishable fetch outcome.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid": "out.files[0].file_id",
-      "declared_bytes": "out.files[0].bytes"
-     }
-    },
-    {
-     "control": {
-      "do": "set_provider_response_bytes",
-      "file_id": "$fid",
-      "bytes": {
-       "$add": [
-        "$declared_bytes",
-        1
-       ]
-      }
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_too_large",
-       "declared_bytes": "$declared_bytes",
-       "limit_bytes": "$declared_bytes",
-       "enforced_at": "fetch_stream"
-      }
-     },
-     "op_id": "op-fetchstream-1"
-    },
-    {
-     "assert": [
-      {
-       "observe": "bytes_streamed",
-       "call": "step:3",
-       "value": {
-        "op": "eq",
-        "value": "$declared_bytes"
-       }
-      }
-     ]
-    }
-   ],
-   "blocked_on_upstream": "U3"
-  },
-  {
-   "name": "fetch_with_no_reachable_provider_fails_with_provider_unreachable",
-   "kind": "error",
-   "operation": "file.fetch",
-   "intent": "Gives file.fetch a transport-specific refusal distinct from every size and integrity code, proving an unfetchable file names the reason it could not be served rather than reporting a mismatch or a generic argument error, and that the answer agrees with the fetchable fact file.list stated.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:down"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
+        },
         {
-         "fetchable": false
-        }
-       ]
-      }
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "provider_unreachable",
-       "file_id": "$fid",
-       "providers": [
+          "assert": [
+            {
+              "path": "$limit",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "$max_transfers",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "$max_inflight",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "$connect_ms",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "$floor_bps",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "$stall_ms",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
         {
-         "subject_id": "<subject_id>",
-         "device_id": "<device_id>",
-         "link": {
-          "state": "not_connected",
-          "reason": "no_route"
-         }
+          "assert": [
+            {
+              "path": "$limit",
+              "op": "type",
+              "value": "uint",
+              "note": "path recovered from context; exclusions: [\"string\", \"float\", \"null\", \"object\"]"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "$limit",
+              "op": "eq",
+              "value": 104857600
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "frame.pid",
+              "op": "absent"
+            },
+            {
+              "path": "frame.port",
+              "op": "absent"
+            },
+            {
+              "path": "frame.schema",
+              "op": "absent"
+            }
+          ]
         }
-       ]
-      }
-     },
-     "op_id": "op-unreach-1"
+      ]
     },
     {
-     "assert": [
-      {
-       "path": "out.files[0].fetchable",
-       "op": "present"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
-   "kind": "malformed",
-   "operation": "file.fetch",
-   "intent": "Proves file.fetch rejects a missing envelope op_id during structural decode, before room lookup or provider contact, even when the room and file inputs are otherwise valid.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "invalid_argument",
-       "field": "op_id",
-       "reason": {
-        "state": "missing"
-       }
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_network_activity",
-       "scope": "step"
-      },
-      {
-       "observe": "bytes_streamed",
-       "call": "step:2",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown",
-   "kind": "error",
-   "operation": "file.fetch",
-   "intent": "Proves a member asking for a file identifier the room's signed history does not contain gets a file-specific code rather than a generic argument error, while confirming this distinction is only ever offered to a member (the non-member answer is covered by the oracle case).",
-   "requires": [
-    "subject",
-    "room:live"
-   ],
-   "steps": [
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": {
-       "$unknown": "<file_id>"
-      }
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_unknown",
-       "file_id": {
-        "$unknown": "<file_id>"
-       }
-      }
-     },
-     "op_id": "op-unknownfile-1"
-    }
-   ]
-  },
-  {
-   "name": "fetch_completed_result_replays_without_a_second_transfer",
-   "kind": "success",
-   "operation": "file.fetch",
-   "intent": "Proves a completed file.fetch result is op_id deduplicated across a same-principal reconnection, so replay returns the original out directly and moves no second copy of the bytes across the network.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "control:reconnect"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "subject:self",
-     "save": {
-      "first": "out"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "file_id": "$fid",
-       "room_id": "$rid",
-       "bytes": "<uint>",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     },
-     "op_id": "op-dedup-fetch"
-    },
-    {
-     "assert": [
-      {
-       "path": "out.local",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "disconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "control": {
-      "do": "reconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "subject:self",
-     "expect": {
-      "ok": true,
-      "out": "$first"
-     },
-     "op_id": "op-dedup-fetch"
-    },
-    {
-     "assert": [
-      {
-       "path": "out",
-       "op": "eq",
-       "value": "$first"
-      },
-      {
-       "observe": "bytes_streamed",
-       "call": "step:6",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "fetch_deadline_scales_with_the_declared_size",
-   "kind": "boundary",
-   "operation": "file.fetch",
-   "intent": "Proves the absolute file.fetch deadline uses the signed total and served floor: one transfer at the floor succeeds, while another reports the exact size-derived budget rather than any fixed timeout, with a truthful accepted-byte count.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "control:limits"
-   ],
-   "steps": [
-    {
-     "control": {
-      "do": "set_limit",
-      "limit": "transfer_connect_allowance_ms",
-      "value": 1000
-     }
-    },
-    {
-     "control": {
-      "do": "set_limit",
-      "limit": "transfer_floor_bits_per_second",
-      "value": 8192
-     }
-    },
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "connect_ms": "frame.limits.transfer_connect_allowance_ms",
-      "floor_bps": "frame.limits.transfer_floor_bits_per_second"
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid_at_floor": "out.files[0].file_id",
-      "total_at_floor": "out.files[0].bytes",
-      "fid_below_floor": "out.files[1].file_id",
-      "total_below_floor": "out.files[1].bytes"
-     }
-    },
-    {
-     "control": {
-      "do": "set_link_rate",
-      "between": [
-       "subject:self",
-       "provider"
+      "name": "client_reads_the_shared_file_limit_from_the_handshake",
+      "kind": "handshake",
+      "operation": "file.share",
+      "targets": [
+        "client_adapter"
       ],
-      "bits_per_second": "$floor_bps"
-     }
+      "intent": "Proves the client's share preflight threshold moves with a harness-reduced served max_shared_file_bytes rather than a compiled-in constant, catching any client that reintroduces one of the six hard-coded copies the size policy exists to delete.",
+      "requires": [],
+      "steps": [
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "max_shared_file_bytes",
+            "value": 1048576
+          }
+        },
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.limits.max_shared_file_bytes",
+              "op": "eq",
+              "value": 1048576
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": "$limit",
+            "source_reports_size": true
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "accepted"
+            },
+            {
+              "path": "frame.accepted",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.source_bytes",
+              "op": "eq",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": true
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
+            }
+          ]
+        }
+      ]
     },
     {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid_at_floor"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "$fid_at_floor",
-       "bytes": "$total_at_floor",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     },
-     "op_id": "op-budget-floor"
-    },
-    {
-     "control": {
-      "do": "set_link_rate",
-      "between": [
-       "subject:self",
-       "provider"
+      "name": "client_renders_the_limit_message_from_the_served_integer",
+      "kind": "handshake",
+      "operation": "file.share",
+      "targets": [
+        "client_adapter"
       ],
-      "bits_per_second": 1
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid_below_floor"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_deadline_exceeded",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total_below_floor"
-       },
-       "budget_ms": {
-        "$transfer_budget_ms": [
-         "$total_below_floor",
-         "$connect_ms",
-         "$floor_bps"
-        ]
-       }
-      }
-     },
-     "op_id": "op-budget-expiry"
-    },
-    {
-     "assert": [
-      {
-       "path": "err.transferred_bytes",
-       "op": "lt",
-       "value": "$total_below_floor"
-      },
-      {
-       "path": "err.transferred_bytes",
-       "op": "gt",
-       "value": 0
-      },
-      {
-       "path": "err.budget_ms",
-       "op": "gt",
-       "value": "$connect_ms"
-      }
-     ]
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field",
-   "kind": "success",
-   "operation": "file.read",
-   "intent": "Proves file.read streams bytes with the peer-declared type carried in a distinctly named, explicitly untrusted field and with no field that presents a type as authoritative fact, which is how v1's never-render-inline HTTP response headers become data now that bytes no longer travel over HTTP.",
-   "requires": [
-    "subject",
-    "room:live",
-    "resource:fetched_file"
-   ],
-   "steps": [
-    {
-     "call": "file.read",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "$fid",
-       "bytes": 4096,
-       "declared_content_type": "application/pdf"
-      }
-     },
-     "stream": {
-      "receive_bytes": 4096
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "out.path",
-       "op": "absent"
-      },
-      {
-       "path": "out.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.file_url",
-       "op": "absent"
-      },
-      {
-       "path": "out.mime",
-       "op": "absent"
-      },
-      {
-       "path": "out.content_type",
-       "op": "absent"
-      },
-      {
-       "path": "out.type",
-       "op": "absent"
-      },
-      {
-       "path": "out.sniffed_type",
-       "op": "absent"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "client_must_not_render_peer_declared_bytes_inline",
-   "kind": "boundary",
-   "operation": "file.read",
-   "targets": [
-    "client_adapter"
-   ],
-   "intent": "Proves a client treats the peer-declared type as a hint only: a peer declaring text/html with a script-bearing body is never rendered inline as markup and never executes, catching a client that restores v1's inline-render behaviour now that the protective HTTP headers are gone.",
-   "requires": [
-    "resource:fetched_file",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.read",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "$fid",
-       "bytes": 4096,
-       "declared_content_type": "text/html"
-      }
-     },
-     "stream": {
-      "receive_bytes": 4096
-     }
-    },
-    {
-     "control": {
-      "do": "client_render_file",
-      "declared_content_type": "text/html",
-      "body_kind": "script_bearing_html"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.decision",
-       "op": "eq",
-       "value": "download_only"
-      },
-      {
-       "path": "frame.executed",
-       "op": "eq",
-       "value": false
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "read_of_a_file_whose_bytes_are_not_held_locally_fails_with_file_not_fetched",
-   "kind": "error",
-   "operation": "file.read",
-   "intent": "Gives file.read its own refusal case, proving that reading a known but unfetched file names that precise condition rather than silently fetching it, returning empty bytes, or answering with a generic argument error.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
-        {}
-       ]
-      }
-     },
-     "save": {
-      "fid": "out.files[0].file_id"
-     }
-    },
-    {
-     "call": "file.read",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_not_fetched",
-       "file_id": "$fid"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "observe": "bytes_streamed",
-       "call": "step:2",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "transfer_cancel_after_the_originating_connection_dropped",
-   "kind": "success",
-   "operation": "transfer.cancel",
-   "intent": "Proves a deferred file.fetch remains cancellable after its originating transport drops: the same principal reconnects, cancels by transfer_op_id, and replaying the original request on that session returns the recorded cancelled stream_aborted result without awaiting a dead connection handle.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "control:reconnect"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "on": "subject:self",
-     "save": {
-      "fid": "out.files[0].file_id",
-      "total": "out.files[0].bytes"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "subject:self",
-     "op_id": "op-cancel-target",
-     "defer": true,
-     "save": {
-      "abandoned_fetch_request": "$request"
-     },
-     "note": "The disconnect abandons this connection-local request handle; it is saved only because the current deferred-call DSL validator requires a handle."
-    },
-    {
-     "control": {
-      "do": "disconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "control": {
-      "do": "reconnect",
-      "on": "subject:self"
-     }
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-cancel-target"
-     },
-     "on": "subject:self",
-     "expect": {
-      "ok": true,
-      "out": {
-       "transfer_op_id": "op-cancel-target",
-       "outcome": {
-        "state": "cancelled"
-       },
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       }
-      }
-     },
-     "save": {
-      "cancelled_bytes": "out.transferred_bytes"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "subject:self",
-     "op_id": "op-cancel-target",
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "stream_aborted",
-       "transferred_bytes": "$cancelled_bytes",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       },
-       "reason": "cancelled"
-      }
-     }
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
-   "kind": "authorization",
-   "operation": "transfer.cancel",
-   "intent": "Proves the principal-scoped cancellation ledger is not an oracle on one daemon: a second principal sees the same transfer_unknown shape for the owner's live transfer and an absent transfer, while the owner can still cancel and receives the original fetch's terminal cancellation reply.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "on": "principal:self",
-     "save": {
-      "fid": "out.files[0].file_id",
-      "total": "out.files[0].bytes"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "principal:self",
-     "op_id": "op-cancel-owned",
-     "defer": true,
-     "save": {
-      "fetch_request": "$request"
-     }
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-cancel-owned"
-     },
-     "on": "principal:second",
-     "save": {
-      "foreign_err": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_unknown",
-       "transfer_op_id": "op-cancel-owned"
-      }
-     }
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-never-existed"
-     },
-     "on": "principal:second",
-     "save": {
-      "absent_err": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_unknown",
-       "transfer_op_id": "op-never-existed"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$foreign_err",
-       "op": "eq_except",
-       "value": {
-        "path": "$absent_err",
-        "keys": [
-         "transfer_op_id"
-        ]
-       }
-      }
-     ]
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-cancel-owned"
-     },
-     "on": "principal:self",
-     "save": {
-      "cancelled_bytes": "out.transferred_bytes"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "transfer_op_id": "op-cancel-owned",
-       "outcome": {
-        "state": "cancelled"
-       },
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       }
-      }
-     }
-    },
-    {
-     "await": {
-      "reply": "$fetch_request"
-     },
-     "on": "principal:self",
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "stream_aborted",
-       "transferred_bytes": "$cancelled_bytes",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       },
-       "reason": "cancelled"
-      }
-     }
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
-   "kind": "error",
-   "operation": "transfer.cancel",
-   "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error \u2014 the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
-   "requires": [
-    "subject"
-   ],
-   "steps": [
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-does-not-exist"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_unknown",
-       "transfer_op_id": "op-does-not-exist"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "err.path",
-       "op": "absent"
-      },
-      {
-       "path": "err.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "err.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "err.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "err.dir",
-       "op": "absent"
-      },
-      {
-       "path": "err.directory",
-       "op": "absent"
-      },
-      {
-       "path": "err.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "err.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "err.uri",
-       "op": "absent"
-      },
-      {
-       "path": "err.file_url",
-       "op": "absent"
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "transfer_cancel_releases_the_concurrent_transfer_slot",
-   "kind": "success",
-   "operation": "transfer.cancel",
-   "intent": "Proves cancellation actually returns the transfer to the daemon budget rather than merely reporting success: after filling the served concurrency ceiling, cancelling op-slot-0 frees that slot for a succeeding fetch, then cleanup cancels the remaining harness-started set.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "control:concurrency"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "max_transfers": "frame.limits.max_concurrent_transfers"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$max_transfers",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "start_transfers",
-      "count": "$max_transfers",
-      "aggregate_bytes": "$max_transfers",
-      "op_id_prefix": "op-slot-"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "resource_exhausted",
-       "resource": "max_concurrent_transfers",
-       "limit": "$max_transfers"
-      }
-     },
-     "op_id": "op-slot-overflow"
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-slot-0"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "transfer_op_id": "op-slot-0",
-       "outcome": {
-        "state": "cancelled"
-       },
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "<uint>"
-       }
-      }
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "file_id": "$fid",
-       "room_id": "$rid",
-       "bytes": "<uint>",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     },
-     "op_id": "op-slot-retry"
-    },
-    {
-     "assert": [
-      {
-       "path": "out.local",
-       "op": "absent"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "cancel_transfers",
-      "op_id_prefix": "op-slot-"
-     }
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "concurrent_transfers_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
-   "kind": "boundary",
-   "operation": "file.fetch",
-   "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of harness-started transfers run, the next is refused, and the harness cleans the started set up at case end.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "control:concurrency"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "max_transfers": "frame.limits.max_concurrent_transfers"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$max_transfers",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "start_transfers",
-      "count": "$max_transfers",
-      "aggregate_bytes": "$max_transfers",
-      "op_id_prefix": "op-conc-"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "resource_exhausted",
-       "resource": "max_concurrent_transfers",
-       "limit": "$max_transfers"
-      }
-     },
-     "op_id": "op-conc-past"
-    },
-    {
-     "control": {
-      "do": "cancel_transfers",
-      "op_id_prefix": "op-conc-"
-     }
-    }
-   ]
-  },
-  {
-   "name": "inflight_transfer_bytes_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
-   "kind": "boundary",
-   "operation": "file.fetch",
-   "intent": "Proves max_transfer_bytes_inflight is independent: harness-started transfers reserve exactly the served byte budget, one more byte is refused, and the harness cleans the started set up at case end.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "control:concurrency"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "max_inflight": "frame.limits.max_transfer_bytes_inflight",
-      "max_transfers": "frame.limits.max_concurrent_transfers"
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$max_inflight",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "start_transfers",
-      "count": 1,
-      "aggregate_bytes": "$max_inflight",
-      "op_id_prefix": "op-bytes-"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid_one_byte"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "resource_exhausted",
-       "resource": "max_transfer_bytes_inflight",
-       "limit": "$max_inflight"
-      }
-     },
-     "op_id": "op-bytes-past"
-    },
-    {
-     "assert": [
-      {
-       "path": "err.limit",
-       "op": "type",
-       "value": "uint"
-      }
-     ]
-    },
-    {
-     "assert": [
-      {
-       "path": "err.resource",
-       "op": "present"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "cancel_transfers",
-      "op_id_prefix": "op-bytes-"
-     }
-    }
-   ]
-  },
-  {
-   "name": "transfer_progress_pushes_report_monotonic_transferred_bytes",
-   "kind": "push",
-   "operation": "file.fetch",
-   "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: transfer pushes carry transfer_op_id, a non-decreasing receiver-accepted byte count, and the signed total, with no room-scoped fields; fails until U2 provides a byte-count channel.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "fid": "out.files[0].file_id",
-      "total": "out.files[0].bytes"
-     },
-     "on": "subject:self"
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "op_id": "op-progress-1",
-     "defer": true,
-     "save": {
-      "fetch_request": "$request"
-     },
-     "on": "subject:self"
-    },
-    {
-     "await": {
-      "push": {
-       "t": "transfer",
-       "transfer_op_id": "op-progress-1",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       }
-      }
-     },
-     "save": {
-      "progress_one": "frame.transferred_bytes"
-     },
-     "on": "subject:self"
-    },
-    {
-     "await": {
-      "push": {
-       "t": "transfer",
-       "transfer_op_id": "op-progress-1",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       }
-      }
-     },
-     "on": "subject:self"
-    },
-    {
-     "assert": [
-      {
-       "path": "frame.transferred_bytes",
-       "op": "gte",
-       "value": "$progress_one"
-      },
-      {
-       "path": "frame.op_id",
-       "op": "absent"
-      },
-      {
-       "path": "frame.room_id",
-       "op": "absent"
-      },
-      {
-       "path": "frame",
-       "op": "no_nulls"
-      }
-     ]
-    },
-    {
-     "await": {
-      "reply": "$fetch_request"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "$fid",
-       "bytes": "$total",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     },
-     "on": "subject:self"
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "transfer_progress_is_delivered_only_to_the_initiating_principal",
-   "kind": "push",
-   "operation": "file.fetch",
-   "intent": "Proves transfer progress is principal-private on one daemon: the owner receives the canonical transfer push, the second principal receives no matching transfer push, and the owner's deferred fetch still reaches terminal success; fails until U2.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file",
-    "observe:frames"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "on": "principal:self",
-     "save": {
-      "fid": "out.files[0].file_id",
-      "total": "out.files[0].bytes"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "on": "principal:self",
-     "op_id": "op-progress-private",
-     "defer": true,
-     "save": {
-      "fetch_request": "$request"
-     }
-    },
-    {
-     "on": "principal:self",
-     "await": {
-      "push": {
-       "t": "transfer",
-       "transfer_op_id": "op-progress-private",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "$total"
-       }
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_push",
-       "on": "principal:second",
-       "match": {
-        "t": "transfer",
-        "transfer_op_id": "op-progress-private"
-       },
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "await": {
-      "reply": "$fetch_request"
-     },
-     "on": "principal:self",
-     "expect": {
-      "ok": true,
-      "out": {
-       "room_id": "$rid",
-       "file_id": "$fid",
-       "bytes": "$total",
-       "digest": "<string>",
-       "provider": {
-        "subject_id": "<subject_id>",
-        "device_id": "<device_id>"
-       }
-      }
-     }
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled",
-   "kind": "error",
-   "operation": "file.fetch",
-   "intent": "Proves a transfer making zero forward progress for transfer_stall_ms terminates with transfer_stalled carrying transferred_bytes and a tagged total rather than hanging to the deadline or reporting a size or integrity failure; fails until U2 makes forward progress observable at all.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up"
-   ],
-   "steps": [
-    {
-     "upgrade": {
-      "query": {},
-      "headers": {}
-     }
-    },
-    {
-     "await": {
-      "frame": {
-       "t": "hello"
-      }
-     },
-     "save": {
-      "stall_ms": "frame.limits.transfer_stall_ms"
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_stalled",
-       "transferred_bytes": 16384,
-       "total": {
-        "state": "known",
-        "bytes": "<uint>"
-       }
-      }
-     },
-     "op_id": "op-stall-1"
-    },
-    {
-     "assert": [
-      {
-       "path": "err.transferred_bytes",
-       "op": "eq",
-       "value": 16384
-      }
-     ]
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid_unsized"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "transfer_stalled",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "unknown"
-       }
-      }
-     },
-     "op_id": "op-stall-2"
-    },
-    {
-     "assert": [
-      {
-       "path": "err",
-       "op": "no_nulls"
-      }
-     ]
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "cancel_result_reports_bytes_transferred",
-   "kind": "success",
-   "operation": "transfer.cancel",
-   "intent": "Proves a cancelled transfer reports how far it got, so a client can tell an immediate cancel from one that abandoned most of a large file; fails until U2 provides the byte count, which is why it is separated from the cancellation cases that do not need it.",
-   "requires": [
-    "subject",
-    "room:live",
-    "link:up",
-    "resource:large_file"
-   ],
-   "steps": [
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$rid",
-      "file_id": "$fid"
-     },
-     "op_id": "op-cancel-bytes",
-     "defer": true,
-     "save": {
-      "fetch_request": "$request"
-     },
-     "on": "subject:self"
-    },
-    {
-     "await": {
-      "push": {
-       "t": "transfer",
-       "transfer_op_id": "op-cancel-bytes",
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "<uint>"
-       }
-      }
-     },
-     "on": "subject:self"
-    },
-    {
-     "call": "transfer.cancel",
-     "in": {
-      "transfer_op_id": "op-cancel-bytes"
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "transfer_op_id": "op-cancel-bytes",
-       "outcome": {
-        "state": "cancelled"
-       },
-       "transferred_bytes": "<uint>",
-       "total": {
-        "state": "known",
-        "bytes": "<uint>"
-       }
-      }
-     },
-     "save": {
-      "cancelled_bytes": "out.transferred_bytes",
-      "cancel_total": "out.total.bytes"
-     },
-     "on": "subject:self"
-    },
-    {
-     "assert": [
-      {
-       "path": "out.transferred_bytes",
-       "op": "gt",
-       "value": 0
-      },
-      {
-       "path": "out.transferred_bytes",
-       "op": "lte",
-       "value": "$cancel_total"
-      },
-      {
-       "path": "out.path",
-       "op": "absent"
-      },
-      {
-       "path": "out.local_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.save_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.data_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.directory",
-       "op": "absent"
-      },
-      {
-       "path": "out.staged_path",
-       "op": "absent"
-      },
-      {
-       "path": "out.download_dir",
-       "op": "absent"
-      },
-      {
-       "path": "out.uri",
-       "op": "absent"
-      },
-      {
-       "path": "out.file_url",
-       "op": "absent"
-      }
-     ],
-     "on": "subject:self"
-    },
-    {
-     "await": {
-      "reply": "$fetch_request"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "stream_aborted",
-       "transferred_bytes": "$cancelled_bytes",
-       "total": {
-        "state": "known",
-        "bytes": "$cancel_total"
-       },
-       "reason": "cancelled"
-      }
-     },
-     "on": "subject:self"
-    }
-   ],
-   "blocked_on_upstream": "U2"
-  },
-  {
-   "name": "file_operations_are_not_a_membership_oracle",
-   "kind": "authorization",
-   "operation": null,
-   "intent": "Proves each room-scoped file operation returns the same room_not_available shape and indistinguishable timing for a foreign room and a well-formed unknown room, while echoing the caller-supplied room_id and opening no upload stream.",
-   "requires": [
-    "subject",
-    "room:foreign",
-    "observe:timing"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$foreign_rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "list_foreign": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$foreign_rid"
-      }
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": {
-       "$unknown": "<room_id>"
-      },
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "save": {
-      "list_unknown": "err",
-      "unknown_rid": "err.room_id"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": {
-        "$unknown": "<room_id>"
-       }
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$list_foreign",
-       "op": "eq_except",
-       "value": {
-        "path": "$list_unknown",
-        "keys": [
-         "room_id"
-        ]
-       }
-      },
-      {
-       "observe": "timing_indistinguishable",
-       "between": [
-        "step:1",
-        "step:2"
-       ]
-      }
-     ]
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$foreign_rid",
-      "file_id": "$foreign_fid"
-     },
-     "op_id": "op-oracle-fetch-foreign",
-     "save": {
-      "fetch_foreign": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$foreign_rid"
-      }
-     }
-    },
-    {
-     "call": "file.fetch",
-     "in": {
-      "room_id": "$unknown_rid",
-      "file_id": {
-       "$unknown": "<file_id>"
-      }
-     },
-     "op_id": "op-oracle-fetch-unknown",
-     "save": {
-      "fetch_unknown": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$unknown_rid"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$fetch_foreign",
-       "op": "eq_except",
-       "value": {
-        "path": "$fetch_unknown",
-        "keys": [
-         "room_id"
-        ]
-       }
-      },
-      {
-       "observe": "timing_indistinguishable",
-       "between": [
-        "step:4",
-        "step:5"
-       ]
-      }
-     ]
-    },
-    {
-     "call": "file.read",
-     "in": {
-      "room_id": "$foreign_rid",
-      "file_id": "$foreign_fid"
-     },
-     "op_id": "op-oracle-read-foreign",
-     "save": {
-      "read_foreign": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$foreign_rid"
-      }
-     }
-    },
-    {
-     "call": "file.read",
-     "in": {
-      "room_id": "$unknown_rid",
-      "file_id": {
-       "$unknown": "<file_id>"
-      }
-     },
-     "op_id": "op-oracle-read-unknown",
-     "save": {
-      "read_unknown": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$unknown_rid"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$read_foreign",
-       "op": "eq_except",
-       "value": {
-        "path": "$read_unknown",
-        "keys": [
-         "room_id"
-        ]
-       }
-      },
-      {
-       "observe": "timing_indistinguishable",
-       "between": [
-        "step:7",
-        "step:8"
-       ]
-      }
-     ]
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$foreign_rid",
-      "name": "a.bin",
-      "declared_bytes": 16,
-      "declared_content_type": "application/octet-stream"
-     },
-     "op_id": "op-oracle-share-foreign",
-     "save": {
-      "share_foreign": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$foreign_rid"
-      }
-     }
-    },
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$unknown_rid",
-      "name": "a.bin",
-      "declared_bytes": 16,
-      "declared_content_type": "application/octet-stream"
-     },
-     "op_id": "op-oracle-share-unknown",
-     "save": {
-      "share_unknown": "err"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "room_not_available",
-       "room_id": "$unknown_rid"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "$share_foreign",
-       "op": "eq_except",
-       "value": {
-        "path": "$share_unknown",
-        "keys": [
-         "room_id"
-        ]
-       }
-      },
-      {
-       "observe": "timing_indistinguishable",
-       "between": [
-        "step:10",
-        "step:11"
-       ]
-      },
-      {
-       "observe": "bytes_streamed",
-       "call": "step:10",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      },
-      {
-       "observe": "bytes_streamed",
-       "call": "step:11",
-       "value": {
-        "op": "eq",
-        "value": 0
-       }
-      }
-     ]
-    }
-   ]
-  },
-  {
-   "name": "file_list_reports_an_unreadable_file_index_rather_than_an_empty_list",
-   "kind": "error",
-   "operation": "file.list",
-   "intent": "Gives file.list its own code, distinct from the room_not_available case the corpus already has. With a known shared file in an available room, the room's file index is made unreadable and the call must answer file_index_unreadable. Catches a daemon that returns files: [] on a read failure, which is uniquely costly here: the user concludes the file was never shared and re-shares it, paying a second transfer of up to max_shared_file_bytes, and the room gains a duplicate signed share event that every member stores forever. It also catches the code substitution that would be worst for diagnosis -- answering room_not_available, which tells a member in good standing that they have lost access to the room when in fact only a local index read failed, sending them to rejoin instead of to restart. fetchable is specified as an evidence-backed fact, and 'I could not read the evidence' is not the same fact as 'there is no file'.",
-   "requires": [
-    "subject",
-    "room:live",
-    "fault:room_index_unreadable",
-    "fault:file_index_unreadable"
-   ],
-   "steps": [
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
+      "intent": "Proves the human-readable limit is rendered from the SERVED integer, so no catalog carries the number verbatim and a served change cannot make a translation lie. Asserted two ways: no locale catalog contains the number, and the rendered string moves when the harness overrides the limit.",
+      "requires": [],
+      "steps": [
         {
-         "file_id": "<file_id>",
-         "digest": "<string>",
-         "fetchable": "<bool>",
-         "self_hosted": "<bool>",
-         "bytes": "<uint>"
-        }
-       ]
-      }
-     },
-     "note": "baseline: the index is readable and names the shared file"
-    },
-    {
-     "assert": [
-      {
-       "path": "out",
-       "op": "no_nulls"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "inject_fault",
-      "fault": "file_index_unreadable"
-     },
-     "note": "the room's file index read path fails -- I/O error or permission denial. The share event and the local blob are untouched; only the read fails."
-    },
-    {
-     "assert": [
-      {
-       "observe": "no_push",
-       "room_id": "$rid",
-       "scope": "case"
-      }
-     ]
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "file_index_unreadable"
-      }
-     }
-    },
-    {
-     "assert": [
-      {
-       "path": "err",
-       "op": "no_nulls"
-      }
-     ]
-    },
-    {
-     "control": {
-      "do": "inject_fault",
-      "fault": "file_index_unreadable"
-     }
-    },
-    {
-     "call": "file.list",
-     "in": {
-      "room_id": "$rid",
-      "cursor": {
-       "state": "start"
-      },
-      "direction": "forward",
-      "limit": 50
-     },
-     "expect": {
-      "ok": true,
-      "out": {
-       "files": [
+          "control": {
+            "do": "set_limit",
+            "limit": "max_shared_file_bytes",
+            "value": 1048576
+          }
+        },
         {
-         "file_id": "<file_id>",
-         "digest": "<string>"
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "client_render_limit",
+            "served_bytes": "$limit"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.source_bytes",
+              "op": "eq",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.rendered",
+              "op": "type",
+              "value": "string"
+            },
+            {
+              "path": "frame.rendered",
+              "op": "byte_len",
+              "value": {
+                "op": "gt",
+                "value": 0
+              }
+            }
+          ]
         }
-       ]
-      }
-     },
-     "note": "the file was there the whole time; the refusal was honest about not being able to see it"
-    }
-   ]
-  },
-  {
-   "name": "a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch",
-   "kind": "error",
-   "operation": "file.share",
-   "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch \u2014 accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
-   "requires": [
-    "subject",
-    "room:live",
-    "resource:shared_file"
-   ],
-   "steps": [
-    {
-     "call": "file.share",
-     "in": {
-      "room_id": "$rid",
-      "name": "mismatch.bin",
-      "declared_bytes": 4096,
-      "declared_content_type": "application/octet-stream"
-     },
-     "expect": {
-      "ok": false,
-      "err": {
-       "code": "declared_size_mismatch",
-       "declared_bytes": 4096,
-       "observed_bytes": 4095
-      }
-     },
-     "op_id": "op-mismatch-1",
-     "stream": {
-      "send_bytes": 4095
-     }
+      ]
     },
     {
-     "assert": [
-      {
-       "path": "err.hint",
-       "op": "absent"
-      }
-     ]
+      "name": "share_below_the_served_limit_succeeds",
+      "kind": "success",
+      "operation": "file.share",
+      "intent": "Establishes the baseline success shape of the streamed share: a file identifier, the authored room fact, the daemon-computed digest and the accepted byte count, with no filesystem path in either direction, catching any regression to v1's path-taking RPC plus separate HTTP upload edge.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "Files"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-share-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "notes.txt",
+            "declared_bytes": 1024,
+            "declared_content_type": "text/plain"
+          },
+          "save": {
+            "fid": "out.file_id"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "<file_id>",
+              "event_id": "<event_id>",
+              "pos": "<uint>",
+              "bytes": 1024,
+              "digest": "<string>"
+            }
+          },
+          "op_id": "op-share-2",
+          "stream": {
+            "send_bytes": 1024
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "file_id": "$fid",
+                  "self_hosted": true,
+                  "fetchable": true,
+                  "bytes": 1024
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     {
-     "assert": [
-      {
-       "observe": "no_event_authored",
-       "scope": "case"
-      }
-     ]
+      "name": "share_at_exactly_the_served_limit_is_accepted",
+      "kind": "boundary",
+      "operation": "file.share",
+      "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes is accepted, catching an off-by-one that would silently refuse the largest legal file.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "AtLimit"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-atlimit-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "exactly-at-limit.bin",
+            "declared_bytes": "$limit",
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "<file_id>",
+              "event_id": "<event_id>",
+              "pos": "<uint>",
+              "bytes": "$limit",
+              "digest": "<string>"
+            }
+          },
+          "op_id": "op-atlimit-2",
+          "stream": {
+            "send_bytes": "$limit"
+          }
+        }
+      ]
+    },
+    {
+      "name": "share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "Proves a client can cancel an admitted upload before sending any DATA by issuing ABORT(cancelled): the daemon acknowledges the ABORT and then replies stream_aborted{cancelled} accounting for zero receiver-accepted bytes -- the 'client ABORT wins' leg of the race table. Catches a daemon that ignores a producer ABORT, replies success, or sends its terminal reply without first acknowledging the ABORT, and a harness whose byte counter could pass without the daemon proving it accepted nothing.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "ClientCancel"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-clientcancel-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "cancelled.bin",
+            "declared_bytes": 1024,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": 0,
+              "total": {
+                "state": "known",
+                "bytes": 1024
+              },
+              "reason": "cancelled"
+            }
+          },
+          "op_id": "op-clientcancel-2",
+          "stream": {
+            "send_bytes": 1024,
+            "fault": "client_abort"
+          }
+        }
+      ]
+    },
+    {
+      "name": "share_malformed_stream_record_aborts_that_stream_as_malformed_frame",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "Proves a client protocol violation mid-stream is stream-local, not connection-fatal: after admission the client sends one structurally malformed byte-stream record (a nonzero reserved byte) on the live (request id, stream id) binding, whose full 48-byte header the daemon can correlate. The daemon aborts only that stream with ABORT(protocol_error) at accepted offset zero, the client ACKs, and file.share resolves to the correlated malformed_frame reply while the connection stays usable. Catches a daemon that closes the connection (4005/4007) on a correlatable malformed record, replies success, or answers without first ABORTing, and a harness that cannot drive a raw malformed record.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "RawRecord"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-rawrecord-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "malformed.bin",
+            "declared_bytes": 1024,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "malformed_frame"
+            }
+          },
+          "op_id": "op-rawrecord-2",
+          "stream": {
+            "send_bytes": 1024,
+            "fault": "raw_record"
+          }
+        }
+      ]
+    },
+    {
+      "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
+      "kind": "boundary",
+      "operation": "file.share",
+      "intent": "Proves the earliest daemon-side enforcement point fires on a declaration one byte above the served limit before OPEN or any body byte, with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "OverByOne"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-over-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "one-past.bin",
+            "declared_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": {
+                "$add": [
+                  "$limit",
+                  1
+                ]
+              },
+              "limit_bytes": "$limit",
+              "enforced_at": "stage_declared"
+            }
+          },
+          "op_id": "op-over-2"
+        },
+        {
+          "assert": [
+            {
+              "path": "err.hint",
+              "op": "absent"
+            },
+            {
+              "path": "err.path",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:5",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_push",
+              "room_id": "$rid",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_event_authored",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "err.declared_bytes",
+              "op": "type",
+              "value": "uint"
+            },
+            {
+              "path": "err.limit_bytes",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "$limit",
+              "op": "type",
+              "value": "uint",
+              "note": "path recovered from context; exclusions: [\"string\"]"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "share_declared_within_limit_but_stream_exceeds_it_aborts_at_stage_stream",
+      "kind": "boundary",
+      "operation": "file.share",
+      "intent": "Proves a declared length is treated as an assertion by an untrusted caller and not as fact: a caller declaring exactly $limit but streaming more is aborted mid-stream with enforced_at=stage_stream after consuming no more than limit_bytes, catching a daemon that enforces only on the declaration.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "LyingDeclaration"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-liar-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "understated.bin",
+            "declared_bytes": "$limit",
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": "$limit",
+              "limit_bytes": "$limit",
+              "enforced_at": "stage_stream"
+            }
+          },
+          "op_id": "op-liar-2",
+          "stream": {
+            "send_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:5",
+              "value": {
+                "op": "eq",
+                "value": "$limit"
+              }
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_push",
+              "room_id": "$rid",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_event_authored",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_durable_mutation",
+              "scope": "case"
+            }
+          ],
+          "note": "an aborted stage leaves no stranded staged file"
+        }
+      ]
+    },
+    {
+      "name": "share_over_limit_in_process_core_is_refused_at_authoring",
+      "kind": "error",
+      "operation": "file.share",
+      "targets": [
+        "in_process_core"
+      ],
+      "intent": "Proves the core authoring layer enforces the limit on file metadata before hashing or blob import, which is the only enforcement point that exists for an in-process adapter with no daemon upload edge, catching an implementation that relies on the stage checks alone.",
+      "requires": [
+        "subject",
+        "room:live",
+        "control:limits"
+      ],
+      "steps": [
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "max_shared_file_bytes",
+            "value": 4096
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "InProcess"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-authoring-1"
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "too-big-in-process.bin",
+            "declared_bytes": 4097,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": 4097,
+              "limit_bytes": 4096,
+              "enforced_at": "authoring"
+            }
+          },
+          "op_id": "op-authoring-2"
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_durable_mutation",
+              "scope": "case"
+            }
+          ],
+          "note": "authoring refusal leaves nothing behind"
+        }
+      ]
+    },
+    {
+      "name": "client_preflight_refuses_over_limit_before_any_bytes_are_sent",
+      "kind": "boundary",
+      "operation": "file.share",
+      "targets": [
+        "client_adapter"
+      ],
+      "intent": "Proves the sixth enforcement point — the client preflight, which by definition never reaches the daemon — refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
+      "requires": [
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": true
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "client_unsized_source_streams_through_a_counting_bound",
+      "kind": "boundary",
+      "operation": "file.share",
+      "targets": [
+        "client_adapter"
+      ],
+      "intent": "Proves a client facing a source that reports no size neither rejects it for lacking a size nor copies it unbounded, but streams it through a byte-counting bound that stops at the served limit, catching the two failure modes the size policy names for the Android SAF path.",
+      "requires": [
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": 65536,
+            "source_reports_size": false
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "accepted"
+            },
+            {
+              "path": "frame.accepted",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 65536
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "client_preflight",
+            "source_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "source_reports_size": false
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "refused"
+            },
+            {
+              "path": "frame.refused",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "path": "frame.bytes_sent",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.requests_emitted",
+              "op": "eq",
+              "value": 0
+            },
+            {
+              "path": "frame.staged_bytes",
+              "op": "lte",
+              "value": "$limit"
+            },
+            {
+              "path": "frame.peak_buffered_bytes",
+              "op": "lte",
+              "value": "$limit"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "share_size_refusal_is_never_reported_as_digest_mismatch",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "First half of the paired direction rule: an over-limit share is reported as file_too_large and never as digest_mismatch, so a size refusal is never dressed up as a false accusation of content tampering against an honest caller.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "PairA"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-pairA-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "oversize.bin",
+            "declared_bytes": {
+              "$add": [
+                "$limit",
+                1
+              ]
+            },
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": {
+                "$add": [
+                  "$limit",
+                  1
+                ]
+              },
+              "limit_bytes": "$limit",
+              "enforced_at": "stage_declared"
+            }
+          },
+          "op_id": "op-pairA-2"
+        }
+      ]
+    },
+    {
+      "name": "fetch_of_corrupt_bytes_within_the_limit_is_digest_mismatch_never_file_too_large",
+      "kind": "error",
+      "operation": "file.fetch",
+      "intent": "Second half of the paired direction rule: a within-limit blob whose bytes do not verify against the signed digest is reported as digest_mismatch carrying expected and observed, never as file_too_large, so a content failure is never mislabelled a size failure and the two codes stay disjoint in both directions.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "digest_mismatch",
+              "expected": "<string>",
+              "observed": "<string>"
+            }
+          },
+          "op_id": "op-pairB-1"
+        }
+      ]
+    },
+    {
+      "name": "share_declared_size_as_a_formatted_string_is_malformed",
+      "kind": "malformed",
+      "operation": "file.share",
+      "intent": "Proves the size is carried as a typed integer and never as a formatted string, refusing both a unit-bearing string and a decimal string with invalid_argument rather than parsing either, catching a client that ships the human rendering onto the wire.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": "100 MiB",
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-malformed-1"
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": "1024",
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-malformed-2"
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_push",
+              "room_id": "$rid",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_event_authored",
+              "scope": "case"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "share_size_null_or_out_of_domain_is_malformed",
+      "kind": "malformed",
+      "operation": "file.share",
+      "intent": "Proves no JSON null carries meaning on the file path — a null size is not read as unknown — and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": null,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-null-1"
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": -1,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-null-3"
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": 1.5,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-null-4"
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "a.bin",
+            "declared_bytes": {
+              "state": "declared"
+            },
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "in.declared_bytes",
+              "reason": {
+                "state": "type",
+                "expected": "uint"
+              }
+            }
+          },
+          "op_id": "op-null-5"
+        }
+      ]
+    },
+    {
+      "name": "share_completed_result_replays_without_a_second_stream_and_authors_once",
+      "kind": "success",
+      "operation": "file.share",
+      "intent": "Proves a completed file.share result is op_id deduplicated across a same-principal reconnection: the replay returns the original out directly, opens no second stream, accepts zero bytes, and performs no second blob import or authored fact.",
+      "requires": [
+        "subject",
+        "room:live",
+        "control:reconnect"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "once.bin",
+            "declared_bytes": 2048,
+            "declared_content_type": "application/octet-stream"
+          },
+          "on": "subject:self",
+          "save": {
+            "first": "out"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "<file_id>",
+              "event_id": "<event_id>",
+              "pos": "<uint>",
+              "bytes": 2048,
+              "digest": "<string>"
+            }
+          },
+          "op_id": "op-dedup-share",
+          "stream": {
+            "send_bytes": 2048
+          }
+        },
+        {
+          "control": {
+            "do": "disconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "control": {
+            "do": "reconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "once.bin",
+            "declared_bytes": 2048,
+            "declared_content_type": "application/octet-stream"
+          },
+          "on": "subject:self",
+          "op_id": "op-dedup-share",
+          "expect": {
+            "ok": true,
+            "out": "$first"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out",
+              "op": "eq",
+              "value": "$first"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:5",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "subject:self",
+          "note": "[bare-string assert 'exactly_one_entry_with' needs manual retranscription]"
+        },
+        {
+          "assert": [
+            {
+              "path": "$first.file_id",
+              "op": "present"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list_names_provider_devices_with_fetchable_and_self_hosted_as_stated_facts",
+      "kind": "success",
+      "operation": "file.list",
+      "intent": "Proves file.list returns named provider devices carrying reachability evidence plus separate fetchable and self_hosted booleans, and carries none of v1's provider count, available boolean, or local path fields, catching any client forced back to inferring availability from a number.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "files": [
+                {
+                  "file_id": "<file_id>",
+                  "name": "design.pdf",
+                  "digest": "<string>",
+                  "providers": [
+                    {
+                      "device_id": "<device_id>",
+                      "subject_id": "<subject_id>",
+                      "link": {
+                        "state": "direct",
+                        "since": "<ts>"
+                      }
+                    }
+                  ],
+                  "fetchable": "<bool>",
+                  "self_hosted": "<bool>",
+                  "bytes": "<uint>",
+                  "declared_content_type": "application/pdf",
+                  "shared_by": "<subject_id>",
+                  "shared_at": "<ts>"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files[*].available",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].providers_count",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].local_bytes",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].fetched",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].fetched_at_ms",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].mime",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].file_url",
+              "op": "absent"
+            },
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files[*].providers",
+              "op": "len",
+              "value": {
+                "op": "gte",
+                "value": 1
+              }
+            },
+            {
+              "path": "out.files[*].fetchable",
+              "op": "type",
+              "value": "bool"
+            },
+            {
+              "path": "out.files[*].self_hosted",
+              "op": "type",
+              "value": "bool"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "out",
+              "op": "no_nulls"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list_reports_fetchable_false_with_a_stated_reason_when_no_provider_is_reachable",
+      "kind": "success",
+      "operation": "file.list",
+      "intent": "Proves fetchable is evidence-backed transport fact and not an inference from membership display state: a provider that room.members reports as an active member but that this daemon holds no link to yields fetchable false with a typed unreachable reason, which is the #50/#94 separation of membership from availability.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "note": "[control shape {\"provider_link\": \"down\"} needs review] [harness orchestration: provider_link]",
+          "control": {
+            "do": "idle",
+            "ms": 0
+          }
+        },
+        {
+          "call": "room.members",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "members": [
+                {
+                  "subject_id": "<string>",
+                  "standing": "active"
+                }
+              ]
+            }
+          },
+          "save": {
+            "member": "out.members[0].subject_id"
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "providers": [
+                    {
+                      "subject_id": "$member",
+                      "device_id": "<string>",
+                      "link": {
+                        "state": "unreachable",
+                        "reason": "no_route"
+                      }
+                    }
+                  ],
+                  "fetchable": false,
+                  "self_hosted": false
+                }
+              ]
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.room.members.standing",
+              "op": "present"
+            },
+            {
+              "path": "out.file.list.fetchable",
+              "op": "present"
+            },
+            {
+              "path": "out.file.list.providers[].reachability",
+              "op": "present"
+            }
+          ]
+        },
+        {
+          "note": "[control shape {\"provider_link\": \"up\"} needs review] [harness orchestration: provider_link]",
+          "control": {
+            "do": "idle",
+            "ms": 0
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "fetchable": true
+                }
+              ]
+            }
+          },
+          "note": "the fact tracks observed transport, not the member list"
+        }
+      ]
+    },
+    {
+      "name": "list_of_a_room_that_is_not_available_answers_room_not_available",
+      "kind": "error",
+      "operation": "file.list",
+      "intent": "Gives file.list its refusal case using the most specific code the v2 taxonomy defines for a room-scoped read, proving an unknown or non-member room never yields a generic argument error or an empty success that would leak that the room does not exist.",
+      "requires": [
+        "subject"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "list_carries_a_hostile_peer_declared_name_as_an_opaque_display_string",
+      "kind": "malformed",
+      "operation": "file.list",
+      "intent": "Proves a peer-chosen file name containing path separators and traversal segments is carried verbatim in a display-only field and never appears in, or is used to construct, any path-typed field, catching a daemon that either silently rewrites peer-signed metadata or treats it as a location.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "name": "../../../etc/passwd",
+                  "declared_content_type": "text/plain"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files[*].path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.files[*].save_dir",
+              "op": "absent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_from_a_reachable_provider_holds_the_bytes_locally",
+      "kind": "success",
+      "operation": "file.fetch",
+      "intent": "Establishes the baseline fetch success shape — the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response — catching any regression to v1's directory-taking, path-returning fetch.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "file_id": "$fid",
+              "room_id": "$rid",
+              "bytes": "<uint>",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          },
+          "op_id": "op-fetch-1"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            },
+            {
+              "path": "out.verified",
+              "op": "absent"
+            },
+            {
+              "path": "out.local",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "file_id": "$fid",
+                  "self_hosted": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files[0].local",
+              "op": "absent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_preflight_refuses_an_oversized_signed_size_before_contacting_a_provider",
+      "kind": "boundary",
+      "operation": "file.fetch",
+      "intent": "Proves the receive side preflights the signed size_bytes against the served limit and refuses with enforced_at=fetch_preflight before opening any connection, which is the enforcement point that does not exist today and the one that prevents an oversized remote blob from ever being reported as an integrity failure.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "limit": "frame.limits.max_shared_file_bytes"
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "fetchable": "<bool>",
+                  "bytes": {
+                    "$add": [
+                      "$limit",
+                      1
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": {
+                "$add": [
+                  "$limit",
+                  1
+                ]
+              },
+              "limit_bytes": "$limit",
+              "enforced_at": "fetch_preflight"
+            }
+          },
+          "op_id": "op-preflight-1"
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:4",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_stream_refuses_a_peer_serving_more_than_it_declared",
+      "kind": "boundary",
+      "operation": "file.fetch",
+      "intent": "Proves the mid-stream fetch bound reports a provider response exceeding the signed declaration as file_too_large at fetch_stream after accepting exactly the declared bytes; it remains blocked until U3 supplies a size-distinguishable fetch outcome.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id",
+            "declared_bytes": "out.files[0].bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "set_provider_response_bytes",
+            "file_id": "$fid",
+            "bytes": {
+              "$add": [
+                "$declared_bytes",
+                1
+              ]
+            }
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_too_large",
+              "declared_bytes": "$declared_bytes",
+              "limit_bytes": "$declared_bytes",
+              "enforced_at": "fetch_stream"
+            }
+          },
+          "op_id": "op-fetchstream-1"
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:3",
+              "value": {
+                "op": "eq",
+                "value": "$declared_bytes"
+              }
+            }
+          ]
+        }
+      ],
+      "blocked_on_upstream": "U3"
+    },
+    {
+      "name": "fetch_with_no_reachable_provider_fails_with_provider_unreachable",
+      "kind": "error",
+      "operation": "file.fetch",
+      "intent": "Gives file.fetch a transport-specific refusal distinct from every size and integrity code, proving an unfetchable file names the reason it could not be served rather than reporting a mismatch or a generic argument error, and that the answer agrees with the fetchable fact file.list stated.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:down"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "fetchable": false
+                }
+              ]
+            }
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "provider_unreachable",
+              "file_id": "$fid",
+              "providers": [
+                {
+                  "subject_id": "<subject_id>",
+                  "device_id": "<device_id>",
+                  "link": {
+                    "state": "not_connected",
+                    "reason": "no_route"
+                  }
+                }
+              ]
+            }
+          },
+          "op_id": "op-unreach-1"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files[0].fetchable",
+              "op": "present"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
+      "kind": "malformed",
+      "operation": "file.fetch",
+      "intent": "Proves file.fetch rejects a missing envelope op_id during structural decode, before room lookup or provider contact, even when the room and file inputs are otherwise valid.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "invalid_argument",
+              "field": "op_id",
+              "reason": {
+                "state": "missing"
+              }
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_network_activity",
+              "scope": "step"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:2",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown",
+      "kind": "error",
+      "operation": "file.fetch",
+      "intent": "Proves a member asking for a file identifier the room's signed history does not contain gets a file-specific code rather than a generic argument error, while confirming this distinction is only ever offered to a member (the non-member answer is covered by the oracle case).",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": {
+              "$unknown": "<file_id>"
+            }
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_unknown",
+              "file_id": {
+                "$unknown": "<file_id>"
+              }
+            }
+          },
+          "op_id": "op-unknownfile-1"
+        }
+      ]
+    },
+    {
+      "name": "fetch_completed_result_replays_without_a_second_transfer",
+      "kind": "success",
+      "operation": "file.fetch",
+      "intent": "Proves a completed file.fetch result is op_id deduplicated across a same-principal reconnection, so replay returns the original out directly and moves no second copy of the bytes across the network.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "control:reconnect"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "subject:self",
+          "save": {
+            "first": "out"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "file_id": "$fid",
+              "room_id": "$rid",
+              "bytes": "<uint>",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          },
+          "op_id": "op-dedup-fetch"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.local",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "disconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "control": {
+            "do": "reconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "subject:self",
+          "expect": {
+            "ok": true,
+            "out": "$first"
+          },
+          "op_id": "op-dedup-fetch"
+        },
+        {
+          "assert": [
+            {
+              "path": "out",
+              "op": "eq",
+              "value": "$first"
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:6",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fetch_deadline_scales_with_the_declared_size",
+      "kind": "boundary",
+      "operation": "file.fetch",
+      "intent": "Proves the absolute file.fetch deadline uses the signed total and served floor: one transfer at the floor succeeds, while another reports the exact size-derived budget rather than any fixed timeout, with a truthful accepted-byte count.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "control:limits"
+      ],
+      "steps": [
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "transfer_connect_allowance_ms",
+            "value": 1000
+          }
+        },
+        {
+          "control": {
+            "do": "set_limit",
+            "limit": "transfer_floor_bits_per_second",
+            "value": 8192
+          }
+        },
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "connect_ms": "frame.limits.transfer_connect_allowance_ms",
+            "floor_bps": "frame.limits.transfer_floor_bits_per_second"
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid_at_floor": "out.files[0].file_id",
+            "total_at_floor": "out.files[0].bytes",
+            "fid_below_floor": "out.files[1].file_id",
+            "total_below_floor": "out.files[1].bytes"
+          }
+        },
+        {
+          "control": {
+            "do": "set_link_rate",
+            "between": [
+              "subject:self",
+              "provider"
+            ],
+            "bits_per_second": "$floor_bps"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid_at_floor"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid_at_floor",
+              "bytes": "$total_at_floor",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          },
+          "op_id": "op-budget-floor"
+        },
+        {
+          "control": {
+            "do": "set_link_rate",
+            "between": [
+              "subject:self",
+              "provider"
+            ],
+            "bits_per_second": 1
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid_below_floor"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_deadline_exceeded",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total_below_floor"
+              },
+              "budget_ms": {
+                "$transfer_budget_ms": [
+                  "$total_below_floor",
+                  "$connect_ms",
+                  "$floor_bps"
+                ]
+              }
+            }
+          },
+          "op_id": "op-budget-expiry"
+        },
+        {
+          "assert": [
+            {
+              "path": "err.transferred_bytes",
+              "op": "lt",
+              "value": "$total_below_floor"
+            },
+            {
+              "path": "err.transferred_bytes",
+              "op": "gt",
+              "value": 0
+            },
+            {
+              "path": "err.budget_ms",
+              "op": "gt",
+              "value": "$connect_ms"
+            }
+          ]
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field",
+      "kind": "success",
+      "operation": "file.read",
+      "intent": "Proves file.read streams bytes with the peer-declared type carried in a distinctly named, explicitly untrusted field and with no field that presents a type as authoritative fact, which is how v1's never-render-inline HTTP response headers become data now that bytes no longer travel over HTTP.",
+      "requires": [
+        "subject",
+        "room:live",
+        "resource:fetched_file"
+      ],
+      "steps": [
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": 4096,
+              "declared_content_type": "application/pdf"
+            }
+          },
+          "stream": {
+            "receive_bytes": 4096
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            },
+            {
+              "path": "out.mime",
+              "op": "absent"
+            },
+            {
+              "path": "out.content_type",
+              "op": "absent"
+            },
+            {
+              "path": "out.type",
+              "op": "absent"
+            },
+            {
+              "path": "out.sniffed_type",
+              "op": "absent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "client_must_not_render_peer_declared_bytes_inline",
+      "kind": "boundary",
+      "operation": "file.read",
+      "targets": [
+        "client_adapter"
+      ],
+      "intent": "Proves a client treats the peer-declared type as a hint only: a peer declaring text/html with a script-bearing body is never rendered inline as markup and never executes, catching a client that restores v1's inline-render behaviour now that the protective HTTP headers are gone.",
+      "requires": [
+        "resource:fetched_file",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": 4096,
+              "declared_content_type": "text/html"
+            }
+          },
+          "stream": {
+            "receive_bytes": 4096
+          }
+        },
+        {
+          "control": {
+            "do": "client_render_file",
+            "declared_content_type": "text/html",
+            "body_kind": "script_bearing_html"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.decision",
+              "op": "eq",
+              "value": "download_only"
+            },
+            {
+              "path": "frame.executed",
+              "op": "eq",
+              "value": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "read_of_a_file_whose_bytes_are_not_held_locally_fails_with_file_not_fetched",
+      "kind": "error",
+      "operation": "file.read",
+      "intent": "Gives file.read its own refusal case, proving that reading a known but unfetched file names that precise condition rather than silently fetching it, returning empty bytes, or answering with a generic argument error.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {}
+              ]
+            }
+          },
+          "save": {
+            "fid": "out.files[0].file_id"
+          }
+        },
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_not_fetched",
+              "file_id": "$fid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:2",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "transfer_cancel_after_the_originating_connection_dropped",
+      "kind": "success",
+      "operation": "transfer.cancel",
+      "intent": "Proves a deferred file.fetch remains cancellable after its originating transport drops: the same principal reconnects, cancels by transfer_op_id, and replaying the original request on that session returns the recorded cancelled stream_aborted result without awaiting a dead connection handle.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "control:reconnect"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "subject:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "subject:self",
+          "op_id": "op-cancel-target",
+          "defer": true,
+          "save": {
+            "abandoned_fetch_request": "$request"
+          },
+          "note": "The disconnect abandons this connection-local request handle; it is saved only because the current deferred-call DSL validator requires a handle."
+        },
+        {
+          "control": {
+            "do": "disconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "control": {
+            "do": "reconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-cancel-target"
+          },
+          "on": "subject:self",
+          "expect": {
+            "ok": true,
+            "out": {
+              "transfer_op_id": "op-cancel-target",
+              "outcome": {
+                "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          },
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "subject:self",
+          "op_id": "op-cancel-target",
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              },
+              "reason": "cancelled"
+            }
+          }
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
+      "kind": "authorization",
+      "operation": "transfer.cancel",
+      "intent": "Proves the principal-scoped cancellation ledger is not an oracle on one daemon: a second principal sees the same transfer_unknown shape for the owner's live transfer and an absent transfer, while the owner can still cancel and receives the original fetch's terminal cancellation reply.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "principal:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "principal:self",
+          "op_id": "op-cancel-owned",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          }
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-cancel-owned"
+          },
+          "on": "principal:second",
+          "save": {
+            "foreign_err": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-cancel-owned"
+            }
+          }
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-never-existed"
+          },
+          "on": "principal:second",
+          "save": {
+            "absent_err": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-never-existed"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$foreign_err",
+              "op": "eq_except",
+              "value": {
+                "path": "$absent_err",
+                "keys": [
+                  "transfer_op_id"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-cancel-owned"
+          },
+          "on": "principal:self",
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "transfer_op_id": "op-cancel-owned",
+              "outcome": {
+                "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          }
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "on": "principal:self",
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              },
+              "reason": "cancelled"
+            }
+          }
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
+      "kind": "error",
+      "operation": "transfer.cancel",
+      "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error — the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
+      "requires": [
+        "subject"
+      ],
+      "steps": [
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-does-not-exist"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_unknown",
+              "transfer_op_id": "op-does-not-exist"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "err.path",
+              "op": "absent"
+            },
+            {
+              "path": "err.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "err.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.directory",
+              "op": "absent"
+            },
+            {
+              "path": "err.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "err.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "err.uri",
+              "op": "absent"
+            },
+            {
+              "path": "err.file_url",
+              "op": "absent"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "transfer_cancel_releases_the_concurrent_transfer_slot",
+      "kind": "success",
+      "operation": "transfer.cancel",
+      "intent": "Proves cancellation actually returns the transfer to the daemon budget rather than merely reporting success: after filling the served concurrency ceiling, cancelling op-slot-0 frees that slot for a succeeding fetch, then cleanup cancels the remaining harness-started set.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "control:concurrency"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "max_transfers": "frame.limits.max_concurrent_transfers"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$max_transfers",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "start_transfers",
+            "count": "$max_transfers",
+            "aggregate_bytes": "$max_transfers",
+            "op_id_prefix": "op-slot-"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "resource_exhausted",
+              "resource": "max_concurrent_transfers",
+              "limit": "$max_transfers"
+            }
+          },
+          "op_id": "op-slot-overflow"
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-slot-0"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "transfer_op_id": "op-slot-0",
+              "outcome": {
+                "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
+              }
+            }
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "file_id": "$fid",
+              "room_id": "$rid",
+              "bytes": "<uint>",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          },
+          "op_id": "op-slot-retry"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.local",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-slot-"
+          }
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "concurrent_transfers_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
+      "kind": "boundary",
+      "operation": "file.fetch",
+      "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of harness-started transfers run, the next is refused, and the harness cleans the started set up at case end.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "control:concurrency"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "max_transfers": "frame.limits.max_concurrent_transfers"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$max_transfers",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "start_transfers",
+            "count": "$max_transfers",
+            "aggregate_bytes": "$max_transfers",
+            "op_id_prefix": "op-conc-"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "resource_exhausted",
+              "resource": "max_concurrent_transfers",
+              "limit": "$max_transfers"
+            }
+          },
+          "op_id": "op-conc-past"
+        },
+        {
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-conc-"
+          }
+        }
+      ]
+    },
+    {
+      "name": "inflight_transfer_bytes_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
+      "kind": "boundary",
+      "operation": "file.fetch",
+      "intent": "Proves max_transfer_bytes_inflight is independent: harness-started transfers reserve exactly the served byte budget, one more byte is refused, and the harness cleans the started set up at case end.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "control:concurrency"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "max_inflight": "frame.limits.max_transfer_bytes_inflight",
+            "max_transfers": "frame.limits.max_concurrent_transfers"
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$max_inflight",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "start_transfers",
+            "count": 1,
+            "aggregate_bytes": "$max_inflight",
+            "op_id_prefix": "op-bytes-"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid_one_byte"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "resource_exhausted",
+              "resource": "max_transfer_bytes_inflight",
+              "limit": "$max_inflight"
+            }
+          },
+          "op_id": "op-bytes-past"
+        },
+        {
+          "assert": [
+            {
+              "path": "err.limit",
+              "op": "type",
+              "value": "uint"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "path": "err.resource",
+              "op": "present"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "cancel_transfers",
+            "op_id_prefix": "op-bytes-"
+          }
+        }
+      ]
+    },
+    {
+      "name": "transfer_progress_pushes_report_monotonic_transferred_bytes",
+      "kind": "push",
+      "operation": "file.fetch",
+      "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: transfer pushes carry transfer_op_id, a non-decreasing receiver-accepted byte count, and the signed total, with no room-scoped fields; fails until U2 provides a byte-count channel.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          },
+          "on": "subject:self"
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "op_id": "op-progress-1",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          },
+          "on": "subject:self"
+        },
+        {
+          "await": {
+            "push": {
+              "t": "transfer",
+              "transfer_op_id": "op-progress-1",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          },
+          "save": {
+            "progress_one": "frame.transferred_bytes"
+          },
+          "on": "subject:self"
+        },
+        {
+          "await": {
+            "push": {
+              "t": "transfer",
+              "transfer_op_id": "op-progress-1",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          },
+          "on": "subject:self"
+        },
+        {
+          "assert": [
+            {
+              "path": "frame.transferred_bytes",
+              "op": "gte",
+              "value": "$progress_one"
+            },
+            {
+              "path": "frame.op_id",
+              "op": "absent"
+            },
+            {
+              "path": "frame.room_id",
+              "op": "absent"
+            },
+            {
+              "path": "frame",
+              "op": "no_nulls"
+            }
+          ]
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": "$total",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          },
+          "on": "subject:self"
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "transfer_progress_is_delivered_only_to_the_initiating_principal",
+      "kind": "push",
+      "operation": "file.fetch",
+      "intent": "Proves transfer progress is principal-private on one daemon: the owner receives the canonical transfer push, the second principal receives no matching transfer push, and the owner's deferred fetch still reaches terminal success; fails until U2.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file",
+        "observe:frames"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "principal:self",
+          "save": {
+            "fid": "out.files[0].file_id",
+            "total": "out.files[0].bytes"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "on": "principal:self",
+          "op_id": "op-progress-private",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          }
+        },
+        {
+          "on": "principal:self",
+          "await": {
+            "push": {
+              "t": "transfer",
+              "transfer_op_id": "op-progress-private",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "$total"
+              }
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_push",
+              "on": "principal:second",
+              "match": {
+                "t": "transfer",
+                "transfer_op_id": "op-progress-private"
+              },
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "on": "principal:self",
+          "expect": {
+            "ok": true,
+            "out": {
+              "room_id": "$rid",
+              "file_id": "$fid",
+              "bytes": "$total",
+              "digest": "<string>",
+              "provider": {
+                "subject_id": "<subject_id>",
+                "device_id": "<device_id>"
+              }
+            }
+          }
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled",
+      "kind": "error",
+      "operation": "file.fetch",
+      "intent": "Proves a transfer making zero forward progress for transfer_stall_ms terminates with transfer_stalled carrying transferred_bytes and a tagged total rather than hanging to the deadline or reporting a size or integrity failure; fails until U2 makes forward progress observable at all.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {},
+            "headers": {}
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          },
+          "save": {
+            "stall_ms": "frame.limits.transfer_stall_ms"
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_stalled",
+              "transferred_bytes": 16384,
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
+              }
+            }
+          },
+          "op_id": "op-stall-1"
+        },
+        {
+          "assert": [
+            {
+              "path": "err.transferred_bytes",
+              "op": "eq",
+              "value": 16384
+            }
+          ]
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid_unsized"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_stalled",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "unknown"
+              }
+            }
+          },
+          "op_id": "op-stall-2"
+        },
+        {
+          "assert": [
+            {
+              "path": "err",
+              "op": "no_nulls"
+            }
+          ]
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "cancel_result_reports_bytes_transferred",
+      "kind": "success",
+      "operation": "transfer.cancel",
+      "intent": "Proves a cancelled transfer reports how far it got, so a client can tell an immediate cancel from one that abandoned most of a large file; fails until U2 provides the byte count, which is why it is separated from the cancellation cases that do not need it.",
+      "requires": [
+        "subject",
+        "room:live",
+        "link:up",
+        "resource:large_file"
+      ],
+      "steps": [
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$rid",
+            "file_id": "$fid"
+          },
+          "op_id": "op-cancel-bytes",
+          "defer": true,
+          "save": {
+            "fetch_request": "$request"
+          },
+          "on": "subject:self"
+        },
+        {
+          "await": {
+            "push": {
+              "t": "transfer",
+              "transfer_op_id": "op-cancel-bytes",
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
+              }
+            }
+          },
+          "on": "subject:self"
+        },
+        {
+          "call": "transfer.cancel",
+          "in": {
+            "transfer_op_id": "op-cancel-bytes"
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "transfer_op_id": "op-cancel-bytes",
+              "outcome": {
+                "state": "cancelled"
+              },
+              "transferred_bytes": "<uint>",
+              "total": {
+                "state": "known",
+                "bytes": "<uint>"
+              }
+            }
+          },
+          "save": {
+            "cancelled_bytes": "out.transferred_bytes",
+            "cancel_total": "out.total.bytes"
+          },
+          "on": "subject:self"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.transferred_bytes",
+              "op": "gt",
+              "value": 0
+            },
+            {
+              "path": "out.transferred_bytes",
+              "op": "lte",
+              "value": "$cancel_total"
+            },
+            {
+              "path": "out.path",
+              "op": "absent"
+            },
+            {
+              "path": "out.local_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.save_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.data_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.directory",
+              "op": "absent"
+            },
+            {
+              "path": "out.staged_path",
+              "op": "absent"
+            },
+            {
+              "path": "out.download_dir",
+              "op": "absent"
+            },
+            {
+              "path": "out.uri",
+              "op": "absent"
+            },
+            {
+              "path": "out.file_url",
+              "op": "absent"
+            }
+          ],
+          "on": "subject:self"
+        },
+        {
+          "await": {
+            "reply": "$fetch_request"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": "$cancelled_bytes",
+              "total": {
+                "state": "known",
+                "bytes": "$cancel_total"
+              },
+              "reason": "cancelled"
+            }
+          },
+          "on": "subject:self"
+        }
+      ],
+      "blocked_on_upstream": "U2"
+    },
+    {
+      "name": "file_operations_are_not_a_membership_oracle",
+      "kind": "authorization",
+      "operation": null,
+      "intent": "Proves each room-scoped file operation returns the same room_not_available shape and indistinguishable timing for a foreign room and a well-formed unknown room, while echoing the caller-supplied room_id and opening no upload stream.",
+      "requires": [
+        "subject",
+        "room:foreign",
+        "observe:timing"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$foreign_rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "list_foreign": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
+            }
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": {
+              "$unknown": "<room_id>"
+            },
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "save": {
+            "list_unknown": "err",
+            "unknown_rid": "err.room_id"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": {
+                "$unknown": "<room_id>"
+              }
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$list_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$list_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:1",
+                "step:2"
+              ]
+            }
+          ]
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$foreign_rid",
+            "file_id": "$foreign_fid"
+          },
+          "op_id": "op-oracle-fetch-foreign",
+          "save": {
+            "fetch_foreign": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
+            }
+          }
+        },
+        {
+          "call": "file.fetch",
+          "in": {
+            "room_id": "$unknown_rid",
+            "file_id": {
+              "$unknown": "<file_id>"
+            }
+          },
+          "op_id": "op-oracle-fetch-unknown",
+          "save": {
+            "fetch_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$fetch_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$fetch_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:4",
+                "step:5"
+              ]
+            }
+          ]
+        },
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$foreign_rid",
+            "file_id": "$foreign_fid"
+          },
+          "op_id": "op-oracle-read-foreign",
+          "save": {
+            "read_foreign": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
+            }
+          }
+        },
+        {
+          "call": "file.read",
+          "in": {
+            "room_id": "$unknown_rid",
+            "file_id": {
+              "$unknown": "<file_id>"
+            }
+          },
+          "op_id": "op-oracle-read-unknown",
+          "save": {
+            "read_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$read_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$read_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:7",
+                "step:8"
+              ]
+            }
+          ]
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$foreign_rid",
+            "name": "a.bin",
+            "declared_bytes": 16,
+            "declared_content_type": "application/octet-stream"
+          },
+          "op_id": "op-oracle-share-foreign",
+          "save": {
+            "share_foreign": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$foreign_rid"
+            }
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$unknown_rid",
+            "name": "a.bin",
+            "declared_bytes": 16,
+            "declared_content_type": "application/octet-stream"
+          },
+          "op_id": "op-oracle-share-unknown",
+          "save": {
+            "share_unknown": "err"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "room_not_available",
+              "room_id": "$unknown_rid"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "$share_foreign",
+              "op": "eq_except",
+              "value": {
+                "path": "$share_unknown",
+                "keys": [
+                  "room_id"
+                ]
+              }
+            },
+            {
+              "observe": "timing_indistinguishable",
+              "between": [
+                "step:10",
+                "step:11"
+              ]
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:10",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:11",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "file_list_reports_an_unreadable_file_index_rather_than_an_empty_list",
+      "kind": "error",
+      "operation": "file.list",
+      "intent": "Gives file.list its own code, distinct from the room_not_available case the corpus already has. With a known shared file in an available room, the room's file index is made unreadable and the call must answer file_index_unreadable. Catches a daemon that returns files: [] on a read failure, which is uniquely costly here: the user concludes the file was never shared and re-shares it, paying a second transfer of up to max_shared_file_bytes, and the room gains a duplicate signed share event that every member stores forever. It also catches the code substitution that would be worst for diagnosis -- answering room_not_available, which tells a member in good standing that they have lost access to the room when in fact only a local index read failed, sending them to rejoin instead of to restart. fetchable is specified as an evidence-backed fact, and 'I could not read the evidence' is not the same fact as 'there is no file'.",
+      "requires": [
+        "subject",
+        "room:live",
+        "fault:room_index_unreadable",
+        "fault:file_index_unreadable"
+      ],
+      "steps": [
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "file_id": "<file_id>",
+                  "digest": "<string>",
+                  "fetchable": "<bool>",
+                  "self_hosted": "<bool>",
+                  "bytes": "<uint>"
+                }
+              ]
+            }
+          },
+          "note": "baseline: the index is readable and names the shared file"
+        },
+        {
+          "assert": [
+            {
+              "path": "out",
+              "op": "no_nulls"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "inject_fault",
+            "fault": "file_index_unreadable"
+          },
+          "note": "the room's file index read path fails -- I/O error or permission denial. The share event and the local blob are untouched; only the read fails."
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_push",
+              "room_id": "$rid",
+              "scope": "case"
+            }
+          ]
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "file_index_unreadable"
+            }
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "err",
+              "op": "no_nulls"
+            }
+          ]
+        },
+        {
+          "control": {
+            "do": "inject_fault",
+            "fault": "file_index_unreadable"
+          }
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "expect": {
+            "ok": true,
+            "out": {
+              "files": [
+                {
+                  "file_id": "<file_id>",
+                  "digest": "<string>"
+                }
+              ]
+            }
+          },
+          "note": "the file was there the whole time; the refusal was honest about not being able to see it"
+        }
+      ]
+    },
+    {
+      "name": "a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch — accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
+      "requires": [
+        "subject",
+        "room:live",
+        "resource:shared_file"
+      ],
+      "steps": [
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "mismatch.bin",
+            "declared_bytes": 4096,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "declared_size_mismatch",
+              "declared_bytes": 4096,
+              "observed_bytes": 4095
+            }
+          },
+          "op_id": "op-mismatch-1",
+          "stream": {
+            "send_bytes": 4095
+          }
+        },
+        {
+          "assert": [
+            {
+              "path": "err.hint",
+              "op": "absent"
+            }
+          ]
+        },
+        {
+          "assert": [
+            {
+              "observe": "no_event_authored",
+              "scope": "case"
+            }
+          ]
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -1,4312 +1,4381 @@
 {
-  "domain": "files",
-  "note": "Hand-authored from docs/protocol-v2.md. NOT generated from any implementation. See ../README.md.",
-  "cases": [
+ "domain": "files",
+ "note": "Hand-authored from docs/protocol-v2.md. NOT generated from any implementation. See ../README.md.",
+ "cases": [
+  {
+   "name": "handshake_serves_the_file_and_transfer_limits_as_integers",
+   "kind": "handshake",
+   "operation": null,
+   "intent": "Proves the shared-file maximum and the four transfer budget fields arrive in the hello limits object as JSON integers and that the served value is the policy value 104857600, so a daemon that stops serving a limit, serves it as a formatted string, or drifts from the ratified number is caught at the handshake before any file operation runs.",
+   "requires": [
+    "subject"
+   ],
+   "steps": [
     {
-      "name": "handshake_serves_the_file_and_transfer_limits_as_integers",
-      "kind": "handshake",
-      "operation": null,
-      "intent": "Proves the shared-file maximum and the four transfer budget fields arrive in the hello limits object as JSON integers and that the served value is the policy value 104857600, so a daemon that stops serving a limit, serves it as a formatted string, or drifts from the ratified number is caught at the handshake before any file operation runs.",
-      "requires": [
-        "subject"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes",
-            "max_transfers": "frame.limits.max_concurrent_transfers",
-            "max_inflight": "frame.limits.max_transfer_bytes_inflight",
-            "connect_ms": "frame.limits.transfer_connect_allowance_ms",
-            "floor_bps": "frame.limits.transfer_floor_bits_per_second",
-            "stall_ms": "frame.limits.transfer_stall_ms"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.t",
-              "op": "eq",
-              "value": "hello"
-            },
-            {
-              "path": "frame.protocol",
-              "op": "eq",
-              "value": 2
-            },
-            {
-              "path": "frame.limits.max_shared_file_bytes",
-              "op": "eq",
-              "value": "<uint>"
-            },
-            {
-              "path": "frame.limits.max_concurrent_transfers",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "frame.limits.max_transfer_bytes_inflight",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "frame.limits.transfer_connect_allowance_ms",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "frame.limits.transfer_floor_bits_per_second",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "frame.limits.transfer_stall_ms",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "$max_transfers",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "$max_inflight",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "$connect_ms",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "$floor_bps",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "$stall_ms",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "type",
-              "value": "uint",
-              "note": "path recovered from context; exclusions: [\"string\", \"float\", \"null\", \"object\"]"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "eq",
-              "value": 104857600
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "frame.pid",
-              "op": "absent"
-            },
-            {
-              "path": "frame.port",
-              "op": "absent"
-            },
-            {
-              "path": "frame.schema",
-              "op": "absent"
-            }
-          ]
-        }
-      ]
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
     },
     {
-      "name": "client_reads_the_shared_file_limit_from_the_handshake",
-      "kind": "handshake",
-      "operation": "file.share",
-      "targets": [
-        "client_adapter"
-      ],
-      "intent": "Proves the client's share preflight threshold moves with a harness-reduced served max_shared_file_bytes rather than a compiled-in constant, catching any client that reintroduces one of the six hard-coded copies the size policy exists to delete.",
-      "requires": [],
-      "steps": [
-        {
-          "control": {
-            "do": "set_limit",
-            "limit": "max_shared_file_bytes",
-            "value": 1048576
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.limits.max_shared_file_bytes",
-              "op": "eq",
-              "value": 1048576
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "client_preflight",
-            "source_bytes": "$limit",
-            "source_reports_size": true
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "accepted"
-            },
-            {
-              "path": "frame.accepted",
-              "op": "eq",
-              "value": true
-            },
-            {
-              "path": "frame.source_bytes",
-              "op": "eq",
-              "value": "$limit"
-            },
-            {
-              "path": "frame.bytes_sent",
-              "op": "eq",
-              "value": "$limit"
-            },
-            {
-              "path": "frame.requests_emitted",
-              "op": "eq",
-              "value": 1
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "client_preflight",
-            "source_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
-            "source_reports_size": true
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "refused"
-            },
-            {
-              "path": "frame.refused",
-              "op": "eq",
-              "value": true
-            },
-            {
-              "path": "frame.bytes_sent",
-              "op": "eq",
-              "value": 0
-            },
-            {
-              "path": "frame.requests_emitted",
-              "op": "eq",
-              "value": 0
-            }
-          ]
-        }
-      ]
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes",
+      "max_transfers": "frame.limits.max_concurrent_transfers",
+      "max_inflight": "frame.limits.max_transfer_bytes_inflight",
+      "connect_ms": "frame.limits.transfer_connect_allowance_ms",
+      "floor_bps": "frame.limits.transfer_floor_bits_per_second",
+      "stall_ms": "frame.limits.transfer_stall_ms"
+     }
     },
     {
-      "name": "client_renders_the_limit_message_from_the_served_integer",
-      "kind": "handshake",
-      "operation": "file.share",
-      "targets": [
-        "client_adapter"
-      ],
-      "intent": "Proves the human-readable limit is rendered from the SERVED integer, so no catalog carries the number verbatim and a served change cannot make a translation lie. Asserted two ways: no locale catalog contains the number, and the rendered string moves when the harness overrides the limit.",
-      "requires": [],
-      "steps": [
-        {
-          "control": {
-            "do": "set_limit",
-            "limit": "max_shared_file_bytes",
-            "value": 1048576
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "control": {
-            "do": "client_render_limit",
-            "served_bytes": "$limit"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.source_bytes",
-              "op": "eq",
-              "value": "$limit"
-            },
-            {
-              "path": "frame.rendered",
-              "op": "type",
-              "value": "string"
-            },
-            {
-              "path": "frame.rendered",
-              "op": "byte_len",
-              "value": {
-                "op": "gt",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
+     "assert": [
+      {
+       "path": "frame.t",
+       "op": "eq",
+       "value": "hello"
+      },
+      {
+       "path": "frame.protocol",
+       "op": "eq",
+       "value": 2
+      },
+      {
+       "path": "frame.limits.max_shared_file_bytes",
+       "op": "eq",
+       "value": "<uint>"
+      },
+      {
+       "path": "frame.limits.max_concurrent_transfers",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "frame.limits.max_transfer_bytes_inflight",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "frame.limits.transfer_connect_allowance_ms",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "frame.limits.transfer_floor_bits_per_second",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "frame.limits.transfer_stall_ms",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
     },
     {
-      "name": "share_below_the_served_limit_succeeds",
-      "kind": "success",
-      "operation": "file.share",
-      "intent": "Establishes the baseline success shape of the streamed share: a file identifier, the authored room fact, the daemon-computed digest and the accepted byte count, with no filesystem path in either direction, catching any regression to v1's path-taking RPC plus separate HTTP upload edge.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "Files"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-share-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "notes.txt",
-            "declared_bytes": 1024,
-            "declared_content_type": "text/plain"
-          },
-          "save": {
-            "fid": "out.file_id"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "<file_id>",
-              "event_id": "<event_id>",
-              "pos": "<uint>",
-              "bytes": 1024,
-              "digest": "<string>"
-            }
-          },
-          "op_id": "op-share-2",
-          "stream": {
-            "send_bytes": 1024
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.path",
-              "op": "absent"
-            },
-            {
-              "path": "out.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.file_url",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "file_id": "$fid",
-                  "self_hosted": true,
-                  "fetchable": true,
-                  "bytes": 1024
-                }
-              ]
-            }
-          }
-        }
-      ]
+     "assert": [
+      {
+       "path": "$limit",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "$max_transfers",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "$max_inflight",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "$connect_ms",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "$floor_bps",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "$stall_ms",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
     },
     {
-      "name": "share_at_exactly_the_served_limit_is_accepted",
-      "kind": "boundary",
-      "operation": "file.share",
-      "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes is accepted, catching an off-by-one that would silently refuse the largest legal file.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "AtLimit"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-atlimit-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "exactly-at-limit.bin",
-            "declared_bytes": "$limit",
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "<file_id>",
-              "event_id": "<event_id>",
-              "pos": "<uint>",
-              "bytes": "$limit",
-              "digest": "<string>"
-            }
-          },
-          "op_id": "op-atlimit-2",
-          "stream": {
-            "send_bytes": "$limit"
-          }
-        }
-      ]
+     "assert": [
+      {
+       "path": "$limit",
+       "op": "type",
+       "value": "uint",
+       "note": "path recovered from context; exclusions: [\"string\", \"float\", \"null\", \"object\"]"
+      }
+     ]
     },
     {
-      "name": "share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled",
-      "kind": "error",
-      "operation": "file.share",
-      "intent": "Proves a client can cancel an admitted upload before sending any DATA by issuing ABORT(cancelled): the daemon acknowledges the ABORT and then replies stream_aborted{cancelled} accounting for zero receiver-accepted bytes -- the 'client ABORT wins' leg of the race table. Catches a daemon that ignores a producer ABORT, replies success, or sends its terminal reply without first acknowledging the ABORT, and a harness whose byte counter could pass without the daemon proving it accepted nothing.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "ClientCancel"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-clientcancel-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "cancelled.bin",
-            "declared_bytes": 1024,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "stream_aborted",
-              "transferred_bytes": 0,
-              "total": {
-                "state": "known",
-                "bytes": 1024
-              },
-              "reason": "cancelled"
-            }
-          },
-          "op_id": "op-clientcancel-2",
-          "stream": {
-            "send_bytes": 1024,
-            "fault": "client_abort"
-          }
-        }
-      ]
+     "assert": [
+      {
+       "path": "$limit",
+       "op": "eq",
+       "value": 104857600
+      }
+     ]
     },
     {
-      "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
-      "kind": "boundary",
-      "operation": "file.share",
-      "intent": "Proves the earliest daemon-side enforcement point fires on a declaration one byte above the served limit before OPEN or any body byte, with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "OverByOne"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-over-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "one-past.bin",
-            "declared_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": {
-                "$add": [
-                  "$limit",
-                  1
-                ]
-              },
-              "limit_bytes": "$limit",
-              "enforced_at": "stage_declared"
-            }
-          },
-          "op_id": "op-over-2"
-        },
-        {
-          "assert": [
-            {
-              "path": "err.hint",
-              "op": "absent"
-            },
-            {
-              "path": "err.path",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
-              "call": "step:5",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_event_authored",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.declared_bytes",
-              "op": "type",
-              "value": "uint"
-            },
-            {
-              "path": "err.limit_bytes",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "$limit",
-              "op": "type",
-              "value": "uint",
-              "note": "path recovered from context; exclusions: [\"string\"]"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "share_declared_within_limit_but_stream_exceeds_it_aborts_at_stage_stream",
-      "kind": "boundary",
-      "operation": "file.share",
-      "intent": "Proves a declared length is treated as an assertion by an untrusted caller and not as fact: a caller declaring exactly $limit but streaming more is aborted mid-stream with enforced_at=stage_stream after consuming no more than limit_bytes, catching a daemon that enforces only on the declaration.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "LyingDeclaration"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-liar-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "understated.bin",
-            "declared_bytes": "$limit",
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": "$limit",
-              "limit_bytes": "$limit",
-              "enforced_at": "stage_stream"
-            }
-          },
-          "op_id": "op-liar-2",
-          "stream": {
-            "send_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
-              "call": "step:5",
-              "value": {
-                "op": "eq",
-                "value": "$limit"
-              }
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_event_authored",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_durable_mutation",
-              "scope": "case"
-            }
-          ],
-          "note": "an aborted stage leaves no stranded staged file"
-        }
-      ]
-    },
-    {
-      "name": "share_over_limit_in_process_core_is_refused_at_authoring",
-      "kind": "error",
-      "operation": "file.share",
-      "targets": [
-        "in_process_core"
-      ],
-      "intent": "Proves the core authoring layer enforces the limit on file metadata before hashing or blob import, which is the only enforcement point that exists for an in-process adapter with no daemon upload edge, catching an implementation that relies on the stage checks alone.",
-      "requires": [
-        "subject",
-        "room:live",
-        "control:limits"
-      ],
-      "steps": [
-        {
-          "control": {
-            "do": "set_limit",
-            "limit": "max_shared_file_bytes",
-            "value": 4096
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "InProcess"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-authoring-1"
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "too-big-in-process.bin",
-            "declared_bytes": 4097,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": 4097,
-              "limit_bytes": 4096,
-              "enforced_at": "authoring"
-            }
-          },
-          "op_id": "op-authoring-2"
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_durable_mutation",
-              "scope": "case"
-            }
-          ],
-          "note": "authoring refusal leaves nothing behind"
-        }
-      ]
-    },
-    {
-      "name": "client_preflight_refuses_over_limit_before_any_bytes_are_sent",
-      "kind": "boundary",
-      "operation": "file.share",
-      "targets": [
-        "client_adapter"
-      ],
-      "intent": "Proves the sixth enforcement point — the client preflight, which by definition never reaches the daemon — refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
-      "requires": [
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "control": {
-            "do": "client_preflight",
-            "source_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
-            "source_reports_size": true
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "refused"
-            },
-            {
-              "path": "frame.refused",
-              "op": "eq",
-              "value": true
-            },
-            {
-              "path": "frame.bytes_sent",
-              "op": "eq",
-              "value": 0
-            },
-            {
-              "path": "frame.requests_emitted",
-              "op": "eq",
-              "value": 0
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "client_unsized_source_streams_through_a_counting_bound",
-      "kind": "boundary",
-      "operation": "file.share",
-      "targets": [
-        "client_adapter"
-      ],
-      "intent": "Proves a client facing a source that reports no size neither rejects it for lacking a size nor copies it unbounded, but streams it through a byte-counting bound that stops at the served limit, catching the two failure modes the size policy names for the Android SAF path.",
-      "requires": [
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "control": {
-            "do": "client_preflight",
-            "source_bytes": 65536,
-            "source_reports_size": false
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "accepted"
-            },
-            {
-              "path": "frame.accepted",
-              "op": "eq",
-              "value": true
-            },
-            {
-              "path": "frame.bytes_sent",
-              "op": "eq",
-              "value": 65536
-            },
-            {
-              "path": "frame.requests_emitted",
-              "op": "eq",
-              "value": 1
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "client_preflight",
-            "source_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
-            "source_reports_size": false
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "refused"
-            },
-            {
-              "path": "frame.refused",
-              "op": "eq",
-              "value": true
-            },
-            {
-              "path": "frame.bytes_sent",
-              "op": "eq",
-              "value": 0
-            },
-            {
-              "path": "frame.requests_emitted",
-              "op": "eq",
-              "value": 0
-            },
-            {
-              "path": "frame.staged_bytes",
-              "op": "lte",
-              "value": "$limit"
-            },
-            {
-              "path": "frame.peak_buffered_bytes",
-              "op": "lte",
-              "value": "$limit"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "share_size_refusal_is_never_reported_as_digest_mismatch",
-      "kind": "error",
-      "operation": "file.share",
-      "intent": "First half of the paired direction rule: an over-limit share is reported as file_too_large and never as digest_mismatch, so a size refusal is never dressed up as a false accusation of content tampering against an honest caller.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "room.create",
-          "in": {
-            "name": "PairA"
-          },
-          "save": {
-            "rid": "out.room_id"
-          },
-          "op_id": "op-pairA-1"
-        },
-        {
-          "call": "room.activate",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "oversize.bin",
-            "declared_bytes": {
-              "$add": [
-                "$limit",
-                1
-              ]
-            },
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": {
-                "$add": [
-                  "$limit",
-                  1
-                ]
-              },
-              "limit_bytes": "$limit",
-              "enforced_at": "stage_declared"
-            }
-          },
-          "op_id": "op-pairA-2"
-        }
-      ]
-    },
-    {
-      "name": "fetch_of_corrupt_bytes_within_the_limit_is_digest_mismatch_never_file_too_large",
-      "kind": "error",
-      "operation": "file.fetch",
-      "intent": "Second half of the paired direction rule: a within-limit blob whose bytes do not verify against the signed digest is reported as digest_mismatch carrying expected and observed, never as file_too_large, so a content failure is never mislabelled a size failure and the two codes stay disjoint in both directions.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "digest_mismatch",
-              "expected": "<string>",
-              "observed": "<string>"
-            }
-          },
-          "op_id": "op-pairB-1"
-        }
-      ]
-    },
-    {
-      "name": "share_declared_size_as_a_formatted_string_is_malformed",
-      "kind": "malformed",
-      "operation": "file.share",
-      "intent": "Proves the size is carried as a typed integer and never as a formatted string, refusing both a unit-bearing string and a decimal string with invalid_argument rather than parsing either, catching a client that ships the human rendering onto the wire.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": "100 MiB",
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-malformed-1"
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": "1024",
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-malformed-2"
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_event_authored",
-              "scope": "case"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "share_size_null_or_out_of_domain_is_malformed",
-      "kind": "malformed",
-      "operation": "file.share",
-      "intent": "Proves no JSON null carries meaning on the file path — a null size is not read as unknown — and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": null,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-null-1"
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": -1,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-null-3"
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": 1.5,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-null-4"
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "a.bin",
-            "declared_bytes": {
-              "state": "declared"
-            },
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "in.declared_bytes",
-              "reason": {
-                "state": "type",
-                "expected": "uint"
-              }
-            }
-          },
-          "op_id": "op-null-5"
-        }
-      ]
-    },
-    {
-      "name": "share_completed_result_replays_without_a_second_stream_and_authors_once",
-      "kind": "success",
-      "operation": "file.share",
-      "intent": "Proves a completed file.share result is op_id deduplicated across a same-principal reconnection: the replay returns the original out directly, opens no second stream, accepts zero bytes, and performs no second blob import or authored fact.",
-      "requires": [
-        "subject",
-        "room:live",
-        "control:reconnect"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {
-              "v": 2,
-              "sg": "$daemon.storage_generation"
-            },
-            "headers": {
-              "Authorization": "Bearer <bearer_from_portfile>"
-            }
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "once.bin",
-            "declared_bytes": 2048,
-            "declared_content_type": "application/octet-stream"
-          },
-          "on": "subject:self",
-          "save": {
-            "first": "out"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "<file_id>",
-              "event_id": "<event_id>",
-              "pos": "<uint>",
-              "bytes": 2048,
-              "digest": "<string>"
-            }
-          },
-          "op_id": "op-dedup-share",
-          "stream": {
-            "send_bytes": 2048
-          }
-        },
-        {
-          "control": {
-            "do": "disconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "control": {
-            "do": "reconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "once.bin",
-            "declared_bytes": 2048,
-            "declared_content_type": "application/octet-stream"
-          },
-          "on": "subject:self",
-          "op_id": "op-dedup-share",
-          "expect": {
-            "ok": true,
-            "out": "$first"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out",
-              "op": "eq",
-              "value": "$first"
-            },
-            {
-              "observe": "bytes_streamed",
-              "call": "step:5",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "on": "subject:self",
-          "note": "[bare-string assert 'exactly_one_entry_with' needs manual retranscription]"
-        },
-        {
-          "assert": [
-            {
-              "path": "$first.file_id",
-              "op": "present"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "list_names_provider_devices_with_fetchable_and_self_hosted_as_stated_facts",
-      "kind": "success",
-      "operation": "file.list",
-      "intent": "Proves file.list returns named provider devices carrying reachability evidence plus separate fetchable and self_hosted booleans, and carries none of v1's provider count, available boolean, or local path fields, catching any client forced back to inferring availability from a number.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "files": [
-                {
-                  "file_id": "<file_id>",
-                  "name": "design.pdf",
-                  "digest": "<string>",
-                  "providers": [
-                    {
-                      "device_id": "<device_id>",
-                      "subject_id": "<subject_id>",
-                      "link": {
-                        "state": "direct",
-                        "since": "<ts>"
-                      }
-                    }
-                  ],
-                  "fetchable": "<bool>",
-                  "self_hosted": "<bool>",
-                  "bytes": "<uint>",
-                  "declared_content_type": "application/pdf",
-                  "shared_by": "<subject_id>",
-                  "shared_at": "<ts>"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[*].available",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].providers_count",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].local_bytes",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].fetched",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].fetched_at_ms",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].mime",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].path",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].file_url",
-              "op": "absent"
-            },
-            {
-              "path": "out.path",
-              "op": "absent"
-            },
-            {
-              "path": "out.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.file_url",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[*].providers",
-              "op": "len",
-              "value": {
-                "op": "gte",
-                "value": 1
-              }
-            },
-            {
-              "path": "out.files[*].fetchable",
-              "op": "type",
-              "value": "bool"
-            },
-            {
-              "path": "out.files[*].self_hosted",
-              "op": "type",
-              "value": "bool"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "out",
-              "op": "no_nulls"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "list_reports_fetchable_false_with_a_stated_reason_when_no_provider_is_reachable",
-      "kind": "success",
-      "operation": "file.list",
-      "intent": "Proves fetchable is evidence-backed transport fact and not an inference from membership display state: a provider that room.members reports as an active member but that this daemon holds no link to yields fetchable false with a typed unreachable reason, which is the #50/#94 separation of membership from availability.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "note": "[control shape {\"provider_link\": \"down\"} needs review] [harness orchestration: provider_link]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
-          "call": "room.members",
-          "in": {
-            "room_id": "$rid"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "members": [
-                {
-                  "subject_id": "<string>",
-                  "standing": "active"
-                }
-              ]
-            }
-          },
-          "save": {
-            "member": "out.members[0].subject_id"
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "providers": [
-                    {
-                      "subject_id": "$member",
-                      "device_id": "<string>",
-                      "link": {
-                        "state": "unreachable",
-                        "reason": "no_route"
-                      }
-                    }
-                  ],
-                  "fetchable": false,
-                  "self_hosted": false
-                }
-              ]
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.room.members.standing",
-              "op": "present"
-            },
-            {
-              "path": "out.file.list.fetchable",
-              "op": "present"
-            },
-            {
-              "path": "out.file.list.providers[].reachability",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "note": "[control shape {\"provider_link\": \"up\"} needs review] [harness orchestration: provider_link]",
-          "control": {
-            "do": "idle",
-            "ms": 0
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "fetchable": true
-                }
-              ]
-            }
-          },
-          "note": "the fact tracks observed transport, not the member list"
-        }
-      ]
-    },
-    {
-      "name": "list_of_a_room_that_is_not_available_answers_room_not_available",
-      "kind": "error",
-      "operation": "file.list",
-      "intent": "Gives file.list its refusal case using the most specific code the v2 taxonomy defines for a room-scoped read, proving an unknown or non-member room never yields a generic argument error or an empty success that would leak that the room does not exist.",
-      "requires": [
-        "subject"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "list_carries_a_hostile_peer_declared_name_as_an_opaque_display_string",
-      "kind": "malformed",
-      "operation": "file.list",
-      "intent": "Proves a peer-chosen file name containing path separators and traversal segments is carried verbatim in a display-only field and never appears in, or is used to construct, any path-typed field, catching a daemon that either silently rewrites peer-signed metadata or treats it as a location.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "name": "../../../etc/passwd",
-                  "declared_content_type": "text/plain"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[*].path",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.files[*].save_dir",
-              "op": "absent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_from_a_reachable_provider_holds_the_bytes_locally",
-      "kind": "success",
-      "operation": "file.fetch",
-      "intent": "Establishes the baseline fetch success shape — the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response — catching any regression to v1's directory-taking, path-returning fetch.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "file_id": "$fid",
-              "room_id": "$rid",
-              "bytes": "<uint>",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          },
-          "op_id": "op-fetch-1"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.path",
-              "op": "absent"
-            },
-            {
-              "path": "out.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.file_url",
-              "op": "absent"
-            },
-            {
-              "path": "out.verified",
-              "op": "absent"
-            },
-            {
-              "path": "out.local",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "file_id": "$fid",
-                  "self_hosted": true
-                }
-              ]
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[0].local",
-              "op": "absent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_preflight_refuses_an_oversized_signed_size_before_contacting_a_provider",
-      "kind": "boundary",
-      "operation": "file.fetch",
-      "intent": "Proves the receive side preflights the signed size_bytes against the served limit and refuses with enforced_at=fetch_preflight before opening any connection, which is the enforcement point that does not exist today and the one that prevents an oversized remote blob from ever being reported as an integrity failure.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "limit": "frame.limits.max_shared_file_bytes"
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "fetchable": "<bool>",
-                  "bytes": {
-                    "$add": [
-                      "$limit",
-                      1
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": {
-                "$add": [
-                  "$limit",
-                  1
-                ]
-              },
-              "limit_bytes": "$limit",
-              "enforced_at": "fetch_preflight"
-            }
-          },
-          "op_id": "op-preflight-1"
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
-              "call": "step:4",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_stream_refuses_a_peer_serving_more_than_it_declared",
-      "kind": "boundary",
-      "operation": "file.fetch",
-      "intent": "Proves the mid-stream fetch bound reports a provider response exceeding the signed declaration as file_too_large at fetch_stream after accepting exactly the declared bytes; it remains blocked until U3 supplies a size-distinguishable fetch outcome.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid": "out.files[0].file_id",
-            "declared_bytes": "out.files[0].bytes"
-          }
-        },
-        {
-          "control": {
-            "do": "set_provider_response_bytes",
-            "file_id": "$fid",
-            "bytes": {
-              "$add": [
-                "$declared_bytes",
-                1
-              ]
-            }
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_too_large",
-              "declared_bytes": "$declared_bytes",
-              "limit_bytes": "$declared_bytes",
-              "enforced_at": "fetch_stream"
-            }
-          },
-          "op_id": "op-fetchstream-1"
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
-              "call": "step:3",
-              "value": {
-                "op": "eq",
-                "value": "$declared_bytes"
-              }
-            }
-          ]
-        }
-      ],
-      "blocked_on_upstream": "U3"
-    },
-    {
-      "name": "fetch_with_no_reachable_provider_fails_with_provider_unreachable",
-      "kind": "error",
-      "operation": "file.fetch",
-      "intent": "Gives file.fetch a transport-specific refusal distinct from every size and integrity code, proving an unfetchable file names the reason it could not be served rather than reporting a mismatch or a generic argument error, and that the answer agrees with the fetchable fact file.list stated.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:down"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "fetchable": false
-                }
-              ]
-            }
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "provider_unreachable",
-              "file_id": "$fid",
-              "providers": [
-                {
-                  "subject_id": "<subject_id>",
-                  "device_id": "<device_id>",
-                  "link": {
-                    "state": "not_connected",
-                    "reason": "no_route"
-                  }
-                }
-              ]
-            }
-          },
-          "op_id": "op-unreach-1"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.files[0].fetchable",
-              "op": "present"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
-      "kind": "malformed",
-      "operation": "file.fetch",
-      "intent": "Proves file.fetch rejects a missing envelope op_id during structural decode, before room lookup or provider contact, even when the room and file inputs are otherwise valid.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "invalid_argument",
-              "field": "op_id",
-              "reason": {
-                "state": "missing"
-              }
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_network_activity",
-              "scope": "step"
-            },
-            {
-              "observe": "bytes_streamed",
-              "call": "step:2",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown",
-      "kind": "error",
-      "operation": "file.fetch",
-      "intent": "Proves a member asking for a file identifier the room's signed history does not contain gets a file-specific code rather than a generic argument error, while confirming this distinction is only ever offered to a member (the non-member answer is covered by the oracle case).",
-      "requires": [
-        "subject",
-        "room:live"
-      ],
-      "steps": [
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": {
-              "$unknown": "<file_id>"
-            }
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_unknown",
-              "file_id": {
-                "$unknown": "<file_id>"
-              }
-            }
-          },
-          "op_id": "op-unknownfile-1"
-        }
-      ]
-    },
-    {
-      "name": "fetch_completed_result_replays_without_a_second_transfer",
-      "kind": "success",
-      "operation": "file.fetch",
-      "intent": "Proves a completed file.fetch result is op_id deduplicated across a same-principal reconnection, so replay returns the original out directly and moves no second copy of the bytes across the network.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "control:reconnect"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "subject:self",
-          "save": {
-            "first": "out"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "file_id": "$fid",
-              "room_id": "$rid",
-              "bytes": "<uint>",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          },
-          "op_id": "op-dedup-fetch"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.local",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "disconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "control": {
-            "do": "reconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "subject:self",
-          "expect": {
-            "ok": true,
-            "out": "$first"
-          },
-          "op_id": "op-dedup-fetch"
-        },
-        {
-          "assert": [
-            {
-              "path": "out",
-              "op": "eq",
-              "value": "$first"
-            },
-            {
-              "observe": "bytes_streamed",
-              "call": "step:6",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "fetch_deadline_scales_with_the_declared_size",
-      "kind": "boundary",
-      "operation": "file.fetch",
-      "intent": "Proves the absolute file.fetch deadline uses the signed total and served floor: one transfer at the floor succeeds, while another reports the exact size-derived budget rather than any fixed timeout, with a truthful accepted-byte count.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "control:limits"
-      ],
-      "steps": [
-        {
-          "control": {
-            "do": "set_limit",
-            "limit": "transfer_connect_allowance_ms",
-            "value": 1000
-          }
-        },
-        {
-          "control": {
-            "do": "set_limit",
-            "limit": "transfer_floor_bits_per_second",
-            "value": 8192
-          }
-        },
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "connect_ms": "frame.limits.transfer_connect_allowance_ms",
-            "floor_bps": "frame.limits.transfer_floor_bits_per_second"
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid_at_floor": "out.files[0].file_id",
-            "total_at_floor": "out.files[0].bytes",
-            "fid_below_floor": "out.files[1].file_id",
-            "total_below_floor": "out.files[1].bytes"
-          }
-        },
-        {
-          "control": {
-            "do": "set_link_rate",
-            "between": [
-              "subject:self",
-              "provider"
-            ],
-            "bits_per_second": "$floor_bps"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid_at_floor"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "$fid_at_floor",
-              "bytes": "$total_at_floor",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          },
-          "op_id": "op-budget-floor"
-        },
-        {
-          "control": {
-            "do": "set_link_rate",
-            "between": [
-              "subject:self",
-              "provider"
-            ],
-            "bits_per_second": 1
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid_below_floor"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_deadline_exceeded",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total_below_floor"
-              },
-              "budget_ms": {
-                "$transfer_budget_ms": [
-                  "$total_below_floor",
-                  "$connect_ms",
-                  "$floor_bps"
-                ]
-              }
-            }
-          },
-          "op_id": "op-budget-expiry"
-        },
-        {
-          "assert": [
-            {
-              "path": "err.transferred_bytes",
-              "op": "lt",
-              "value": "$total_below_floor"
-            },
-            {
-              "path": "err.transferred_bytes",
-              "op": "gt",
-              "value": 0
-            },
-            {
-              "path": "err.budget_ms",
-              "op": "gt",
-              "value": "$connect_ms"
-            }
-          ]
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field",
-      "kind": "success",
-      "operation": "file.read",
-      "intent": "Proves file.read streams bytes with the peer-declared type carried in a distinctly named, explicitly untrusted field and with no field that presents a type as authoritative fact, which is how v1's never-render-inline HTTP response headers become data now that bytes no longer travel over HTTP.",
-      "requires": [
-        "subject",
-        "room:live",
-        "resource:fetched_file"
-      ],
-      "steps": [
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "$fid",
-              "bytes": 4096,
-              "declared_content_type": "application/pdf"
-            }
-          },
-          "stream": {
-            "receive_bytes": 4096
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "out.path",
-              "op": "absent"
-            },
-            {
-              "path": "out.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.file_url",
-              "op": "absent"
-            },
-            {
-              "path": "out.mime",
-              "op": "absent"
-            },
-            {
-              "path": "out.content_type",
-              "op": "absent"
-            },
-            {
-              "path": "out.type",
-              "op": "absent"
-            },
-            {
-              "path": "out.sniffed_type",
-              "op": "absent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "client_must_not_render_peer_declared_bytes_inline",
-      "kind": "boundary",
-      "operation": "file.read",
-      "targets": [
-        "client_adapter"
-      ],
-      "intent": "Proves a client treats the peer-declared type as a hint only: a peer declaring text/html with a script-bearing body is never rendered inline as markup and never executes, catching a client that restores v1's inline-render behaviour now that the protective HTTP headers are gone.",
-      "requires": [
-        "resource:fetched_file",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "$fid",
-              "bytes": 4096,
-              "declared_content_type": "text/html"
-            }
-          },
-          "stream": {
-            "receive_bytes": 4096
-          }
-        },
-        {
-          "control": {
-            "do": "client_render_file",
-            "declared_content_type": "text/html",
-            "body_kind": "script_bearing_html"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.decision",
-              "op": "eq",
-              "value": "download_only"
-            },
-            {
-              "path": "frame.executed",
-              "op": "eq",
-              "value": false
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "read_of_a_file_whose_bytes_are_not_held_locally_fails_with_file_not_fetched",
-      "kind": "error",
-      "operation": "file.read",
-      "intent": "Gives file.read its own refusal case, proving that reading a known but unfetched file names that precise condition rather than silently fetching it, returning empty bytes, or answering with a generic argument error.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {}
-              ]
-            }
-          },
-          "save": {
-            "fid": "out.files[0].file_id"
-          }
-        },
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_not_fetched",
-              "file_id": "$fid"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "observe": "bytes_streamed",
-              "call": "step:2",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "transfer_cancel_after_the_originating_connection_dropped",
-      "kind": "success",
-      "operation": "transfer.cancel",
-      "intent": "Proves a deferred file.fetch remains cancellable after its originating transport drops: the same principal reconnects, cancels by transfer_op_id, and replaying the original request on that session returns the recorded cancelled stream_aborted result without awaiting a dead connection handle.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "control:reconnect"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "on": "subject:self",
-          "save": {
-            "fid": "out.files[0].file_id",
-            "total": "out.files[0].bytes"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "subject:self",
-          "op_id": "op-cancel-target",
-          "defer": true,
-          "save": {
-            "abandoned_fetch_request": "$request"
-          },
-          "note": "The disconnect abandons this connection-local request handle; it is saved only because the current deferred-call DSL validator requires a handle."
-        },
-        {
-          "control": {
-            "do": "disconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "control": {
-            "do": "reconnect",
-            "on": "subject:self"
-          }
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-cancel-target"
-          },
-          "on": "subject:self",
-          "expect": {
-            "ok": true,
-            "out": {
-              "transfer_op_id": "op-cancel-target",
-              "outcome": {
-                "state": "cancelled"
-              },
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              }
-            }
-          },
-          "save": {
-            "cancelled_bytes": "out.transferred_bytes"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "subject:self",
-          "op_id": "op-cancel-target",
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "stream_aborted",
-              "transferred_bytes": "$cancelled_bytes",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              },
-              "reason": "cancelled"
-            }
-          }
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
-      "kind": "authorization",
-      "operation": "transfer.cancel",
-      "intent": "Proves the principal-scoped cancellation ledger is not an oracle on one daemon: a second principal sees the same transfer_unknown shape for the owner's live transfer and an absent transfer, while the owner can still cancel and receives the original fetch's terminal cancellation reply.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "on": "principal:self",
-          "save": {
-            "fid": "out.files[0].file_id",
-            "total": "out.files[0].bytes"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "principal:self",
-          "op_id": "op-cancel-owned",
-          "defer": true,
-          "save": {
-            "fetch_request": "$request"
-          }
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-cancel-owned"
-          },
-          "on": "principal:second",
-          "save": {
-            "foreign_err": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_unknown",
-              "transfer_op_id": "op-cancel-owned"
-            }
-          }
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-never-existed"
-          },
-          "on": "principal:second",
-          "save": {
-            "absent_err": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_unknown",
-              "transfer_op_id": "op-never-existed"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$foreign_err",
-              "op": "eq_except",
-              "value": {
-                "path": "$absent_err",
-                "keys": [
-                  "transfer_op_id"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-cancel-owned"
-          },
-          "on": "principal:self",
-          "save": {
-            "cancelled_bytes": "out.transferred_bytes"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "transfer_op_id": "op-cancel-owned",
-              "outcome": {
-                "state": "cancelled"
-              },
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              }
-            }
-          }
-        },
-        {
-          "await": {
-            "reply": "$fetch_request"
-          },
-          "on": "principal:self",
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "stream_aborted",
-              "transferred_bytes": "$cancelled_bytes",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              },
-              "reason": "cancelled"
-            }
-          }
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
-      "kind": "error",
-      "operation": "transfer.cancel",
-      "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error — the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
-      "requires": [
-        "subject"
-      ],
-      "steps": [
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-does-not-exist"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_unknown",
-              "transfer_op_id": "op-does-not-exist"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "err.path",
-              "op": "absent"
-            },
-            {
-              "path": "err.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "err.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "err.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "err.dir",
-              "op": "absent"
-            },
-            {
-              "path": "err.directory",
-              "op": "absent"
-            },
-            {
-              "path": "err.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "err.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "err.uri",
-              "op": "absent"
-            },
-            {
-              "path": "err.file_url",
-              "op": "absent"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "transfer_cancel_releases_the_concurrent_transfer_slot",
-      "kind": "success",
-      "operation": "transfer.cancel",
-      "intent": "Proves cancellation actually returns the transfer to the daemon budget rather than merely reporting success: after filling the served concurrency ceiling, cancelling op-slot-0 frees that slot for a succeeding fetch, then cleanup cancels the remaining harness-started set.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "control:concurrency"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "max_transfers": "frame.limits.max_concurrent_transfers"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$max_transfers",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "start_transfers",
-            "count": "$max_transfers",
-            "aggregate_bytes": "$max_transfers",
-            "op_id_prefix": "op-slot-"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "resource_exhausted",
-              "resource": "max_concurrent_transfers",
-              "limit": "$max_transfers"
-            }
-          },
-          "op_id": "op-slot-overflow"
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-slot-0"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "transfer_op_id": "op-slot-0",
-              "outcome": {
-                "state": "cancelled"
-              },
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "<uint>"
-              }
-            }
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "file_id": "$fid",
-              "room_id": "$rid",
-              "bytes": "<uint>",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          },
-          "op_id": "op-slot-retry"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.local",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "cancel_transfers",
-            "op_id_prefix": "op-slot-"
-          }
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "concurrent_transfers_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
-      "kind": "boundary",
-      "operation": "file.fetch",
-      "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of harness-started transfers run, the next is refused, and the harness cleans the started set up at case end.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "control:concurrency"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "max_transfers": "frame.limits.max_concurrent_transfers"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$max_transfers",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "start_transfers",
-            "count": "$max_transfers",
-            "aggregate_bytes": "$max_transfers",
-            "op_id_prefix": "op-conc-"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "resource_exhausted",
-              "resource": "max_concurrent_transfers",
-              "limit": "$max_transfers"
-            }
-          },
-          "op_id": "op-conc-past"
-        },
-        {
-          "control": {
-            "do": "cancel_transfers",
-            "op_id_prefix": "op-conc-"
-          }
-        }
-      ]
-    },
-    {
-      "name": "inflight_transfer_bytes_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
-      "kind": "boundary",
-      "operation": "file.fetch",
-      "intent": "Proves max_transfer_bytes_inflight is independent: harness-started transfers reserve exactly the served byte budget, one more byte is refused, and the harness cleans the started set up at case end.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "control:concurrency"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "max_inflight": "frame.limits.max_transfer_bytes_inflight",
-            "max_transfers": "frame.limits.max_concurrent_transfers"
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$max_inflight",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "start_transfers",
-            "count": 1,
-            "aggregate_bytes": "$max_inflight",
-            "op_id_prefix": "op-bytes-"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid_one_byte"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "resource_exhausted",
-              "resource": "max_transfer_bytes_inflight",
-              "limit": "$max_inflight"
-            }
-          },
-          "op_id": "op-bytes-past"
-        },
-        {
-          "assert": [
-            {
-              "path": "err.limit",
-              "op": "type",
-              "value": "uint"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "path": "err.resource",
-              "op": "present"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "cancel_transfers",
-            "op_id_prefix": "op-bytes-"
-          }
-        }
-      ]
-    },
-    {
-      "name": "transfer_progress_pushes_report_monotonic_transferred_bytes",
-      "kind": "push",
-      "operation": "file.fetch",
-      "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: transfer pushes carry transfer_op_id, a non-decreasing receiver-accepted byte count, and the signed total, with no room-scoped fields; fails until U2 provides a byte-count channel.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "fid": "out.files[0].file_id",
-            "total": "out.files[0].bytes"
-          },
-          "on": "subject:self"
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "op_id": "op-progress-1",
-          "defer": true,
-          "save": {
-            "fetch_request": "$request"
-          },
-          "on": "subject:self"
-        },
-        {
-          "await": {
-            "push": {
-              "t": "transfer",
-              "transfer_op_id": "op-progress-1",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              }
-            }
-          },
-          "save": {
-            "progress_one": "frame.transferred_bytes"
-          },
-          "on": "subject:self"
-        },
-        {
-          "await": {
-            "push": {
-              "t": "transfer",
-              "transfer_op_id": "op-progress-1",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              }
-            }
-          },
-          "on": "subject:self"
-        },
-        {
-          "assert": [
-            {
-              "path": "frame.transferred_bytes",
-              "op": "gte",
-              "value": "$progress_one"
-            },
-            {
-              "path": "frame.op_id",
-              "op": "absent"
-            },
-            {
-              "path": "frame.room_id",
-              "op": "absent"
-            },
-            {
-              "path": "frame",
-              "op": "no_nulls"
-            }
-          ]
-        },
-        {
-          "await": {
-            "reply": "$fetch_request"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "$fid",
-              "bytes": "$total",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          },
-          "on": "subject:self"
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "transfer_progress_is_delivered_only_to_the_initiating_principal",
-      "kind": "push",
-      "operation": "file.fetch",
-      "intent": "Proves transfer progress is principal-private on one daemon: the owner receives the canonical transfer push, the second principal receives no matching transfer push, and the owner's deferred fetch still reaches terminal success; fails until U2.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file",
-        "observe:frames"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "on": "principal:self",
-          "save": {
-            "fid": "out.files[0].file_id",
-            "total": "out.files[0].bytes"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "on": "principal:self",
-          "op_id": "op-progress-private",
-          "defer": true,
-          "save": {
-            "fetch_request": "$request"
-          }
-        },
-        {
-          "on": "principal:self",
-          "await": {
-            "push": {
-              "t": "transfer",
-              "transfer_op_id": "op-progress-private",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "$total"
-              }
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_push",
-              "on": "principal:second",
-              "match": {
-                "t": "transfer",
-                "transfer_op_id": "op-progress-private"
-              },
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "await": {
-            "reply": "$fetch_request"
-          },
-          "on": "principal:self",
-          "expect": {
-            "ok": true,
-            "out": {
-              "room_id": "$rid",
-              "file_id": "$fid",
-              "bytes": "$total",
-              "digest": "<string>",
-              "provider": {
-                "subject_id": "<subject_id>",
-                "device_id": "<device_id>"
-              }
-            }
-          }
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled",
-      "kind": "error",
-      "operation": "file.fetch",
-      "intent": "Proves a transfer making zero forward progress for transfer_stall_ms terminates with transfer_stalled carrying transferred_bytes and a tagged total rather than hanging to the deadline or reporting a size or integrity failure; fails until U2 makes forward progress observable at all.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up"
-      ],
-      "steps": [
-        {
-          "upgrade": {
-            "query": {},
-            "headers": {}
-          }
-        },
-        {
-          "await": {
-            "frame": {
-              "t": "hello"
-            }
-          },
-          "save": {
-            "stall_ms": "frame.limits.transfer_stall_ms"
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_stalled",
-              "transferred_bytes": 16384,
-              "total": {
-                "state": "known",
-                "bytes": "<uint>"
-              }
-            }
-          },
-          "op_id": "op-stall-1"
-        },
-        {
-          "assert": [
-            {
-              "path": "err.transferred_bytes",
-              "op": "eq",
-              "value": 16384
-            }
-          ]
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid_unsized"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "transfer_stalled",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "unknown"
-              }
-            }
-          },
-          "op_id": "op-stall-2"
-        },
-        {
-          "assert": [
-            {
-              "path": "err",
-              "op": "no_nulls"
-            }
-          ]
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "cancel_result_reports_bytes_transferred",
-      "kind": "success",
-      "operation": "transfer.cancel",
-      "intent": "Proves a cancelled transfer reports how far it got, so a client can tell an immediate cancel from one that abandoned most of a large file; fails until U2 provides the byte count, which is why it is separated from the cancellation cases that do not need it.",
-      "requires": [
-        "subject",
-        "room:live",
-        "link:up",
-        "resource:large_file"
-      ],
-      "steps": [
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$rid",
-            "file_id": "$fid"
-          },
-          "op_id": "op-cancel-bytes",
-          "defer": true,
-          "save": {
-            "fetch_request": "$request"
-          },
-          "on": "subject:self"
-        },
-        {
-          "await": {
-            "push": {
-              "t": "transfer",
-              "transfer_op_id": "op-cancel-bytes",
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "<uint>"
-              }
-            }
-          },
-          "on": "subject:self"
-        },
-        {
-          "call": "transfer.cancel",
-          "in": {
-            "transfer_op_id": "op-cancel-bytes"
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "transfer_op_id": "op-cancel-bytes",
-              "outcome": {
-                "state": "cancelled"
-              },
-              "transferred_bytes": "<uint>",
-              "total": {
-                "state": "known",
-                "bytes": "<uint>"
-              }
-            }
-          },
-          "save": {
-            "cancelled_bytes": "out.transferred_bytes",
-            "cancel_total": "out.total.bytes"
-          },
-          "on": "subject:self"
-        },
-        {
-          "assert": [
-            {
-              "path": "out.transferred_bytes",
-              "op": "gt",
-              "value": 0
-            },
-            {
-              "path": "out.transferred_bytes",
-              "op": "lte",
-              "value": "$cancel_total"
-            },
-            {
-              "path": "out.path",
-              "op": "absent"
-            },
-            {
-              "path": "out.local_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.save_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.data_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.directory",
-              "op": "absent"
-            },
-            {
-              "path": "out.staged_path",
-              "op": "absent"
-            },
-            {
-              "path": "out.download_dir",
-              "op": "absent"
-            },
-            {
-              "path": "out.uri",
-              "op": "absent"
-            },
-            {
-              "path": "out.file_url",
-              "op": "absent"
-            }
-          ],
-          "on": "subject:self"
-        },
-        {
-          "await": {
-            "reply": "$fetch_request"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "stream_aborted",
-              "transferred_bytes": "$cancelled_bytes",
-              "total": {
-                "state": "known",
-                "bytes": "$cancel_total"
-              },
-              "reason": "cancelled"
-            }
-          },
-          "on": "subject:self"
-        }
-      ],
-      "blocked_on_upstream": "U2"
-    },
-    {
-      "name": "file_operations_are_not_a_membership_oracle",
-      "kind": "authorization",
-      "operation": null,
-      "intent": "Proves each room-scoped file operation returns the same room_not_available shape and indistinguishable timing for a foreign room and a well-formed unknown room, while echoing the caller-supplied room_id and opening no upload stream.",
-      "requires": [
-        "subject",
-        "room:foreign",
-        "observe:timing"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$foreign_rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "list_foreign": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$foreign_rid"
-            }
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": {
-              "$unknown": "<room_id>"
-            },
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "save": {
-            "list_unknown": "err",
-            "unknown_rid": "err.room_id"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": {
-                "$unknown": "<room_id>"
-              }
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$list_foreign",
-              "op": "eq_except",
-              "value": {
-                "path": "$list_unknown",
-                "keys": [
-                  "room_id"
-                ]
-              }
-            },
-            {
-              "observe": "timing_indistinguishable",
-              "between": [
-                "step:1",
-                "step:2"
-              ]
-            }
-          ]
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$foreign_rid",
-            "file_id": "$foreign_fid"
-          },
-          "op_id": "op-oracle-fetch-foreign",
-          "save": {
-            "fetch_foreign": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$foreign_rid"
-            }
-          }
-        },
-        {
-          "call": "file.fetch",
-          "in": {
-            "room_id": "$unknown_rid",
-            "file_id": {
-              "$unknown": "<file_id>"
-            }
-          },
-          "op_id": "op-oracle-fetch-unknown",
-          "save": {
-            "fetch_unknown": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$unknown_rid"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$fetch_foreign",
-              "op": "eq_except",
-              "value": {
-                "path": "$fetch_unknown",
-                "keys": [
-                  "room_id"
-                ]
-              }
-            },
-            {
-              "observe": "timing_indistinguishable",
-              "between": [
-                "step:4",
-                "step:5"
-              ]
-            }
-          ]
-        },
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$foreign_rid",
-            "file_id": "$foreign_fid"
-          },
-          "op_id": "op-oracle-read-foreign",
-          "save": {
-            "read_foreign": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$foreign_rid"
-            }
-          }
-        },
-        {
-          "call": "file.read",
-          "in": {
-            "room_id": "$unknown_rid",
-            "file_id": {
-              "$unknown": "<file_id>"
-            }
-          },
-          "op_id": "op-oracle-read-unknown",
-          "save": {
-            "read_unknown": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$unknown_rid"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$read_foreign",
-              "op": "eq_except",
-              "value": {
-                "path": "$read_unknown",
-                "keys": [
-                  "room_id"
-                ]
-              }
-            },
-            {
-              "observe": "timing_indistinguishable",
-              "between": [
-                "step:7",
-                "step:8"
-              ]
-            }
-          ]
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$foreign_rid",
-            "name": "a.bin",
-            "declared_bytes": 16,
-            "declared_content_type": "application/octet-stream"
-          },
-          "op_id": "op-oracle-share-foreign",
-          "save": {
-            "share_foreign": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$foreign_rid"
-            }
-          }
-        },
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$unknown_rid",
-            "name": "a.bin",
-            "declared_bytes": 16,
-            "declared_content_type": "application/octet-stream"
-          },
-          "op_id": "op-oracle-share-unknown",
-          "save": {
-            "share_unknown": "err"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "room_not_available",
-              "room_id": "$unknown_rid"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "$share_foreign",
-              "op": "eq_except",
-              "value": {
-                "path": "$share_unknown",
-                "keys": [
-                  "room_id"
-                ]
-              }
-            },
-            {
-              "observe": "timing_indistinguishable",
-              "between": [
-                "step:10",
-                "step:11"
-              ]
-            },
-            {
-              "observe": "bytes_streamed",
-              "call": "step:10",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            },
-            {
-              "observe": "bytes_streamed",
-              "call": "step:11",
-              "value": {
-                "op": "eq",
-                "value": 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "file_list_reports_an_unreadable_file_index_rather_than_an_empty_list",
-      "kind": "error",
-      "operation": "file.list",
-      "intent": "Gives file.list its own code, distinct from the room_not_available case the corpus already has. With a known shared file in an available room, the room's file index is made unreadable and the call must answer file_index_unreadable. Catches a daemon that returns files: [] on a read failure, which is uniquely costly here: the user concludes the file was never shared and re-shares it, paying a second transfer of up to max_shared_file_bytes, and the room gains a duplicate signed share event that every member stores forever. It also catches the code substitution that would be worst for diagnosis -- answering room_not_available, which tells a member in good standing that they have lost access to the room when in fact only a local index read failed, sending them to rejoin instead of to restart. fetchable is specified as an evidence-backed fact, and 'I could not read the evidence' is not the same fact as 'there is no file'.",
-      "requires": [
-        "subject",
-        "room:live",
-        "fault:room_index_unreadable",
-        "fault:file_index_unreadable"
-      ],
-      "steps": [
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "file_id": "<file_id>",
-                  "digest": "<string>",
-                  "fetchable": "<bool>",
-                  "self_hosted": "<bool>",
-                  "bytes": "<uint>"
-                }
-              ]
-            }
-          },
-          "note": "baseline: the index is readable and names the shared file"
-        },
-        {
-          "assert": [
-            {
-              "path": "out",
-              "op": "no_nulls"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "inject_fault",
-            "fault": "file_index_unreadable"
-          },
-          "note": "the room's file index read path fails -- I/O error or permission denial. The share event and the local blob are untouched; only the read fails."
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_push",
-              "room_id": "$rid",
-              "scope": "case"
-            }
-          ]
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "file_index_unreadable"
-            }
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "err",
-              "op": "no_nulls"
-            }
-          ]
-        },
-        {
-          "control": {
-            "do": "inject_fault",
-            "fault": "file_index_unreadable"
-          }
-        },
-        {
-          "call": "file.list",
-          "in": {
-            "room_id": "$rid",
-            "cursor": {
-              "state": "start"
-            },
-            "direction": "forward",
-            "limit": 50
-          },
-          "expect": {
-            "ok": true,
-            "out": {
-              "files": [
-                {
-                  "file_id": "<file_id>",
-                  "digest": "<string>"
-                }
-              ]
-            }
-          },
-          "note": "the file was there the whole time; the refusal was honest about not being able to see it"
-        }
-      ]
-    },
-    {
-      "name": "a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch",
-      "kind": "error",
-      "operation": "file.share",
-      "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch — accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
-      "requires": [
-        "subject",
-        "room:live",
-        "resource:shared_file"
-      ],
-      "steps": [
-        {
-          "call": "file.share",
-          "in": {
-            "room_id": "$rid",
-            "name": "mismatch.bin",
-            "declared_bytes": 4096,
-            "declared_content_type": "application/octet-stream"
-          },
-          "expect": {
-            "ok": false,
-            "err": {
-              "code": "declared_size_mismatch",
-              "declared_bytes": 4096,
-              "observed_bytes": 4095
-            }
-          },
-          "op_id": "op-mismatch-1",
-          "stream": {
-            "send_bytes": 4095
-          }
-        },
-        {
-          "assert": [
-            {
-              "path": "err.hint",
-              "op": "absent"
-            }
-          ]
-        },
-        {
-          "assert": [
-            {
-              "observe": "no_event_authored",
-              "scope": "case"
-            }
-          ]
-        }
-      ]
+     "assert": [
+      {
+       "path": "frame.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "frame.pid",
+       "op": "absent"
+      },
+      {
+       "path": "frame.port",
+       "op": "absent"
+      },
+      {
+       "path": "frame.schema",
+       "op": "absent"
+      }
+     ]
     }
-  ]
+   ]
+  },
+  {
+   "name": "client_reads_the_shared_file_limit_from_the_handshake",
+   "kind": "handshake",
+   "operation": "file.share",
+   "targets": [
+    "client_adapter"
+   ],
+   "intent": "Proves the client's share preflight threshold moves with a harness-reduced served max_shared_file_bytes rather than a compiled-in constant, catching any client that reintroduces one of the six hard-coded copies the size policy exists to delete.",
+   "requires": [],
+   "steps": [
+    {
+     "control": {
+      "do": "set_limit",
+      "limit": "max_shared_file_bytes",
+      "value": 1048576
+     }
+    },
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.limits.max_shared_file_bytes",
+       "op": "eq",
+       "value": 1048576
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "client_preflight",
+      "source_bytes": "$limit",
+      "source_reports_size": true
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "accepted"
+      },
+      {
+       "path": "frame.accepted",
+       "op": "eq",
+       "value": true
+      },
+      {
+       "path": "frame.source_bytes",
+       "op": "eq",
+       "value": "$limit"
+      },
+      {
+       "path": "frame.bytes_sent",
+       "op": "eq",
+       "value": "$limit"
+      },
+      {
+       "path": "frame.requests_emitted",
+       "op": "eq",
+       "value": 1
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "client_preflight",
+      "source_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      },
+      "source_reports_size": true
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "refused"
+      },
+      {
+       "path": "frame.refused",
+       "op": "eq",
+       "value": true
+      },
+      {
+       "path": "frame.bytes_sent",
+       "op": "eq",
+       "value": 0
+      },
+      {
+       "path": "frame.requests_emitted",
+       "op": "eq",
+       "value": 0
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "client_renders_the_limit_message_from_the_served_integer",
+   "kind": "handshake",
+   "operation": "file.share",
+   "targets": [
+    "client_adapter"
+   ],
+   "intent": "Proves the human-readable limit is rendered from the SERVED integer, so no catalog carries the number verbatim and a served change cannot make a translation lie. Asserted two ways: no locale catalog contains the number, and the rendered string moves when the harness overrides the limit.",
+   "requires": [],
+   "steps": [
+    {
+     "control": {
+      "do": "set_limit",
+      "limit": "max_shared_file_bytes",
+      "value": 1048576
+     }
+    },
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "control": {
+      "do": "client_render_limit",
+      "served_bytes": "$limit"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.source_bytes",
+       "op": "eq",
+       "value": "$limit"
+      },
+      {
+       "path": "frame.rendered",
+       "op": "type",
+       "value": "string"
+      },
+      {
+       "path": "frame.rendered",
+       "op": "byte_len",
+       "value": {
+        "op": "gt",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "share_below_the_served_limit_succeeds",
+   "kind": "success",
+   "operation": "file.share",
+   "intent": "Establishes the baseline success shape of the streamed share: a file identifier, the authored room fact, the daemon-computed digest and the accepted byte count, with no filesystem path in either direction, catching any regression to v1's path-taking RPC plus separate HTTP upload edge.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "Files"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-share-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "notes.txt",
+      "declared_bytes": 1024,
+      "declared_content_type": "text/plain"
+     },
+     "save": {
+      "fid": "out.file_id"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "<file_id>",
+       "event_id": "<event_id>",
+       "pos": "<uint>",
+       "bytes": 1024,
+       "digest": "<string>"
+      }
+     },
+     "op_id": "op-share-2",
+     "stream": {
+      "send_bytes": 1024
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.path",
+       "op": "absent"
+      },
+      {
+       "path": "out.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.file_url",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "file_id": "$fid",
+         "self_hosted": true,
+         "fetchable": true,
+         "bytes": 1024
+        }
+       ]
+      }
+     }
+    }
+   ]
+  },
+  {
+   "name": "share_at_exactly_the_served_limit_is_accepted",
+   "kind": "boundary",
+   "operation": "file.share",
+   "intent": "Proves the comparison against the served maximum is strictly greater-than, so a file of exactly max_shared_file_bytes is accepted, catching an off-by-one that would silently refuse the largest legal file.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "AtLimit"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-atlimit-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "exactly-at-limit.bin",
+      "declared_bytes": "$limit",
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "<file_id>",
+       "event_id": "<event_id>",
+       "pos": "<uint>",
+       "bytes": "$limit",
+       "digest": "<string>"
+      }
+     },
+     "op_id": "op-atlimit-2",
+     "stream": {
+      "send_bytes": "$limit"
+     }
+    }
+   ]
+  },
+  {
+   "name": "share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled",
+   "kind": "error",
+   "operation": "file.share",
+   "intent": "Proves a client can cancel an admitted upload before sending any DATA by issuing ABORT(cancelled): the daemon acknowledges the ABORT and then replies stream_aborted{cancelled} accounting for zero receiver-accepted bytes -- the 'client ABORT wins' leg of the race table. Catches a daemon that ignores a producer ABORT, replies success, or sends its terminal reply without first acknowledging the ABORT, and a harness whose byte counter could pass without the daemon proving it accepted nothing.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "ClientCancel"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-clientcancel-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "cancelled.bin",
+      "declared_bytes": 1024,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "stream_aborted",
+       "transferred_bytes": 0,
+       "total": {
+        "state": "known",
+        "bytes": 1024
+       },
+       "reason": "cancelled"
+      }
+     },
+     "op_id": "op-clientcancel-2",
+     "stream": {
+      "send_bytes": 1024,
+      "fault": "client_abort"
+     }
+    }
+   ]
+  },
+  {
+   "name": "share_malformed_stream_record_aborts_that_stream_as_malformed_frame",
+   "kind": "error",
+   "operation": "file.share",
+   "intent": "Proves a client protocol violation mid-stream is stream-local, not connection-fatal: after admission the client sends one structurally malformed byte-stream record (a nonzero reserved byte) on the live (request id, stream id) binding, whose full 48-byte header the daemon can correlate. The daemon aborts only that stream with ABORT(protocol_error) at accepted offset zero, the client ACKs, and file.share resolves to the correlated malformed_frame reply while the connection stays usable. Catches a daemon that closes the connection (4005/4007) on a correlatable malformed record, replies success, or answers without first ABORTing, and a harness that cannot drive a raw malformed record.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "RawRecord"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-rawrecord-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "malformed.bin",
+      "declared_bytes": 1024,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "malformed_frame"
+      }
+     },
+     "op_id": "op-rawrecord-2",
+     "stream": {
+      "send_bytes": 1024,
+      "fault": "raw_record"
+     }
+    }
+   ]
+  },
+  {
+   "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
+   "kind": "boundary",
+   "operation": "file.share",
+   "intent": "Proves the earliest daemon-side enforcement point fires on a declaration one byte above the served limit before OPEN or any body byte, with file_too_large carrying declared_bytes, limit_bytes and enforced_at=stage_declared.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "OverByOne"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-over-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "one-past.bin",
+      "declared_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      },
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": {
+        "$add": [
+         "$limit",
+         1
+        ]
+       },
+       "limit_bytes": "$limit",
+       "enforced_at": "stage_declared"
+      }
+     },
+     "op_id": "op-over-2"
+    },
+    {
+     "assert": [
+      {
+       "path": "err.hint",
+       "op": "absent"
+      },
+      {
+       "path": "err.path",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "bytes_streamed",
+       "call": "step:5",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_push",
+       "room_id": "$rid",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_event_authored",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "path": "err.declared_bytes",
+       "op": "type",
+       "value": "uint"
+      },
+      {
+       "path": "err.limit_bytes",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "path": "$limit",
+       "op": "type",
+       "value": "uint",
+       "note": "path recovered from context; exclusions: [\"string\"]"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "share_declared_within_limit_but_stream_exceeds_it_aborts_at_stage_stream",
+   "kind": "boundary",
+   "operation": "file.share",
+   "intent": "Proves a declared length is treated as an assertion by an untrusted caller and not as fact: a caller declaring exactly $limit but streaming more is aborted mid-stream with enforced_at=stage_stream after consuming no more than limit_bytes, catching a daemon that enforces only on the declaration.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "LyingDeclaration"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-liar-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "understated.bin",
+      "declared_bytes": "$limit",
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": "$limit",
+       "limit_bytes": "$limit",
+       "enforced_at": "stage_stream"
+      }
+     },
+     "op_id": "op-liar-2",
+     "stream": {
+      "send_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "observe": "bytes_streamed",
+       "call": "step:5",
+       "value": {
+        "op": "eq",
+        "value": "$limit"
+       }
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_push",
+       "room_id": "$rid",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_event_authored",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_durable_mutation",
+       "scope": "case"
+      }
+     ],
+     "note": "an aborted stage leaves no stranded staged file"
+    }
+   ]
+  },
+  {
+   "name": "share_over_limit_in_process_core_is_refused_at_authoring",
+   "kind": "error",
+   "operation": "file.share",
+   "targets": [
+    "in_process_core"
+   ],
+   "intent": "Proves the core authoring layer enforces the limit on file metadata before hashing or blob import, which is the only enforcement point that exists for an in-process adapter with no daemon upload edge, catching an implementation that relies on the stage checks alone.",
+   "requires": [
+    "subject",
+    "room:live",
+    "control:limits"
+   ],
+   "steps": [
+    {
+     "control": {
+      "do": "set_limit",
+      "limit": "max_shared_file_bytes",
+      "value": 4096
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "InProcess"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-authoring-1"
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "too-big-in-process.bin",
+      "declared_bytes": 4097,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": 4097,
+       "limit_bytes": 4096,
+       "enforced_at": "authoring"
+      }
+     },
+     "op_id": "op-authoring-2"
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_durable_mutation",
+       "scope": "case"
+      }
+     ],
+     "note": "authoring refusal leaves nothing behind"
+    }
+   ]
+  },
+  {
+   "name": "client_preflight_refuses_over_limit_before_any_bytes_are_sent",
+   "kind": "boundary",
+   "operation": "file.share",
+   "targets": [
+    "client_adapter"
+   ],
+   "intent": "Proves the sixth enforcement point \u2014 the client preflight, which by definition never reaches the daemon \u2014 refuses a source above the served limit with zero bytes sent, zero request frames emitted and no local copy made.",
+   "requires": [
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "control": {
+      "do": "client_preflight",
+      "source_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      },
+      "source_reports_size": true
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "refused"
+      },
+      {
+       "path": "frame.refused",
+       "op": "eq",
+       "value": true
+      },
+      {
+       "path": "frame.bytes_sent",
+       "op": "eq",
+       "value": 0
+      },
+      {
+       "path": "frame.requests_emitted",
+       "op": "eq",
+       "value": 0
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "client_unsized_source_streams_through_a_counting_bound",
+   "kind": "boundary",
+   "operation": "file.share",
+   "targets": [
+    "client_adapter"
+   ],
+   "intent": "Proves a client facing a source that reports no size neither rejects it for lacking a size nor copies it unbounded, but streams it through a byte-counting bound that stops at the served limit, catching the two failure modes the size policy names for the Android SAF path.",
+   "requires": [
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "control": {
+      "do": "client_preflight",
+      "source_bytes": 65536,
+      "source_reports_size": false
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "accepted"
+      },
+      {
+       "path": "frame.accepted",
+       "op": "eq",
+       "value": true
+      },
+      {
+       "path": "frame.bytes_sent",
+       "op": "eq",
+       "value": 65536
+      },
+      {
+       "path": "frame.requests_emitted",
+       "op": "eq",
+       "value": 1
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "client_preflight",
+      "source_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      },
+      "source_reports_size": false
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "refused"
+      },
+      {
+       "path": "frame.refused",
+       "op": "eq",
+       "value": true
+      },
+      {
+       "path": "frame.bytes_sent",
+       "op": "eq",
+       "value": 0
+      },
+      {
+       "path": "frame.requests_emitted",
+       "op": "eq",
+       "value": 0
+      },
+      {
+       "path": "frame.staged_bytes",
+       "op": "lte",
+       "value": "$limit"
+      },
+      {
+       "path": "frame.peak_buffered_bytes",
+       "op": "lte",
+       "value": "$limit"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "share_size_refusal_is_never_reported_as_digest_mismatch",
+   "kind": "error",
+   "operation": "file.share",
+   "intent": "First half of the paired direction rule: an over-limit share is reported as file_too_large and never as digest_mismatch, so a size refusal is never dressed up as a false accusation of content tampering against an honest caller.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "room.create",
+     "in": {
+      "name": "PairA"
+     },
+     "save": {
+      "rid": "out.room_id"
+     },
+     "op_id": "op-pairA-1"
+    },
+    {
+     "call": "room.activate",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "oversize.bin",
+      "declared_bytes": {
+       "$add": [
+        "$limit",
+        1
+       ]
+      },
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": {
+        "$add": [
+         "$limit",
+         1
+        ]
+       },
+       "limit_bytes": "$limit",
+       "enforced_at": "stage_declared"
+      }
+     },
+     "op_id": "op-pairA-2"
+    }
+   ]
+  },
+  {
+   "name": "fetch_of_corrupt_bytes_within_the_limit_is_digest_mismatch_never_file_too_large",
+   "kind": "error",
+   "operation": "file.fetch",
+   "intent": "Second half of the paired direction rule: a within-limit blob whose bytes do not verify against the signed digest is reported as digest_mismatch carrying expected and observed, never as file_too_large, so a content failure is never mislabelled a size failure and the two codes stay disjoint in both directions.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "digest_mismatch",
+       "expected": "<string>",
+       "observed": "<string>"
+      }
+     },
+     "op_id": "op-pairB-1"
+    }
+   ]
+  },
+  {
+   "name": "share_declared_size_as_a_formatted_string_is_malformed",
+   "kind": "malformed",
+   "operation": "file.share",
+   "intent": "Proves the size is carried as a typed integer and never as a formatted string, refusing both a unit-bearing string and a decimal string with invalid_argument rather than parsing either, catching a client that ships the human rendering onto the wire.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": "100 MiB",
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-malformed-1"
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": "1024",
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-malformed-2"
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_push",
+       "room_id": "$rid",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_event_authored",
+       "scope": "case"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "share_size_null_or_out_of_domain_is_malformed",
+   "kind": "malformed",
+   "operation": "file.share",
+   "intent": "Proves no JSON null carries meaning on the file path \u2014 a null size is not read as unknown \u2014 and that a negative or fractional byte count is refused rather than coerced into u64, catching the v1 compatibility-nullability this generation exists to shed.",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": null,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-null-1"
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": -1,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-null-3"
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": 1.5,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-null-4"
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "a.bin",
+      "declared_bytes": {
+       "state": "declared"
+      },
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "in.declared_bytes",
+       "reason": {
+        "state": "type",
+        "expected": "uint"
+       }
+      }
+     },
+     "op_id": "op-null-5"
+    }
+   ]
+  },
+  {
+   "name": "share_completed_result_replays_without_a_second_stream_and_authors_once",
+   "kind": "success",
+   "operation": "file.share",
+   "intent": "Proves a completed file.share result is op_id deduplicated across a same-principal reconnection: the replay returns the original out directly, opens no second stream, accepts zero bytes, and performs no second blob import or authored fact.",
+   "requires": [
+    "subject",
+    "room:live",
+    "control:reconnect"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {
+       "v": 2,
+       "sg": "$daemon.storage_generation"
+      },
+      "headers": {
+       "Authorization": "Bearer <bearer_from_portfile>"
+      }
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "once.bin",
+      "declared_bytes": 2048,
+      "declared_content_type": "application/octet-stream"
+     },
+     "on": "subject:self",
+     "save": {
+      "first": "out"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "<file_id>",
+       "event_id": "<event_id>",
+       "pos": "<uint>",
+       "bytes": 2048,
+       "digest": "<string>"
+      }
+     },
+     "op_id": "op-dedup-share",
+     "stream": {
+      "send_bytes": 2048
+     }
+    },
+    {
+     "control": {
+      "do": "disconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "control": {
+      "do": "reconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "once.bin",
+      "declared_bytes": 2048,
+      "declared_content_type": "application/octet-stream"
+     },
+     "on": "subject:self",
+     "op_id": "op-dedup-share",
+     "expect": {
+      "ok": true,
+      "out": "$first"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out",
+       "op": "eq",
+       "value": "$first"
+      },
+      {
+       "observe": "bytes_streamed",
+       "call": "step:5",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "on": "subject:self",
+     "note": "[bare-string assert 'exactly_one_entry_with' needs manual retranscription]"
+    },
+    {
+     "assert": [
+      {
+       "path": "$first.file_id",
+       "op": "present"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "list_names_provider_devices_with_fetchable_and_self_hosted_as_stated_facts",
+   "kind": "success",
+   "operation": "file.list",
+   "intent": "Proves file.list returns named provider devices carrying reachability evidence plus separate fetchable and self_hosted booleans, and carries none of v1's provider count, available boolean, or local path fields, catching any client forced back to inferring availability from a number.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "files": [
+        {
+         "file_id": "<file_id>",
+         "name": "design.pdf",
+         "digest": "<string>",
+         "providers": [
+          {
+           "device_id": "<device_id>",
+           "subject_id": "<subject_id>",
+           "link": {
+            "state": "direct",
+            "since": "<ts>"
+           }
+          }
+         ],
+         "fetchable": "<bool>",
+         "self_hosted": "<bool>",
+         "bytes": "<uint>",
+         "declared_content_type": "application/pdf",
+         "shared_by": "<subject_id>",
+         "shared_at": "<ts>"
+        }
+       ]
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.files[*].available",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].providers_count",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].local_bytes",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].fetched",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].fetched_at_ms",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].mime",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].path",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].file_url",
+       "op": "absent"
+      },
+      {
+       "path": "out.path",
+       "op": "absent"
+      },
+      {
+       "path": "out.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.file_url",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "path": "out.files[*].providers",
+       "op": "len",
+       "value": {
+        "op": "gte",
+        "value": 1
+       }
+      },
+      {
+       "path": "out.files[*].fetchable",
+       "op": "type",
+       "value": "bool"
+      },
+      {
+       "path": "out.files[*].self_hosted",
+       "op": "type",
+       "value": "bool"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "path": "out",
+       "op": "no_nulls"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "list_reports_fetchable_false_with_a_stated_reason_when_no_provider_is_reachable",
+   "kind": "success",
+   "operation": "file.list",
+   "intent": "Proves fetchable is evidence-backed transport fact and not an inference from membership display state: a provider that room.members reports as an active member but that this daemon holds no link to yields fetchable false with a typed unreachable reason, which is the #50/#94 separation of membership from availability.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "note": "[control shape {\"provider_link\": \"down\"} needs review] [harness orchestration: provider_link]",
+     "control": {
+      "do": "idle",
+      "ms": 0
+     }
+    },
+    {
+     "call": "room.members",
+     "in": {
+      "room_id": "$rid"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "members": [
+        {
+         "subject_id": "<string>",
+         "standing": "active"
+        }
+       ]
+      }
+     },
+     "save": {
+      "member": "out.members[0].subject_id"
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "providers": [
+          {
+           "subject_id": "$member",
+           "device_id": "<string>",
+           "link": {
+            "state": "unreachable",
+            "reason": "no_route"
+           }
+          }
+         ],
+         "fetchable": false,
+         "self_hosted": false
+        }
+       ]
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.room.members.standing",
+       "op": "present"
+      },
+      {
+       "path": "out.file.list.fetchable",
+       "op": "present"
+      },
+      {
+       "path": "out.file.list.providers[].reachability",
+       "op": "present"
+      }
+     ]
+    },
+    {
+     "note": "[control shape {\"provider_link\": \"up\"} needs review] [harness orchestration: provider_link]",
+     "control": {
+      "do": "idle",
+      "ms": 0
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "fetchable": true
+        }
+       ]
+      }
+     },
+     "note": "the fact tracks observed transport, not the member list"
+    }
+   ]
+  },
+  {
+   "name": "list_of_a_room_that_is_not_available_answers_room_not_available",
+   "kind": "error",
+   "operation": "file.list",
+   "intent": "Gives file.list its refusal case using the most specific code the v2 taxonomy defines for a room-scoped read, proving an unknown or non-member room never yields a generic argument error or an empty success that would leak that the room does not exist.",
+   "requires": [
+    "subject"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "blake3:0000000000000000000000000000000000000000000000000000000000000000"
+      }
+     }
+    }
+   ]
+  },
+  {
+   "name": "list_carries_a_hostile_peer_declared_name_as_an_opaque_display_string",
+   "kind": "malformed",
+   "operation": "file.list",
+   "intent": "Proves a peer-chosen file name containing path separators and traversal segments is carried verbatim in a display-only field and never appears in, or is used to construct, any path-typed field, catching a daemon that either silently rewrites peer-signed metadata or treats it as a location.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "name": "../../../etc/passwd",
+         "declared_content_type": "text/plain"
+        }
+       ]
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.files[*].path",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.files[*].save_dir",
+       "op": "absent"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_from_a_reachable_provider_holds_the_bytes_locally",
+   "kind": "success",
+   "operation": "file.fetch",
+   "intent": "Establishes the baseline fetch success shape \u2014 the transfer outcome, the verified digest and the naming of the provider that served it, with no save_dir in the request and no path in the response \u2014 catching any regression to v1's directory-taking, path-returning fetch.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "file_id": "$fid",
+       "room_id": "$rid",
+       "bytes": "<uint>",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     },
+     "op_id": "op-fetch-1"
+    },
+    {
+     "assert": [
+      {
+       "path": "out.path",
+       "op": "absent"
+      },
+      {
+       "path": "out.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.file_url",
+       "op": "absent"
+      },
+      {
+       "path": "out.verified",
+       "op": "absent"
+      },
+      {
+       "path": "out.local",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "file_id": "$fid",
+         "self_hosted": true
+        }
+       ]
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.files[0].local",
+       "op": "absent"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_preflight_refuses_an_oversized_signed_size_before_contacting_a_provider",
+   "kind": "boundary",
+   "operation": "file.fetch",
+   "intent": "Proves the receive side preflights the signed size_bytes against the served limit and refuses with enforced_at=fetch_preflight before opening any connection, which is the enforcement point that does not exist today and the one that prevents an oversized remote blob from ever being reported as an integrity failure.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "limit": "frame.limits.max_shared_file_bytes"
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "fetchable": "<bool>",
+         "bytes": {
+          "$add": [
+           "$limit",
+           1
+          ]
+         }
+        }
+       ]
+      }
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": {
+        "$add": [
+         "$limit",
+         1
+        ]
+       },
+       "limit_bytes": "$limit",
+       "enforced_at": "fetch_preflight"
+      }
+     },
+     "op_id": "op-preflight-1"
+    },
+    {
+     "assert": [
+      {
+       "observe": "bytes_streamed",
+       "call": "step:4",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_stream_refuses_a_peer_serving_more_than_it_declared",
+   "kind": "boundary",
+   "operation": "file.fetch",
+   "intent": "Proves the mid-stream fetch bound reports a provider response exceeding the signed declaration as file_too_large at fetch_stream after accepting exactly the declared bytes; it remains blocked until U3 supplies a size-distinguishable fetch outcome.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid": "out.files[0].file_id",
+      "declared_bytes": "out.files[0].bytes"
+     }
+    },
+    {
+     "control": {
+      "do": "set_provider_response_bytes",
+      "file_id": "$fid",
+      "bytes": {
+       "$add": [
+        "$declared_bytes",
+        1
+       ]
+      }
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_too_large",
+       "declared_bytes": "$declared_bytes",
+       "limit_bytes": "$declared_bytes",
+       "enforced_at": "fetch_stream"
+      }
+     },
+     "op_id": "op-fetchstream-1"
+    },
+    {
+     "assert": [
+      {
+       "observe": "bytes_streamed",
+       "call": "step:3",
+       "value": {
+        "op": "eq",
+        "value": "$declared_bytes"
+       }
+      }
+     ]
+    }
+   ],
+   "blocked_on_upstream": "U3"
+  },
+  {
+   "name": "fetch_with_no_reachable_provider_fails_with_provider_unreachable",
+   "kind": "error",
+   "operation": "file.fetch",
+   "intent": "Gives file.fetch a transport-specific refusal distinct from every size and integrity code, proving an unfetchable file names the reason it could not be served rather than reporting a mismatch or a generic argument error, and that the answer agrees with the fetchable fact file.list stated.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:down"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "fetchable": false
+        }
+       ]
+      }
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "provider_unreachable",
+       "file_id": "$fid",
+       "providers": [
+        {
+         "subject_id": "<subject_id>",
+         "device_id": "<device_id>",
+         "link": {
+          "state": "not_connected",
+          "reason": "no_route"
+         }
+        }
+       ]
+      }
+     },
+     "op_id": "op-unreach-1"
+    },
+    {
+     "assert": [
+      {
+       "path": "out.files[0].fetchable",
+       "op": "present"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_without_envelope_op_id_is_invalid_before_room_or_provider_work",
+   "kind": "malformed",
+   "operation": "file.fetch",
+   "intent": "Proves file.fetch rejects a missing envelope op_id during structural decode, before room lookup or provider contact, even when the room and file inputs are otherwise valid.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "invalid_argument",
+       "field": "op_id",
+       "reason": {
+        "state": "missing"
+       }
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_network_activity",
+       "scope": "step"
+      },
+      {
+       "observe": "bytes_streamed",
+       "call": "step:2",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown",
+   "kind": "error",
+   "operation": "file.fetch",
+   "intent": "Proves a member asking for a file identifier the room's signed history does not contain gets a file-specific code rather than a generic argument error, while confirming this distinction is only ever offered to a member (the non-member answer is covered by the oracle case).",
+   "requires": [
+    "subject",
+    "room:live"
+   ],
+   "steps": [
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": {
+       "$unknown": "<file_id>"
+      }
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_unknown",
+       "file_id": {
+        "$unknown": "<file_id>"
+       }
+      }
+     },
+     "op_id": "op-unknownfile-1"
+    }
+   ]
+  },
+  {
+   "name": "fetch_completed_result_replays_without_a_second_transfer",
+   "kind": "success",
+   "operation": "file.fetch",
+   "intent": "Proves a completed file.fetch result is op_id deduplicated across a same-principal reconnection, so replay returns the original out directly and moves no second copy of the bytes across the network.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "control:reconnect"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "subject:self",
+     "save": {
+      "first": "out"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "file_id": "$fid",
+       "room_id": "$rid",
+       "bytes": "<uint>",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     },
+     "op_id": "op-dedup-fetch"
+    },
+    {
+     "assert": [
+      {
+       "path": "out.local",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "disconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "control": {
+      "do": "reconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "subject:self",
+     "expect": {
+      "ok": true,
+      "out": "$first"
+     },
+     "op_id": "op-dedup-fetch"
+    },
+    {
+     "assert": [
+      {
+       "path": "out",
+       "op": "eq",
+       "value": "$first"
+      },
+      {
+       "observe": "bytes_streamed",
+       "call": "step:6",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "fetch_deadline_scales_with_the_declared_size",
+   "kind": "boundary",
+   "operation": "file.fetch",
+   "intent": "Proves the absolute file.fetch deadline uses the signed total and served floor: one transfer at the floor succeeds, while another reports the exact size-derived budget rather than any fixed timeout, with a truthful accepted-byte count.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "control:limits"
+   ],
+   "steps": [
+    {
+     "control": {
+      "do": "set_limit",
+      "limit": "transfer_connect_allowance_ms",
+      "value": 1000
+     }
+    },
+    {
+     "control": {
+      "do": "set_limit",
+      "limit": "transfer_floor_bits_per_second",
+      "value": 8192
+     }
+    },
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "connect_ms": "frame.limits.transfer_connect_allowance_ms",
+      "floor_bps": "frame.limits.transfer_floor_bits_per_second"
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid_at_floor": "out.files[0].file_id",
+      "total_at_floor": "out.files[0].bytes",
+      "fid_below_floor": "out.files[1].file_id",
+      "total_below_floor": "out.files[1].bytes"
+     }
+    },
+    {
+     "control": {
+      "do": "set_link_rate",
+      "between": [
+       "subject:self",
+       "provider"
+      ],
+      "bits_per_second": "$floor_bps"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid_at_floor"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "$fid_at_floor",
+       "bytes": "$total_at_floor",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     },
+     "op_id": "op-budget-floor"
+    },
+    {
+     "control": {
+      "do": "set_link_rate",
+      "between": [
+       "subject:self",
+       "provider"
+      ],
+      "bits_per_second": 1
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid_below_floor"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_deadline_exceeded",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total_below_floor"
+       },
+       "budget_ms": {
+        "$transfer_budget_ms": [
+         "$total_below_floor",
+         "$connect_ms",
+         "$floor_bps"
+        ]
+       }
+      }
+     },
+     "op_id": "op-budget-expiry"
+    },
+    {
+     "assert": [
+      {
+       "path": "err.transferred_bytes",
+       "op": "lt",
+       "value": "$total_below_floor"
+      },
+      {
+       "path": "err.transferred_bytes",
+       "op": "gt",
+       "value": 0
+      },
+      {
+       "path": "err.budget_ms",
+       "op": "gt",
+       "value": "$connect_ms"
+      }
+     ]
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "read_streams_a_held_file_with_the_peer_declared_type_in_an_untrusted_field",
+   "kind": "success",
+   "operation": "file.read",
+   "intent": "Proves file.read streams bytes with the peer-declared type carried in a distinctly named, explicitly untrusted field and with no field that presents a type as authoritative fact, which is how v1's never-render-inline HTTP response headers become data now that bytes no longer travel over HTTP.",
+   "requires": [
+    "subject",
+    "room:live",
+    "resource:fetched_file"
+   ],
+   "steps": [
+    {
+     "call": "file.read",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "$fid",
+       "bytes": 4096,
+       "declared_content_type": "application/pdf"
+      }
+     },
+     "stream": {
+      "receive_bytes": 4096
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "out.path",
+       "op": "absent"
+      },
+      {
+       "path": "out.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.file_url",
+       "op": "absent"
+      },
+      {
+       "path": "out.mime",
+       "op": "absent"
+      },
+      {
+       "path": "out.content_type",
+       "op": "absent"
+      },
+      {
+       "path": "out.type",
+       "op": "absent"
+      },
+      {
+       "path": "out.sniffed_type",
+       "op": "absent"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "client_must_not_render_peer_declared_bytes_inline",
+   "kind": "boundary",
+   "operation": "file.read",
+   "targets": [
+    "client_adapter"
+   ],
+   "intent": "Proves a client treats the peer-declared type as a hint only: a peer declaring text/html with a script-bearing body is never rendered inline as markup and never executes, catching a client that restores v1's inline-render behaviour now that the protective HTTP headers are gone.",
+   "requires": [
+    "resource:fetched_file",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.read",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "$fid",
+       "bytes": 4096,
+       "declared_content_type": "text/html"
+      }
+     },
+     "stream": {
+      "receive_bytes": 4096
+     }
+    },
+    {
+     "control": {
+      "do": "client_render_file",
+      "declared_content_type": "text/html",
+      "body_kind": "script_bearing_html"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.decision",
+       "op": "eq",
+       "value": "download_only"
+      },
+      {
+       "path": "frame.executed",
+       "op": "eq",
+       "value": false
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "read_of_a_file_whose_bytes_are_not_held_locally_fails_with_file_not_fetched",
+   "kind": "error",
+   "operation": "file.read",
+   "intent": "Gives file.read its own refusal case, proving that reading a known but unfetched file names that precise condition rather than silently fetching it, returning empty bytes, or answering with a generic argument error.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {}
+       ]
+      }
+     },
+     "save": {
+      "fid": "out.files[0].file_id"
+     }
+    },
+    {
+     "call": "file.read",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_not_fetched",
+       "file_id": "$fid"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "observe": "bytes_streamed",
+       "call": "step:2",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "transfer_cancel_after_the_originating_connection_dropped",
+   "kind": "success",
+   "operation": "transfer.cancel",
+   "intent": "Proves a deferred file.fetch remains cancellable after its originating transport drops: the same principal reconnects, cancels by transfer_op_id, and replaying the original request on that session returns the recorded cancelled stream_aborted result without awaiting a dead connection handle.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "control:reconnect"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "on": "subject:self",
+     "save": {
+      "fid": "out.files[0].file_id",
+      "total": "out.files[0].bytes"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "subject:self",
+     "op_id": "op-cancel-target",
+     "defer": true,
+     "save": {
+      "abandoned_fetch_request": "$request"
+     },
+     "note": "The disconnect abandons this connection-local request handle; it is saved only because the current deferred-call DSL validator requires a handle."
+    },
+    {
+     "control": {
+      "do": "disconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "control": {
+      "do": "reconnect",
+      "on": "subject:self"
+     }
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-cancel-target"
+     },
+     "on": "subject:self",
+     "expect": {
+      "ok": true,
+      "out": {
+       "transfer_op_id": "op-cancel-target",
+       "outcome": {
+        "state": "cancelled"
+       },
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       }
+      }
+     },
+     "save": {
+      "cancelled_bytes": "out.transferred_bytes"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "subject:self",
+     "op_id": "op-cancel-target",
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "stream_aborted",
+       "transferred_bytes": "$cancelled_bytes",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       },
+       "reason": "cancelled"
+      }
+     }
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown",
+   "kind": "authorization",
+   "operation": "transfer.cancel",
+   "intent": "Proves the principal-scoped cancellation ledger is not an oracle on one daemon: a second principal sees the same transfer_unknown shape for the owner's live transfer and an absent transfer, while the owner can still cancel and receives the original fetch's terminal cancellation reply.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "on": "principal:self",
+     "save": {
+      "fid": "out.files[0].file_id",
+      "total": "out.files[0].bytes"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "principal:self",
+     "op_id": "op-cancel-owned",
+     "defer": true,
+     "save": {
+      "fetch_request": "$request"
+     }
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-cancel-owned"
+     },
+     "on": "principal:second",
+     "save": {
+      "foreign_err": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_unknown",
+       "transfer_op_id": "op-cancel-owned"
+      }
+     }
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-never-existed"
+     },
+     "on": "principal:second",
+     "save": {
+      "absent_err": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_unknown",
+       "transfer_op_id": "op-never-existed"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$foreign_err",
+       "op": "eq_except",
+       "value": {
+        "path": "$absent_err",
+        "keys": [
+         "transfer_op_id"
+        ]
+       }
+      }
+     ]
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-cancel-owned"
+     },
+     "on": "principal:self",
+     "save": {
+      "cancelled_bytes": "out.transferred_bytes"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "transfer_op_id": "op-cancel-owned",
+       "outcome": {
+        "state": "cancelled"
+       },
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       }
+      }
+     }
+    },
+    {
+     "await": {
+      "reply": "$fetch_request"
+     },
+     "on": "principal:self",
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "stream_aborted",
+       "transferred_bytes": "$cancelled_bytes",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       },
+       "reason": "cancelled"
+      }
+     }
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown",
+   "kind": "error",
+   "operation": "transfer.cancel",
+   "intent": "Gives transfer.cancel its own most specific code, proving a cancel naming no transfer is not answered with a generic argument error \u2014 the distinction the spec demands so a conformance corpus can assert something about this operation at all.",
+   "requires": [
+    "subject"
+   ],
+   "steps": [
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-does-not-exist"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_unknown",
+       "transfer_op_id": "op-does-not-exist"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "err.path",
+       "op": "absent"
+      },
+      {
+       "path": "err.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "err.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "err.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "err.dir",
+       "op": "absent"
+      },
+      {
+       "path": "err.directory",
+       "op": "absent"
+      },
+      {
+       "path": "err.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "err.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "err.uri",
+       "op": "absent"
+      },
+      {
+       "path": "err.file_url",
+       "op": "absent"
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "transfer_cancel_releases_the_concurrent_transfer_slot",
+   "kind": "success",
+   "operation": "transfer.cancel",
+   "intent": "Proves cancellation actually returns the transfer to the daemon budget rather than merely reporting success: after filling the served concurrency ceiling, cancelling op-slot-0 frees that slot for a succeeding fetch, then cleanup cancels the remaining harness-started set.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "control:concurrency"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "max_transfers": "frame.limits.max_concurrent_transfers"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$max_transfers",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "start_transfers",
+      "count": "$max_transfers",
+      "aggregate_bytes": "$max_transfers",
+      "op_id_prefix": "op-slot-"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "resource_exhausted",
+       "resource": "max_concurrent_transfers",
+       "limit": "$max_transfers"
+      }
+     },
+     "op_id": "op-slot-overflow"
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-slot-0"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "transfer_op_id": "op-slot-0",
+       "outcome": {
+        "state": "cancelled"
+       },
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "<uint>"
+       }
+      }
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "file_id": "$fid",
+       "room_id": "$rid",
+       "bytes": "<uint>",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     },
+     "op_id": "op-slot-retry"
+    },
+    {
+     "assert": [
+      {
+       "path": "out.local",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "cancel_transfers",
+      "op_id_prefix": "op-slot-"
+     }
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "concurrent_transfers_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
+   "kind": "boundary",
+   "operation": "file.fetch",
+   "intent": "Proves max_concurrent_transfers is enforced as a refusal rather than absorbed: exactly the served number of harness-started transfers run, the next is refused, and the harness cleans the started set up at case end.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "control:concurrency"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "max_transfers": "frame.limits.max_concurrent_transfers"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$max_transfers",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "start_transfers",
+      "count": "$max_transfers",
+      "aggregate_bytes": "$max_transfers",
+      "op_id_prefix": "op-conc-"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "resource_exhausted",
+       "resource": "max_concurrent_transfers",
+       "limit": "$max_transfers"
+      }
+     },
+     "op_id": "op-conc-past"
+    },
+    {
+     "control": {
+      "do": "cancel_transfers",
+      "op_id_prefix": "op-conc-"
+     }
+    }
+   ]
+  },
+  {
+   "name": "inflight_transfer_bytes_at_the_served_limit_are_accepted_and_one_more_is_exhausted",
+   "kind": "boundary",
+   "operation": "file.fetch",
+   "intent": "Proves max_transfer_bytes_inflight is independent: harness-started transfers reserve exactly the served byte budget, one more byte is refused, and the harness cleans the started set up at case end.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "control:concurrency"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "max_inflight": "frame.limits.max_transfer_bytes_inflight",
+      "max_transfers": "frame.limits.max_concurrent_transfers"
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$max_inflight",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "start_transfers",
+      "count": 1,
+      "aggregate_bytes": "$max_inflight",
+      "op_id_prefix": "op-bytes-"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid_one_byte"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "resource_exhausted",
+       "resource": "max_transfer_bytes_inflight",
+       "limit": "$max_inflight"
+      }
+     },
+     "op_id": "op-bytes-past"
+    },
+    {
+     "assert": [
+      {
+       "path": "err.limit",
+       "op": "type",
+       "value": "uint"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "path": "err.resource",
+       "op": "present"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "cancel_transfers",
+      "op_id_prefix": "op-bytes-"
+     }
+    }
+   ]
+  },
+  {
+   "name": "transfer_progress_pushes_report_monotonic_transferred_bytes",
+   "kind": "push",
+   "operation": "file.fetch",
+   "intent": "Proves a long transfer is observable rather than indistinguishable from a hang: transfer pushes carry transfer_op_id, a non-decreasing receiver-accepted byte count, and the signed total, with no room-scoped fields; fails until U2 provides a byte-count channel.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "fid": "out.files[0].file_id",
+      "total": "out.files[0].bytes"
+     },
+     "on": "subject:self"
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "op_id": "op-progress-1",
+     "defer": true,
+     "save": {
+      "fetch_request": "$request"
+     },
+     "on": "subject:self"
+    },
+    {
+     "await": {
+      "push": {
+       "t": "transfer",
+       "transfer_op_id": "op-progress-1",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       }
+      }
+     },
+     "save": {
+      "progress_one": "frame.transferred_bytes"
+     },
+     "on": "subject:self"
+    },
+    {
+     "await": {
+      "push": {
+       "t": "transfer",
+       "transfer_op_id": "op-progress-1",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       }
+      }
+     },
+     "on": "subject:self"
+    },
+    {
+     "assert": [
+      {
+       "path": "frame.transferred_bytes",
+       "op": "gte",
+       "value": "$progress_one"
+      },
+      {
+       "path": "frame.op_id",
+       "op": "absent"
+      },
+      {
+       "path": "frame.room_id",
+       "op": "absent"
+      },
+      {
+       "path": "frame",
+       "op": "no_nulls"
+      }
+     ]
+    },
+    {
+     "await": {
+      "reply": "$fetch_request"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "$fid",
+       "bytes": "$total",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     },
+     "on": "subject:self"
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "transfer_progress_is_delivered_only_to_the_initiating_principal",
+   "kind": "push",
+   "operation": "file.fetch",
+   "intent": "Proves transfer progress is principal-private on one daemon: the owner receives the canonical transfer push, the second principal receives no matching transfer push, and the owner's deferred fetch still reaches terminal success; fails until U2.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file",
+    "observe:frames"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "on": "principal:self",
+     "save": {
+      "fid": "out.files[0].file_id",
+      "total": "out.files[0].bytes"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "on": "principal:self",
+     "op_id": "op-progress-private",
+     "defer": true,
+     "save": {
+      "fetch_request": "$request"
+     }
+    },
+    {
+     "on": "principal:self",
+     "await": {
+      "push": {
+       "t": "transfer",
+       "transfer_op_id": "op-progress-private",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "$total"
+       }
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_push",
+       "on": "principal:second",
+       "match": {
+        "t": "transfer",
+        "transfer_op_id": "op-progress-private"
+       },
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "await": {
+      "reply": "$fetch_request"
+     },
+     "on": "principal:self",
+     "expect": {
+      "ok": true,
+      "out": {
+       "room_id": "$rid",
+       "file_id": "$fid",
+       "bytes": "$total",
+       "digest": "<string>",
+       "provider": {
+        "subject_id": "<subject_id>",
+        "device_id": "<device_id>"
+       }
+      }
+     }
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled",
+   "kind": "error",
+   "operation": "file.fetch",
+   "intent": "Proves a transfer making zero forward progress for transfer_stall_ms terminates with transfer_stalled carrying transferred_bytes and a tagged total rather than hanging to the deadline or reporting a size or integrity failure; fails until U2 makes forward progress observable at all.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up"
+   ],
+   "steps": [
+    {
+     "upgrade": {
+      "query": {},
+      "headers": {}
+     }
+    },
+    {
+     "await": {
+      "frame": {
+       "t": "hello"
+      }
+     },
+     "save": {
+      "stall_ms": "frame.limits.transfer_stall_ms"
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_stalled",
+       "transferred_bytes": 16384,
+       "total": {
+        "state": "known",
+        "bytes": "<uint>"
+       }
+      }
+     },
+     "op_id": "op-stall-1"
+    },
+    {
+     "assert": [
+      {
+       "path": "err.transferred_bytes",
+       "op": "eq",
+       "value": 16384
+      }
+     ]
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid_unsized"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "transfer_stalled",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "unknown"
+       }
+      }
+     },
+     "op_id": "op-stall-2"
+    },
+    {
+     "assert": [
+      {
+       "path": "err",
+       "op": "no_nulls"
+      }
+     ]
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "cancel_result_reports_bytes_transferred",
+   "kind": "success",
+   "operation": "transfer.cancel",
+   "intent": "Proves a cancelled transfer reports how far it got, so a client can tell an immediate cancel from one that abandoned most of a large file; fails until U2 provides the byte count, which is why it is separated from the cancellation cases that do not need it.",
+   "requires": [
+    "subject",
+    "room:live",
+    "link:up",
+    "resource:large_file"
+   ],
+   "steps": [
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$rid",
+      "file_id": "$fid"
+     },
+     "op_id": "op-cancel-bytes",
+     "defer": true,
+     "save": {
+      "fetch_request": "$request"
+     },
+     "on": "subject:self"
+    },
+    {
+     "await": {
+      "push": {
+       "t": "transfer",
+       "transfer_op_id": "op-cancel-bytes",
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "<uint>"
+       }
+      }
+     },
+     "on": "subject:self"
+    },
+    {
+     "call": "transfer.cancel",
+     "in": {
+      "transfer_op_id": "op-cancel-bytes"
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "transfer_op_id": "op-cancel-bytes",
+       "outcome": {
+        "state": "cancelled"
+       },
+       "transferred_bytes": "<uint>",
+       "total": {
+        "state": "known",
+        "bytes": "<uint>"
+       }
+      }
+     },
+     "save": {
+      "cancelled_bytes": "out.transferred_bytes",
+      "cancel_total": "out.total.bytes"
+     },
+     "on": "subject:self"
+    },
+    {
+     "assert": [
+      {
+       "path": "out.transferred_bytes",
+       "op": "gt",
+       "value": 0
+      },
+      {
+       "path": "out.transferred_bytes",
+       "op": "lte",
+       "value": "$cancel_total"
+      },
+      {
+       "path": "out.path",
+       "op": "absent"
+      },
+      {
+       "path": "out.local_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.save_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.data_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.directory",
+       "op": "absent"
+      },
+      {
+       "path": "out.staged_path",
+       "op": "absent"
+      },
+      {
+       "path": "out.download_dir",
+       "op": "absent"
+      },
+      {
+       "path": "out.uri",
+       "op": "absent"
+      },
+      {
+       "path": "out.file_url",
+       "op": "absent"
+      }
+     ],
+     "on": "subject:self"
+    },
+    {
+     "await": {
+      "reply": "$fetch_request"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "stream_aborted",
+       "transferred_bytes": "$cancelled_bytes",
+       "total": {
+        "state": "known",
+        "bytes": "$cancel_total"
+       },
+       "reason": "cancelled"
+      }
+     },
+     "on": "subject:self"
+    }
+   ],
+   "blocked_on_upstream": "U2"
+  },
+  {
+   "name": "file_operations_are_not_a_membership_oracle",
+   "kind": "authorization",
+   "operation": null,
+   "intent": "Proves each room-scoped file operation returns the same room_not_available shape and indistinguishable timing for a foreign room and a well-formed unknown room, while echoing the caller-supplied room_id and opening no upload stream.",
+   "requires": [
+    "subject",
+    "room:foreign",
+    "observe:timing"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$foreign_rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "list_foreign": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$foreign_rid"
+      }
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": {
+       "$unknown": "<room_id>"
+      },
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "save": {
+      "list_unknown": "err",
+      "unknown_rid": "err.room_id"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": {
+        "$unknown": "<room_id>"
+       }
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$list_foreign",
+       "op": "eq_except",
+       "value": {
+        "path": "$list_unknown",
+        "keys": [
+         "room_id"
+        ]
+       }
+      },
+      {
+       "observe": "timing_indistinguishable",
+       "between": [
+        "step:1",
+        "step:2"
+       ]
+      }
+     ]
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$foreign_rid",
+      "file_id": "$foreign_fid"
+     },
+     "op_id": "op-oracle-fetch-foreign",
+     "save": {
+      "fetch_foreign": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$foreign_rid"
+      }
+     }
+    },
+    {
+     "call": "file.fetch",
+     "in": {
+      "room_id": "$unknown_rid",
+      "file_id": {
+       "$unknown": "<file_id>"
+      }
+     },
+     "op_id": "op-oracle-fetch-unknown",
+     "save": {
+      "fetch_unknown": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$unknown_rid"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$fetch_foreign",
+       "op": "eq_except",
+       "value": {
+        "path": "$fetch_unknown",
+        "keys": [
+         "room_id"
+        ]
+       }
+      },
+      {
+       "observe": "timing_indistinguishable",
+       "between": [
+        "step:4",
+        "step:5"
+       ]
+      }
+     ]
+    },
+    {
+     "call": "file.read",
+     "in": {
+      "room_id": "$foreign_rid",
+      "file_id": "$foreign_fid"
+     },
+     "op_id": "op-oracle-read-foreign",
+     "save": {
+      "read_foreign": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$foreign_rid"
+      }
+     }
+    },
+    {
+     "call": "file.read",
+     "in": {
+      "room_id": "$unknown_rid",
+      "file_id": {
+       "$unknown": "<file_id>"
+      }
+     },
+     "op_id": "op-oracle-read-unknown",
+     "save": {
+      "read_unknown": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$unknown_rid"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$read_foreign",
+       "op": "eq_except",
+       "value": {
+        "path": "$read_unknown",
+        "keys": [
+         "room_id"
+        ]
+       }
+      },
+      {
+       "observe": "timing_indistinguishable",
+       "between": [
+        "step:7",
+        "step:8"
+       ]
+      }
+     ]
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$foreign_rid",
+      "name": "a.bin",
+      "declared_bytes": 16,
+      "declared_content_type": "application/octet-stream"
+     },
+     "op_id": "op-oracle-share-foreign",
+     "save": {
+      "share_foreign": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$foreign_rid"
+      }
+     }
+    },
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$unknown_rid",
+      "name": "a.bin",
+      "declared_bytes": 16,
+      "declared_content_type": "application/octet-stream"
+     },
+     "op_id": "op-oracle-share-unknown",
+     "save": {
+      "share_unknown": "err"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "room_not_available",
+       "room_id": "$unknown_rid"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "$share_foreign",
+       "op": "eq_except",
+       "value": {
+        "path": "$share_unknown",
+        "keys": [
+         "room_id"
+        ]
+       }
+      },
+      {
+       "observe": "timing_indistinguishable",
+       "between": [
+        "step:10",
+        "step:11"
+       ]
+      },
+      {
+       "observe": "bytes_streamed",
+       "call": "step:10",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      },
+      {
+       "observe": "bytes_streamed",
+       "call": "step:11",
+       "value": {
+        "op": "eq",
+        "value": 0
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "name": "file_list_reports_an_unreadable_file_index_rather_than_an_empty_list",
+   "kind": "error",
+   "operation": "file.list",
+   "intent": "Gives file.list its own code, distinct from the room_not_available case the corpus already has. With a known shared file in an available room, the room's file index is made unreadable and the call must answer file_index_unreadable. Catches a daemon that returns files: [] on a read failure, which is uniquely costly here: the user concludes the file was never shared and re-shares it, paying a second transfer of up to max_shared_file_bytes, and the room gains a duplicate signed share event that every member stores forever. It also catches the code substitution that would be worst for diagnosis -- answering room_not_available, which tells a member in good standing that they have lost access to the room when in fact only a local index read failed, sending them to rejoin instead of to restart. fetchable is specified as an evidence-backed fact, and 'I could not read the evidence' is not the same fact as 'there is no file'.",
+   "requires": [
+    "subject",
+    "room:live",
+    "fault:room_index_unreadable",
+    "fault:file_index_unreadable"
+   ],
+   "steps": [
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "file_id": "<file_id>",
+         "digest": "<string>",
+         "fetchable": "<bool>",
+         "self_hosted": "<bool>",
+         "bytes": "<uint>"
+        }
+       ]
+      }
+     },
+     "note": "baseline: the index is readable and names the shared file"
+    },
+    {
+     "assert": [
+      {
+       "path": "out",
+       "op": "no_nulls"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "inject_fault",
+      "fault": "file_index_unreadable"
+     },
+     "note": "the room's file index read path fails -- I/O error or permission denial. The share event and the local blob are untouched; only the read fails."
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_push",
+       "room_id": "$rid",
+       "scope": "case"
+      }
+     ]
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "file_index_unreadable"
+      }
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "err",
+       "op": "no_nulls"
+      }
+     ]
+    },
+    {
+     "control": {
+      "do": "inject_fault",
+      "fault": "file_index_unreadable"
+     }
+    },
+    {
+     "call": "file.list",
+     "in": {
+      "room_id": "$rid",
+      "cursor": {
+       "state": "start"
+      },
+      "direction": "forward",
+      "limit": 50
+     },
+     "expect": {
+      "ok": true,
+      "out": {
+       "files": [
+        {
+         "file_id": "<file_id>",
+         "digest": "<string>"
+        }
+       ]
+      }
+     },
+     "note": "the file was there the whole time; the refusal was honest about not being able to see it"
+    }
+   ]
+  },
+  {
+   "name": "a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch",
+   "kind": "error",
+   "operation": "file.share",
+   "intent": "Pins file.share's own distinctive code and its honesty rule: a stream whose byte count disagrees with its declared size is declared_size_mismatch, NEVER digest_mismatch \u2014 accusing an honest declaration error of being corrupt content is the false-accusation the size policy forbids. Catches a daemon that conflates the two, which is also the exact code an over-limit size refusal must never produce.",
+   "requires": [
+    "subject",
+    "room:live",
+    "resource:shared_file"
+   ],
+   "steps": [
+    {
+     "call": "file.share",
+     "in": {
+      "room_id": "$rid",
+      "name": "mismatch.bin",
+      "declared_bytes": 4096,
+      "declared_content_type": "application/octet-stream"
+     },
+     "expect": {
+      "ok": false,
+      "err": {
+       "code": "declared_size_mismatch",
+       "declared_bytes": 4096,
+       "observed_bytes": 4095
+      }
+     },
+     "op_id": "op-mismatch-1",
+     "stream": {
+      "send_bytes": 4095
+     }
+    },
+    {
+     "assert": [
+      {
+       "path": "err.hint",
+       "op": "absent"
+      }
+     ]
+    },
+    {
+     "assert": [
+      {
+       "observe": "no_event_authored",
+       "scope": "case"
+      }
+     ]
+    }
+   ]
+  }
+ ]
 }

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -453,6 +453,20 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   if (fault === 'client_abort') {
     return await driveClientAbortUpload({ session, tracker, replyState, waitMs });
   }
+  // `raw_record` is a client protocol violation: after admission the client
+  // sends one structurally malformed Binary record on the live binding (a
+  // nonzero reserved byte — a full 48-byte header the daemon can correlate,
+  // so it is stream-local, not the header-unparseable 4007 class). The daemon
+  // (receiver) aborts only that stream with ABORT(protocol_error) at accepted
+  // offset zero, the client ACKs (0x05), and the request resolves to the
+  // correlated `malformed_frame` terminal reply while the connection stays
+  // usable — the "recoverable stream-local violation" leg of the framing
+  // record (docs/protocol-v2.md § Malformed stream records; matched by the
+  // daemon integration test websocket_data_too_large_within_frame_limit_
+  // aborts_stream_not_connection in crates/jeliyad/src/serve.rs).
+  if (fault === 'raw_record') {
+    return await driveRawRecordUpload({ session, tracker, replyState, waitMs });
+  }
   if (fault !== undefined) {
     throw new Error(`unknown stream fault ${JSON.stringify(fault)} on file.share`);
   }
@@ -721,6 +735,95 @@ async function driveClientAbortUpload({ session, tracker, replyState, waitMs }) 
   if (err.transferred_bytes !== undefined && err.transferred_bytes !== accepted) {
     throw new AssertFailure(
       `terminal transferred_bytes ${err.transferred_bytes} disagrees with the ${accepted} receiver-accepted bytes`,
+    );
+  }
+  return reply;
+}
+
+/**
+ * Drive a client-originated raw-record protocol violation. After admission the
+ * client sends exactly one structurally malformed DATA record on the active
+ * binding: a valid 48-byte header and magic, correct id and stream id, but a
+ * nonzero reserved byte (bytes 5..8 MUST be zero). Because the header is
+ * correlatable to the live stream, the daemon rejects only that stream rather
+ * than closing the connection: it sends ABORT(protocol_error) at accepted
+ * offset zero (nothing was accepted), the client ACKs it (0x05), and the
+ * request resolves to the correlated `malformed_frame` terminal reply. A
+ * daemon that instead closes the connection, replies success, or answers
+ * without first ABORTing is a violation. Receiver-accepted bytes are zero.
+ */
+async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
+  const accepted = 0;
+  // One malformed DATA record: correct binding, corrupt reserved byte 5.
+  const raw = encodeRecord({
+    kind: KIND.DATA,
+    id: tracker.id,
+    streamId: tracker.streamId,
+    offset: 0,
+    payload: Buffer.from([0x00]),
+  });
+  raw.writeUInt8(0x01, 5); // reserved bytes MUST be zero — this makes it malformed
+  session.sendBinary(raw);
+
+  let ackSeen = false;
+  for (;;) {
+    if (replyState.done && tracker.queue.length === 0) break;
+    const ev = await tracker.next(replyState, waitMs, ackSeen ? 'the terminal reply' : 'the daemon ABORT for the malformed record');
+    if (ev.reply) break;
+    const rec = ev.record;
+    checkBinding(tracker, rec);
+    if (rec.kind === KIND.CREDIT) {
+      // A send window granted before the daemon parsed our malformed record is
+      // tolerated, but it can never acknowledge bytes we never sent, and none
+      // may arrive after the ABORT retires the binding.
+      if (ackSeen) {
+        throw new AssertFailure('daemon sent CREDIT after acknowledging the malformed-record ABORT — the binding retired at ACK');
+      }
+      if (rec.offset > accepted) {
+        throw new AssertFailure(`daemon CREDIT acknowledged ${rec.offset} bytes after a zero-progress malformed record`);
+      }
+      continue;
+    }
+    if (rec.kind === KIND.ABORT) {
+      // The daemon aborts the stream it could correlate. Its reason is
+      // protocol_error (0x04) and its accepted high-water is zero.
+      validateAbort(rec, accepted, UPLOAD_DAEMON_ABORT_REASONS);
+      if (rec.value !== ABORT_REASON.protocol_error) {
+        throw new AssertFailure(
+          `daemon ABORT reason ${rec.value} for a malformed record is not protocol_error (0x04)`,
+        );
+      }
+      if (rec.offset !== accepted) {
+        throw new AssertFailure(
+          `daemon ABORT accepted count ${rec.offset} disagrees with the ${accepted} bytes it accepted from a malformed record`,
+        );
+      }
+      if (tracker.replySeq !== undefined) {
+        throw new AssertFailure('daemon sent its terminal reply before receiving the malformed-record ABORT acknowledgement');
+      }
+      tracker.accepted = accepted;
+      session.sendBinary(
+        encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: accepted, value: 0x05 }),
+      );
+      ackSeen = true;
+      continue;
+    }
+    throw new AssertFailure(`daemon sent unexpected ${rec.kindName} after a client malformed record`);
+  }
+  if (tracker.queue.length) {
+    throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after the terminal reply`);
+  }
+  if (!ackSeen) {
+    throw new AssertFailure('daemon replied to a malformed record without first ABORTing the stream');
+  }
+  const reply = await settleReply(replyState);
+  if (reply && reply.ok) {
+    throw new AssertFailure('file.share replied success after a client malformed record');
+  }
+  const err = (reply && reply.err) || {};
+  if (err.code !== 'malformed_frame') {
+    throw new AssertFailure(
+      `a stream-local malformed record must resolve to malformed_frame, got ${JSON.stringify(reply.err)}`,
     );
   }
   return reply;

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -241,6 +241,12 @@ const STREAM_ONLY_ERRORS = new Set([
   'transfer_stalled',
   'transfer_deadline_exceeded',
   'stream_aborted',
+  // A correlated malformed_frame for a byte-stream record is only reachable
+  // AFTER OPEN installed the (request id, stream id) binding — the daemon has
+  // to have admitted the stream and examined the injected record to produce
+  // it. Treating it as pre-OPEN-legal would let a daemon fabricate the
+  // raw_record outcome without ever admitting or parsing the record.
+  'malformed_frame',
 ]);
 
 function checkPreOpenError(reply, op) {
@@ -785,6 +791,16 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
       continue;
     }
     if (rec.kind === KIND.ABORT) {
+      // The client ACK retires the binding ("Only ACK or that timeout retires
+      // the binding"; "Any later DATA, CREDIT, END, or terminal control for
+      // the retired stream is malformed" — docs/protocol-v2.md §END, abort,
+      // and cancellation). A SECOND daemon ABORT after our ACK is therefore
+      // malformed traffic on a dead stream, never a terminal we re-acknowledge.
+      if (ackSeen) {
+        throw new AssertFailure(
+          'daemon sent a second ABORT after the malformed-record ACK retired the binding',
+        );
+      }
       // The daemon aborts the stream it could correlate. Its reason is
       // protocol_error (0x04) and its accepted high-water is zero.
       validateAbort(rec, accepted, UPLOAD_DAEMON_ABORT_REASONS);
@@ -824,6 +840,21 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
   if (err.code !== 'malformed_frame') {
     throw new AssertFailure(
       `a stream-local malformed record must resolve to malformed_frame, got ${JSON.stringify(reply.err)}`,
+    );
+  }
+  // A recoverable stream-local violation must leave the WebSocket usable —
+  // "Other requests remain usable only on the request-local paths above"
+  // (docs/protocol-v2.md §Malformed stream records). Prove it: send an
+  // unrelated, idempotent typed request on the SAME session after the terminal
+  // reply. A daemon that runs the correct ABORT→ACK→malformed_frame exchange
+  // and THEN closes the connection (the 4005/4007 class this case exists to
+  // catch) fails here instead of passing. subject.ensure carries no tracker,
+  // so it never enters callRecords and cannot perturb a later bytes_streamed
+  // observation, which reads only the runner's per-step records.
+  const liveness = await session.call('subject.ensure', {}, { timeoutMs: Math.min(waitMs, 10_000) });
+  if (!liveness || !liveness.ok) {
+    throw new AssertFailure(
+      `connection was not usable after a stream-local malformed_frame: ${JSON.stringify(liveness)}`,
     );
   }
   return reply;

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -471,7 +471,7 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   // daemon integration test websocket_data_too_large_within_frame_limit_
   // aborts_stream_not_connection in crates/jeliyad/src/serve.rs).
   if (fault === 'raw_record') {
-    return await driveRawRecordUpload({ session, tracker, replyState, waitMs });
+    return await driveRawRecordUpload({ session, tracker, replyState, waitMs, limitBytes });
   }
   if (fault !== undefined) {
     throw new Error(`unknown stream fault ${JSON.stringify(fault)} on file.share`);
@@ -758,8 +758,17 @@ async function driveClientAbortUpload({ session, tracker, replyState, waitMs }) 
  * daemon that instead closes the connection, replies success, or answers
  * without first ABORTing is a violation. Receiver-accepted bytes are zero.
  */
-async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
+async function driveRawRecordUpload({ session, tracker, replyState, waitMs, limitBytes }) {
   const accepted = 0;
+  // The served shared-file bound gates CREDIT range validation; a daemon that
+  // fails to serve it as a usable integer fails, never gets an invented cap.
+  if (typeof limitBytes !== 'number' || !Number.isInteger(limitBytes) || limitBytes < 0) {
+    throw new AssertFailure(
+      `served max_shared_file_bytes ${JSON.stringify(limitBytes)} is unusable for byte streaming`,
+    );
+  }
+  const limit = limitBytes;
+  let sendThrough = 0;
   // One malformed DATA record: correct binding, corrupt reserved byte 5.
   const raw = encodeRecord({
     kind: KIND.DATA,
@@ -780,14 +789,31 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
     checkBinding(tracker, rec);
     if (rec.kind === KIND.CREDIT) {
       // A send window granted before the daemon parsed our malformed record is
-      // tolerated, but it can never acknowledge bytes we never sent, and none
-      // may arrive after the ABORT retires the binding.
+      // tolerated, but its SHAPE and RANGE must satisfy the same rules the
+      // normal upload path enforces: a payload, a regressing or inverted
+      // window, or a send_through beyond the served bound is malformed
+      // regardless of the injected fault — accepting one here would let a
+      // non-conformant daemon pass this case.
       if (ackSeen) {
         throw new AssertFailure('daemon sent CREDIT after acknowledging the malformed-record ABORT — the binding retired at ACK');
       }
+      if (rec.payload) throw new AssertFailure('daemon CREDIT carried a payload');
+      if (rec.value < sendThrough || rec.offset > rec.value) {
+        throw new AssertFailure(
+          `daemon CREDIT regressed or inverted: (${rec.offset}, ${rec.value}) after (${accepted}, ${sendThrough})`,
+        );
+      }
+      if (rec.value > limit + 1) {
+        // The wire bound on upload credit is max_shared_file_bytes + 1.
+        throw new AssertFailure(
+          `daemon CREDIT send_through ${rec.value} exceeds max_shared_file_bytes + 1 (${limit + 1})`,
+        );
+      }
+      // It can never acknowledge bytes we never sent.
       if (rec.offset > accepted) {
         throw new AssertFailure(`daemon CREDIT acknowledged ${rec.offset} bytes after a zero-progress malformed record`);
       }
+      sendThrough = rec.value;
       continue;
     }
     if (rec.kind === KIND.ABORT) {
@@ -857,6 +883,19 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs }) {
       `connection was not usable after a stream-local malformed_frame: ${JSON.stringify(liveness)}`,
     );
   }
+  // Re-examine the retired stream after the liveness await: a daemon that sent
+  // a late DATA/CREDIT/END/ABORT while subject.ensure was pending had the
+  // record queued into this still-registered tracker without failing the
+  // liveness call, and any traffic on a binding retired by the ACK is
+  // malformed. (Anything arriving after this check, once the runner retires
+  // the tracker, becomes the connection-fatal unbindable-record class and is
+  // surfaced by the case-end sticky-violation scan.)
+  if (tracker.queue.length) {
+    throw new AssertFailure(
+      `daemon sent ${tracker.queue[0].kindName} for the retired stream after the terminal reply`,
+    );
+  }
+  if (tracker.failure) throw tracker.failure;
   return reply;
 }
 

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -1,616 +1,616 @@
 {
- "corpus": "jeliya protocol v2",
- "spec": "../../docs/protocol-v2.md",
- "dsl": "./README.md",
- "authored": "by hand, from the specification. NOT generated from any implementation.",
- "replayable": {
-  "structural_validation": true,
-  "selected_json_envelope_subject_slice": {
-   "status": "partial",
-   "ci_selected_cases": 22
+  "corpus": "jeliya protocol v2",
+  "spec": "../../docs/protocol-v2.md",
+  "dsl": "./README.md",
+  "authored": "by hand, from the specification. NOT generated from any implementation.",
+  "replayable": {
+    "structural_validation": true,
+    "selected_json_envelope_subject_slice": {
+      "status": "partial",
+      "ci_selected_cases": 22
+    },
+    "binary_byte_stream_executor": {
+      "status": "partial",
+      "send_bytes": "implemented",
+      "receive_bytes": "implemented_no_executable_case",
+      "bytes_streamed_observation": "implemented",
+      "client_abort_fault": "implemented",
+      "raw_record_fault": "implemented",
+      "credit_pause_transport_drop_faults": "unimplemented"
+    },
+    "adapter_targeted_declarative_cases": "declarative_only"
   },
-  "binary_byte_stream_executor": {
-   "status": "partial",
-   "send_bytes": "implemented",
-   "receive_bytes": "implemented_no_executable_case",
-   "bytes_streamed_observation": "implemented",
-   "client_abort_fault": "implemented",
-   "raw_record_fault": "implemented",
-   "credit_pause_transport_drop_faults": "unimplemented"
+  "rules": {
+    "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
+    "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
+    "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
+    "counts_are_computed": "every count in this file is derived from the current fixture JSON, not asserted alongside it. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
   },
-  "adapter_targeted_declarative_cases": "declarative_only"
- },
- "rules": {
-  "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
-  "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
-  "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
-  "counts_are_computed": "every count in this file is derived from the current fixture JSON, not asserted alongside it. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
- },
- "blocked_on_upstream": {
-  "U1": "ConnEvent must carry the connection generation and a typed offline reason",
-  "U2": "a progress-observing or streaming blob-fetch API (8 cases: 3 progress/stall, 1 deadline, 4 cancellation)",
-  "U3": "a size-distinguishable fetch outcome (1 fetch-stream size case)",
-  "U4": "harness cannot restart a daemon within a case"
- },
- "blocked_case_counts": {
-  "U1": 5,
-  "U2": 8,
-  "U3": 1,
-  "U4": 1,
-  "blocked_on_record": 1
- },
- "blocked_on_upstream_cases": {
-  "U1": [
-   {
-    "file": "handshake.json",
-    "case": "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason"
-   },
-   {
-    "file": "pipes.json",
-    "case": "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability"
-   },
-   {
-    "file": "rooms.json",
-    "case": "room_peers_ignores_a_stale_generation_teardown"
-   },
-   {
-    "file": "rooms.json",
-    "case": "room_peers_reports_a_typed_reason_for_a_device_it_cannot_reach"
-   },
-   {
-    "file": "timeline-streams.json",
-    "case": "peer_push_carries_the_connection_generation_and_a_typed_offline_reason"
-   }
-  ],
-  "U2": [
-   {
-    "file": "files.json",
-    "case": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled"
-   },
-   {
-    "file": "files.json",
-    "case": "cancel_result_reports_bytes_transferred"
-   },
-   {
-    "file": "files.json",
-    "case": "fetch_deadline_scales_with_the_declared_size"
-   },
-   {
-    "file": "files.json",
-    "case": "transfer_cancel_after_the_originating_connection_dropped"
-   },
-   {
-    "file": "files.json",
-    "case": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown"
-   },
-   {
-    "file": "files.json",
-    "case": "transfer_cancel_releases_the_concurrent_transfer_slot"
-   },
-   {
-    "file": "files.json",
-    "case": "transfer_progress_is_delivered_only_to_the_initiating_principal"
-   },
-   {
-    "file": "files.json",
-    "case": "transfer_progress_pushes_report_monotonic_transferred_bytes"
-   }
-  ],
-  "U3": [
-   {
-    "file": "files.json",
-    "case": "fetch_stream_refuses_a_peer_serving_more_than_it_declared"
-   }
-  ],
-  "U4": [
-   {
-    "file": "handshake.json",
-    "case": "the_daemon_incarnation_changes_across_a_restart"
-   }
-  ]
- },
- "blocked_on_record_cases": [
-  {
-   "file": "timeline-streams.json",
-   "case": "message_send_omitting_op_id_is_refused_naming_the_field",
-   "record": "op_id_optional_but_deduplicated"
-  }
- ],
- "target_counts": {
-  "untargeted": 340,
-  "daemon": 0,
-  "in_process_core": 1,
-  "client_adapter": 5
- },
- "totals": {
-  "cases": 346,
-  "attributed_to_an_operation": 239,
-  "not_operation_scoped": 107,
-  "conforming_to_the_dsl": 346,
-  "distinct_step_verbs_in_use": 7,
-  "quarantined": 0,
-  "blocked_on_upstream": 15,
-  "blocked_on_record": 1
- },
- "per_file_totals": {
-  "files.json": {
-   "cases": 45,
-   "attributed_to_an_operation": 43,
-   "not_operation_scoped": 2,
-   "blocked_on_upstream": {
-    "U1": 0,
+  "blocked_on_upstream": {
+    "U1": "ConnEvent must carry the connection generation and a typed offline reason",
+    "U2": "a progress-observing or streaming blob-fetch API (8 cases: 3 progress/stall, 1 deadline, 4 cancellation)",
+    "U3": "a size-distinguishable fetch outcome (1 fetch-stream size case)",
+    "U4": "harness cannot restart a daemon within a case"
+  },
+  "blocked_case_counts": {
+    "U1": 5,
     "U2": 8,
     "U3": 1,
-    "U4": 0
-   },
-   "blocked_on_record": 0
+    "U4": 1,
+    "blocked_on_record": 1
   },
-  "handshake.json": {
-   "cases": 72,
-   "attributed_to_an_operation": 0,
-   "not_operation_scoped": 72,
-   "blocked_on_upstream": {
-    "U1": 1,
-    "U2": 0,
-    "U3": 0,
-    "U4": 1
-   },
-   "blocked_on_record": 0
+  "blocked_on_upstream_cases": {
+    "U1": [
+      {
+        "file": "handshake.json",
+        "case": "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason"
+      },
+      {
+        "file": "pipes.json",
+        "case": "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability"
+      },
+      {
+        "file": "rooms.json",
+        "case": "room_peers_ignores_a_stale_generation_teardown"
+      },
+      {
+        "file": "rooms.json",
+        "case": "room_peers_reports_a_typed_reason_for_a_device_it_cannot_reach"
+      },
+      {
+        "file": "timeline-streams.json",
+        "case": "peer_push_carries_the_connection_generation_and_a_typed_offline_reason"
+      }
+    ],
+    "U2": [
+      {
+        "file": "files.json",
+        "case": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled"
+      },
+      {
+        "file": "files.json",
+        "case": "cancel_result_reports_bytes_transferred"
+      },
+      {
+        "file": "files.json",
+        "case": "fetch_deadline_scales_with_the_declared_size"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_after_the_originating_connection_dropped"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_cancel_releases_the_concurrent_transfer_slot"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_progress_is_delivered_only_to_the_initiating_principal"
+      },
+      {
+        "file": "files.json",
+        "case": "transfer_progress_pushes_report_monotonic_transferred_bytes"
+      }
+    ],
+    "U3": [
+      {
+        "file": "files.json",
+        "case": "fetch_stream_refuses_a_peer_serving_more_than_it_declared"
+      }
+    ],
+    "U4": [
+      {
+        "file": "handshake.json",
+        "case": "the_daemon_incarnation_changes_across_a_restart"
+      }
+    ]
   },
-  "invites.json": {
-   "cases": 37,
-   "attributed_to_an_operation": 34,
-   "not_operation_scoped": 3,
-   "blocked_on_upstream": {
-    "U1": 0,
-    "U2": 0,
-    "U3": 0,
-    "U4": 0
-   },
-   "blocked_on_record": 0
+  "blocked_on_record_cases": [
+    {
+      "file": "timeline-streams.json",
+      "case": "message_send_omitting_op_id_is_refused_naming_the_field",
+      "record": "op_id_optional_but_deduplicated"
+    }
+  ],
+  "target_counts": {
+    "untargeted": 340,
+    "daemon": 0,
+    "in_process_core": 1,
+    "client_adapter": 5
   },
-  "pipes.json": {
-   "cases": 43,
-   "attributed_to_an_operation": 37,
-   "not_operation_scoped": 6,
-   "blocked_on_upstream": {
-    "U1": 1,
-    "U2": 0,
-    "U3": 0,
-    "U4": 0
-   },
-   "blocked_on_record": 0
+  "totals": {
+    "cases": 346,
+    "attributed_to_an_operation": 239,
+    "not_operation_scoped": 107,
+    "conforming_to_the_dsl": 346,
+    "distinct_step_verbs_in_use": 7,
+    "quarantined": 0,
+    "blocked_on_upstream": 15,
+    "blocked_on_record": 1
   },
-  "rooms.json": {
-   "cases": 65,
-   "attributed_to_an_operation": 59,
-   "not_operation_scoped": 6,
-   "blocked_on_upstream": {
-    "U1": 2,
-    "U2": 0,
-    "U3": 0,
-    "U4": 0
-   },
-   "blocked_on_record": 0
+  "per_file_totals": {
+    "files.json": {
+      "cases": 45,
+      "attributed_to_an_operation": 43,
+      "not_operation_scoped": 2,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 8,
+        "U3": 1,
+        "U4": 0
+      },
+      "blocked_on_record": 0
+    },
+    "handshake.json": {
+      "cases": 72,
+      "attributed_to_an_operation": 0,
+      "not_operation_scoped": 72,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0,
+        "U4": 1
+      },
+      "blocked_on_record": 0
+    },
+    "invites.json": {
+      "cases": 37,
+      "attributed_to_an_operation": 34,
+      "not_operation_scoped": 3,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 0,
+        "U3": 0,
+        "U4": 0
+      },
+      "blocked_on_record": 0
+    },
+    "pipes.json": {
+      "cases": 43,
+      "attributed_to_an_operation": 37,
+      "not_operation_scoped": 6,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0,
+        "U4": 0
+      },
+      "blocked_on_record": 0
+    },
+    "rooms.json": {
+      "cases": 65,
+      "attributed_to_an_operation": 59,
+      "not_operation_scoped": 6,
+      "blocked_on_upstream": {
+        "U1": 2,
+        "U2": 0,
+        "U3": 0,
+        "U4": 0
+      },
+      "blocked_on_record": 0
+    },
+    "subject-daemon.json": {
+      "cases": 24,
+      "attributed_to_an_operation": 19,
+      "not_operation_scoped": 5,
+      "blocked_on_upstream": {
+        "U1": 0,
+        "U2": 0,
+        "U3": 0,
+        "U4": 0
+      },
+      "blocked_on_record": 0
+    },
+    "timeline-streams.json": {
+      "cases": 60,
+      "attributed_to_an_operation": 47,
+      "not_operation_scoped": 13,
+      "blocked_on_upstream": {
+        "U1": 1,
+        "U2": 0,
+        "U3": 0,
+        "U4": 0
+      },
+      "blocked_on_record": 1
+    }
   },
-  "subject-daemon.json": {
-   "cases": 24,
-   "attributed_to_an_operation": 19,
-   "not_operation_scoped": 5,
-   "blocked_on_upstream": {
-    "U1": 0,
-    "U2": 0,
-    "U3": 0,
-    "U4": 0
-   },
-   "blocked_on_record": 0
+  "exemptions": {
+    "room.deactivate": {
+      "from": "required_per_operation",
+      "reason": "Every way room.deactivate can fail is already a cross-cutting refusal: no subject, no such room, or membership ended. Deactivating a room the caller may act in always succeeds, because it withdraws local participation and asks nothing of the network. A code that no reachable state produces would buy a green cell in this table and nothing else.",
+      "reviewed_in": "#212"
+    }
   },
-  "timeline-streams.json": {
-   "cases": 60,
-   "attributed_to_an_operation": 47,
-   "not_operation_scoped": 13,
-   "blocked_on_upstream": {
-    "U1": 1,
-    "U2": 0,
-    "U3": 0,
-    "U4": 0
-   },
-   "blocked_on_record": 1
-  }
- },
- "exemptions": {
-  "room.deactivate": {
-   "from": "required_per_operation",
-   "reason": "Every way room.deactivate can fail is already a cross-cutting refusal: no subject, no such room, or membership ended. Deactivating a room the caller may act in always succeeds, because it withdraws local participation and asks nothing of the network. A code that no reachable state produces would buy a green cell in this table and nothing else.",
-   "reviewed_in": "#212"
-  }
- },
- "taxonomy_code_count": 64,
- "codes_without_a_case": {
-  "note": "Computed from literal expect.err.code on a direct call matching case.operation, with canonical file-error validation; notes, intents, setup calls, generic nested objects, and authoring_notes do not count. frame_too_large, idle_timeout, malformed_frame, and not_ready count only through their verified named close/status fixtures.",
-  "codes": [
-   "forbidden_origin",
-   "pairing_code_invalid",
-   "protocol_unsupported",
-   "role_not_grantable",
-   "session_expired",
-   "storage_generation_mismatch",
-   "unauthenticated",
-   "unknown_operation"
-  ]
- },
- "coverage": {
-  "daemon.stop": {
-   "cases": 4,
-   "success": true,
-   "distinctive_code": "shutdown_in_progress",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
+  "taxonomy_code_count": 64,
+  "codes_without_a_case": {
+    "note": "Computed from literal expect.err.code on a direct call matching case.operation, with canonical file-error validation; notes, intents, setup calls, generic nested objects, and authoring_notes do not count. frame_too_large, idle_timeout, malformed_frame, and not_ready count only through their verified named close/status fixtures.",
+    "codes": [
+      "forbidden_origin",
+      "pairing_code_invalid",
+      "protocol_unsupported",
+      "role_not_grantable",
+      "session_expired",
+      "storage_generation_mismatch",
+      "unauthenticated",
+      "unknown_operation"
+    ]
   },
-  "file.fetch": {
-   "cases": 14,
-   "success": true,
-   "distinctive_code": "provider_unreachable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
+  "coverage": {
+    "daemon.stop": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "shutdown_in_progress",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "file.fetch": {
+      "cases": 14,
+      "success": true,
+      "distinctive_code": "provider_unreachable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "file.list": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "file_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "file.read": {
+      "cases": 3,
+      "success": true,
+      "distinctive_code": "file_not_fetched",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "file.share": {
+      "cases": 16,
+      "success": true,
+      "distinctive_code": "declared_size_mismatch",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "fleet.list": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "fleet_projection_unavailable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "invite.list": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "invite_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "invite.mint": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "invitee_already_member",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "invite.redeem": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "capability_invalid",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "invite.revoke": {
+      "cases": 7,
+      "success": true,
+      "distinctive_code": "capability_redeemed",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "member.remove": {
+      "cases": 10,
+      "success": true,
+      "distinctive_code": "authority_cannot_be_removed",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "message.send": {
+      "cases": 11,
+      "success": true,
+      "distinctive_code": "message_too_large",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "pipe.connect": {
+      "cases": 7,
+      "success": true,
+      "distinctive_code": "pipe_unreachable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "pipe.list": {
+      "cases": 7,
+      "success": true,
+      "distinctive_code": "pipe_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "pipe.publish": {
+      "cases": 16,
+      "success": true,
+      "distinctive_code": "pipe_target_refused",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "pipe.release": {
+      "cases": 3,
+      "success": true,
+      "distinctive_code": "connection_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "pipe.revoke": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "pipe_not_publisher",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.activate": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "transport_unavailable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.archive": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "room_still_active",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.create": {
+      "cases": 9,
+      "success": true,
+      "distinctive_code": "room_name_invalid",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.deactivate": {
+      "cases": 3,
+      "success": true,
+      "distinctive_code": null,
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.leave": {
+      "cases": 4,
+      "success": true,
+      "distinctive_code": "sole_authority_cannot_leave",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.list": {
+      "cases": 6,
+      "success": true,
+      "distinctive_code": "room_index_unreadable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.members": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "membership_unresolved",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.peers": {
+      "cases": 6,
+      "success": true,
+      "distinctive_code": "room_not_live",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "room.timeline": {
+      "cases": 9,
+      "success": true,
+      "distinctive_code": "cursor_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "status.history": {
+      "cases": 7,
+      "success": true,
+      "distinctive_code": "status_subject_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "status.post": {
+      "cases": 12,
+      "success": true,
+      "distinctive_code": "status_label_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "stream.resync": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "resync_required",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "stream.subscribe": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "subscription_limit_reached",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "stream.unsubscribe": {
+      "cases": 2,
+      "success": true,
+      "distinctive_code": "subscription_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "subject.ensure": {
+      "cases": 12,
+      "success": true,
+      "distinctive_code": "subject_store_unwritable",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    },
+    "transfer.cancel": {
+      "cases": 5,
+      "success": true,
+      "distinctive_code": "transfer_unknown",
+      "distinctive_code_has_a_case": true,
+      "satisfies_required_kinds": true
+    }
   },
-  "file.list": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "file_index_unreadable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
+  "operations_not_yet_satisfying_required_kinds": [],
+  "severity_derivation": {
+    "note": "severity is derived from the closed label set and SERVED; no signed severity field exists",
+    "map": {
+      "online": "ok",
+      "idle": "ok",
+      "claiming": "ok",
+      "working": "ok",
+      "done": "ok",
+      "failed": "failed",
+      "blocked": "review"
+    }
   },
-  "file.read": {
-   "cases": 3,
-   "success": true,
-   "distinctive_code": "file_not_fetched",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
+  "operation_null_cases": {
+    "note": "operation:null is legal for genuinely cross-cutting cases — gate behaviour, envelope framing, handshake, non-oracle properties spanning several operations, and multi-operation invariants. Every one of these is cross-cutting by intent (its own `intent` names a property no single operation owns), never by omission. The count here feeds totals.not_operation_scoped.",
+    "by_file": {
+      "files.json": [
+        "file_operations_are_not_a_membership_oracle",
+        "handshake_serves_the_file_and_transfer_limits_as_integers"
+      ],
+      "handshake.json": [
+        "a_duplicate_in_flight_id_is_refused_and_executes_only_once",
+        "a_frame_of_exactly_max_frame_bytes_is_parsed_and_answered",
+        "a_frame_one_byte_past_max_frame_bytes_closes_4005_without_being_parsed",
+        "a_frame_with_no_id_is_not_executed",
+        "a_gate_refused_upgrade_consumes_no_connection_slot",
+        "a_non_object_in_is_refused_and_a_null_in_is_refused",
+        "a_push_carries_t_and_never_id",
+        "an_array_at_the_length_bound_parses_and_one_past_it_is_invalid_argument",
+        "an_envelope_id_may_be_reused_after_its_reply_completes",
+        "an_op_name_at_the_codec_bound_parses_and_one_past_it_is_invalid_argument",
+        "an_over_limit_frame_mutates_nothing",
+        "an_unknown_op_is_a_correlated_error_reply_not_a_close",
+        "close_code_4003_is_emitted_when_the_daemon_is_not_ready",
+        "close_code_4004_is_emitted_on_idle_timeout",
+        "close_code_4005_is_emitted_for_frame_too_large",
+        "connections_at_the_served_limit_are_admitted_and_one_past_is_resource_exhausted",
+        "credential_comparison_is_timing_indistinguishable",
+        "daemon_token_is_refused_in_a_url_or_a_body",
+        "error_envelopes_for_a_foreign_room_and_an_unknown_room_are_indistinguishable",
+        "error_reply_carries_ok_false_a_code_and_no_hint",
+        "every_application_close_code_in_the_corpus_is_in_the_defined_table",
+        "gate_admits_a_supported_generation_and_a_matching_storage_generation",
+        "gate_check_1_refuses_a_non_loopback_host_with_forbidden_origin",
+        "gate_check_2_admits_an_absent_origin",
+        "gate_check_2_refuses_a_non_loopback_origin_with_forbidden_origin",
+        "gate_check_3_refuses_a_non_canonical_v_value",
+        "gate_check_3_refuses_a_repeated_v_parameter",
+        "gate_check_3_refuses_an_absent_v_which_is_exactly_a_v1_client",
+        "gate_check_3_refuses_an_unsupported_declared_generation",
+        "gate_check_4_refuses_a_mismatched_storage_generation",
+        "gate_check_4_refuses_an_absent_sg",
+        "gate_check_5_refuses_an_absent_and_a_wrong_credential",
+        "gate_order_host_precedes_protocol_and_storage_and_credential",
+        "gate_order_origin_precedes_protocol",
+        "gate_order_protocol_precedes_storage",
+        "gate_order_storage_precedes_credential",
+        "gate_refusal_mutates_nothing",
+        "gate_rejection_reveals_nothing_about_local_state",
+        "gate_runs_before_the_upgrade_so_a_refusal_is_a_status_not_a_close_code",
+        "health_limits_object_carries_all_sixteen_named_integer_fields",
+        "health_serves_the_version_object_and_no_data_dir",
+        "hello_carries_a_daemon_incarnation_identity",
+        "hello_carries_no_pid_no_port_and_no_data_dir",
+        "hello_is_the_first_frame_and_arrives_exactly_once",
+        "hello_limits_are_identical_to_the_layer_0_limits",
+        "hello_protocol_and_storage_generation_echo_the_admitted_gate_values",
+        "hello_resume_state_is_a_tagged_variant_never_a_null",
+        "hello_subject_absent_is_a_tagged_variant_with_no_null_ids",
+        "hello_subject_present_is_a_tagged_variant_with_both_ids",
+        "inflight_requests_at_the_served_limit_are_all_answered",
+        "limits_are_read_from_the_wire_not_compiled_in",
+        "max_shared_file_bytes_is_the_ratified_integer_never_a_string",
+        "min_protocol_equals_protocol_because_v2_supports_one_generation",
+        "nesting_at_the_depth_bound_parses_and_one_past_it_is_invalid_argument",
+        "no_frame_in_the_corpus_uses_a_semantic_null",
+        "no_push_frame_reaches_a_connection_that_is_not_a_member",
+        "one_request_past_max_inflight_is_resource_exhausted_not_a_close",
+        "op_id_dedup_survives_reconnection_and_a_new_envelope_id",
+        "op_ids_do_not_collide_across_session_principals",
+        "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason",
+        "rejection_body_is_the_v2_error_envelope_never_plain_text_and_never_a_hint",
+        "replies_may_arrive_out_of_order_and_pushes_are_not_held_behind_a_call",
+        "request_and_reply_correlate_by_id",
+        "sec_fetch_site_is_not_a_credential",
+        "session_endpoint_requires_an_exact_loopback_origin_and_is_rate_limited",
+        "session_ticket_expires_and_never_carries_the_daemon_token",
+        "session_ticket_is_single_use_and_burned_on_redemption",
+        "storage_generation_is_discoverable_before_the_gate",
+        "the_daemon_incarnation_changes_across_a_restart",
+        "the_daemon_incarnation_is_stable_across_connections",
+        "version_object_is_byte_identical_across_ready_line_portfile_and_health",
+        "wrong_typed_envelope_members_are_refused_without_executing"
+      ],
+      "invites.json": [
+        "an_unredeemed_capability_grants_no_room_scoped_answer",
+        "an_unredeemed_capability_holder_receives_no_pushes_for_the_room",
+        "revocation_and_redemption_facts_advance_the_room_position_without_gaps"
+      ],
+      "pipes.json": [
+        "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability",
+        "membership_presence_availability_and_pipe_reachability_are_four_distinct_answers",
+        "pipe_facts_reach_subscribers_with_strictly_increasing_room_positions",
+        "pipe_operations_are_not_a_membership_oracle",
+        "pipe_pushes_stop_at_the_membership_boundary",
+        "pipe_release_and_pipe_revoke_are_not_the_same_withdrawal"
+      ],
+      "rooms.json": [
+        "lifecycle_left_room_refuses_every_write_and_every_live_read",
+        "lifecycle_removed_room_refuses_every_write_and_every_live_read",
+        "membership_pushes_carry_strictly_increasing_per_room_positions",
+        "non_oracle_absent_and_foreign_rooms_are_indistinguishable",
+        "non_oracle_an_unredeemed_invite_grants_no_room_scoped_access",
+        "non_oracle_timing_is_indistinguishable"
+      ],
+      "subject-daemon.json": [
+        "a_frame_with_no_recoverable_id_closes_4007_malformed_frame",
+        "hello_carries_subject_state_and_omits_pid_port_and_data_dir",
+        "no_frame_in_a_subject_session_ever_echoes_the_daemon_credential",
+        "one_precondition_gets_one_answer_across_every_subject_requiring_operation",
+        "subject_store_unreadable_fails_the_connection_closed_and_does_not_clobber"
+      ],
+      "timeline-streams.json": [
+        "a_position_discontinuity_is_detectable_without_any_gap_frame",
+        "a_push_never_carries_an_id_and_a_reply_always_does",
+        "gap_frame_open_variant_omits_pos_rather_than_nulling_it",
+        "gap_frame_states_a_bounded_range_as_a_tagged_variant",
+        "invariant_147_multi_room_routing_loses_nothing_and_skips_nothing",
+        "peer_push_carries_the_connection_generation_and_a_typed_offline_reason",
+        "positions_are_strictly_increasing_and_contiguous_within_one_room",
+        "positions_carry_no_cross_room_order_and_are_never_comparable_between_rooms",
+        "pushes_are_forwarded_while_a_request_is_still_outstanding",
+        "pushes_stop_when_membership_ends",
+        "reconnect_reports_resume_state_and_does_not_silently_restore_subscriptions",
+        "served_limits_are_mutually_consistent_so_an_at_limit_body_fits_one_frame",
+        "the_push_stream_is_not_a_membership_oracle"
+      ]
+    },
+    "count": 107
   },
-  "file.share": {
-   "cases": 16,
-   "success": true,
-   "distinctive_code": "declared_size_mismatch",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "fleet.list": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "fleet_projection_unavailable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "invite.list": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "invite_index_unreadable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "invite.mint": {
-   "cases": 11,
-   "success": true,
-   "distinctive_code": "invitee_already_member",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "invite.redeem": {
-   "cases": 11,
-   "success": true,
-   "distinctive_code": "capability_invalid",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "invite.revoke": {
-   "cases": 7,
-   "success": true,
-   "distinctive_code": "capability_redeemed",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "member.remove": {
-   "cases": 10,
-   "success": true,
-   "distinctive_code": "authority_cannot_be_removed",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "message.send": {
-   "cases": 11,
-   "success": true,
-   "distinctive_code": "message_too_large",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "pipe.connect": {
-   "cases": 7,
-   "success": true,
-   "distinctive_code": "pipe_unreachable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "pipe.list": {
-   "cases": 7,
-   "success": true,
-   "distinctive_code": "pipe_index_unreadable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "pipe.publish": {
-   "cases": 16,
-   "success": true,
-   "distinctive_code": "pipe_target_refused",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "pipe.release": {
-   "cases": 3,
-   "success": true,
-   "distinctive_code": "connection_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "pipe.revoke": {
-   "cases": 4,
-   "success": true,
-   "distinctive_code": "pipe_not_publisher",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.activate": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "transport_unavailable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.archive": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "room_still_active",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.create": {
-   "cases": 9,
-   "success": true,
-   "distinctive_code": "room_name_invalid",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.deactivate": {
-   "cases": 3,
-   "success": true,
-   "distinctive_code": null,
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.leave": {
-   "cases": 4,
-   "success": true,
-   "distinctive_code": "sole_authority_cannot_leave",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.list": {
-   "cases": 6,
-   "success": true,
-   "distinctive_code": "room_index_unreadable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.members": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "membership_unresolved",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.peers": {
-   "cases": 6,
-   "success": true,
-   "distinctive_code": "room_not_live",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "room.timeline": {
-   "cases": 9,
-   "success": true,
-   "distinctive_code": "cursor_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "status.history": {
-   "cases": 7,
-   "success": true,
-   "distinctive_code": "status_subject_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "status.post": {
-   "cases": 12,
-   "success": true,
-   "distinctive_code": "status_label_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "stream.resync": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "resync_required",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "stream.subscribe": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "subscription_limit_reached",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "stream.unsubscribe": {
-   "cases": 2,
-   "success": true,
-   "distinctive_code": "subscription_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "subject.ensure": {
-   "cases": 12,
-   "success": true,
-   "distinctive_code": "subject_store_unwritable",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  },
-  "transfer.cancel": {
-   "cases": 5,
-   "success": true,
-   "distinctive_code": "transfer_unknown",
-   "distinctive_code_has_a_case": true,
-   "satisfies_required_kinds": true
-  }
- },
- "operations_not_yet_satisfying_required_kinds": [],
- "severity_derivation": {
-  "note": "severity is derived from the closed label set and SERVED; no signed severity field exists",
-  "map": {
-   "online": "ok",
-   "idle": "ok",
-   "claiming": "ok",
-   "working": "ok",
-   "done": "ok",
-   "failed": "failed",
-   "blocked": "review"
-  }
- },
- "operation_null_cases": {
-  "note": "operation:null is legal for genuinely cross-cutting cases \u2014 gate behaviour, envelope framing, handshake, non-oracle properties spanning several operations, and multi-operation invariants. Every one of these is cross-cutting by intent (its own `intent` names a property no single operation owns), never by omission. The count here feeds totals.not_operation_scoped.",
-  "by_file": {
-   "files.json": [
-    "file_operations_are_not_a_membership_oracle",
-    "handshake_serves_the_file_and_transfer_limits_as_integers"
-   ],
-   "handshake.json": [
-    "a_duplicate_in_flight_id_is_refused_and_executes_only_once",
-    "a_frame_of_exactly_max_frame_bytes_is_parsed_and_answered",
-    "a_frame_one_byte_past_max_frame_bytes_closes_4005_without_being_parsed",
-    "a_frame_with_no_id_is_not_executed",
-    "a_gate_refused_upgrade_consumes_no_connection_slot",
-    "a_non_object_in_is_refused_and_a_null_in_is_refused",
-    "a_push_carries_t_and_never_id",
-    "an_array_at_the_length_bound_parses_and_one_past_it_is_invalid_argument",
-    "an_envelope_id_may_be_reused_after_its_reply_completes",
-    "an_op_name_at_the_codec_bound_parses_and_one_past_it_is_invalid_argument",
-    "an_over_limit_frame_mutates_nothing",
-    "an_unknown_op_is_a_correlated_error_reply_not_a_close",
-    "close_code_4003_is_emitted_when_the_daemon_is_not_ready",
-    "close_code_4004_is_emitted_on_idle_timeout",
-    "close_code_4005_is_emitted_for_frame_too_large",
-    "connections_at_the_served_limit_are_admitted_and_one_past_is_resource_exhausted",
-    "credential_comparison_is_timing_indistinguishable",
-    "daemon_token_is_refused_in_a_url_or_a_body",
-    "error_envelopes_for_a_foreign_room_and_an_unknown_room_are_indistinguishable",
-    "error_reply_carries_ok_false_a_code_and_no_hint",
-    "every_application_close_code_in_the_corpus_is_in_the_defined_table",
-    "gate_admits_a_supported_generation_and_a_matching_storage_generation",
-    "gate_check_1_refuses_a_non_loopback_host_with_forbidden_origin",
-    "gate_check_2_admits_an_absent_origin",
-    "gate_check_2_refuses_a_non_loopback_origin_with_forbidden_origin",
-    "gate_check_3_refuses_a_non_canonical_v_value",
-    "gate_check_3_refuses_a_repeated_v_parameter",
-    "gate_check_3_refuses_an_absent_v_which_is_exactly_a_v1_client",
-    "gate_check_3_refuses_an_unsupported_declared_generation",
-    "gate_check_4_refuses_a_mismatched_storage_generation",
-    "gate_check_4_refuses_an_absent_sg",
-    "gate_check_5_refuses_an_absent_and_a_wrong_credential",
-    "gate_order_host_precedes_protocol_and_storage_and_credential",
-    "gate_order_origin_precedes_protocol",
-    "gate_order_protocol_precedes_storage",
-    "gate_order_storage_precedes_credential",
-    "gate_refusal_mutates_nothing",
-    "gate_rejection_reveals_nothing_about_local_state",
-    "gate_runs_before_the_upgrade_so_a_refusal_is_a_status_not_a_close_code",
-    "health_limits_object_carries_all_sixteen_named_integer_fields",
-    "health_serves_the_version_object_and_no_data_dir",
-    "hello_carries_a_daemon_incarnation_identity",
-    "hello_carries_no_pid_no_port_and_no_data_dir",
-    "hello_is_the_first_frame_and_arrives_exactly_once",
-    "hello_limits_are_identical_to_the_layer_0_limits",
-    "hello_protocol_and_storage_generation_echo_the_admitted_gate_values",
-    "hello_resume_state_is_a_tagged_variant_never_a_null",
-    "hello_subject_absent_is_a_tagged_variant_with_no_null_ids",
-    "hello_subject_present_is_a_tagged_variant_with_both_ids",
-    "inflight_requests_at_the_served_limit_are_all_answered",
-    "limits_are_read_from_the_wire_not_compiled_in",
-    "max_shared_file_bytes_is_the_ratified_integer_never_a_string",
-    "min_protocol_equals_protocol_because_v2_supports_one_generation",
-    "nesting_at_the_depth_bound_parses_and_one_past_it_is_invalid_argument",
-    "no_frame_in_the_corpus_uses_a_semantic_null",
-    "no_push_frame_reaches_a_connection_that_is_not_a_member",
-    "one_request_past_max_inflight_is_resource_exhausted_not_a_close",
-    "op_id_dedup_survives_reconnection_and_a_new_envelope_id",
-    "op_ids_do_not_collide_across_session_principals",
-    "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason",
-    "rejection_body_is_the_v2_error_envelope_never_plain_text_and_never_a_hint",
-    "replies_may_arrive_out_of_order_and_pushes_are_not_held_behind_a_call",
-    "request_and_reply_correlate_by_id",
-    "sec_fetch_site_is_not_a_credential",
-    "session_endpoint_requires_an_exact_loopback_origin_and_is_rate_limited",
-    "session_ticket_expires_and_never_carries_the_daemon_token",
-    "session_ticket_is_single_use_and_burned_on_redemption",
-    "storage_generation_is_discoverable_before_the_gate",
-    "the_daemon_incarnation_changes_across_a_restart",
-    "the_daemon_incarnation_is_stable_across_connections",
-    "version_object_is_byte_identical_across_ready_line_portfile_and_health",
-    "wrong_typed_envelope_members_are_refused_without_executing"
-   ],
-   "invites.json": [
-    "an_unredeemed_capability_grants_no_room_scoped_answer",
-    "an_unredeemed_capability_holder_receives_no_pushes_for_the_room",
-    "revocation_and_redemption_facts_advance_the_room_position_without_gaps"
-   ],
-   "pipes.json": [
-    "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability",
-    "membership_presence_availability_and_pipe_reachability_are_four_distinct_answers",
-    "pipe_facts_reach_subscribers_with_strictly_increasing_room_positions",
-    "pipe_operations_are_not_a_membership_oracle",
-    "pipe_pushes_stop_at_the_membership_boundary",
-    "pipe_release_and_pipe_revoke_are_not_the_same_withdrawal"
-   ],
-   "rooms.json": [
-    "lifecycle_left_room_refuses_every_write_and_every_live_read",
-    "lifecycle_removed_room_refuses_every_write_and_every_live_read",
-    "membership_pushes_carry_strictly_increasing_per_room_positions",
-    "non_oracle_absent_and_foreign_rooms_are_indistinguishable",
-    "non_oracle_an_unredeemed_invite_grants_no_room_scoped_access",
-    "non_oracle_timing_is_indistinguishable"
-   ],
-   "subject-daemon.json": [
-    "a_frame_with_no_recoverable_id_closes_4007_malformed_frame",
-    "hello_carries_subject_state_and_omits_pid_port_and_data_dir",
-    "no_frame_in_a_subject_session_ever_echoes_the_daemon_credential",
-    "one_precondition_gets_one_answer_across_every_subject_requiring_operation",
-    "subject_store_unreadable_fails_the_connection_closed_and_does_not_clobber"
-   ],
-   "timeline-streams.json": [
-    "a_position_discontinuity_is_detectable_without_any_gap_frame",
-    "a_push_never_carries_an_id_and_a_reply_always_does",
-    "gap_frame_open_variant_omits_pos_rather_than_nulling_it",
-    "gap_frame_states_a_bounded_range_as_a_tagged_variant",
-    "invariant_147_multi_room_routing_loses_nothing_and_skips_nothing",
-    "peer_push_carries_the_connection_generation_and_a_typed_offline_reason",
-    "positions_are_strictly_increasing_and_contiguous_within_one_room",
-    "positions_carry_no_cross_room_order_and_are_never_comparable_between_rooms",
-    "pushes_are_forwarded_while_a_request_is_still_outstanding",
-    "pushes_stop_when_membership_ends",
-    "reconnect_reports_resume_state_and_does_not_silently_restore_subscriptions",
-    "served_limits_are_mutually_consistent_so_an_at_limit_body_fits_one_frame",
-    "the_push_stream_is_not_a_membership_oracle"
-   ]
-  },
-  "count": 107
- },
- "normalization": "Normalized in #213; `files.json` re-transcribed in pass 3, which added the `stream` DSL key (the files domain is not expressible without it), restored the record's file request and reply shapes, repaired the split assertion fragments, and retired two cases whose subject - an unknown declared size - v2 does not represent."
+  "normalization": "Normalized in #213; `files.json` re-transcribed in pass 3, which added the `stream` DSL key (the files domain is not expressible without it), restored the record's file request and reply shapes, repaired the split assertion fragments, and retired two cases whose subject - an unknown declared size - v2 does not represent."
 }

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -1,615 +1,616 @@
 {
-  "corpus": "jeliya protocol v2",
-  "spec": "../../docs/protocol-v2.md",
-  "dsl": "./README.md",
-  "authored": "by hand, from the specification. NOT generated from any implementation.",
-  "replayable": {
-    "structural_validation": true,
-    "selected_json_envelope_subject_slice": {
-      "status": "partial",
-      "ci_selected_cases": 22
-    },
-    "binary_byte_stream_executor": {
-      "status": "partial",
-      "send_bytes": "implemented",
-      "receive_bytes": "implemented_no_executable_case",
-      "bytes_streamed_observation": "implemented",
-      "client_abort_fault": "implemented",
-      "raw_record_credit_pause_transport_drop_faults": "unimplemented"
-    },
-    "adapter_targeted_declarative_cases": "declarative_only"
+ "corpus": "jeliya protocol v2",
+ "spec": "../../docs/protocol-v2.md",
+ "dsl": "./README.md",
+ "authored": "by hand, from the specification. NOT generated from any implementation.",
+ "replayable": {
+  "structural_validation": true,
+  "selected_json_envelope_subject_slice": {
+   "status": "partial",
+   "ci_selected_cases": 22
   },
-  "rules": {
-    "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
-    "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
-    "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
-    "counts_are_computed": "every count in this file is derived from the current fixture JSON, not asserted alongside it. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
+  "binary_byte_stream_executor": {
+   "status": "partial",
+   "send_bytes": "implemented",
+   "receive_bytes": "implemented_no_executable_case",
+   "bytes_streamed_observation": "implemented",
+   "client_abort_fault": "implemented",
+   "raw_record_fault": "implemented",
+   "credit_pause_transport_drop_faults": "unimplemented"
   },
-  "blocked_on_upstream": {
-    "U1": "ConnEvent must carry the connection generation and a typed offline reason",
-    "U2": "a progress-observing or streaming blob-fetch API (8 cases: 3 progress/stall, 1 deadline, 4 cancellation)",
-    "U3": "a size-distinguishable fetch outcome (1 fetch-stream size case)",
-    "U4": "harness cannot restart a daemon within a case"
-  },
-  "blocked_case_counts": {
-    "U1": 5,
+  "adapter_targeted_declarative_cases": "declarative_only"
+ },
+ "rules": {
+  "required_per_operation": "at least one success case, and at least one error case using that operation's OWN most specific code. A cross-cutting code such as subject_absent or room_not_available does NOT satisfy the error requirement.",
+  "exemptions_fail": "a case marked blocked_on_upstream FAILS until the named upstream change lands. It is never skipped: a skipped case reads as coverage, a failing case reads as work.",
+  "distinctive_code_exemption": "an operation may be exempt from the distinctive-code rule only with a stated reason in `exemptions`. An unexplained null is not an exemption.",
+  "counts_are_computed": "every count in this file is derived from the current fixture JSON, not asserted alongside it. totals.cases equals the sum of coverage[].cases plus totals.not_operation_scoped."
+ },
+ "blocked_on_upstream": {
+  "U1": "ConnEvent must carry the connection generation and a typed offline reason",
+  "U2": "a progress-observing or streaming blob-fetch API (8 cases: 3 progress/stall, 1 deadline, 4 cancellation)",
+  "U3": "a size-distinguishable fetch outcome (1 fetch-stream size case)",
+  "U4": "harness cannot restart a daemon within a case"
+ },
+ "blocked_case_counts": {
+  "U1": 5,
+  "U2": 8,
+  "U3": 1,
+  "U4": 1,
+  "blocked_on_record": 1
+ },
+ "blocked_on_upstream_cases": {
+  "U1": [
+   {
+    "file": "handshake.json",
+    "case": "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason"
+   },
+   {
+    "file": "pipes.json",
+    "case": "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability"
+   },
+   {
+    "file": "rooms.json",
+    "case": "room_peers_ignores_a_stale_generation_teardown"
+   },
+   {
+    "file": "rooms.json",
+    "case": "room_peers_reports_a_typed_reason_for_a_device_it_cannot_reach"
+   },
+   {
+    "file": "timeline-streams.json",
+    "case": "peer_push_carries_the_connection_generation_and_a_typed_offline_reason"
+   }
+  ],
+  "U2": [
+   {
+    "file": "files.json",
+    "case": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled"
+   },
+   {
+    "file": "files.json",
+    "case": "cancel_result_reports_bytes_transferred"
+   },
+   {
+    "file": "files.json",
+    "case": "fetch_deadline_scales_with_the_declared_size"
+   },
+   {
+    "file": "files.json",
+    "case": "transfer_cancel_after_the_originating_connection_dropped"
+   },
+   {
+    "file": "files.json",
+    "case": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown"
+   },
+   {
+    "file": "files.json",
+    "case": "transfer_cancel_releases_the_concurrent_transfer_slot"
+   },
+   {
+    "file": "files.json",
+    "case": "transfer_progress_is_delivered_only_to_the_initiating_principal"
+   },
+   {
+    "file": "files.json",
+    "case": "transfer_progress_pushes_report_monotonic_transferred_bytes"
+   }
+  ],
+  "U3": [
+   {
+    "file": "files.json",
+    "case": "fetch_stream_refuses_a_peer_serving_more_than_it_declared"
+   }
+  ],
+  "U4": [
+   {
+    "file": "handshake.json",
+    "case": "the_daemon_incarnation_changes_across_a_restart"
+   }
+  ]
+ },
+ "blocked_on_record_cases": [
+  {
+   "file": "timeline-streams.json",
+   "case": "message_send_omitting_op_id_is_refused_naming_the_field",
+   "record": "op_id_optional_but_deduplicated"
+  }
+ ],
+ "target_counts": {
+  "untargeted": 340,
+  "daemon": 0,
+  "in_process_core": 1,
+  "client_adapter": 5
+ },
+ "totals": {
+  "cases": 346,
+  "attributed_to_an_operation": 239,
+  "not_operation_scoped": 107,
+  "conforming_to_the_dsl": 346,
+  "distinct_step_verbs_in_use": 7,
+  "quarantined": 0,
+  "blocked_on_upstream": 15,
+  "blocked_on_record": 1
+ },
+ "per_file_totals": {
+  "files.json": {
+   "cases": 45,
+   "attributed_to_an_operation": 43,
+   "not_operation_scoped": 2,
+   "blocked_on_upstream": {
+    "U1": 0,
     "U2": 8,
     "U3": 1,
-    "U4": 1,
-    "blocked_on_record": 1
+    "U4": 0
+   },
+   "blocked_on_record": 0
   },
-  "blocked_on_upstream_cases": {
-    "U1": [
-      {
-        "file": "handshake.json",
-        "case": "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason"
-      },
-      {
-        "file": "pipes.json",
-        "case": "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability"
-      },
-      {
-        "file": "rooms.json",
-        "case": "room_peers_ignores_a_stale_generation_teardown"
-      },
-      {
-        "file": "rooms.json",
-        "case": "room_peers_reports_a_typed_reason_for_a_device_it_cannot_reach"
-      },
-      {
-        "file": "timeline-streams.json",
-        "case": "peer_push_carries_the_connection_generation_and_a_typed_offline_reason"
-      }
-    ],
-    "U2": [
-      {
-        "file": "files.json",
-        "case": "a_transfer_with_no_forward_progress_fails_with_transfer_stalled"
-      },
-      {
-        "file": "files.json",
-        "case": "cancel_result_reports_bytes_transferred"
-      },
-      {
-        "file": "files.json",
-        "case": "fetch_deadline_scales_with_the_declared_size"
-      },
-      {
-        "file": "files.json",
-        "case": "transfer_cancel_after_the_originating_connection_dropped"
-      },
-      {
-        "file": "files.json",
-        "case": "transfer_cancel_by_a_different_principal_is_indistinguishable_from_unknown"
-      },
-      {
-        "file": "files.json",
-        "case": "transfer_cancel_releases_the_concurrent_transfer_slot"
-      },
-      {
-        "file": "files.json",
-        "case": "transfer_progress_is_delivered_only_to_the_initiating_principal"
-      },
-      {
-        "file": "files.json",
-        "case": "transfer_progress_pushes_report_monotonic_transferred_bytes"
-      }
-    ],
-    "U3": [
-      {
-        "file": "files.json",
-        "case": "fetch_stream_refuses_a_peer_serving_more_than_it_declared"
-      }
-    ],
-    "U4": [
-      {
-        "file": "handshake.json",
-        "case": "the_daemon_incarnation_changes_across_a_restart"
-      }
-    ]
+  "handshake.json": {
+   "cases": 72,
+   "attributed_to_an_operation": 0,
+   "not_operation_scoped": 72,
+   "blocked_on_upstream": {
+    "U1": 1,
+    "U2": 0,
+    "U3": 0,
+    "U4": 1
+   },
+   "blocked_on_record": 0
   },
-  "blocked_on_record_cases": [
-    {
-      "file": "timeline-streams.json",
-      "case": "message_send_omitting_op_id_is_refused_naming_the_field",
-      "record": "op_id_optional_but_deduplicated"
-    }
-  ],
-  "target_counts": {
-    "untargeted": 339,
-    "daemon": 0,
-    "in_process_core": 1,
-    "client_adapter": 5
+  "invites.json": {
+   "cases": 37,
+   "attributed_to_an_operation": 34,
+   "not_operation_scoped": 3,
+   "blocked_on_upstream": {
+    "U1": 0,
+    "U2": 0,
+    "U3": 0,
+    "U4": 0
+   },
+   "blocked_on_record": 0
   },
-  "totals": {
-    "cases": 345,
-    "attributed_to_an_operation": 238,
-    "not_operation_scoped": 107,
-    "conforming_to_the_dsl": 345,
-    "distinct_step_verbs_in_use": 7,
-    "quarantined": 0,
-    "blocked_on_upstream": 15,
-    "blocked_on_record": 1
+  "pipes.json": {
+   "cases": 43,
+   "attributed_to_an_operation": 37,
+   "not_operation_scoped": 6,
+   "blocked_on_upstream": {
+    "U1": 1,
+    "U2": 0,
+    "U3": 0,
+    "U4": 0
+   },
+   "blocked_on_record": 0
   },
-  "per_file_totals": {
-    "files.json": {
-      "cases": 44,
-      "attributed_to_an_operation": 42,
-      "not_operation_scoped": 2,
-      "blocked_on_upstream": {
-        "U1": 0,
-        "U2": 8,
-        "U3": 1,
-        "U4": 0
-      },
-      "blocked_on_record": 0
-    },
-    "handshake.json": {
-      "cases": 72,
-      "attributed_to_an_operation": 0,
-      "not_operation_scoped": 72,
-      "blocked_on_upstream": {
-        "U1": 1,
-        "U2": 0,
-        "U3": 0,
-        "U4": 1
-      },
-      "blocked_on_record": 0
-    },
-    "invites.json": {
-      "cases": 37,
-      "attributed_to_an_operation": 34,
-      "not_operation_scoped": 3,
-      "blocked_on_upstream": {
-        "U1": 0,
-        "U2": 0,
-        "U3": 0,
-        "U4": 0
-      },
-      "blocked_on_record": 0
-    },
-    "pipes.json": {
-      "cases": 43,
-      "attributed_to_an_operation": 37,
-      "not_operation_scoped": 6,
-      "blocked_on_upstream": {
-        "U1": 1,
-        "U2": 0,
-        "U3": 0,
-        "U4": 0
-      },
-      "blocked_on_record": 0
-    },
-    "rooms.json": {
-      "cases": 65,
-      "attributed_to_an_operation": 59,
-      "not_operation_scoped": 6,
-      "blocked_on_upstream": {
-        "U1": 2,
-        "U2": 0,
-        "U3": 0,
-        "U4": 0
-      },
-      "blocked_on_record": 0
-    },
-    "subject-daemon.json": {
-      "cases": 24,
-      "attributed_to_an_operation": 19,
-      "not_operation_scoped": 5,
-      "blocked_on_upstream": {
-        "U1": 0,
-        "U2": 0,
-        "U3": 0,
-        "U4": 0
-      },
-      "blocked_on_record": 0
-    },
-    "timeline-streams.json": {
-      "cases": 60,
-      "attributed_to_an_operation": 47,
-      "not_operation_scoped": 13,
-      "blocked_on_upstream": {
-        "U1": 1,
-        "U2": 0,
-        "U3": 0,
-        "U4": 0
-      },
-      "blocked_on_record": 1
-    }
+  "rooms.json": {
+   "cases": 65,
+   "attributed_to_an_operation": 59,
+   "not_operation_scoped": 6,
+   "blocked_on_upstream": {
+    "U1": 2,
+    "U2": 0,
+    "U3": 0,
+    "U4": 0
+   },
+   "blocked_on_record": 0
   },
-  "exemptions": {
-    "room.deactivate": {
-      "from": "required_per_operation",
-      "reason": "Every way room.deactivate can fail is already a cross-cutting refusal: no subject, no such room, or membership ended. Deactivating a room the caller may act in always succeeds, because it withdraws local participation and asks nothing of the network. A code that no reachable state produces would buy a green cell in this table and nothing else.",
-      "reviewed_in": "#212"
-    }
+  "subject-daemon.json": {
+   "cases": 24,
+   "attributed_to_an_operation": 19,
+   "not_operation_scoped": 5,
+   "blocked_on_upstream": {
+    "U1": 0,
+    "U2": 0,
+    "U3": 0,
+    "U4": 0
+   },
+   "blocked_on_record": 0
   },
-  "taxonomy_code_count": 64,
-  "codes_without_a_case": {
-    "note": "Computed from literal expect.err.code on a direct call matching case.operation, with canonical file-error validation; notes, intents, setup calls, generic nested objects, and authoring_notes do not count. frame_too_large, idle_timeout, malformed_frame, and not_ready count only through their verified named close/status fixtures.",
-    "codes": [
-      "forbidden_origin",
-      "pairing_code_invalid",
-      "protocol_unsupported",
-      "role_not_grantable",
-      "session_expired",
-      "storage_generation_mismatch",
-      "unauthenticated",
-      "unknown_operation"
-    ]
+  "timeline-streams.json": {
+   "cases": 60,
+   "attributed_to_an_operation": 47,
+   "not_operation_scoped": 13,
+   "blocked_on_upstream": {
+    "U1": 1,
+    "U2": 0,
+    "U3": 0,
+    "U4": 0
+   },
+   "blocked_on_record": 1
+  }
+ },
+ "exemptions": {
+  "room.deactivate": {
+   "from": "required_per_operation",
+   "reason": "Every way room.deactivate can fail is already a cross-cutting refusal: no subject, no such room, or membership ended. Deactivating a room the caller may act in always succeeds, because it withdraws local participation and asks nothing of the network. A code that no reachable state produces would buy a green cell in this table and nothing else.",
+   "reviewed_in": "#212"
+  }
+ },
+ "taxonomy_code_count": 64,
+ "codes_without_a_case": {
+  "note": "Computed from literal expect.err.code on a direct call matching case.operation, with canonical file-error validation; notes, intents, setup calls, generic nested objects, and authoring_notes do not count. frame_too_large, idle_timeout, malformed_frame, and not_ready count only through their verified named close/status fixtures.",
+  "codes": [
+   "forbidden_origin",
+   "pairing_code_invalid",
+   "protocol_unsupported",
+   "role_not_grantable",
+   "session_expired",
+   "storage_generation_mismatch",
+   "unauthenticated",
+   "unknown_operation"
+  ]
+ },
+ "coverage": {
+  "daemon.stop": {
+   "cases": 4,
+   "success": true,
+   "distinctive_code": "shutdown_in_progress",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
   },
-  "coverage": {
-    "daemon.stop": {
-      "cases": 4,
-      "success": true,
-      "distinctive_code": "shutdown_in_progress",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "file.fetch": {
-      "cases": 14,
-      "success": true,
-      "distinctive_code": "provider_unreachable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "file.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "file_index_unreadable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "file.read": {
-      "cases": 3,
-      "success": true,
-      "distinctive_code": "file_not_fetched",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "file.share": {
-      "cases": 15,
-      "success": true,
-      "distinctive_code": "declared_size_mismatch",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "fleet.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "fleet_projection_unavailable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "invite.list": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "invite_index_unreadable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "invite.mint": {
-      "cases": 11,
-      "success": true,
-      "distinctive_code": "invitee_already_member",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "invite.redeem": {
-      "cases": 11,
-      "success": true,
-      "distinctive_code": "capability_invalid",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "invite.revoke": {
-      "cases": 7,
-      "success": true,
-      "distinctive_code": "capability_redeemed",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "member.remove": {
-      "cases": 10,
-      "success": true,
-      "distinctive_code": "authority_cannot_be_removed",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "message.send": {
-      "cases": 11,
-      "success": true,
-      "distinctive_code": "message_too_large",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "pipe.connect": {
-      "cases": 7,
-      "success": true,
-      "distinctive_code": "pipe_unreachable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "pipe.list": {
-      "cases": 7,
-      "success": true,
-      "distinctive_code": "pipe_index_unreadable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "pipe.publish": {
-      "cases": 16,
-      "success": true,
-      "distinctive_code": "pipe_target_refused",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "pipe.release": {
-      "cases": 3,
-      "success": true,
-      "distinctive_code": "connection_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "pipe.revoke": {
-      "cases": 4,
-      "success": true,
-      "distinctive_code": "pipe_not_publisher",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.activate": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "transport_unavailable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.archive": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "room_still_active",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.create": {
-      "cases": 9,
-      "success": true,
-      "distinctive_code": "room_name_invalid",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.deactivate": {
-      "cases": 3,
-      "success": true,
-      "distinctive_code": null,
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.leave": {
-      "cases": 4,
-      "success": true,
-      "distinctive_code": "sole_authority_cannot_leave",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.list": {
-      "cases": 6,
-      "success": true,
-      "distinctive_code": "room_index_unreadable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.members": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "membership_unresolved",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.peers": {
-      "cases": 6,
-      "success": true,
-      "distinctive_code": "room_not_live",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "room.timeline": {
-      "cases": 9,
-      "success": true,
-      "distinctive_code": "cursor_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "status.history": {
-      "cases": 7,
-      "success": true,
-      "distinctive_code": "status_subject_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "status.post": {
-      "cases": 12,
-      "success": true,
-      "distinctive_code": "status_label_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "stream.resync": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "resync_required",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "stream.subscribe": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "subscription_limit_reached",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "stream.unsubscribe": {
-      "cases": 2,
-      "success": true,
-      "distinctive_code": "subscription_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "subject.ensure": {
-      "cases": 12,
-      "success": true,
-      "distinctive_code": "subject_store_unwritable",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    },
-    "transfer.cancel": {
-      "cases": 5,
-      "success": true,
-      "distinctive_code": "transfer_unknown",
-      "distinctive_code_has_a_case": true,
-      "satisfies_required_kinds": true
-    }
+  "file.fetch": {
+   "cases": 14,
+   "success": true,
+   "distinctive_code": "provider_unreachable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
   },
-  "operations_not_yet_satisfying_required_kinds": [],
-  "severity_derivation": {
-    "note": "severity is derived from the closed label set and SERVED; no signed severity field exists",
-    "map": {
-      "online": "ok",
-      "idle": "ok",
-      "claiming": "ok",
-      "working": "ok",
-      "done": "ok",
-      "failed": "failed",
-      "blocked": "review"
-    }
+  "file.list": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "file_index_unreadable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
   },
-  "operation_null_cases": {
-    "note": "operation:null is legal for genuinely cross-cutting cases \u2014 gate behaviour, envelope framing, handshake, non-oracle properties spanning several operations, and multi-operation invariants. Every one of these is cross-cutting by intent (its own `intent` names a property no single operation owns), never by omission. The count here feeds totals.not_operation_scoped.",
-    "by_file": {
-      "files.json": [
-        "file_operations_are_not_a_membership_oracle",
-        "handshake_serves_the_file_and_transfer_limits_as_integers"
-      ],
-      "handshake.json": [
-        "a_duplicate_in_flight_id_is_refused_and_executes_only_once",
-        "a_frame_of_exactly_max_frame_bytes_is_parsed_and_answered",
-        "a_frame_one_byte_past_max_frame_bytes_closes_4005_without_being_parsed",
-        "a_frame_with_no_id_is_not_executed",
-        "a_gate_refused_upgrade_consumes_no_connection_slot",
-        "a_non_object_in_is_refused_and_a_null_in_is_refused",
-        "a_push_carries_t_and_never_id",
-        "an_array_at_the_length_bound_parses_and_one_past_it_is_invalid_argument",
-        "an_envelope_id_may_be_reused_after_its_reply_completes",
-        "an_op_name_at_the_codec_bound_parses_and_one_past_it_is_invalid_argument",
-        "an_over_limit_frame_mutates_nothing",
-        "an_unknown_op_is_a_correlated_error_reply_not_a_close",
-        "close_code_4003_is_emitted_when_the_daemon_is_not_ready",
-        "close_code_4004_is_emitted_on_idle_timeout",
-        "close_code_4005_is_emitted_for_frame_too_large",
-        "connections_at_the_served_limit_are_admitted_and_one_past_is_resource_exhausted",
-        "credential_comparison_is_timing_indistinguishable",
-        "daemon_token_is_refused_in_a_url_or_a_body",
-        "error_envelopes_for_a_foreign_room_and_an_unknown_room_are_indistinguishable",
-        "error_reply_carries_ok_false_a_code_and_no_hint",
-        "every_application_close_code_in_the_corpus_is_in_the_defined_table",
-        "gate_admits_a_supported_generation_and_a_matching_storage_generation",
-        "gate_check_1_refuses_a_non_loopback_host_with_forbidden_origin",
-        "gate_check_2_admits_an_absent_origin",
-        "gate_check_2_refuses_a_non_loopback_origin_with_forbidden_origin",
-        "gate_check_3_refuses_a_non_canonical_v_value",
-        "gate_check_3_refuses_a_repeated_v_parameter",
-        "gate_check_3_refuses_an_absent_v_which_is_exactly_a_v1_client",
-        "gate_check_3_refuses_an_unsupported_declared_generation",
-        "gate_check_4_refuses_a_mismatched_storage_generation",
-        "gate_check_4_refuses_an_absent_sg",
-        "gate_check_5_refuses_an_absent_and_a_wrong_credential",
-        "gate_order_host_precedes_protocol_and_storage_and_credential",
-        "gate_order_origin_precedes_protocol",
-        "gate_order_protocol_precedes_storage",
-        "gate_order_storage_precedes_credential",
-        "gate_refusal_mutates_nothing",
-        "gate_rejection_reveals_nothing_about_local_state",
-        "gate_runs_before_the_upgrade_so_a_refusal_is_a_status_not_a_close_code",
-        "health_limits_object_carries_all_sixteen_named_integer_fields",
-        "health_serves_the_version_object_and_no_data_dir",
-        "hello_carries_a_daemon_incarnation_identity",
-        "hello_carries_no_pid_no_port_and_no_data_dir",
-        "hello_is_the_first_frame_and_arrives_exactly_once",
-        "hello_limits_are_identical_to_the_layer_0_limits",
-        "hello_protocol_and_storage_generation_echo_the_admitted_gate_values",
-        "hello_resume_state_is_a_tagged_variant_never_a_null",
-        "hello_subject_absent_is_a_tagged_variant_with_no_null_ids",
-        "hello_subject_present_is_a_tagged_variant_with_both_ids",
-        "inflight_requests_at_the_served_limit_are_all_answered",
-        "limits_are_read_from_the_wire_not_compiled_in",
-        "max_shared_file_bytes_is_the_ratified_integer_never_a_string",
-        "min_protocol_equals_protocol_because_v2_supports_one_generation",
-        "nesting_at_the_depth_bound_parses_and_one_past_it_is_invalid_argument",
-        "no_frame_in_the_corpus_uses_a_semantic_null",
-        "no_push_frame_reaches_a_connection_that_is_not_a_member",
-        "one_request_past_max_inflight_is_resource_exhausted_not_a_close",
-        "op_id_dedup_survives_reconnection_and_a_new_envelope_id",
-        "op_ids_do_not_collide_across_session_principals",
-        "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason",
-        "rejection_body_is_the_v2_error_envelope_never_plain_text_and_never_a_hint",
-        "replies_may_arrive_out_of_order_and_pushes_are_not_held_behind_a_call",
-        "request_and_reply_correlate_by_id",
-        "sec_fetch_site_is_not_a_credential",
-        "session_endpoint_requires_an_exact_loopback_origin_and_is_rate_limited",
-        "session_ticket_expires_and_never_carries_the_daemon_token",
-        "session_ticket_is_single_use_and_burned_on_redemption",
-        "storage_generation_is_discoverable_before_the_gate",
-        "the_daemon_incarnation_changes_across_a_restart",
-        "the_daemon_incarnation_is_stable_across_connections",
-        "version_object_is_byte_identical_across_ready_line_portfile_and_health",
-        "wrong_typed_envelope_members_are_refused_without_executing"
-      ],
-      "invites.json": [
-        "an_unredeemed_capability_grants_no_room_scoped_answer",
-        "an_unredeemed_capability_holder_receives_no_pushes_for_the_room",
-        "revocation_and_redemption_facts_advance_the_room_position_without_gaps"
-      ],
-      "pipes.json": [
-        "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability",
-        "membership_presence_availability_and_pipe_reachability_are_four_distinct_answers",
-        "pipe_facts_reach_subscribers_with_strictly_increasing_room_positions",
-        "pipe_operations_are_not_a_membership_oracle",
-        "pipe_pushes_stop_at_the_membership_boundary",
-        "pipe_release_and_pipe_revoke_are_not_the_same_withdrawal"
-      ],
-      "rooms.json": [
-        "lifecycle_left_room_refuses_every_write_and_every_live_read",
-        "lifecycle_removed_room_refuses_every_write_and_every_live_read",
-        "membership_pushes_carry_strictly_increasing_per_room_positions",
-        "non_oracle_absent_and_foreign_rooms_are_indistinguishable",
-        "non_oracle_an_unredeemed_invite_grants_no_room_scoped_access",
-        "non_oracle_timing_is_indistinguishable"
-      ],
-      "subject-daemon.json": [
-        "a_frame_with_no_recoverable_id_closes_4007_malformed_frame",
-        "hello_carries_subject_state_and_omits_pid_port_and_data_dir",
-        "no_frame_in_a_subject_session_ever_echoes_the_daemon_credential",
-        "one_precondition_gets_one_answer_across_every_subject_requiring_operation",
-        "subject_store_unreadable_fails_the_connection_closed_and_does_not_clobber"
-      ],
-      "timeline-streams.json": [
-        "a_position_discontinuity_is_detectable_without_any_gap_frame",
-        "a_push_never_carries_an_id_and_a_reply_always_does",
-        "gap_frame_open_variant_omits_pos_rather_than_nulling_it",
-        "gap_frame_states_a_bounded_range_as_a_tagged_variant",
-        "invariant_147_multi_room_routing_loses_nothing_and_skips_nothing",
-        "peer_push_carries_the_connection_generation_and_a_typed_offline_reason",
-        "positions_are_strictly_increasing_and_contiguous_within_one_room",
-        "positions_carry_no_cross_room_order_and_are_never_comparable_between_rooms",
-        "pushes_are_forwarded_while_a_request_is_still_outstanding",
-        "pushes_stop_when_membership_ends",
-        "reconnect_reports_resume_state_and_does_not_silently_restore_subscriptions",
-        "served_limits_are_mutually_consistent_so_an_at_limit_body_fits_one_frame",
-        "the_push_stream_is_not_a_membership_oracle"
-      ]
-    },
-    "count": 107
+  "file.read": {
+   "cases": 3,
+   "success": true,
+   "distinctive_code": "file_not_fetched",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
   },
-  "normalization": "Normalized in #213; `files.json` re-transcribed in pass 3, which added the `stream` DSL key (the files domain is not expressible without it), restored the record's file request and reply shapes, repaired the split assertion fragments, and retired two cases whose subject - an unknown declared size - v2 does not represent."
+  "file.share": {
+   "cases": 16,
+   "success": true,
+   "distinctive_code": "declared_size_mismatch",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "fleet.list": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "fleet_projection_unavailable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "invite.list": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "invite_index_unreadable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "invite.mint": {
+   "cases": 11,
+   "success": true,
+   "distinctive_code": "invitee_already_member",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "invite.redeem": {
+   "cases": 11,
+   "success": true,
+   "distinctive_code": "capability_invalid",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "invite.revoke": {
+   "cases": 7,
+   "success": true,
+   "distinctive_code": "capability_redeemed",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "member.remove": {
+   "cases": 10,
+   "success": true,
+   "distinctive_code": "authority_cannot_be_removed",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "message.send": {
+   "cases": 11,
+   "success": true,
+   "distinctive_code": "message_too_large",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "pipe.connect": {
+   "cases": 7,
+   "success": true,
+   "distinctive_code": "pipe_unreachable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "pipe.list": {
+   "cases": 7,
+   "success": true,
+   "distinctive_code": "pipe_index_unreadable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "pipe.publish": {
+   "cases": 16,
+   "success": true,
+   "distinctive_code": "pipe_target_refused",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "pipe.release": {
+   "cases": 3,
+   "success": true,
+   "distinctive_code": "connection_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "pipe.revoke": {
+   "cases": 4,
+   "success": true,
+   "distinctive_code": "pipe_not_publisher",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.activate": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "transport_unavailable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.archive": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "room_still_active",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.create": {
+   "cases": 9,
+   "success": true,
+   "distinctive_code": "room_name_invalid",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.deactivate": {
+   "cases": 3,
+   "success": true,
+   "distinctive_code": null,
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.leave": {
+   "cases": 4,
+   "success": true,
+   "distinctive_code": "sole_authority_cannot_leave",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.list": {
+   "cases": 6,
+   "success": true,
+   "distinctive_code": "room_index_unreadable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.members": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "membership_unresolved",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.peers": {
+   "cases": 6,
+   "success": true,
+   "distinctive_code": "room_not_live",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "room.timeline": {
+   "cases": 9,
+   "success": true,
+   "distinctive_code": "cursor_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "status.history": {
+   "cases": 7,
+   "success": true,
+   "distinctive_code": "status_subject_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "status.post": {
+   "cases": 12,
+   "success": true,
+   "distinctive_code": "status_label_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "stream.resync": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "resync_required",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "stream.subscribe": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "subscription_limit_reached",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "stream.unsubscribe": {
+   "cases": 2,
+   "success": true,
+   "distinctive_code": "subscription_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "subject.ensure": {
+   "cases": 12,
+   "success": true,
+   "distinctive_code": "subject_store_unwritable",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  },
+  "transfer.cancel": {
+   "cases": 5,
+   "success": true,
+   "distinctive_code": "transfer_unknown",
+   "distinctive_code_has_a_case": true,
+   "satisfies_required_kinds": true
+  }
+ },
+ "operations_not_yet_satisfying_required_kinds": [],
+ "severity_derivation": {
+  "note": "severity is derived from the closed label set and SERVED; no signed severity field exists",
+  "map": {
+   "online": "ok",
+   "idle": "ok",
+   "claiming": "ok",
+   "working": "ok",
+   "done": "ok",
+   "failed": "failed",
+   "blocked": "review"
+  }
+ },
+ "operation_null_cases": {
+  "note": "operation:null is legal for genuinely cross-cutting cases \u2014 gate behaviour, envelope framing, handshake, non-oracle properties spanning several operations, and multi-operation invariants. Every one of these is cross-cutting by intent (its own `intent` names a property no single operation owns), never by omission. The count here feeds totals.not_operation_scoped.",
+  "by_file": {
+   "files.json": [
+    "file_operations_are_not_a_membership_oracle",
+    "handshake_serves_the_file_and_transfer_limits_as_integers"
+   ],
+   "handshake.json": [
+    "a_duplicate_in_flight_id_is_refused_and_executes_only_once",
+    "a_frame_of_exactly_max_frame_bytes_is_parsed_and_answered",
+    "a_frame_one_byte_past_max_frame_bytes_closes_4005_without_being_parsed",
+    "a_frame_with_no_id_is_not_executed",
+    "a_gate_refused_upgrade_consumes_no_connection_slot",
+    "a_non_object_in_is_refused_and_a_null_in_is_refused",
+    "a_push_carries_t_and_never_id",
+    "an_array_at_the_length_bound_parses_and_one_past_it_is_invalid_argument",
+    "an_envelope_id_may_be_reused_after_its_reply_completes",
+    "an_op_name_at_the_codec_bound_parses_and_one_past_it_is_invalid_argument",
+    "an_over_limit_frame_mutates_nothing",
+    "an_unknown_op_is_a_correlated_error_reply_not_a_close",
+    "close_code_4003_is_emitted_when_the_daemon_is_not_ready",
+    "close_code_4004_is_emitted_on_idle_timeout",
+    "close_code_4005_is_emitted_for_frame_too_large",
+    "connections_at_the_served_limit_are_admitted_and_one_past_is_resource_exhausted",
+    "credential_comparison_is_timing_indistinguishable",
+    "daemon_token_is_refused_in_a_url_or_a_body",
+    "error_envelopes_for_a_foreign_room_and_an_unknown_room_are_indistinguishable",
+    "error_reply_carries_ok_false_a_code_and_no_hint",
+    "every_application_close_code_in_the_corpus_is_in_the_defined_table",
+    "gate_admits_a_supported_generation_and_a_matching_storage_generation",
+    "gate_check_1_refuses_a_non_loopback_host_with_forbidden_origin",
+    "gate_check_2_admits_an_absent_origin",
+    "gate_check_2_refuses_a_non_loopback_origin_with_forbidden_origin",
+    "gate_check_3_refuses_a_non_canonical_v_value",
+    "gate_check_3_refuses_a_repeated_v_parameter",
+    "gate_check_3_refuses_an_absent_v_which_is_exactly_a_v1_client",
+    "gate_check_3_refuses_an_unsupported_declared_generation",
+    "gate_check_4_refuses_a_mismatched_storage_generation",
+    "gate_check_4_refuses_an_absent_sg",
+    "gate_check_5_refuses_an_absent_and_a_wrong_credential",
+    "gate_order_host_precedes_protocol_and_storage_and_credential",
+    "gate_order_origin_precedes_protocol",
+    "gate_order_protocol_precedes_storage",
+    "gate_order_storage_precedes_credential",
+    "gate_refusal_mutates_nothing",
+    "gate_rejection_reveals_nothing_about_local_state",
+    "gate_runs_before_the_upgrade_so_a_refusal_is_a_status_not_a_close_code",
+    "health_limits_object_carries_all_sixteen_named_integer_fields",
+    "health_serves_the_version_object_and_no_data_dir",
+    "hello_carries_a_daemon_incarnation_identity",
+    "hello_carries_no_pid_no_port_and_no_data_dir",
+    "hello_is_the_first_frame_and_arrives_exactly_once",
+    "hello_limits_are_identical_to_the_layer_0_limits",
+    "hello_protocol_and_storage_generation_echo_the_admitted_gate_values",
+    "hello_resume_state_is_a_tagged_variant_never_a_null",
+    "hello_subject_absent_is_a_tagged_variant_with_no_null_ids",
+    "hello_subject_present_is_a_tagged_variant_with_both_ids",
+    "inflight_requests_at_the_served_limit_are_all_answered",
+    "limits_are_read_from_the_wire_not_compiled_in",
+    "max_shared_file_bytes_is_the_ratified_integer_never_a_string",
+    "min_protocol_equals_protocol_because_v2_supports_one_generation",
+    "nesting_at_the_depth_bound_parses_and_one_past_it_is_invalid_argument",
+    "no_frame_in_the_corpus_uses_a_semantic_null",
+    "no_push_frame_reaches_a_connection_that_is_not_a_member",
+    "one_request_past_max_inflight_is_resource_exhausted_not_a_close",
+    "op_id_dedup_survives_reconnection_and_a_new_envelope_id",
+    "op_ids_do_not_collide_across_session_principals",
+    "peer_push_carries_t_no_id_a_generation_and_a_tagged_offline_reason",
+    "rejection_body_is_the_v2_error_envelope_never_plain_text_and_never_a_hint",
+    "replies_may_arrive_out_of_order_and_pushes_are_not_held_behind_a_call",
+    "request_and_reply_correlate_by_id",
+    "sec_fetch_site_is_not_a_credential",
+    "session_endpoint_requires_an_exact_loopback_origin_and_is_rate_limited",
+    "session_ticket_expires_and_never_carries_the_daemon_token",
+    "session_ticket_is_single_use_and_burned_on_redemption",
+    "storage_generation_is_discoverable_before_the_gate",
+    "the_daemon_incarnation_changes_across_a_restart",
+    "the_daemon_incarnation_is_stable_across_connections",
+    "version_object_is_byte_identical_across_ready_line_portfile_and_health",
+    "wrong_typed_envelope_members_are_refused_without_executing"
+   ],
+   "invites.json": [
+    "an_unredeemed_capability_grants_no_room_scoped_answer",
+    "an_unredeemed_capability_holder_receives_no_pushes_for_the_room",
+    "revocation_and_redemption_facts_advance_the_room_position_without_gaps"
+   ],
+   "pipes.json": [
+    "a_stale_generation_teardown_does_not_rewrite_presence_or_pipe_reachability",
+    "membership_presence_availability_and_pipe_reachability_are_four_distinct_answers",
+    "pipe_facts_reach_subscribers_with_strictly_increasing_room_positions",
+    "pipe_operations_are_not_a_membership_oracle",
+    "pipe_pushes_stop_at_the_membership_boundary",
+    "pipe_release_and_pipe_revoke_are_not_the_same_withdrawal"
+   ],
+   "rooms.json": [
+    "lifecycle_left_room_refuses_every_write_and_every_live_read",
+    "lifecycle_removed_room_refuses_every_write_and_every_live_read",
+    "membership_pushes_carry_strictly_increasing_per_room_positions",
+    "non_oracle_absent_and_foreign_rooms_are_indistinguishable",
+    "non_oracle_an_unredeemed_invite_grants_no_room_scoped_access",
+    "non_oracle_timing_is_indistinguishable"
+   ],
+   "subject-daemon.json": [
+    "a_frame_with_no_recoverable_id_closes_4007_malformed_frame",
+    "hello_carries_subject_state_and_omits_pid_port_and_data_dir",
+    "no_frame_in_a_subject_session_ever_echoes_the_daemon_credential",
+    "one_precondition_gets_one_answer_across_every_subject_requiring_operation",
+    "subject_store_unreadable_fails_the_connection_closed_and_does_not_clobber"
+   ],
+   "timeline-streams.json": [
+    "a_position_discontinuity_is_detectable_without_any_gap_frame",
+    "a_push_never_carries_an_id_and_a_reply_always_does",
+    "gap_frame_open_variant_omits_pos_rather_than_nulling_it",
+    "gap_frame_states_a_bounded_range_as_a_tagged_variant",
+    "invariant_147_multi_room_routing_loses_nothing_and_skips_nothing",
+    "peer_push_carries_the_connection_generation_and_a_typed_offline_reason",
+    "positions_are_strictly_increasing_and_contiguous_within_one_room",
+    "positions_carry_no_cross_room_order_and_are_never_comparable_between_rooms",
+    "pushes_are_forwarded_while_a_request_is_still_outstanding",
+    "pushes_stop_when_membership_ends",
+    "reconnect_reports_resume_state_and_does_not_silently_restore_subscriptions",
+    "served_limits_are_mutually_consistent_so_an_at_limit_body_fits_one_frame",
+    "the_push_stream_is_not_a_membership_oracle"
+   ]
+  },
+  "count": 107
+ },
+ "normalization": "Normalized in #213; `files.json` re-transcribed in pass 3, which added the `stream` DSL key (the files domain is not expressible without it), restored the record's file request and reply shapes, repaired the split assertion fragments, and retired two cases whose subject - an unknown declared size - v2 does not represent."
 }

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -7,7 +7,7 @@
     "structural_validation": true,
     "selected_json_envelope_subject_slice": {
       "status": "partial",
-      "ci_selected_cases": 22
+      "ci_selected_cases": 24
     },
     "binary_byte_stream_executor": {
       "status": "partial",

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -46,12 +46,17 @@ const STREAMING_OPS = new Map([
 ]);
 // Client-originated stream faults expressible alongside a direction on an
 // upload's `stream` key. The vocabulary is closed so a misspelling fails loudly.
-// Only `client_abort` (a producer cancel after admission but before any DATA)
-// is executed by the harness today; the daemon must ACK it and reply
-// stream_aborted{cancelled}. The other client faults named by the framing
-// record (raw-record injection, credit-pause, transport-drop) and every
-// download-side fault remain declarative until the executor drives them.
-const STREAM_FAULTS = new Set(["client_abort"]);
+// Executed by the harness today:
+//   - `client_abort`: a producer cancel after admission but before any DATA;
+//     the daemon ACKs it and replies stream_aborted{cancelled}.
+//   - `raw_record`: a structurally malformed record (nonzero reserved byte) on
+//     the live binding; the daemon aborts only that stream with
+//     ABORT(protocol_error), the client ACKs, and the request resolves to the
+//     correlated malformed_frame reply while the connection stays usable.
+// Still declarative until the executor drives them: credit-pause and
+// transport-drop, and every download-side fault (the download path has no
+// executable single-subject fixture — see the manifest ledger).
+const STREAM_FAULTS = new Set(["client_abort", "raw_record"]);
 const KINDS = new Set(["success", "error", "malformed", "boundary", "authorization", "handshake", "push", "ordering"]);
 const PRE_OPEN_STREAM_CODES = new Set([
   "invalid_argument", "subject_absent", "room_not_available", "membership_ended",
@@ -108,6 +113,13 @@ const FILE_ERROR_KEYS = new Map([
   ["subject_absent", ["code"]],
   ["op_id_conflict", ["code", "op_id"]],
   ["file_index_unreadable", ["code"]],
+  // A stream-local malformed record on an admitted file.share resolves to the
+  // request's own correlated `malformed_frame` terminal reply (not a connection
+  // close), so it appears as a file-domain terminal. Its wire shape is the bare
+  // code — the daemon carries no extra fields (crates/jeliyad/src/serve.rs
+  // asserts `terminal.err == MalformedFrame`). It remains a transport code too
+  // (see TRANSPORT_CODE_FIXTURES), where it is represented by the 4007 close.
+  ["malformed_frame", ["code"]],
 ]);
 const TRANSPORT_CODE_FIXTURES = new Map([
   ["frame_too_large", "close_code_4005_is_emitted_for_frame_too_large"],
@@ -1379,7 +1391,8 @@ if (isObject(manifest)) {
       receive_bytes: "implemented_no_executable_case",
       bytes_streamed_observation: "implemented",
       client_abort_fault: "implemented",
-      raw_record_credit_pause_transport_drop_faults: "unimplemented",
+      raw_record_fault: "implemented",
+      credit_pause_transport_drop_faults: "unimplemented",
     },
     adapter_targeted_declarative_cases: "declarative_only",
   };


### PR DESCRIPTION
## What

Executes the `raw_record` client stream-fault control in the protocol-v2 conformance harness — the second of the four client-originated faults the framing record names (#233, R-B), after `client_abort`.

After the daemon admits a `file.share` upload, the client sends exactly one structurally malformed record on the live (request id, stream id) binding: a full, correlatable 48-byte header with a nonzero reserved byte. The daemon must abort **only that stream** with `ABORT(protocol_error)` at accepted offset zero, the client ACKs (0x05), and the request resolves to the correlated `malformed_frame` terminal reply while the connection stays usable — the "recoverable stream-local violation" leg of `docs/protocol-v2.md` § Malformed stream records.

No Rust changed: the daemon was already conformant (pinned by `websocket_data_too_large_within_frame_limit_aborts_stream_not_connection` in `crates/jeliyad/src/serve.rs`). The harness was the lagging side.

## Change surface (all conformance/corpus files)

- `conformance/v2/harness/stream.mjs` — `driveRawRecordUpload`, wired into `runUpload` beside `client_abort`; adversarial-review hardening (below).
- `conformance/v2/files.json` — one case transcribed from the record (`share_malformed_stream_record_aborts_that_stream_as_malformed_frame`).
- `scripts/check-v2-corpus.mjs` — `raw_record` added to the closed `STREAM_FAULTS` set; `malformed_frame` given its bare-code canonical file-error matcher (the daemon's real wire shape: serde `tag="code"` unit variant).
- `conformance/v2/manifest.json` + `conformance/v2/README.md` — executor ledger split truthfully (`raw_record_fault: implemented`; credit-pause and transport-drop still `unimplemented`); computed counts updated; original 2-space JSON indentation preserved.

## Adversarial review (two read-only reviewers) and what it changed

Claim 2 of the first slice (no false-green) broke in three windows, all closed in `79a29b3`:

1. **MAJOR** — a daemon could run the correct ABORT→ACK→`malformed_frame` exchange and *then close the connection* and still pass, though the spec requires "other requests remain usable". Fix: the driver now proves same-session usability with an unrelated idempotent `subject.ensure` after the terminal reply (carries no tracker, so it cannot perturb `bytes_streamed`).
2. **MINOR** — a second daemon ABORT after our ACK (a terminal control on a retired binding, malformed per the spec) was silently re-ACKed. Fix: rejected.
3. **pre-OPEN hardening** — `malformed_frame` added to `STREAM_ONLY_ERRORS` so a daemon cannot fabricate the outcome with a pre-OPEN reply that never admitted or examined the record.

A throwaway mock-session negative probe (not committed) confirmed each guard rejects its target misbehaviour for the *intended* reason — the first probe run tripped an unrelated check and was corrected before being trusted.

## What I ran (all in the `wave2/233-harness-faults` worktree)

- `node --test conformance/v2/harness/stream.test.mjs` — **47/47 pass**
- `node --test scripts/check-v2-corpus.test.mjs` — **19/19 pass**
- `node scripts/check-v2-corpus.mjs` — **346 cases, 2136 steps, OK** (exit 0)
- `cargo +1.96.0 build -p jeliyad` (harness target only; no Rust source changed — `git diff a84187f..HEAD` shows zero `.rs` files)
- Live replay vs a real daemon (`node conformance/v2/harness/main.mjs target/debug/jeliyad`) — **3/3 PASS**:
  - `share_malformed_stream_record_aborts_that_stream_as_malformed_frame` (new)
  - `share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled` (regression)
  - `a_frame_one_byte_past_max_frame_bytes_closes_4005_unparsed` (regression)

Not run (out of scope for this slice, no Rust/JS product code touched): full `cargo test --locked --workspace`, wasm-graph/docs/i18n gates.

## Honest residuals (unchanged, recorded in the manifest)

- `credit_pause` and `transport_drop` upload fault controls: qualified but not implemented here.
- Download-side faults (client as receiver): blocked on R-A — no single-subject executable download fixture exists (`file.read` needs a peer-fetched file).
- Full-corpus A/B measurement (R-C) not recorded; 15 cases still fail-as-expected behind U1–U4.

Closes part of #233.
