### PR TITLE
test(conformance): execute the upload-side credit_pause stream fault in the v2 harness (#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,9 +455,10 @@ jobs:
           # gate pins the reliably-green slice so a regression in the
           # implemented surface goes red. The file cases exercise the binary
           # byte-stream executor (upload streaming, pre-OPEN refusals with
-          # bytes_streamed 0, and a declared-size-mismatch stream) and both
-          # executed client-fault controls (producer cancel, stream-local
-          # malformed record); the at-limit and over-limit cases stream the
+          # bytes_streamed 0, and a declared-size-mismatch stream) and all
+          # three executed client-fault controls (producer cancel, stream-local
+          # malformed record, and a credit-paused upload stalling at zero
+          # accepted progress); the at-limit and over-limit cases stream the
           # served 100 MiB bound and stay local-only.
           node main.mjs ../../../target/debug/jeliyad \
             --case subject_ensure_creates_the_subject_on_a_fresh_daemon \
@@ -481,6 +482,7 @@ jobs:
             --case a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch \
             --case share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled \
             --case share_malformed_stream_record_aborts_that_stream_as_malformed_frame \
+            --case share_upload_paused_for_credit_stalls_and_terminates_transfer_stalled \
             --case list_of_a_room_that_is_not_available_answers_room_not_available \
             --case fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown \
             --case transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -30,23 +30,23 @@ claims:
 
 | Slice | Status | What the claim means |
 |---|---|---|
-| Structural validation | Implemented for all 346 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
-| Selected JSON-envelope/subject slice | Partial (22 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
-| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the two client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; and `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the credit-pause and transport-drop fault controls remain unimplemented, so backpressure and disconnect stream cases are still declarative. |
+| Structural validation | Implemented for all 347 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
+| Selected JSON-envelope/subject slice | Partial (25 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
+| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the three client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable; and `stream: {send_bytes, fault: "credit_pause"}`, a producer legally paused for credit (the upload-side form: the initial CREDIT window is consumed with no DATA at all) whose zero accepted progress must make the daemon abort the stream at accepted offset zero, draw the client ACK, and resolve `transfer_stalled{transferred_bytes: 0}` with the known declared total while the connection stays usable (the abort's wire reason is not asserted — the record grounds `operation_error` only for deadline expiry). The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the transport-drop fault control remains unimplemented, so disconnect stream cases are still declarative. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
 |---|---:|
-| Cases | 346 |
-| Attributed to an operation | 239 |
+| Cases | 347 |
+| Attributed to an operation | 240 |
 | `operation: null` | 107 |
-| Untargeted / in-process-core / client-adapter targeted | 340 / 1 / 5 |
+| Untargeted / in-process-core / client-adapter targeted | 341 / 1 / 5 |
 | Distinct step verbs in use | 7 |
 | Taxonomy codes / without a direct canonical operation case or verified transport representation | 64 / 8 (`forbidden_origin`, `pairing_code_invalid`, `protocol_unsupported`, `role_not_grantable`, `session_expired`, `storage_generation_mismatch`, `unauthenticated`, `unknown_operation`) |
 | Blocked on upstream | 15 (U1: 5, U2: 8, U3: 1, U4: 1) |
 | Blocked on a settled record contradiction | 1 |
 
-Per-file case totals are: `files.json` 45, `handshake.json` 72,
+Per-file case totals are: `files.json` 46, `handshake.json` 72,
 `invites.json` 37, `pipes.json` 43, `rooms.json` 65,
 `subject-daemon.json` 24, and `timeline-streams.json` 60.
 
@@ -266,7 +266,7 @@ is invalid, because no other operation streams. The value is a `<uint>`, a
 limit" without compiling the number in.
 
 An upload may carry an optional **`fault`** beside `send_bytes` to make the
-*client* misbehave on purpose. The vocabulary is closed. Two values are executed
+*client* misbehave on purpose. The vocabulary is closed. Three values are executed
 end-to-end by the single-subject harness today:
 
 - `client_abort`: after the daemon admits the stream (OPEN) but before any DATA
@@ -280,11 +280,22 @@ end-to-end by the single-subject harness today:
   accepted offset zero, the client ACKs (0x05), and the request resolves to the
   correlated `malformed_frame` reply while the connection stays usable — the
   "recoverable stream-local violation" leg of the framing record.
+- `credit_pause`: after admission the client consumes the daemon's initial
+  CREDIT window by sending no DATA at all — a producer legally paused for
+  credit, the upload-side (single-subject) form of the backpressure control.
+  Zero accepted progress for `transfer_stall_ms` must make the daemon abort the
+  stream at accepted offset zero, the client ACKs, and the request resolves to
+  `transfer_stalled{transferred_bytes: 0}` with the known declared total while
+  the connection stays usable (the abort's wire reason is not asserted — the
+  record grounds `operation_error` only for deadline expiry). The fixture's
+  size must make the stall window strictly shorter than the size-aware
+  absolute budget, or it would be asserting the wrong timer; the executor
+  proves that ordering from the served limits before idling.
 
 `fault` is legal only on `file.share`, because `file.read` has no executable
 download fixture at all (it needs a peer-fetched file the single-subject harness
-cannot stage). The record's remaining client faults — credit-pause and
-transport-drop — remain declarative until the executor drives them, and adding a
+cannot stage). The record's remaining client fault — transport-drop — remains
+declarative until the executor drives it, and adding a
 value here without the executor to run it is not permitted.
 
 A fresh admitted daemon `file.share` or `file.read` requires its matching stream.

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -703,6 +703,80 @@
       ]
     },
     {
+      "name": "share_upload_paused_for_credit_stalls_and_terminates_transfer_stalled",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "Proves a producer legally paused for credit -- it consumes the daemon's initial CREDIT window with no DATA at all, and an active transfer counts as connection activity so no idle timeout races it -- is neither left hanging nor answered at the wrong time: with zero accepted progress the daemon's stall window fires, the stream is aborted locally (daemon ABORT operation_error at accepted offset zero, acknowledged by the client) and only then does file.share terminate with transfer_stalled accounting zero transferred bytes against the known declared total, while the connection stays usable for later requests. Catches a daemon that ignores a zero-progress pause until the absolute deadline or forever, counts the unaccepted credit window as progress, replies without first aborting, miscounts accepted bytes, or closes the connection.",
+      "requires": [
+        "subject",
+        "room:live"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "CreditPause"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-creditpause-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "paused.bin",
+            "declared_bytes": 65536,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "transfer_stalled",
+              "transferred_bytes": 0,
+              "total": {
+                "state": "known",
+                "bytes": 65536
+              }
+            }
+          },
+          "op_id": "op-creditpause-2",
+          "stream": {
+            "send_bytes": 65536,
+            "fault": "credit_pause"
+          }
+        }
+      ]
+    },
+    {
       "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
       "kind": "boundary",
       "operation": "file.share",

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -634,6 +634,8 @@ export class Runner {
         inflightBytes: hello.limits?.max_transfer_bytes_inflight,
         concurrentLimit: hello.limits?.max_concurrent_transfers,
         stallMs: hello.limits?.transfer_stall_ms,
+        allowanceMs: hello.limits?.transfer_connect_allowance_ms,
+        floorBps: hello.limits?.transfer_floor_bits_per_second,
         waitMs,
       });
     } finally {

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -326,9 +326,9 @@ export function streamWaitMs(spec, servedLimits = {}, timeoutScale = 1) {
   return Math.min(waitMs, 80_000) * timeoutScale;
 }
 
-export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs = 60_000 }) {
+export async function runStreamingCall({ session, tracker, replyState, spec, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, allowanceMs, floorBps, waitMs = 60_000 }) {
   if (spec.send_bytes !== undefined) {
-    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs, fault: spec.fault });
+    return runUpload({ session, tracker, replyState, sendBytes: Number(spec.send_bytes), declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, allowanceMs, floorBps, waitMs, fault: spec.fault });
   }
   if (spec.receive_bytes !== undefined) {
     // Client-originated download faults (credit-pause, receiver ABORT) are not
@@ -423,7 +423,7 @@ async function yieldAfterSend(session, tracker) {
 }
 
 /** Upload: race a pre-OPEN terminal reply against OPEN, then honour CREDIT. */
-async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, waitMs, fault }) {
+async function runUpload({ session, tracker, replyState, sendBytes, declaredBytes, maxPayload, limitBytes, inflightBytes, concurrentLimit, stallMs, allowanceMs, floorBps, waitMs, fault }) {
   const first = await tracker.next(replyState, waitMs, 'OPEN or a pre-OPEN terminal reply');
   if (first.reply) {
     // Terminal before admission: zero bytes, no stream. A `stream`-carrying
@@ -472,6 +472,23 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   // aborts_stream_not_connection in crates/jeliyad/src/serve.rs).
   if (fault === 'raw_record') {
     return await driveRawRecordUpload({ session, tracker, replyState, waitMs, limitBytes });
+  }
+  // `credit_pause` is a legal credit-bounded pause: after admission the client
+  // consumes the initial CREDIT with NO DATA at all and waits, a producer
+  // correctly paused for credit (docs/protocol-v2.md § Credit and bounded
+  // backpressure: the producer "pauses both source reads and WebSocket writes
+  // when it has no credit"; an active transfer counts as connection activity,
+  // so idle_timeout_ms does not race it). The daemon's accepted progress stays
+  // at zero, so after transfer_stall_ms it must abort the stream and resolve
+  // the request to transfer_stalled{transferred_bytes: 0} — with a known total,
+  // since the OPEN total exists (the upload-side, single-subject form of the
+  // record's no-forward-progress case; matched by the daemon integration test
+  // websocket_file_share_no_progress_stalls_and_survives_exact_ack in
+  // crates/jeliyad/src/serve.rs). The stall must win the race with the
+  // absolute deadline for this declared size, or the fixture would be asserting
+  // the wrong timer — the driver proves the served budget ordering up front.
+  if (fault === 'credit_pause') {
+    return await driveCreditPauseUpload({ session, tracker, replyState, waitMs, declaredBytes, stallMs, allowanceMs, floorBps, limitBytes });
   }
   if (fault !== undefined) {
     throw new Error(`unknown stream fault ${JSON.stringify(fault)} on file.share`);
@@ -890,6 +907,216 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs, limi
   // malformed. (Anything arriving after this check, once the runner retires
   // the tracker, becomes the connection-fatal unbindable-record class and is
   // surfaced by the case-end sticky-violation scan.)
+  if (tracker.queue.length) {
+    throw new AssertFailure(
+      `daemon sent ${tracker.queue[0].kindName} for the retired stream after the terminal reply`,
+    );
+  }
+  if (tracker.failure) throw tracker.failure;
+  return reply;
+}
+
+/**
+ * Drive a legal credit-bounded upload pause. After OPEN the client consumes
+ * the daemon's initial CREDIT by sending NO DATA at all — a producer
+ * legitimately paused for credit with nothing to send — and holds the stream
+ * open. Accepted progress stays at zero, so the daemon's stall timer
+ * (transfer_stall_ms) must fire: it sends ABORT(operation_error, 0x05) at
+ * accepted offset zero, the client ACKs (kind 0x06, value 0x05, offset 0),
+ * and only then does the request resolve to the terminal typed error
+ * transfer_stalled{transferred_bytes: 0, total: known}.
+ *
+ * The served stall budget must win the race with the absolute deadline for
+ * this declared size (budget = transfer_connect_allowance_ms +
+ * ceil(declared*8*1000/floor)); the driver proves that ordering from the
+ * served limits BEFORE idling, so a fixture whose size would hit the deadline
+ * first (and thus assert the wrong timer) is an executor error, never a
+ * silent pass. A daemon that ignores a zero-progress pause, closes the
+ * connection, replies without first ABORTing, miscounts its accepted bytes,
+ * or answers with any other terminal fails here.
+ */
+async function driveCreditPauseUpload({ session, tracker, replyState, waitMs, declaredBytes, stallMs, allowanceMs, floorBps, limitBytes }) {
+  // The stall gauge contract: these served budgets must be positive JSON
+  // integers — a malformed value is an invalid configuration, never a
+  // disabled check (same rule the stall gauge applies to transfer_stall_ms).
+  if (typeof stallMs !== 'number' || !Number.isInteger(stallMs) || stallMs <= 0) {
+    throw new AssertFailure(`served transfer_stall_ms ${JSON.stringify(stallMs)} is unusable for the credit-pause fault`);
+  }
+  if (typeof allowanceMs !== 'number' || !Number.isInteger(allowanceMs) || allowanceMs < 0) {
+    throw new AssertFailure(`served transfer_connect_allowance_ms ${JSON.stringify(allowanceMs)} is unusable for the credit-pause fault`);
+  }
+  if (typeof floorBps !== 'number' || !Number.isInteger(floorBps) || floorBps <= 0) {
+    throw new AssertFailure(`served transfer_floor_bits_per_second ${JSON.stringify(floorBps)} is unusable for the credit-pause fault`);
+  }
+  // The served shared-file bound gates the upload credit window (the spec's
+  // wire bound is max_shared_file_bytes + 1 — the observation sentinel may
+  // legitimately exceed the OPEN total, so openTotal is NOT the bound here).
+  if (typeof limitBytes !== 'number' || !Number.isInteger(limitBytes) || limitBytes < 0) {
+    throw new AssertFailure(
+      `served max_shared_file_bytes ${JSON.stringify(limitBytes)} is unusable for byte streaming`,
+    );
+  }
+  const limit = limitBytes;
+  const declared = Number(declaredBytes);
+  if (!Number.isFinite(declared) || !Number.isInteger(declared) || declared < 0) {
+    throw new Error(`declared_bytes ${JSON.stringify(declaredBytes)} is unusable for the credit-pause fault`);
+  }
+  // The absolute budget the daemon arms at admission. For the stall to be the
+  // asserted timer it must be STRICTLY longer than the stall window; equality
+  // would make the outcome timer-order-dependent (the spec's ACTIVE race
+  // order is cancellation, then deadline, then stall), which a conformance
+  // case must never assert. A fixture/served-limits mismatch is an executor
+  // error (the runner's ERROR verdict), never a daemon conformance failure —
+  // the daemon is fully conformant under limits the fixture was not sized
+  // for, and blaming it would be a dishonest red.
+  const budgetMs = allowanceMs + Math.ceil((declared * 8 * 1000) / floorBps);
+  if (budgetMs <= stallMs) {
+    throw new Error(
+      `credit_pause fixture is mis-sized for these served limits: the absolute budget ${budgetMs}ms (allowance ${allowanceMs} + ceil(${declared}*8*1000/${floorBps})) does not strictly exceed transfer_stall_ms ${stallMs}, so the stall timer would not be the asserted outcome — a fixture/served-limits mismatch, not a daemon conformance failure`,
+    );
+  }
+  // The stall outcome must also be observable inside the harness patience
+  // (capped under the case watchdog): a served stall window at or beyond the
+  // wait cannot be awaited honestly, and timing out late would misreport it.
+  if (stallMs >= waitMs) {
+    throw new Error(
+      `credit_pause fixture is unrunnable under these served limits: transfer_stall_ms ${stallMs} is not observable within the harness patience ${waitMs}ms (capped under the case watchdog) — a fixture/served-limits mismatch, not a daemon conformance failure`,
+    );
+  }
+
+  const accepted = 0;
+  let abortSeen = null;
+  let ackSent = false;
+  let creditWindow = null;
+  for (;;) {
+    if (replyState.done && tracker.queue.length === 0) break;
+    const what = abortSeen
+      ? 'the terminal reply'
+      : creditWindow !== null
+        ? 'the stall ABORT'
+        : 'the initial CREDIT, a pre-emptive daemon ABORT, or the terminal reply';
+    const ev = await tracker.next(replyState, waitMs, what);
+    if (ev.reply) break;
+    const rec = ev.record;
+    checkBinding(tracker, rec);
+    // Per-direction ordering means nothing delivered after the daemon's ABORT
+    // can be an older in-flight record — the binding is retired by our ACK.
+    if (ackSent) {
+      throw new AssertFailure(`daemon sent ${rec.kindName} after its ABORT was acknowledged — the binding retired at ACK`);
+    }
+    if (rec.kind === KIND.CREDIT) {
+      // The initial send window is the pause's precondition: the client
+      // holds granted credit and sends nothing. Its offset must be zero
+      // (nothing was sent, so nothing can be acknowledged) and its value is
+      // bound by the upload wire bound max_shared_file_bytes + 1 — the
+      // one-byte observation sentinel may exceed the OPEN total, exactly as
+      // the normal upload path allows.
+      if (rec.payload) throw new AssertFailure('daemon CREDIT carried a payload');
+      if (rec.offset !== 0) {
+        throw new AssertFailure(
+          `daemon CREDIT acknowledged ${rec.offset} bytes when the client has sent none`,
+        );
+      }
+      if (rec.value > limit + 1) {
+        throw new AssertFailure(
+          `daemon CREDIT send_through ${rec.value} exceeds max_shared_file_bytes + 1 (${limit + 1})`,
+        );
+      }
+      if (creditWindow === null) {
+        creditWindow = rec.value;
+        continue;
+      }
+      // The client sent nothing and nothing was accepted, so cumulative
+      // credit may not move — an identical repeat is idempotent and legal,
+      // but any change would mean the daemon counted progress that never
+      // happened (or regressed a monotonic counter).
+      if (rec.value !== creditWindow) {
+        throw new AssertFailure(
+          `daemon moved cumulative CREDIT (send_through ${creditWindow} -> ${rec.value}) while the client was paused at zero sent bytes`,
+        );
+      }
+      continue;
+    }
+    if (rec.kind === KIND.ABORT) {
+      // The stall (or any ACTIVE-race) abort. A zero-progress pause can only
+      // be aborted at accepted offset zero — validateAbort already bounds the
+      // offset by the zero bytes actually sent — and the ABORT must precede
+      // the typed terminal reply (reply only after ACK).
+      validateAbort(rec, accepted, UPLOAD_DAEMON_ABORT_REASONS);
+      if (tracker.replySeq !== undefined) {
+        // Observable prefix only: this catches a reply that arrived with (or
+        // before) the ABORT itself. A reply the daemon SENT after the ABORT
+        // but before reading our ACK crosses the ACK on the wire and is not
+        // distinguishable from a legal post-ACK reply by a black-box client;
+        // that deeper obligation is unobservable here (the same boundary the
+        // client_abort and raw_record drivers document).
+        throw new AssertFailure('daemon sent its terminal reply before receiving the stall ABORT acknowledgement');
+      }
+      abortSeen = rec;
+      tracker.accepted = accepted;
+      session.sendBinary(
+        encodeRecord({ kind: KIND.ACK, id: tracker.id, streamId: tracker.streamId, offset: accepted, value: 0x05 }),
+      );
+      ackSent = true;
+      continue;
+    }
+    throw new AssertFailure(`daemon sent unexpected ${rec.kindName} while the client was paused for credit`);
+  }
+  if (tracker.queue.length) {
+    throw new AssertFailure(`daemon sent ${tracker.queue[0].kindName} after the terminal reply`);
+  }
+  if (!abortSeen) {
+    throw new AssertFailure(
+      'file.share resolved without a daemon ABORT while the client was paused at zero accepted progress',
+    );
+  }
+  const reply = await settleReply(replyState);
+  if (reply && reply.ok) {
+    throw new AssertFailure('file.share replied success for a stream the daemon aborted at zero progress');
+  }
+  const err = (reply && reply.err) || {};
+  if (err.code !== 'transfer_stalled') {
+    throw new AssertFailure(
+      `a zero-progress credit pause must resolve to transfer_stalled, got ${JSON.stringify(reply.err)}`,
+    );
+  }
+  if (err.transferred_bytes !== undefined && err.transferred_bytes !== accepted) {
+    throw new AssertFailure(
+      `terminal transferred_bytes ${err.transferred_bytes} disagrees with the ${accepted} receiver-accepted bytes`,
+    );
+  }
+  if (err.total !== undefined) {
+    if (!err.total || err.total.state !== 'known' || err.total.bytes !== tracker.openTotal) {
+      throw new AssertFailure(
+        `terminal total ${JSON.stringify(err.total)} disagrees with the admitted OPEN total ${tracker.openTotal}`,
+      );
+    }
+  }
+  if (abortSeen) {
+    // Bind the ABORT's claimed reason to the terminal reply — the same
+    // correlation the normal upload and download paths enforce: reasons
+    // 0x01-0x03 must resolve to stream_aborted carrying that reason, 0x04 to
+    // malformed_frame, and operation_error to the typed operation error. A
+    // daemon that ABORTs claiming cancelled or sink_failed and then replies
+    // transfer_stalled contradicts its own claimed reason; a daemon that
+    // ABORTs with protocol_error and replies transfer_stalled resolves the
+    // wrong error class.
+    checkAbortReplyCorrelation(abortSeen, reply, { accepted: abortSeen.offset, total: tracker.openTotal });
+  }
+  // A stream-local terminal failure must leave the connection usable, exactly
+  // like the raw_record leg: prove it with an unrelated idempotent call on
+  // the same session after the terminal reply (subject.ensure carries no
+  // tracker, so it cannot perturb a later bytes_streamed observation).
+  const liveness = await session.call('subject.ensure', {}, { timeoutMs: Math.min(waitMs, 10_000) });
+  if (!liveness || !liveness.ok) {
+    throw new AssertFailure(
+      `connection was not usable after a stall-aborted upload: ${JSON.stringify(liveness)}`,
+    );
+  }
+  // Re-examine the retired stream after the liveness await: late traffic on a
+  // binding retired by the ACK is malformed and must surface here rather than
+  // pass (anything after the runner retires the tracker is the connection-
+  // fatal unbindable-record class, caught by the case-end sticky scan).
   if (tracker.queue.length) {
     throw new AssertFailure(
       `daemon sent ${tracker.queue[0].kindName} for the retired stream after the terminal reply`,

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -985,6 +985,10 @@ async function driveCreditPauseUpload({ session, tracker, replyState, waitMs, de
   }
 
   const accepted = 0;
+  // Stamped when this driver takes over (OPEN delivered) — the daemon's stall
+  // timer starts at admission, strictly earlier, which is why the lower-bound
+  // check below carries slack for that delivery offset.
+  const openReceivedAt = Date.now();
   let abortSeen = null;
   let ackSent = false;
   let creditWindow = null;
@@ -1043,6 +1047,30 @@ async function driveCreditPauseUpload({ session, tracker, replyState, waitMs, de
       // offset by the zero bytes actually sent — and the ABORT must precede
       // the typed terminal reply (reply only after ACK).
       validateAbort(rec, accepted, UPLOAD_DAEMON_ABORT_REASONS);
+      // The pause's PREMISE is the initial CREDIT window: the record makes
+      // the receiver's initial CREDIT after OPEN mandatory ("The receiver
+      // sends initial CREDIT after OPEN"), and this fixture holds that window
+      // unsent. A daemon that aborts before granting it was never paused FOR
+      // CREDIT — accepting its ABORT would let a CREDIT-omitting daemon pass
+      // the case the premise exists to pin.
+      if (creditWindow === null) {
+        throw new AssertFailure(
+          'daemon ABORTed before sending the mandatory initial CREDIT — the credit-pause premise was never established',
+        );
+      }
+      // The stall window must have elapsed before transfer_stalled is a
+      // truthful code ("No forward progress within the stall window"): the
+      // daemon's timer starts at admission, the harness stamps OPEN at
+      // delivery (a strictly later instant), so the bound carries slack for
+      // that delivery offset rather than false-reding a compliant daemon.
+      // Only the LOWER bound is asserted — how long the daemon waited past
+      // the window is deadline territory, owned by deadline-designed
+      // fixtures, and an upper bound would trade determinism for flake.
+      if (Date.now() - openReceivedAt < stallMs - Math.min(5_000, Math.floor(stallMs / 2))) {
+        throw new AssertFailure(
+          `daemon ABORTed the zero-progress pause ${Date.now() - openReceivedAt}ms after OPEN, before the served transfer_stall_ms ${stallMs} window elapsed — transfer_stalled is not yet a truthful outcome`,
+        );
+      }
       if (tracker.replySeq !== undefined) {
         // Observable prefix only: this catches a reply that arrived with (or
         // before) the ABORT itself. A reply the daemon SENT after the ABORT

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -7,7 +7,7 @@
     "structural_validation": true,
     "selected_json_envelope_subject_slice": {
       "status": "partial",
-      "ci_selected_cases": 24
+      "ci_selected_cases": 25
     },
     "binary_byte_stream_executor": {
       "status": "partial",
@@ -16,7 +16,8 @@
       "bytes_streamed_observation": "implemented",
       "client_abort_fault": "implemented",
       "raw_record_fault": "implemented",
-      "credit_pause_transport_drop_faults": "unimplemented"
+      "credit_pause_fault": "implemented",
+      "transport_drop_fault": "unimplemented"
     },
     "adapter_targeted_declarative_cases": "declarative_only"
   },
@@ -117,16 +118,16 @@
     }
   ],
   "target_counts": {
-    "untargeted": 340,
+    "untargeted": 341,
     "daemon": 0,
     "in_process_core": 1,
     "client_adapter": 5
   },
   "totals": {
-    "cases": 346,
-    "attributed_to_an_operation": 239,
+    "cases": 347,
+    "attributed_to_an_operation": 240,
     "not_operation_scoped": 107,
-    "conforming_to_the_dsl": 346,
+    "conforming_to_the_dsl": 347,
     "distinct_step_verbs_in_use": 7,
     "quarantined": 0,
     "blocked_on_upstream": 15,
@@ -134,8 +135,8 @@
   },
   "per_file_totals": {
     "files.json": {
-      "cases": 45,
-      "attributed_to_an_operation": 43,
+      "cases": 46,
+      "attributed_to_an_operation": 44,
       "not_operation_scoped": 2,
       "blocked_on_upstream": {
         "U1": 0,
@@ -269,7 +270,7 @@
       "satisfies_required_kinds": true
     },
     "file.share": {
-      "cases": 16,
+      "cases": 17,
       "success": true,
       "distinctive_code": "declared_size_mismatch",
       "distinctive_code_has_a_case": true,

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -53,10 +53,15 @@ const STREAMING_OPS = new Map([
 //     the live binding; the daemon aborts only that stream with
 //     ABORT(protocol_error), the client ACKs, and the request resolves to the
 //     correlated malformed_frame reply while the connection stays usable.
-// Still declarative until the executor drives them: credit-pause and
-// transport-drop, and every download-side fault (the download path has no
-// executable single-subject fixture — see the manifest ledger).
-const STREAM_FAULTS = new Set(["client_abort", "raw_record"]);
+//   - `credit_pause`: a producer legally paused for credit (the upload-side,
+//     single-subject form — the client consumes the initial CREDIT window with
+//     no DATA); zero accepted progress for transfer_stall_ms must abort the
+//     stream and resolve transfer_stalled{transferred_bytes: 0}.
+// Still declarative until the executor drives them: transport-drop, and every
+// download-side fault (the download path has no executable single-subject
+// fixture — see the manifest ledger; download-side credit-pause is parked on
+// the same R-A gap).
+const STREAM_FAULTS = new Set(["client_abort", "raw_record", "credit_pause"]);
 const KINDS = new Set(["success", "error", "malformed", "boundary", "authorization", "handshake", "push", "ordering"]);
 const PRE_OPEN_STREAM_CODES = new Set([
   "invalid_argument", "subject_absent", "room_not_available", "membership_ended",
@@ -1392,7 +1397,8 @@ if (isObject(manifest)) {
       bytes_streamed_observation: "implemented",
       client_abort_fault: "implemented",
       raw_record_fault: "implemented",
-      credit_pause_transport_drop_faults: "unimplemented",
+      credit_pause_fault: "implemented",
+      transport_drop_fault: "unimplemented",
     },
     adapter_targeted_declarative_cases: "declarative_only",
   };


### PR DESCRIPTION
## Summary

Executes the third client-originated upload fault the single-subject conformance
harness can drive end-to-end: `stream: {send_bytes, fault: "credit_pause"}`.
After admission the client consumes the daemon's initial CREDIT window by
sending no DATA at all — a producer legally paused for credit — and the
daemon's zero-accepted-progress stall window must fire: it aborts the stream at
accepted offset zero, the client ACKs (0x05), and the request resolves to
`transfer_stalled{transferred_bytes: 0, total: {state: known, bytes: declared}}`
while the connection stays usable (proved by a post-terminal `subject.ensure`
on the same session).

The fixture is transcribed from `docs/protocol-v2.md` (§Credit and bounded
backpressure, §END, abort, and cancellation, §Disconnects and retries;
transferred-byte counting; the error table), never from the implementation.
`declared_bytes` 65536 is chosen so the served stall window (30 s) strictly
precedes the size-aware absolute budget (5 s + 64 s = 69 s) — and the executor
PROVES that ordering from the served limits before idling, so a mis-sized
fixture is an executor error, never a false verdict.

Change surface (7 files, no Rust — the daemon was already conformant, pinned by
`websocket_file_share_no_progress_stalls_and_survives_exact_ack`):

- `conformance/v2/harness/stream.mjs` — `driveCreditPauseUpload` beside
  `client_abort`/`raw_record`; guards: initial CREDIT shape and wire bound
  (`max_shared_file_bytes + 1`; the +1 observation sentinel may exceed the OPEN
  total), no cumulative-credit movement during the pause (idempotent repeats
  legal), reply-before-ACK, post-ACK traffic, wrong terminals, dishonest
  byte/total accounting, ABORT-reason↔terminal correlation, post-terminal
  liveness, late traffic on the retired binding.
- `conformance/v2/files.json` — one new case:
  `share_upload_paused_for_credit_stalls_and_terminates_transfer_stalled`.
- `scripts/check-v2-corpus.mjs` — `credit_pause` in the closed `STREAM_FAULTS`;
  executor ledger split (`credit_pause_fault` implemented /
  `transport_drop_fault` unimplemented — sibling branch).
- `conformance/v2/manifest.json`, `conformance/v2/README.md` — ledgers and
  computed counts in lockstep (347 cases, files.json 46, file.share 17, CI
  slice 25). Drive-by honesty fix: README's stale "22 CI-selected cases"
  corrected (the manifest already said 24; CI now runs 25 with the new case).
- `.github/workflows/ci.yml` — the new case in the live replay slice.

Download-side credit-pause stays parked on R-A (no single-subject download
fixture) — not claimed anywhere in this PR.

## What was run (this worktree, against target/debug/jeliyad)

1. `node --test conformance/v2/harness/stream.test.mjs` — 47/47 pass
2. `node --test scripts/check-v2-corpus.test.mjs` — 19/19 pass
3. `node scripts/check-v2-corpus.mjs` — 347 cases OK
4. Full CI selector list (25 cases, extracted from ci.yml) replayed live —
   25/25 PASS (`--verbose` shows the new case resolving
   `err {"code":"transfer_stalled","transferred_bytes":0,"total":{"state":"known","bytes":65536}}`,
   accepted 0)
5. Negative probes (throwaway mock-session script, deleted before commit):
   16/16 — every new guard rejected its target misbehaviour FOR THE INTENDED
   REASON; legal-path controls passed (including the sentinel-window
   allowance and idempotent repeated CREDIT).
6. Adversarial review: 2 read-only claim-attack reviewers (executor guards
   C1–C8; ledger/independence L1–L6). Findings fixed in-commit: stall-ABORT
   reason now bound to the terminal via `checkAbortReplyCorrelation`; mis-sized
   fixtures (budget ≤ stall, or stall beyond harness patience) are plain
   executor errors (ERROR verdict) instead of blaming a conformant daemon;
   README no longer asserts the stall ABORT's wire reason (the record grounds
   `operation_error` only for deadline expiry). One rejected-with-reason: the
   ACK-ordering observability boundary (a reply sent after the ABORT but before
   the daemon reads our ACK crosses our ACK on the wire and is indistinguishable
   from a legal post-ACK reply by a black-box client) — documented in place,
   same boundary as both merged sibling drivers. Post-fix: 4/4 targeted
   re-probes; all four gates re-run green.

Closes part of #233 (the upload-side credit-pause slice). Download-side
credit-pause and the download corpus remain parked on R-A.
