### PR TITLE
test(conformance): execute the transport_drop stream fault in the v2 harness (#233)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,10 +455,12 @@ jobs:
           # gate pins the reliably-green slice so a regression in the
           # implemented surface goes red. The file cases exercise the binary
           # byte-stream executor (upload streaming, pre-OPEN refusals with
-          # bytes_streamed 0, and a declared-size-mismatch stream) and both
-          # executed client-fault controls (producer cancel, stream-local
-          # malformed record); the at-limit and over-limit cases stream the
-          # served 100 MiB bound and stay local-only.
+          # bytes_streamed 0, and a declared-size-mismatch stream) and all
+          # three executed client-fault controls (producer cancel, stream-local
+          # malformed record, and a transport-dropped partial upload whose
+          # op_id replay must return the recorded stream_aborted{transport_
+          # lost}); the at-limit and over-limit cases stream the served
+          # 100 MiB bound and stay local-only.
           node main.mjs ../../../target/debug/jeliyad \
             --case subject_ensure_creates_the_subject_on_a_fresh_daemon \
             --case subject_ensure_never_returns_secret_material \
@@ -481,6 +483,7 @@ jobs:
             --case a_stream_that_disagrees_with_its_declaration_is_declared_size_mismatch \
             --case share_cancelled_by_the_client_before_any_bytes_aborts_as_cancelled \
             --case share_malformed_stream_record_aborts_that_stream_as_malformed_frame \
+            --case share_upload_transport_drop_records_stream_aborted_for_replay \
             --case list_of_a_room_that_is_not_available_answers_room_not_available \
             --case fetch_of_a_file_id_not_in_this_rooms_history_fails_with_file_unknown \
             --case transfer_cancel_of_an_unknown_op_id_fails_with_transfer_unknown

--- a/conformance/v2/README.md
+++ b/conformance/v2/README.md
@@ -30,23 +30,23 @@ claims:
 
 | Slice | Status | What the claim means |
 |---|---|---|
-| Structural validation | Implemented for all 346 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
-| Selected JSON-envelope/subject slice | Partial (22 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
-| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the two client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; and `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the credit-pause and transport-drop fault controls remain unimplemented, so backpressure and disconnect stream cases are still declarative. |
+| Structural validation | Implemented for all 347 cases | `scripts/check-v2-corpus.mjs` parses every fixture and validates the closed DSL vocabulary, strengthened file-domain assertion/error semantics (including per-case `$variable` binding in `files.json`), and manifest ledgers. It does not establish every case's semantic correctness and is not protocol evidence. |
+| Selected JSON-envelope/subject slice | Partial (25 CI-selected cases) | The Node harness runs this selected JSON-envelope, subject-lifecycle, and executable-file slice against `jeliyad`; this is not corpus coverage. It is not a smoke, E2E, or Dart execution claim. |
+| Binary byte-stream executor | Partial | The harness encodes/decodes Binary OPEN/DATA/CREDIT/END/ABORT/ACK records and drives `stream: {send_bytes}` uploads and `stream: {receive_bytes}` downloads with real receiver-accepted `bytes_streamed` accounting. It also drives the three client-originated upload faults the single-subject harness can execute end-to-end: `stream: {send_bytes, fault: "client_abort"}`, a producer cancel before any DATA that must draw the daemon's ACK and a `stream_aborted{cancelled}` terminal accounting for zero accepted bytes; `stream: {send_bytes, fault: "raw_record"}`, one structurally malformed record (nonzero reserved byte) on the live binding that must draw a stream-local daemon ABORT(protocol_error), the client ACK, and a correlated `malformed_frame` terminal reply while the connection stays usable; and `stream: {send_bytes, fault: "transport_drop"}`, a pre-END transport loss on a healthy partial upload (one CREDIT-acknowledged DATA record, then the socket dropped with no close frame — the same disconnect the `control: {do: disconnect}` verb drives, needed here mid-duplex-call where a control step cannot run) whose op_id replay on a reconnected same-principal session must return the recorded `stream_aborted{transport_lost}` with exactly the acknowledged byte count, open no second stream, and author no share. A transport_drop step carries no expect and no save — it has no terminal reply to match, and the recorded outcome is asserted by the replay step. The download path still has no executable fixture (`resource:fetched_file` and `link:*` preconditions are unestablishable single-subject), and the credit-pause fault control remains unimplemented on this branch (its upload-side executor lands separately), so backpressure cases are still declarative here. |
 | Adapter-target executors | Unimplemented / declarative | Cases may name adapters to which they apply, but no executor proves an in-process-core or client-adapter obligation. A target mismatch is not a pass. |
 
 | Computed corpus fact | Value |
 |---|---:|
-| Cases | 346 |
-| Attributed to an operation | 239 |
+| Cases | 347 |
+| Attributed to an operation | 240 |
 | `operation: null` | 107 |
-| Untargeted / in-process-core / client-adapter targeted | 340 / 1 / 5 |
+| Untargeted / in-process-core / client-adapter targeted | 341 / 1 / 5 |
 | Distinct step verbs in use | 7 |
 | Taxonomy codes / without a direct canonical operation case or verified transport representation | 64 / 8 (`forbidden_origin`, `pairing_code_invalid`, `protocol_unsupported`, `role_not_grantable`, `session_expired`, `storage_generation_mismatch`, `unauthenticated`, `unknown_operation`) |
 | Blocked on upstream | 15 (U1: 5, U2: 8, U3: 1, U4: 1) |
 | Blocked on a settled record contradiction | 1 |
 
-Per-file case totals are: `files.json` 45, `handshake.json` 72,
+Per-file case totals are: `files.json` 46, `handshake.json` 72,
 `invites.json` 37, `pipes.json` 43, `rooms.json` 65,
 `subject-daemon.json` 24, and `timeline-streams.json` 60.
 
@@ -266,7 +266,7 @@ is invalid, because no other operation streams. The value is a `<uint>`, a
 limit" without compiling the number in.
 
 An upload may carry an optional **`fault`** beside `send_bytes` to make the
-*client* misbehave on purpose. The vocabulary is closed. Two values are executed
+*client* misbehave on purpose. The vocabulary is closed. Three values are executed
 end-to-end by the single-subject harness today:
 
 - `client_abort`: after the daemon admits the stream (OPEN) but before any DATA
@@ -280,12 +280,26 @@ end-to-end by the single-subject harness today:
   accepted offset zero, the client ACKs (0x05), and the request resolves to the
   correlated `malformed_frame` reply while the connection stays usable — the
   "recoverable stream-local violation" leg of the framing record.
+- `transport_drop`: after admission the client streams one healthy partial DATA
+  record and waits for the cumulative CREDIT that proves the daemon accepted
+  those bytes, then drops the WebSocket with no close frame — the same
+  transport loss the `control: {do: disconnect}` verb drives, needed here in
+  the middle of a duplex streaming call where a control step cannot run. No
+  byte stream survives its connection: the daemon must abort the share, remove
+  staging, release its reservation, author no event, and, under the request's
+  `op_id`, record `stream_aborted{transport_lost}` carrying exactly the
+  acknowledged byte count. The step has no terminal reply on that connection,
+  so a `transport_drop` stream step carries **no `expect` and no `save`** (there
+  is nothing to match or capture — fabricating one is forbidden); the recorded
+  outcome is asserted by the fixture's reconnect + same-`op_id` replay step,
+  which must return the recorded failure without opening a second stream.
 
 `fault` is legal only on `file.share`, because `file.read` has no executable
 download fixture at all (it needs a peer-fetched file the single-subject harness
-cannot stage). The record's remaining client faults — credit-pause and
-transport-drop — remain declarative until the executor drives them, and adding a
-value here without the executor to run it is not permitted.
+cannot stage). The record's remaining client fault — credit-pause — remains
+declarative until its executor lands (the upload-side executor arrives on a
+sibling branch), and adding a value here without the executor to run it is not
+permitted.
 
 A fresh admitted daemon `file.share` or `file.read` requires its matching stream.
 A terminal refusal before OPEN has no stream and records zero receiver-accepted

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -703,6 +703,143 @@
       ]
     },
     {
+      "name": "share_upload_transport_drop_records_stream_aborted_for_replay",
+      "kind": "error",
+      "operation": "file.share",
+      "intent": "Proves no byte stream survives its WebSocket connection: an upload whose transport drops after the daemon has CREDIT-acknowledged a healthy partial record -- one full 65536-byte window of a 131072-byte declaration, before any END -- must be aborted with all staging dropped, no authored share, and, under the request's op_id, a recorded stream_aborted{transport_lost} carrying exactly the bytes the daemon can prove it accepted, so the same principal's replay of that op_id returns the recorded failure without opening a second stream. Catches a daemon that leaves the op_id unrecorded (a replay would re-stream from zero), records success or a different reason, miscounts the accepted bytes, or authors the share despite losing the transport.",
+      "requires": [
+        "subject",
+        "room:live",
+        "control:reconnect"
+      ],
+      "steps": [
+        {
+          "upgrade": {
+            "query": {
+              "v": 2,
+              "sg": "$daemon.storage_generation"
+            },
+            "headers": {
+              "Authorization": "Bearer <bearer_from_portfile>"
+            }
+          }
+        },
+        {
+          "await": {
+            "frame": {
+              "t": "hello"
+            }
+          }
+        },
+        {
+          "call": "room.create",
+          "in": {
+            "name": "TransportDrop"
+          },
+          "save": {
+            "rid": "out.room_id"
+          },
+          "op_id": "op-tdrop-1"
+        },
+        {
+          "call": "room.activate",
+          "in": {
+            "room_id": "$rid"
+          },
+          "expect": {
+            "ok": true
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "dropped.bin",
+            "declared_bytes": 131072,
+            "declared_content_type": "application/octet-stream"
+          },
+          "note": "The executor streams one full 65536-byte DATA window, waits for the cumulative CREDIT that proves the daemon accepted it, then drops the socket with no close frame. The step has no terminal reply on this connection, so it carries no expect and no save.",
+          "op_id": "op-tdrop-2",
+          "stream": {
+            "send_bytes": 131072,
+            "fault": "transport_drop"
+          }
+        },
+        {
+          "control": {
+            "do": "reconnect",
+            "on": "subject:self"
+          }
+        },
+        {
+          "call": "file.share",
+          "in": {
+            "room_id": "$rid",
+            "name": "dropped.bin",
+            "declared_bytes": 131072,
+            "declared_content_type": "application/octet-stream"
+          },
+          "expect": {
+            "ok": false,
+            "err": {
+              "code": "stream_aborted",
+              "transferred_bytes": 65536,
+              "total": {
+                "state": "known",
+                "bytes": 131072
+              },
+              "reason": "transport_lost"
+            }
+          },
+          "op_id": "op-tdrop-2"
+        },
+        {
+          "assert": [
+            {
+              "observe": "bytes_streamed",
+              "call": "step:5",
+              "value": {
+                "op": "eq",
+                "value": 65536
+              }
+            },
+            {
+              "observe": "bytes_streamed",
+              "call": "step:7",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "call": "file.list",
+          "in": {
+            "room_id": "$rid",
+            "cursor": {
+              "state": "start"
+            },
+            "direction": "forward",
+            "limit": 50
+          },
+          "on": "subject:self"
+        },
+        {
+          "assert": [
+            {
+              "path": "out.files",
+              "op": "len",
+              "value": {
+                "op": "eq",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "share_one_byte_past_the_served_limit_is_refused_at_stage_declared",
       "kind": "boundary",
       "operation": "file.share",

--- a/conformance/v2/files.json
+++ b/conformance/v2/files.json
@@ -826,6 +826,7 @@
           "on": "subject:self"
         },
         {
+          "note": "The settled staging-residue half of the no_durable_mutation observation proves the aborted upload left no stranded staging file; the signature half compares against the baseline refreshed after file.list, so only post-list mutation fails it. Reservation release is not observable here (the served inflight budget dwarfs one upload) and stays pinned by the daemon's own integration test.",
           "assert": [
             {
               "path": "out.files",
@@ -834,6 +835,10 @@
                 "op": "eq",
                 "value": 0
               }
+            },
+            {
+              "observe": "no_durable_mutation",
+              "scope": "step"
             }
           ]
         }

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -514,8 +514,14 @@ export class Runner {
         // reply to expose, and fabricating one is forbidden), the call
         // counts as not-ok for the refused-baseline semantics, and the
         // validator forbids expect/save on this shape so no matcher ever
-        // runs. The tracker's accepted count (already recorded) is what a
-        // later bytes_streamed observation reads.
+        // runs. The reply roots are CLEARED, not left holding the previous
+        // step's reply — a later assert or save-only step reading out/err/
+        // frame must find nothing rather than silently match stale values
+        // from before the drop. The tracker's accepted count (already
+        // recorded) is what a later bytes_streamed observation reads.
+        vars.out = undefined;
+        vars.err = undefined;
+        vars.frame = undefined;
         ctxState.lastCallOk = false;
         ctxState.networkActivity++;
         this.log(`  -> transport dropped (accepted ${record.accepted})`);

--- a/conformance/v2/harness/runner.mjs
+++ b/conformance/v2/harness/runner.mjs
@@ -12,7 +12,7 @@ import { startDaemon } from './daemon.mjs';
 import { Session } from './session.mjs';
 import { AssertContext, AssertFailure, TransportFailure, evalAssert, subsetMatch } from './assert.mjs';
 import { resolvePath, resolveValue } from './values.mjs';
-import { CallStreamTracker, maxDataPayloadBytes, runStreamingCall, streamWaitMs } from './stream.mjs';
+import { CallStreamTracker, maxDataPayloadBytes, runStreamingCall, streamWaitMs, isTransportDroppedMarker } from './stream.mjs';
 
 /** The outcome of one case. */
 export const Outcome = {
@@ -507,6 +507,20 @@ export class Runner {
     let reply;
     if (streamSpec) {
       reply = await this.#streamCall(s, step.call, input, streamSpec, { opId, record });
+      if (isTransportDroppedMarker(reply)) {
+        // A transport_drop step ends with NO terminal reply on the wire —
+        // the socket is deliberately dropped pre-END. Treat the step as
+        // reply-less: nothing is exposed under out/err/frame (there is no
+        // reply to expose, and fabricating one is forbidden), the call
+        // counts as not-ok for the refused-baseline semantics, and the
+        // validator forbids expect/save on this shape so no matcher ever
+        // runs. The tracker's accepted count (already recorded) is what a
+        // later bytes_streamed observation reads.
+        ctxState.lastCallOk = false;
+        ctxState.networkActivity++;
+        this.log(`  -> transport dropped (accepted ${record.accepted})`);
+        return reply;
+      }
       this.log(`  -> ${reply.ok ? 'ok' : 'err ' + JSON.stringify(reply.err)} (accepted ${record.accepted})`);
     } else {
       const { id, reply: replyPromise } = s.startCall(step.call, input, { opId });

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -961,9 +961,17 @@ async function driveTransportDropUpload({ session, tracker, replyState, sendByte
   // One full window is the only healthy partial the daemon's refill policy
   // acknowledges mid-file; a declared total within one window would make the
   // acknowledgement arrive only with the whole file, which is not a partial.
-  if (!Number.isInteger(sendBytes) || sendBytes <= maxPayload) {
+  // Both quantities gate the design: the OPEN total (already validated equal
+  // to declared_bytes by the caller) must exceed one window so the record is
+  // a genuine partial of the declaration, and send_bytes must cover the
+  // window so the record stays within the bytes the fixture declares it
+  // streams. send_bytes alone is not enough — it is deliberately independent
+  // of declared_bytes in the DSL, so a fixture declaring less than it sends
+  // would otherwise slip a whole-file or over-declaration record through and
+  // misreport the daemon's refusal as a conformance failure.
+  if (!Number.isInteger(sendBytes) || sendBytes < maxPayload || tracker.openTotal <= maxPayload) {
     throw new Error(
-      `transport_drop needs a declared total above one DATA window (${maxPayload} bytes) so a single full-window record is a healthy partial, got ${sendBytes}`,
+      `transport_drop needs a declared total (OPEN ${tracker.openTotal}) above one DATA window (${maxPayload} bytes) and a send_bytes (${sendBytes}) that covers the window, so a single full-window record is a healthy partial — a fixture/executor sizing mismatch, not a daemon conformance failure`,
     );
   }
   const chunkLen = maxPayload;
@@ -1045,8 +1053,27 @@ async function driveTransportDropUpload({ session, tracker, replyState, sendByte
           );
         }
         if (rec.value < chunkLen) {
-          throw new AssertFailure(
-            `daemon initial CREDIT window ${rec.value} cannot carry the one full-window DATA record (${chunkLen}) this fault sends`,
+          // A window smaller than the design's one full record is not a
+          // daemon violation — the record makes maxPayload a per-record
+          // maximum only, and the receiver's byte-bounded capacity may be
+          // any smaller window. But this fixture's one-full-window partial
+          // (and its exact byte-count assertions) are sized to the canonical
+          // window, so a divergent flow-control window is a fixture/limits
+          // mismatch: an executor error, never a conformance failure blamed
+          // on the daemon. Truly honoring arbitrary windows needs the
+          // fixture's transferred_bytes to be dynamic — recorded as a
+          // follow-up, not silently accepted here.
+          throw new Error(
+            `transport_drop fixture is mis-sized for this daemon's flow control: the initial CREDIT window is ${rec.value} bytes, not the one full window (${chunkLen}) this fixture's partial and its byte-count assertions are built on — a fixture/limits mismatch, not a daemon conformance failure`,
+          );
+        }
+        if (rec.value > chunkLen) {
+          // Larger windows break the design the other way: one record would
+          // not consume the window, so the refill policy would never
+          // acknowledge mid-file and the drop precondition could not be
+          // established honestly. Same mismatch class.
+          throw new Error(
+            `transport_drop fixture is mis-sized for this daemon's flow control: the initial CREDIT window is ${rec.value} bytes, larger than the one full window (${chunkLen}) the single-record partial is built on, so no mid-file acknowledgement would ever arrive — a fixture/limits mismatch, not a daemon conformance failure`,
           );
         }
         creditWindow = rec.value;
@@ -1074,6 +1101,17 @@ async function driveTransportDropUpload({ session, tracker, replyState, sendByte
         acknowledged = rec.offset;
         tracker.accepted = acknowledged;
         prevCredit = { offset: rec.offset, value: rec.value };
+        // The transport has NOT dropped yet: if the daemon already settled a
+        // terminal reply (batched with this CREDIT — Session stamps
+        // replySeq synchronously on delivery), it fabricated an outcome
+        // while the connection was still live. The drop must never bury that
+        // violation; the same wire-order stamp the sibling drivers check is
+        // authoritative here too.
+        if (tracker.replySeq !== undefined) {
+          throw new AssertFailure(
+            'daemon settled its terminal reply before the transport dropped — the request was still live on an open connection',
+          );
+        }
         // The precondition is proven: the daemon has accepted exactly the
         // partial bytes. Drop the transport now, pre-END.
         drop();

--- a/conformance/v2/harness/stream.mjs
+++ b/conformance/v2/harness/stream.mjs
@@ -473,6 +473,24 @@ async function runUpload({ session, tracker, replyState, sendBytes, declaredByte
   if (fault === 'raw_record') {
     return await driveRawRecordUpload({ session, tracker, replyState, waitMs, limitBytes });
   }
+  // `transport_drop` is a pre-END transport loss (docs/protocol-v2.md
+  // § Disconnects and retries): the client streams a healthy PARTIAL upload
+  // — one DATA record, acknowledged by the daemon's cumulative CREDIT — and
+  // then drops the WebSocket with no close frame (the same terminate() the
+  // control:{do:disconnect} verb drives; a stream step cannot use that verb
+  // because a duplex call cannot return before its terminal reply, which
+  // this fault deliberately never lets arrive). No byte stream survives its
+  // connection: the daemon must abort the share, drop staging, release its
+  // reservation, author nothing, and — under the request's op_id — record
+  // stream_aborted{transport_lost} for replay. The step has NO wire reply,
+  // so the driver returns a LOCAL OBSERVATION marker (never a synthetic
+  // reply envelope) and the runner treats it as reply-less; the fixture's
+  // reconnect + same-op_id replay asserts the recorded failure (matched by
+  // the daemon integration test websocket_file_share_disconnect_replays_
+  // pre_and_post_end_results in crates/jeliyad/src/serve.rs).
+  if (fault === 'transport_drop') {
+    return await driveTransportDropUpload({ session, tracker, replyState, sendBytes, waitMs, limitBytes, maxPayload });
+  }
   if (fault !== undefined) {
     throw new Error(`unknown stream fault ${JSON.stringify(fault)} on file.share`);
   }
@@ -897,6 +915,190 @@ async function driveRawRecordUpload({ session, tracker, replyState, waitMs, limi
   }
   if (tracker.failure) throw tracker.failure;
   return reply;
+}
+
+/** The marker a transport_drop step returns: this fault deliberately ends
+ * with NO terminal reply on the wire (the socket is dropped pre-END), so the
+ * driver reports a local observation — never a synthetic reply envelope. The
+ * runner treats a step carrying this marker as reply-less: nothing to match,
+ * capture, or expose under out/err/frame. */
+export function isTransportDroppedMarker(value) {
+  return value !== null && typeof value === 'object' && value.transportDropped === true;
+}
+
+/**
+ * Drive a pre-END transport loss on a healthy partial upload. The daemon's
+ * cumulative CREDIT is the only forward-progress signal, and its refill
+ * policy acknowledges a DATA record only when the record consumed the whole
+ * granted window (or completed the file) — so the healthy partial here is
+ * exactly ONE FULL WINDOW: the declared total must exceed one window (the
+ * served max DATA payload), the client sends a single DATA record of that
+ * size, and the daemon's cumulative CREDIT must acknowledge exactly those
+ * bytes. That acknowledgement pins what the daemon must later record. The
+ * client then terminates the socket with no close frame. No byte stream
+ * survives its connection: the daemon aborts the share, removes staging,
+ * releases its reservation, authors no event, and (under the request's
+ * op_id) records stream_aborted{transport_lost, transferred_bytes: the
+ * acknowledged count} — asserted by the fixture's reconnect + same-op_id
+ * replay, not here, because there is no reply on this connection to assert
+ * against.
+ *
+ * Guards before the drop: the declared total exceeds one window (else the
+ * fault would be a whole-file upload, not a partial — a fixture/sizing
+ * error, never a daemon failure), the initial CREDIT shape and bound, the
+ * acknowledgement landing exactly on the DATA record's end boundary, no
+ * credit beyond what was sent, no daemon ABORT of the healthy stream, and
+ * no terminal reply arriving before the drop (a reply here would mean the
+ * daemon settled the request while the producer was still active).
+ */
+async function driveTransportDropUpload({ session, tracker, replyState, sendBytes, waitMs, limitBytes, maxPayload }) {
+  if (typeof limitBytes !== 'number' || !Number.isInteger(limitBytes) || limitBytes < 0) {
+    throw new AssertFailure(
+      `served max_shared_file_bytes ${JSON.stringify(limitBytes)} is unusable for byte streaming`,
+    );
+  }
+  const limit = limitBytes;
+  // One full window is the only healthy partial the daemon's refill policy
+  // acknowledges mid-file; a declared total within one window would make the
+  // acknowledgement arrive only with the whole file, which is not a partial.
+  if (!Number.isInteger(sendBytes) || sendBytes <= maxPayload) {
+    throw new Error(
+      `transport_drop needs a declared total above one DATA window (${maxPayload} bytes) so a single full-window record is a healthy partial, got ${sendBytes}`,
+    );
+  }
+  const chunkLen = maxPayload;
+  const sent = chunkLen;
+  let creditWindow = null;
+  let acknowledged = null;
+  let dataSent = false;
+  let dropped = false;
+  // The previous CREDIT's (offset, value), for the monotonicity contract.
+  let prevCredit = null;
+
+  const drop = () => {
+    // The same primitive the control:{do:disconnect} verb drives — no close
+    // frame, no drain. Outstanding waiters on this connection fail; the
+    // marker below is returned before any such failure can be misread as
+    // this step's reply.
+    session.disconnect();
+    dropped = true;
+  };
+
+  for (;;) {
+    const what = dropped
+      ? 'the local drop'
+      : acknowledged === null
+        ? (creditWindow === null ? 'the initial CREDIT' : `the cumulative CREDIT acknowledging ${sent}`)
+        : 'the drop';
+    if (dropped) break;
+    if (creditWindow !== null && !dataSent && acknowledged === null && tracker.queue.length === 0 && !replyState.done) {
+      // Send the one full-window DATA record as soon as the initial window
+      // exists — exactly once (a second record at the same offset would be
+      // client malformation, not this fault).
+      const payload = patternChunk(0, chunkLen);
+      tracker.generated += chunkLen;
+      session.sendBinary(
+        encodeRecord({ kind: KIND.DATA, id: tracker.id, streamId: tracker.streamId, offset: 0, payload }),
+      );
+      tracker.socketSent += chunkLen;
+      dataSent = true;
+      await yieldAfterSend(session, tracker);
+      continue;
+    }
+    const ev = await tracker.next(replyState, waitMs, what);
+    if (ev.reply) {
+      throw new AssertFailure(
+        `file.share settled its terminal reply while the producer was still active — the transport had not dropped yet`,
+      );
+    }
+    const rec = ev.record;
+    checkBinding(tracker, rec);
+    if (rec.kind === KIND.CREDIT) {
+      if (rec.payload) throw new AssertFailure('daemon CREDIT carried a payload');
+      // The spec's credit contract is monotonic and non-inverted
+      // (accepted_through <= send_through, both only ever advance) — the
+      // same rule the normal upload path enforces on every window.
+      if (rec.offset > rec.value) {
+        throw new AssertFailure(
+          `daemon CREDIT inverted: accepted ${rec.offset} through a send_through of ${rec.value}`,
+        );
+      }
+      if (prevCredit && (rec.offset < prevCredit.offset || rec.value < prevCredit.value)) {
+        throw new AssertFailure(
+          `daemon CREDIT regressed: (${rec.offset}, ${rec.value}) after (${prevCredit.offset}, ${prevCredit.value})`,
+        );
+      }
+      if (rec.offset > sent) {
+        throw new AssertFailure(
+          `daemon CREDIT acknowledged ${rec.offset} bytes beyond the ${sent} actually sent`,
+        );
+      }
+      if (rec.value > limit + 1) {
+        throw new AssertFailure(
+          `daemon CREDIT send_through ${rec.value} exceeds max_shared_file_bytes + 1 (${limit + 1})`,
+        );
+      }
+      if (creditWindow === null) {
+        if (rec.offset !== 0) {
+          throw new AssertFailure(
+            `daemon CREDIT acknowledged ${rec.offset} bytes when the client had sent none`,
+          );
+        }
+        if (rec.value < chunkLen) {
+          throw new AssertFailure(
+            `daemon initial CREDIT window ${rec.value} cannot carry the one full-window DATA record (${chunkLen}) this fault sends`,
+          );
+        }
+        creditWindow = rec.value;
+        prevCredit = { offset: rec.offset, value: rec.value };
+        continue;
+      }
+      // Cumulative credit may only advance on the accepted record boundary —
+      // the daemon has seen exactly one DATA record, so the only legal
+      // positive acknowledgement is exactly the record's end.
+      if (rec.offset !== 0 && rec.offset !== sent) {
+        throw new AssertFailure(
+          `daemon CREDIT acknowledged ${rec.offset}, inside the single ${sent}-byte DATA record rather than on its boundary`,
+        );
+      }
+      if (rec.offset === sent) {
+        if (!dataSent) {
+          // A cumulative acknowledgement of bytes that were never put on the
+          // wire — e.g. a daemon batching initial + cumulative CREDIT before
+          // the client could send its one record — is fabricated progress:
+          // the daemon cannot have accepted bytes it never received.
+          throw new AssertFailure(
+            `daemon CREDIT acknowledged ${rec.offset} bytes before the client's DATA record was on the wire`,
+          );
+        }
+        acknowledged = rec.offset;
+        tracker.accepted = acknowledged;
+        prevCredit = { offset: rec.offset, value: rec.value };
+        // The precondition is proven: the daemon has accepted exactly the
+        // partial bytes. Drop the transport now, pre-END.
+        drop();
+        break;
+      }
+      prevCredit = { offset: rec.offset, value: rec.value };
+      continue;
+    }
+    if (rec.kind === KIND.ABORT) {
+      throw new AssertFailure(
+        `daemon ABORTed a healthy partial upload (accepted ${rec.offset}) while the client awaited the cumulative CREDIT — a receiver must acknowledge the bytes it accepted`,
+      );
+    }
+    throw new AssertFailure(`daemon sent unexpected ${rec.kindName} before the transport drop`);
+  }
+  if (!dropped) {
+    throw new AssertFailure('transport_drop failed to drop the connection');
+  }
+  if (acknowledged !== sent) {
+    throw new AssertFailure(
+      `transport_drop dropped the connection before the daemon acknowledged the ${sent} accepted bytes`,
+    );
+  }
+  // No terminal reply exists for this step; report the local observation.
+  return { transportDropped: true, acceptedBytes: acknowledged };
 }
 
 /** Download: grant a bounded window, accept DATA, advance cumulative CREDIT

--- a/conformance/v2/manifest.json
+++ b/conformance/v2/manifest.json
@@ -7,7 +7,7 @@
     "structural_validation": true,
     "selected_json_envelope_subject_slice": {
       "status": "partial",
-      "ci_selected_cases": 24
+      "ci_selected_cases": 25
     },
     "binary_byte_stream_executor": {
       "status": "partial",
@@ -16,7 +16,8 @@
       "bytes_streamed_observation": "implemented",
       "client_abort_fault": "implemented",
       "raw_record_fault": "implemented",
-      "credit_pause_transport_drop_faults": "unimplemented"
+      "credit_pause_fault": "unimplemented",
+      "transport_drop_fault": "implemented"
     },
     "adapter_targeted_declarative_cases": "declarative_only"
   },
@@ -117,16 +118,16 @@
     }
   ],
   "target_counts": {
-    "untargeted": 340,
+    "untargeted": 341,
     "daemon": 0,
     "in_process_core": 1,
     "client_adapter": 5
   },
   "totals": {
-    "cases": 346,
-    "attributed_to_an_operation": 239,
+    "cases": 347,
+    "attributed_to_an_operation": 240,
     "not_operation_scoped": 107,
-    "conforming_to_the_dsl": 346,
+    "conforming_to_the_dsl": 347,
     "distinct_step_verbs_in_use": 7,
     "quarantined": 0,
     "blocked_on_upstream": 15,
@@ -134,8 +135,8 @@
   },
   "per_file_totals": {
     "files.json": {
-      "cases": 45,
-      "attributed_to_an_operation": 43,
+      "cases": 46,
+      "attributed_to_an_operation": 44,
       "not_operation_scoped": 2,
       "blocked_on_upstream": {
         "U1": 0,
@@ -269,7 +270,7 @@
       "satisfies_required_kinds": true
     },
     "file.share": {
-      "cases": 16,
+      "cases": 17,
       "success": true,
       "distinctive_code": "declared_size_mismatch",
       "distinctive_code_has_a_case": true,

--- a/scripts/check-v2-corpus.mjs
+++ b/scripts/check-v2-corpus.mjs
@@ -53,10 +53,18 @@ const STREAMING_OPS = new Map([
 //     the live binding; the daemon aborts only that stream with
 //     ABORT(protocol_error), the client ACKs, and the request resolves to the
 //     correlated malformed_frame reply while the connection stays usable.
-// Still declarative until the executor drives them: credit-pause and
-// transport-drop, and every download-side fault (the download path has no
-// executable single-subject fixture — see the manifest ledger).
-const STREAM_FAULTS = new Set(["client_abort", "raw_record"]);
+//   - `transport_drop`: a pre-END transport loss on a healthy partial upload
+//     (the client streams one acknowledged DATA record, then drops the socket
+//     with no close frame); the daemon must abort, drop staging, release its
+//     reservation, author nothing, and record stream_aborted{transport_lost}
+//     under the op_id for replay. The step itself has NO terminal reply, so a
+//     transport_drop stream step carries no expect and no save; the recorded
+//     result is asserted by the fixture's replay step.
+// Still declarative until the executor drives them: credit-pause (its
+// upload-side executor lands on a sibling branch) and every download-side
+// fault (the download path has no executable single-subject fixture — see
+// the manifest ledger; download-side credit-pause is parked on R-A).
+const STREAM_FAULTS = new Set(["client_abort", "raw_record", "transport_drop"]);
 const KINDS = new Set(["success", "error", "malformed", "boundary", "authorization", "handshake", "push", "ordering"]);
 const PRE_OPEN_STREAM_CODES = new Set([
   "invalid_argument", "subject_absent", "room_not_available", "membership_ended",
@@ -776,6 +784,20 @@ function checkStep(step, file, caseName, stepIdx) {
           } else if (!STREAM_FAULTS.has(step.stream.fault)) {
             fail(file, caseName, where,
               `stream.fault "${step.stream.fault}" is not in the closed set {${[...STREAM_FAULTS].join(", ")}}`);
+          } else if (step.stream.fault === "transport_drop") {
+            // This fault deliberately ends with NO terminal reply on the wire
+            // (the socket is dropped pre-END), so there is nothing a matcher
+            // could match or a capture could read — a fixture carrying
+            // expect/save here would be fabricating a reply the daemon never
+            // sent. The recorded outcome is asserted by a later replay step.
+            if (step.expect !== undefined) {
+              fail(file, caseName, where,
+                `a transport_drop stream step has no terminal reply to match — assert the recorded result on the replay step instead`);
+            }
+            if (step.save !== undefined) {
+              fail(file, caseName, where,
+                `a transport_drop stream step has no reply to capture from — the recorded result is read on the replay step instead`);
+            }
           }
         }
       }
@@ -1392,7 +1414,8 @@ if (isObject(manifest)) {
       bytes_streamed_observation: "implemented",
       client_abort_fault: "implemented",
       raw_record_fault: "implemented",
-      credit_pause_transport_drop_faults: "unimplemented",
+      credit_pause_fault: "unimplemented",
+      transport_drop_fault: "implemented",
     },
     adapter_targeted_declarative_cases: "declarative_only",
   };


### PR DESCRIPTION
NOTE: sibling of the credit_pause branch (233b). Whichever merges second takes
the union reconciliation (PRE-VERIFIED in a throwaway worktree: all four gates
green, 26/26 live — recipe in the orchestration STATUS): STREAM_FAULTS gains
both faults, all four ledger entries "implemented", counts 348 cases /
files.json 47 / file.share 18 / CI slice 26. On THIS branch credit_pause is
honestly unimplemented.

## Summary

Executes the fourth client-originated upload fault: `stream: {send_bytes,
fault: "transport_drop"}` — the pre-END transport-loss control the record's
executor contract names, reconciled with the existing `control:{do:
disconnect}` DSL verb rather than a parallel dialect: the executor calls the
SAME `Session.disconnect()` primitive (no close frame), and the fixture uses
the EXISTING `control:{do:reconnect}` verb for the same-principal replay. What
the control verb genuinely cannot express — dropping the transport in the
middle of a duplex streaming call (a stream step cannot return before its
terminal reply) — is exactly and only what the fault executor adds.

Choreography (from docs/protocol-v2.md §Disconnects and retries): on an
admitted upload whose declared total exceeds one DATA window (131072), the
client sends exactly one full-window DATA record (65536), waits for the
daemon's cumulative CREDIT acknowledging those bytes, then drops the socket
with no close frame. No byte stream survives its connection: the daemon must
abort the share, drop staging, release its reservation, author no event, and
record `stream_aborted{transport_lost}` under the op_id. The fixture's
reconnect + same-op_id replay step asserts the recorded failure:
`transferred_bytes` exactly the acknowledged 65536, no second stream, and
`file.list` empty (no authored share). The drop step itself has NO wire reply —
modeled as a LOCAL observation marker, never a synthetic reply envelope, and
the validator now REJECTS `expect`/`save` on a transport_drop stream step
(a fixture matching or capturing there would fabricate a reply the daemon
never sent).

The one-full-window partial is not a stylistic choice: the daemon's receiver
refill policy (and the spec's own credit semantics) acknowledges a DATA record
only when it consumed the whole granted window or completed the file, so a
sub-window partial is never credited mid-file. The driver therefore REQUIRES
`declared > one window` and refuses smaller totals as plain executor errors
(fixture/sizing mismatch, never a daemon conformance failure).

Change surface (7 files, no Rust — daemon already conformant, pinned by
`websocket_file_share_disconnect_replays_pre_and_post_end_results`):

- `conformance/v2/harness/stream.mjs` — `driveTransportDropUpload` beside the
  other three faults; guards: initial CREDIT shape/wire bound and window
  capacity, mid-record / beyond-sent acknowledgements rejected, daemon ABORT
  of the healthy partial rejected, terminal-reply-before-drop rejected,
  exactly-one-DATA latch, drop only after the acknowledging CREDIT.
- `conformance/v2/harness/runner.mjs` — `isTransportDroppedMarker` branch in
  `#doCall`: reply-less step, nothing exposed under out/err/frame,
  refused-baseline semantics.
- `conformance/v2/files.json` — one new case:
  `share_upload_transport_drop_records_stream_aborted_for_replay`.
- `scripts/check-v2-corpus.mjs` — `transport_drop` in the closed
  `STREAM_FAULTS` + the no-expect/no-save rule.
- `conformance/v2/manifest.json`, `conformance/v2/README.md` — branch-accurate
  lockstep (347 cases, files.json 46, file.share 17, CI slice 25;
  `credit_pause_fault: unimplemented` ON THIS BRANCH).
- `.github/workflows/ci.yml` — the new case in the live replay slice.

## What was run (this worktree, against target/debug/jeliyad)

1. `node --test conformance/v2/harness/stream.test.mjs` — 47/47 pass
2. `node --test scripts/check-v2-corpus.test.mjs` — 19/19 pass
3. `node scripts/check-v2-corpus.mjs` — 347 cases OK
4. This branch's full CI selector list (25 cases) replayed live — 25/25 PASS
   (`--verbose`: `-> transport dropped (accepted 65536)`, replay returns
   `err {"code":"stream_aborted","transferred_bytes":65536,"total":{"state":"known","bytes":131072},"reason":"transport_lost"}`,
   `file.list` empty).
5. Negative probes (throwaway, deleted before commit): executor 12+4/16
   against a mock session, each for the INTENDED reason — the legal control
   asserts exactly ONE DATA record is sent (a first-draft duplicate-send loop
   is the bug it caught), the marker shape, and that the socket was dropped;
   the mis-sizing guard throws a plain Error (executor error class, not a
   daemon FAIL). Validator 2/2: `expect` and `save` on the transport_drop step
   each rejected for their intended reasons (probed against the real validator
   with the fixture mutated then restored and re-validated).
6. Adversarial review: 2 read-only claim-attack reviewers (guards T1–T8;
   ledger/independence M1–M6). Ledger reviewer: all six HOLD. Guard reviewer:
   T1/T2/T3/T5/T6/T7 HOLD; T4 was BROKEN two ways, both FIXED in `4908684` —
   (a) a daemon batching initial + cumulative CREDIT before the client's DATA
   write made the harness drop with ZERO bytes on the wire and still pass;
   a cumulative acknowledgement now requires the DATA record to have been
   sent; (b) regressed/inverted cumulative CREDIT passed unchecked — the
   spec's monotonicity contract is now enforced on every CREDIT, same
   language as the normal upload path. Post-fix probes 4/4; all four gates
   re-run green (47/47, 19/19, 347 OK, live 25/25).
7. Union pre-verification: the 233b ∪ 233c merge was resolved as a deliberate
   union in a throwaway worktree and all four gates ran green on it — 47/47,
   19/19, corpus 348 cases OK, 26-case live slice 26/26 PASS (both new fault
   cases together). Recipe recorded in the orchestration STATUS for whichever
   PR merges second.

Closes part of #233 (the transport_drop slice). Download-side faults and the
download corpus remain parked on R-A.
